### PR TITLE
feat(skills): isolate concurrent agent work

### DIFF
--- a/harlan-agent-kit/references/worktree-isolation.md
+++ b/harlan-agent-kit/references/worktree-isolation.md
@@ -1,0 +1,35 @@
+# Worktree isolation contract
+
+Use a live task claim to detect concurrent repository mutation. A worktree's existence does not prove an agent is active.
+
+## Claim interface
+
+Prefer an active controller's atomic claim when it records the normalized repository, absolute checkout, session owner, and lease. The controller must support acquire, list, renew, and release operations.
+
+Without that interface, use `${CLAUDE_SKILL_DIR}/../../scripts/worktree-claim.sh`. Resolve the same path relative to the active `SKILL.md` when `CLAUDE_SKILL_DIR` is unavailable.
+
+Create one stable session ID with the controller's task ID or `bash SCRIPT new-session`. Reuse it for the entire task.
+
+Before the first edit, run:
+
+```bash
+bash SCRIPT acquire --path "$PWD" --session "$TASK_SESSION_ID"
+```
+
+The helper normalizes identity through the repository's common Git directory and absolute worktree root. It serializes operations with `flock`. Claims expire after 15 minutes by default. Every operation removes expired claims.
+
+Run `acquire` again before each mutation phase and at least every five minutes to renew the lease. Run `list` to inspect live claims. Run `release` at task completion. Only the owning session can renew or release a live checkout claim.
+
+## Isolation decision
+
+If the selected checkout already belongs to this task, reuse it.
+
+If the shared checkout claim succeeds with `other_active: false`, work there. Do not create a worktree.
+
+If another session owns the shared checkout, or a successful shared claim reports `other_active: true`, do not edit there. Release any claim owned by this session. Run `wt list --format=json`. Reuse this task's worktree or create one with `wt switch --create <branch> --base <base>`. Acquire the new checkout before editing it.
+
+A live claim in another worktree still proves concurrent repository work. A stale claim or an unclaimed worktree does not.
+
+Never share a mutation worktree between tasks. If claim ownership is missing or ambiguous, stop before editing the shared checkout.
+
+When the task reaches its cleanup point, release its claim. If the task created a worktree, use `wt remove <branch>`. Never force removal.

--- a/harlan-agent-kit/scripts/worktree-claim.sh
+++ b/harlan-agent-kit/scripts/worktree-claim.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo 'usage: worktree-claim.sh <new-session|acquire|list|release> [--path PATH] [--session ID] [--lease SECONDS]' >&2
+  exit 64
+}
+
+command_name=${1:-}
+[[ -n "$command_name" ]] || usage
+shift
+
+claim_path=$PWD
+claim_session=${HARLAN_AGENT_TASK_ID:-${CODEX_THREAD_ID:-}}
+claim_lease=900
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path)
+      [[ $# -ge 2 ]] || usage
+      claim_path=$2
+      shift 2
+      ;;
+    --session)
+      [[ $# -ge 2 ]] || usage
+      claim_session=$2
+      shift 2
+      ;;
+    --lease)
+      [[ $# -ge 2 ]] || usage
+      claim_lease=$2
+      shift 2
+      ;;
+    *) usage ;;
+  esac
+done
+
+if [[ "$command_name" == 'new-session' ]]; then
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  else
+    tr '[:upper:]' '[:lower:]' < /proc/sys/kernel/random/uuid
+  fi
+  exit 0
+fi
+
+command -v flock >/dev/null 2>&1 || { echo 'flock is required' >&2; exit 69; }
+command -v jq >/dev/null 2>&1 || { echo 'jq is required' >&2; exit 69; }
+
+case "$command_name" in
+  acquire|release)
+    [[ -n "$claim_session" && "$claim_session" != *$'\n'* ]] || { echo 'a stable session ID is required' >&2; exit 64; }
+    ;;
+  list) ;;
+  *) usage ;;
+esac
+
+if ! [[ "$claim_lease" =~ ^[0-9]+$ ]] || (( claim_lease < 1 || claim_lease > 3600 )); then
+  echo 'lease must be between 1 and 3600 seconds' >&2
+  exit 64
+fi
+
+repository_root=$(git -C "$claim_path" rev-parse --show-toplevel 2>/dev/null) || { echo 'path is not in a Git repository' >&2; exit 69; }
+repository_root=$(realpath "$repository_root")
+common_git_dir=$(git -C "$claim_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || { echo 'cannot resolve the common Git directory' >&2; exit 69; }
+common_git_dir=$(realpath "$common_git_dir")
+claim_root="$common_git_dir/harlan-agent-kit/worktree-claims"
+mkdir -p "$claim_root"
+
+claim_key=$(printf '%s' "$repository_root" | sha256sum | cut -d' ' -f1)
+claim_file="$claim_root/$claim_key.json"
+mutex_file="$claim_root/.mutex"
+now_epoch=$(date +%s)
+
+exec 9>"$mutex_file"
+flock -x 9
+
+shopt -s nullglob
+for candidate in "$claim_root"/*.json; do
+  expires_epoch=$(jq -r '.expires_epoch // 0' "$candidate" 2>/dev/null || echo 0)
+  if ! [[ "$expires_epoch" =~ ^[0-9]+$ ]] || (( expires_epoch <= now_epoch )); then
+    rm -f -- "$candidate"
+  fi
+done
+
+if [[ "$command_name" == 'list' ]]; then
+  claim_files=("$claim_root"/*.json)
+  if (( ${#claim_files[@]} == 0 )); then
+    echo '[]'
+  else
+    jq -s 'sort_by(.worktree)' "${claim_files[@]}"
+  fi
+  exit 0
+fi
+
+if [[ "$command_name" == 'release' ]]; then
+  if [[ ! -f "$claim_file" ]]; then
+    jq -n --arg repository "$common_git_dir" --arg worktree "$repository_root" '{ released: false, reason: "not_found", repository: $repository, worktree: $worktree }'
+    exit 0
+  fi
+
+  existing_session=$(jq -r '.session // empty' "$claim_file")
+  if [[ "$existing_session" != "$claim_session" ]]; then
+    jq -n --arg owner "$existing_session" '{ released: false, reason: "owner_mismatch", owner: $owner }'
+    exit 3
+  fi
+
+  rm -f -- "$claim_file"
+  jq -n --arg repository "$common_git_dir" --arg worktree "$repository_root" '{ released: true, repository: $repository, worktree: $worktree }'
+  exit 0
+fi
+
+if [[ -f "$claim_file" ]]; then
+  existing_session=$(jq -r '.session // empty' "$claim_file")
+  if [[ "$existing_session" != "$claim_session" ]]; then
+    jq -n --arg owner "$existing_session" --arg repository "$common_git_dir" --arg worktree "$repository_root" '{ claimed: false, reason: "checkout_claimed", owner: $owner, repository: $repository, worktree: $worktree }'
+    exit 2
+  fi
+fi
+
+other_active=false
+for candidate in "$claim_root"/*.json; do
+  candidate_session=$(jq -r '.session // empty' "$candidate")
+  if [[ "$candidate_session" != "$claim_session" ]]; then
+    other_active=true
+    break
+  fi
+done
+
+expires_epoch=$((now_epoch + claim_lease))
+claim_tmp="$claim_root/.$claim_key.$$.tmp"
+jq -n \
+  --arg repository "$common_git_dir" \
+  --arg worktree "$repository_root" \
+  --arg session "$claim_session" \
+  --argjson refreshed_epoch "$now_epoch" \
+  --argjson expires_epoch "$expires_epoch" \
+  '{ repository: $repository, worktree: $worktree, session: $session, refreshed_epoch: $refreshed_epoch, expires_epoch: $expires_epoch }' > "$claim_tmp"
+mv -f -- "$claim_tmp" "$claim_file"
+
+jq -n \
+  --arg repository "$common_git_dir" \
+  --arg worktree "$repository_root" \
+  --arg session "$claim_session" \
+  --argjson other_active "$other_active" \
+  --argjson expires_epoch "$expires_epoch" \
+  '{ claimed: true, repository: $repository, worktree: $worktree, session: $session, other_active: $other_active, expires_epoch: $expires_epoch }'

--- a/harlan-agent-kit/scripts/worktree-claim.test.sh
+++ b/harlan-agent-kit/scripts/worktree-claim.test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+claim_script="$script_dir/worktree-claim.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+repo="$test_root/repo"
+other="$test_root/other"
+git init -q "$repo"
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name Test
+touch "$repo/seed"
+git -C "$repo" add seed
+git -C "$repo" commit -qm seed
+git -C "$repo" worktree add -qb other "$other"
+
+bash "$claim_script" acquire --path "$repo" --session first --lease 30 | jq -e '.claimed and (.other_active == false)' >/dev/null
+bash "$claim_script" acquire --path "$other" --session second --lease 30 | jq -e '.claimed and .other_active' >/dev/null
+bash "$claim_script" list --path "$repo" | jq -e 'length == 2' >/dev/null
+
+if bash "$claim_script" release --path "$repo" --session wrong >/dev/null 2>&1; then
+  echo 'wrong owner released a claim' >&2
+  exit 1
+fi
+
+bash "$claim_script" release --path "$repo" --session first | jq -e '.released' >/dev/null
+bash "$claim_script" release --path "$other" --session second | jq -e '.released' >/dev/null
+
+first_status="$test_root/first.status"
+second_status="$test_root/second.status"
+(set +e; bash "$claim_script" acquire --path "$repo" --session contender-one --lease 30 >/dev/null 2>&1; echo "$?" > "$first_status") &
+(set +e; bash "$claim_script" acquire --path "$repo" --session contender-two --lease 30 >/dev/null 2>&1; echo "$?" > "$second_status") &
+wait
+
+statuses=$(sort "$first_status" "$second_status" | tr '\n' ' ')
+if [[ "$statuses" != '0 2 ' ]]; then
+  echo "expected one owner and one conflict, received: $statuses" >&2
+  exit 1
+fi
+
+owner=$(bash "$claim_script" list --path "$repo" | jq -r '.[0].session')
+bash "$claim_script" release --path "$repo" --session "$owner" >/dev/null
+
+bash "$claim_script" acquire --path "$repo" --session stale --lease 1 >/dev/null
+sleep 2
+bash "$claim_script" acquire --path "$repo" --session recovered --lease 30 | jq -e '.claimed' >/dev/null
+bash "$claim_script" release --path "$repo" --session recovered >/dev/null
+
+echo 'worktree claim tests passed'

--- a/harlan-agent-kit/skills/adversarial-review/SKILL.md
+++ b/harlan-agent-kit/skills/adversarial-review/SKILL.md
@@ -11,6 +11,8 @@ Returning findings without posting and confirming the status comment is incomple
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/adversarial-review/SKILL.md
+++ b/harlan-agent-kit/skills/adversarial-review/SKILL.md
@@ -11,7 +11,7 @@ Returning findings without posting and confirming the status comment is incomple
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/adversarial-review/SKILL.md
+++ b/harlan-agent-kit/skills/adversarial-review/SKILL.md
@@ -9,6 +9,14 @@ Review exactly one pull request. Disprove correctness where possible, repair wha
 
 Returning findings without posting and confirming the status comment is incomplete.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
+Keep the review read only until mutation authority exists. Apply this rule before any repair or branch alignment edit.
+
 ## Load contracts
 
 Read these completely before reviewing:

--- a/harlan-agent-kit/skills/adversarial-review/references/mutation-authority.md
+++ b/harlan-agent-kit/skills/adversarial-review/references/mutation-authority.md
@@ -25,7 +25,19 @@ A PR head branch is writable only when at least one condition holds:
 
 Continue read only when the head is not writable. Record the permission boundary in the bot status.
 
-Never force push, amend published commits, dismiss reviews, approve, merge, or push the base branch.
+Adversarial review authority never permits force pushing, amending published commits, dismissing reviews, approving, merging, or pushing the base branch.
+
+## Ownership merge
+
+The `take-ownership` skill may merge only when every condition holds:
+
+1. The current request explicitly says `$take-ownership`, `/take-ownership`, `get this merged`, or `land this`.
+2. The base repository owner exactly matches the authenticated GitHub login.
+3. `adversarial-review` reports `PASS` for the exact remote head.
+4. Required checks and approvals pass for that same head.
+5. The repository's normal merge method or merge queue accepts the change without administrator bypass.
+
+This authority does not let `adversarial-review` merge. It never permits self-approval, force push, branch-protection bypass, or merging maintained and external repositories.
 
 ## Default branch repair
 

--- a/harlan-agent-kit/skills/adversarial-review/references/mutation-authority.md
+++ b/harlan-agent-kit/skills/adversarial-review/references/mutation-authority.md
@@ -31,13 +31,13 @@ Adversarial review authority never permits force pushing, amending published com
 
 The `take-ownership` skill may merge only when every condition holds:
 
-1. The current request explicitly says `$take-ownership`, `/take-ownership`, `get this merged`, or `land this`.
+1. The user gave an explicit, unnegated merge instruction for the resolved pull request, and it still applies immediately before merge.
 2. The base repository owner exactly matches the authenticated GitHub login.
 3. `adversarial-review` reports `PASS` for the exact remote head.
 4. Required checks and approvals pass for that same head.
 5. The repository's normal merge method or merge queue accepts the change without administrator bypass.
 
-This authority does not let `adversarial-review` merge. It never permits self-approval, force push, branch-protection bypass, or merging maintained and external repositories.
+Skill selection and generated default prompts never grant merge authority. This authority does not let `adversarial-review` merge. It never permits self-approval, force push, branch-protection bypass, or merging maintained and external repositories.
 
 ## Default branch repair
 

--- a/harlan-agent-kit/skills/glossary/SKILL.md
+++ b/harlan-agent-kit/skills/glossary/SKILL.md
@@ -11,7 +11,7 @@ argument-hint: "[init | audit | add <term>]"
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/glossary/SKILL.md
+++ b/harlan-agent-kit/skills/glossary/SKILL.md
@@ -9,6 +9,12 @@ argument-hint: "[init | audit | add <term>]"
 
 `GLOSSARY.md` at the repo root is the canonical name for every product concept. One concept, one word, everywhere: UI strings, public API names, doc headings, route segments, error messages, commit subjects.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## The failure mode this exists to stop
 
 An agent given a concept with no established name invents one, then propagates it. A single feature ends up shipping as **Sprint** in the dashboard, `runBatch()` in the SDK, "campaign" in the docs, and `/jobs` in the URL. Nobody decided that. It accretes one plausible-in-isolation naming choice at a time, and by the time a human notices, the term is in a published API and a customer's bookmarks.

--- a/harlan-agent-kit/skills/glossary/SKILL.md
+++ b/harlan-agent-kit/skills/glossary/SKILL.md
@@ -11,6 +11,8 @@ argument-hint: "[init | audit | add <term>]"
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
@@ -10,6 +10,12 @@ Surface architectural friction in a TypeScript package (library, CLI, or pnpm mo
 
 Vocabulary, principles, and forbidden patterns live in their canonical files; this file references them. Use the terms in [LANGUAGE.md](LANGUAGE.md) exactly. This skill is _informed_ by the project's domain model (`CONTEXT.md`, `docs/adr/`).
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## Companion files
 
 - [LANGUAGE.md](LANGUAGE.md) — full vocabulary and principles.

--- a/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
@@ -12,6 +12,8 @@ Vocabulary, principles, and forbidden patterns live in their canonical files; th
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
@@ -12,7 +12,7 @@ Vocabulary, principles, and forbidden patterns live in their canonical files; th
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/issue-triage/SKILL.md
+++ b/harlan-agent-kit/skills/issue-triage/SKILL.md
@@ -9,7 +9,7 @@ Triage all open issues and rank by difficulty/impact.
 
 ## Worktree isolation
 
-Before follow-on edits, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before follow-on edits, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/issue-triage/SKILL.md
+++ b/harlan-agent-kit/skills/issue-triage/SKILL.md
@@ -7,6 +7,12 @@ context: fork
 
 Triage all open issues and rank by difficulty/impact.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Triage stays read only. Use `wt` for follow-on implementation only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command.
+
 ## Gotchas
 
 - **GitHub API rate limits** -- `gh issue list` with `--limit 100`+ can hit rate limits on busy repos. If you get a 403, reduce the batch size or add `--label` filters.
@@ -68,15 +74,15 @@ On subsequent runs, read the log and highlight what changed since last triage.
 
 8. **Highlight high priorities** -- impact 4-5 regardless of difficulty
 
-9. **Offer worktree setup** -- prompt user with options:
+9. **Offer worktree setup only for concurrent implementation** -- use `wt` when another agent is already active in this repository, or when two selected issues will run concurrently. Otherwise do not create a worktree. Prompt user with options:
    - "Create worktrees for quick wins (difficulty 1-2, impact 2+)?"
    - "Create worktrees for high priorities (impact 4-5)?"
    - "Pick specific issues by number?"
 
-   For each selected issue, create an isolated worktree using `wt` (git worktree manager):
+   For each selected issue, create an isolated worktree using `wt`:
    ```bash
-   wt switch --create fix/<number>-<slug>
+   wt switch --create fix/<number>-<slug> --base <base>
    ```
-   Where `<slug>` is a kebab-case short title (first 4-5 words). `wt switch --create` creates a new branch + worktree from current HEAD.
+   Where `<slug>` is a kebab-case short title (first 4-5 words).
 
-   After creation, list worktrees with `wt list` so user can open them in separate sessions.
+   After creation, run `wt list --format=json`. Give each agent the selected worktree's absolute `path`.

--- a/harlan-agent-kit/skills/issue-triage/SKILL.md
+++ b/harlan-agent-kit/skills/issue-triage/SKILL.md
@@ -9,6 +9,8 @@ Triage all open issues and rank by difficulty/impact.
 
 ## Worktree isolation
 
+Before follow-on edits, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Triage stays read only. Use `wt` for follow-on implementation only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command.

--- a/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
@@ -13,6 +13,8 @@ Full lifecycle frontend skill: setup, build, polish. Detects the right phase fro
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
@@ -13,7 +13,7 @@ Full lifecycle frontend skill: setup, build, polish. Detects the right phase fro
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
@@ -11,6 +11,12 @@ effort: max
 
 Full lifecycle frontend skill: setup, build, polish. Detects the right phase from project state.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 Job artifacts, contract format, dev server, checkpointing, and the handoff schema live in [references/workflow.md](references/workflow.md). Read it before Phase 2 or Phase 3.
 
 ## Craft Principles

--- a/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
@@ -14,6 +14,12 @@ You are an **adversarial reviewer**, not the implementer. Default assumption: th
 
 Never fix what you find. You are the evaluator.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+If the builder used `wt` because another agent was active in the repository, review that same worktree. Run `wt list --format=json`, read its absolute `path`, and pass it as `workdir` to every command. Otherwise review the current checkout. Never create a worktree solely for review.
+
 ## Injected State
 
 !`bash -c 'OUT=$(ls -t .claude/context/jobs/ 2>/dev/null | head -10); if [ -n "$OUT" ]; then echo "$OUT"; else echo "NO_JOBS"; fi'`

--- a/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
@@ -22,9 +22,11 @@ Resolve the builder checkout before reading job state. Build candidate roots fro
 
 ## Job Resolution
 
-`$ARGUMENTS` may contain a job ID, for example `/nuxt-frontend-review landing-0331-1423`. Match that exact directory across candidate roots. Without an ID, select the most recently modified job directory across those roots.
+`$ARGUMENTS` may contain a job ID or absolute builder path, for example `/nuxt-frontend-review landing-0331-1423`. Match an exact job ID across candidate roots or use the named absolute path.
 
-If an exact ID exists in several roots, or the builder root remains ambiguous, stop and request its absolute path. Never guess which diff to review.
+If an exact ID exists in more than one root, or the builder root remains ambiguous, stop and request its absolute path. Never guess which diff to review.
+
+Without an ID or path, prefer the newest job in the current checkout. If the current checkout has no job, use another root only when exactly one candidate root contains jobs. If more than one other root contains jobs, require an exact job ID or absolute builder path.
 
 Set `REVIEW_ROOT` to the selected absolute checkout path. Set `JOB_DIR` to the absolute `{REVIEW_ROOT}/.claude/context/jobs/{resolved-job-id}` path. Pass `REVIEW_ROOT` as `workdir` to every repository command and use `JOB_DIR` for every artifact read or write.
 

--- a/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
@@ -18,30 +18,23 @@ Never fix what you find. You are the evaluator.
 
 An existing worktree alone does not prove another agent is active.
 
-If the builder used `wt` because another agent was active in the repository, review that same worktree. Run `wt list --format=json`, read its absolute `path`, and pass it as `workdir` to every command. Otherwise review the current checkout. Never create a worktree solely for review.
-
-## Injected State
-
-!`bash -c 'OUT=$(ls -t .claude/context/jobs/ 2>/dev/null | head -10); if [ -n "$OUT" ]; then echo "$OUT"; else echo "NO_JOBS"; fi'`
-!`bash -c 'JOB=$(ls -t .claude/context/jobs/ 2>/dev/null | head -1); if [ -n "$JOB" ]; then echo "LATEST_JOB=$JOB"; if [ -f ".claude/context/jobs/$JOB/build-handoff.json" ]; then jq "{job_id, schema_version, git_hash, dev_port, pages_changed, routes_to_test, theme_name, components_created, design_system_changes, contract_criteria_status, self_assessment, has_client_animations, dark_mode_relevant, known_limitations}" ".claude/context/jobs/$JOB/build-handoff.json" 2>/dev/null; else echo "NO_HANDOFF"; fi; else echo "NO_HANDOFF"; fi'`
-!`bash -c 'JOB=$(ls -t .claude/context/jobs/ 2>/dev/null | head -1); if [ -n "$JOB" ]; then OUT=$(grep -E "^\[C[0-9]+\]" ".claude/context/jobs/$JOB/build-contract.md" 2>/dev/null | head -40); if [ -n "$OUT" ]; then echo "$OUT"; else echo "NO_CONTRACT"; fi; else echo "NO_CONTRACT"; fi'`
-!`bash -c 'JOB=$(ls -t .claude/context/jobs/ 2>/dev/null | head -1); if [ -n "$JOB" ]; then HASH=$(jq -r ".git_hash // empty" ".claude/context/jobs/$JOB/build-handoff.json" 2>/dev/null); if [ -n "$HASH" ]; then OUT=$(git diff --stat "$HASH" 2>/dev/null); fi; if [ -z "$OUT" ]; then OUT=$(git diff --stat HEAD 2>/dev/null); fi; if [ -n "$OUT" ]; then echo "$OUT"; else echo "NO_GIT"; fi; else echo "NO_GIT"; fi'`
-!`bash -c 'JOB=$(ls -t .claude/context/jobs/ 2>/dev/null | head -1); if [ -n "$JOB" ]; then HASH=$(jq -r ".git_hash // empty" ".claude/context/jobs/$JOB/build-handoff.json" 2>/dev/null); if [ -n "$HASH" ]; then OUT=$(git diff --name-only "$HASH" -- "*.vue" "*.ts" "*.css" 2>/dev/null | head -30); fi; if [ -z "$OUT" ]; then OUT=$(git diff --name-only HEAD -- "*.vue" "*.ts" "*.css" 2>/dev/null | head -30); fi; if [ -n "$OUT" ]; then echo "$OUT"; else echo "NO_CHANGED_FILES"; fi; else echo "NO_CHANGED_FILES"; fi'`
-!`bash -c 'for i in 1 2 3; do P=$(shuf -i 10000-65535 -n 1); ss -tln 2>/dev/null | grep -q ":$P " || { echo "REVIEW_PORT=$P"; exit 0; }; done; echo "REVIEW_PORT=NONE_FREE"'`
-!`if command -v dev-browser >/dev/null 2>&1; then echo "DEV_BROWSER=true"; else echo "DEV_BROWSER=false"; fi`
-!`bash -c 'JOB=$(ls -t .claude/context/jobs/ 2>/dev/null | head -1); if [ -n "$JOB" ] && [ -f ".claude/context/jobs/$JOB/review-calibration.md" ]; then cat ".claude/context/jobs/$JOB/review-calibration.md"; else echo "NO_CALIBRATION"; fi'`
+Resolve the builder checkout before reading job state. Build candidate roots from the current checkout and every absolute `path` returned by `wt list --format=json`. Never create a worktree solely for review.
 
 ## Job Resolution
 
-`$ARGUMENTS` may contain a job ID (e.g. `/nuxt-frontend-review landing-0331-1423`). Match it against the injected job list; otherwise use LATEST_JOB. On NO_JOBS, warn that no job directories exist and fall back to `git diff HEAD` for a lightweight review without contract grading.
+`$ARGUMENTS` may contain a job ID, for example `/nuxt-frontend-review landing-0331-1423`. Match that exact directory across candidate roots. Without an ID, select the most recently modified job directory across those roots.
 
-Set `JOB_DIR` = `.claude/context/jobs/{resolved-job-id}` for all artifact reads/writes.
+If an exact ID exists in several roots, or the builder root remains ambiguous, stop and request its absolute path. Never guess which diff to review.
+
+Set `REVIEW_ROOT` to the selected absolute checkout path. Set `JOB_DIR` to the absolute `{REVIEW_ROOT}/.claude/context/jobs/{resolved-job-id}` path. Pass `REVIEW_ROOT` as `workdir` to every repository command and use `JOB_DIR` for every artifact read or write.
+
+After resolving these paths, discover state at runtime. Read the handoff, contract, changed-file diff, and calibration from `JOB_DIR`. Allocate `REVIEW_PORT` against active listeners. Detect `DEV_BROWSER` from `REVIEW_ROOT`. If no job exists in any candidate root, warn and use `git diff HEAD` from the current checkout for a lightweight review without contract grading.
 
 Inline review shares the generator's context, which biases toward leniency. For high-stakes reviews, start a fresh conversation.
 
 ## Step 0: Calibration
 
-Calibration data was injected above. Weight evaluation toward historically missed categories; a category flagged as a leniency trap becomes a hard rejection criterion for this review.
+Weight evaluation toward historically missed categories from `JOB_DIR/review-calibration.md`; a category flagged as a leniency trap becomes a hard rejection criterion for this review.
 
 Guard against these in yourself, always:
 - "Works on desktop so mobile is probably fine": it is not. Check.
@@ -132,7 +125,7 @@ Zero issues found means re-examine the three highest-complexity components with 
 
 ## Step 4: Visual Verification
 
-`DEV_BROWSER` was injected above. Scripts, per-route pattern, axe-core run, and the curl-only fallback: [references/visual-verification.md](references/visual-verification.md).
+Use the runtime `DEV_BROWSER` result. Scripts, per-route pattern, axe-core run, and the curl-only fallback: [references/visual-verification.md](references/visual-verification.md).
 
 Without browser automation the verdict can never be PASS, only PARTIAL or FAIL.
 

--- a/harlan-agent-kit/skills/nuxt-frontend-review/references/dev-server.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-review/references/dev-server.md
@@ -2,7 +2,7 @@
 
 ## Start on a random port
 
-Use the injected `REVIEW_PORT` (random, retried 3× against `ss -tln`). If `NONE_FREE`, re-run the allocation manually.
+Use the runtime `REVIEW_PORT` allocation. Try three random ports against `ss -tln`. If none is free, repeat the allocation.
 
 Detect project type and start the matching command in the background:
 

--- a/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
@@ -8,6 +8,12 @@ effort: high
 
 Surface architectural friction in a Nuxt codebase and propose **deepening opportunities** — refactors that turn shallow modules into deep ones, using Nuxt's own extension points as seams. The aim is testability and AI-navigability.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## Vocabulary and principles
 
 Use the terms in [LANGUAGE.md](LANGUAGE.md) exactly — **module**, **interface**, **implementation**, **depth**, **seam**, **adapter**, **leverage**, **locality**. Don't drift into "component," "service," "API," or "boundary."

--- a/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
@@ -10,6 +10,8 @@ Surface architectural friction in a Nuxt codebase and propose **deepening opport
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
@@ -10,7 +10,7 @@ Surface architectural friction in a Nuxt codebase and propose **deepening opport
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/pkg-conform/SKILL.md
+++ b/harlan-agent-kit/skills/pkg-conform/SKILL.md
@@ -10,6 +10,8 @@ Conform a package to standardized architecture, or scaffold a new one.
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/pkg-conform/SKILL.md
+++ b/harlan-agent-kit/skills/pkg-conform/SKILL.md
@@ -8,6 +8,12 @@ user_invocable: true
 
 Conform a package to standardized architecture, or scaffold a new one.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## Usage
 
 ```

--- a/harlan-agent-kit/skills/pkg-conform/SKILL.md
+++ b/harlan-agent-kit/skills/pkg-conform/SKILL.md
@@ -10,7 +10,7 @@ Conform a package to standardized architecture, or scaffold a new one.
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/pr-owner/SKILL.md
+++ b/harlan-agent-kit/skills/pr-owner/SKILL.md
@@ -9,6 +9,12 @@ Own one PR until its production result is verified or visibly blocked. A merge i
 
 Personal site repositories under `~/sites` enable this convention by default. Other repositories require explicit selection.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## Load contracts
 
 Read these completely:
@@ -60,7 +66,7 @@ Do not infer deployment success from an unrelated green workflow. Match the comm
 
 When an owned site fails CI or deployment, prove the failure belongs to the owned merge before editing.
 
-Create an isolated worktree from the current remote default branch. Add a failing test when behavior or validation broke. Apply the smallest repair and run focused checks.
+If another agent is active in the repository, create the repair worktree with `wt switch --create <branch> --base <remote-default-branch>`. Otherwise use the current checkout and a normal repair branch. Add a failing test when behavior or validation broke. Apply the smallest repair and run focused checks.
 
 For CI-only repairs, use `chore: fix ci`. For a production behavior repair, use a precise conventional `fix:` subject.
 
@@ -84,7 +90,7 @@ If smoke verification exposes a regression, return to Repair failures.
 
 Update and confirm the existing marked bot comment. Preserve review evidence and append merge SHA, deployment target, deployment outcome, and smoke evidence.
 
-Close ownership only with `Deployment: VERIFIED`, `Deployment: BLOCKED`, or an explicit cancellation. Clean the worktree after closure.
+Close ownership only with `Deployment: VERIFIED`, `Deployment: BLOCKED`, or an explicit cancellation. If this task created a worktree, run `wt remove <branch>` after closure. Do not force removal.
 
 ## Examples
 

--- a/harlan-agent-kit/skills/pr-owner/SKILL.md
+++ b/harlan-agent-kit/skills/pr-owner/SKILL.md
@@ -11,7 +11,7 @@ Personal site repositories under `~/sites` enable this convention by default. Ot
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when ownership closes. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/pr-owner/SKILL.md
+++ b/harlan-agent-kit/skills/pr-owner/SKILL.md
@@ -11,6 +11,8 @@ Personal site repositories under `~/sites` enable this convention by default. Ot
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when ownership closes. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
@@ -66,11 +68,13 @@ Do not infer deployment success from an unrelated green workflow. Match the comm
 
 When an owned site fails CI or deployment, prove the failure belongs to the owned merge before editing.
 
-If another agent is active in the repository, create the repair worktree with `wt switch --create <branch> --base <remote-default-branch>`. Otherwise use the current checkout and a normal repair branch. Add a failing test when behavior or validation broke. Apply the smallest repair and run focused checks.
+Fetch the remote default branch and record its exact head. Never build a repair from the merged feature checkout.
+
+Create a repair branch from that remote default head. If another agent is active, use `wt switch --create <branch> --base <remote>/<default-branch>`. Otherwise use `git switch -c <branch> <remote>/<default-branch>`. Add a failing test when behavior or validation broke. Apply the smallest repair and run focused checks.
 
 For CI-only repairs, use `chore: fix ci`. For a production behavior repair, use a precise conventional `fix:` subject.
 
-Recheck the remote default branch SHA immediately before a normal push. If it changed, rebuild the repair on the new head. Never force push or bypass branch protection.
+Recheck the remote default branch SHA immediately before a normal push. If it changed, rebuild the repair on the new head. If the default branch repair contract permits a direct push, push the verified repair commit to the unchanged remote default branch. Never force push or bypass branch protection.
 
 If branch protection rejects the push, create a normal repair PR through `pr`. Never weaken protection.
 

--- a/harlan-agent-kit/skills/pr-triage/SKILL.md
+++ b/harlan-agent-kit/skills/pr-triage/SKILL.md
@@ -7,6 +7,12 @@ description: Triage all open pull requests in Harlan's owned GitHub repositories
 
 Turn the owned PR backlog into a ranked merge queue. Never merge.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Discovery stays read only. Use `wt` for a repair worker only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command.
+
 ## Load contracts
 
 Read these completely before discovery:

--- a/harlan-agent-kit/skills/pr-triage/SKILL.md
+++ b/harlan-agent-kit/skills/pr-triage/SKILL.md
@@ -9,7 +9,7 @@ Turn the owned PR backlog into a ranked merge queue. Never merge.
 
 ## Worktree isolation
 
-Before repair edits, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before repair edits, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/pr-triage/SKILL.md
+++ b/harlan-agent-kit/skills/pr-triage/SKILL.md
@@ -9,6 +9,8 @@ Turn the owned PR backlog into a ranked merge queue. Never merge.
 
 ## Worktree isolation
 
+Before repair edits, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Discovery stays read only. Use `wt` for a repair worker only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command.

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -35,6 +35,8 @@ git status --short
 git branch --show-current
 ```
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. If no other agent is active there, keep the current checkout. If it is on the default branch, create a normal task branch with `git switch -c BRANCH`, then continue to Step 1.

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -11,11 +11,11 @@ Create or update a pull request for the current branch. Idempotent -- safe to ru
 - **Never amend published commits** -- CI and reviewers lose context. Always fix-forward with new commits.
 - **Never `--force` push** during a PR -- rewrites shared history. Use `git push` (regular) after new commits.
 - **Never `--no-verify`** -- if hooks fail, fix the underlying issue.
-- **Patch export on main can fail** -- if there are binary files or complex renames, `git diff` won't capture them. Fall back to `git stash` instead of patch files.
+- **Never move unknown changes** -- shared checkout changes may belong to another task. Copy only changes this task owns.
 - **`gh pr create` fails silently with bad body** -- always use HEREDOC for the body, never inline quotes.
 - **CI flakes vs real failures** -- if the same check fails twice with different errors, it's flaky. If same error, it's real. Don't retry flakes more than once.
 - **CodeRabbit reviews can be noisy** -- address security/correctness findings, but style suggestions are optional. Don't block the loop on nitpicks.
-- **Worktree cleanup** -- if you forget `wt delete`, orphaned worktrees accumulate. Always clean up after merge.
+- **Worktree cleanup** -- if you forget `wt remove`, orphaned worktrees accumulate. Clean up after merge.
 
 ## Data Storage
 
@@ -28,39 +28,29 @@ echo "$(date -I) $(git branch --show-current) PR_URL" >> "${CLAUDE_PLUGIN_DATA}/
 
 Read previous PRs when context is useful (e.g., finding related PRs, avoiding duplicate work).
 
-## Step 0: Branch Check
+## Step 0: Own a Branch
 
 ```bash
+git status --short
 git branch --show-current
 ```
 
-**If on `main`** -> isolate work into a new branch via `wt` (git worktree manager).
+An existing worktree alone does not prove another agent is active.
 
-`wt` creates parallel worktrees so you can work on branches without touching the main checkout. Key commands:
-- `wt switch --create BRANCH` -- create new branch + worktree from current HEAD (changes shell cwd)
-- `wt switch BRANCH` -- switch into an existing worktree (changes shell cwd)
-- `wt switch main` -- switch back to main worktree
+Use `wt` only when another agent is actively modifying the same repository. If no other agent is active there, keep the current checkout. If it is on the default branch, create a normal task branch with `git switch -c BRANCH`, then continue to Step 1.
 
-Steps:
+If another agent is active in the repository:
 
-1. Derive a branch name from the session's changes (e.g. `feat/add-widget`, `fix/login-bug`). Use `git diff --stat` and `git status` to inform the name.
-2. Save uncommitted changes, create worktree, apply patches:
-   ```bash
-   git diff > /tmp/pr-changes.patch
-   git diff --cached > /tmp/pr-staged.patch
-   wt switch --create BRANCH_NAME
-   git apply /tmp/pr-changes.patch 2>/dev/null
-   git apply /tmp/pr-staged.patch 2>/dev/null
-   ```
-   Note: `wt switch` resets the shell cwd to the worktree directory automatically.
-3. Commit the changes in the worktree, then continue from Step 1 **inside the worktree directory**.
-4. After PR is created, switch back and clean up:
-   ```bash
-   wt switch main
-   git checkout .
-   ```
+1. Run `wt list --format=json`.
+2. Reuse this task's existing worktree with `wt switch BRANCH` when one exists.
+3. Otherwise derive a branch name such as `feat/add-widget` or `fix/login-bug`.
+4. Create it from the intended base with `wt switch --create BRANCH --base BASE`.
+5. Run `wt list --format=json` again. Read the branch's absolute `path`.
+6. Pass that path as `workdir` to every later command, including CI repairs.
 
-**If NOT on `main`** -> continue normally.
+If this task's changes already exist in a shared checkout, leave that checkout untouched. Copy only verified task-owned changes into the new worktree. Use `git diff --binary` for tracked files and copy owned untracked files individually. Verify the destination diff before continuing. Never reset, clean, stash, or overwrite the source checkout.
+
+Never share a mutation worktree between tasks. Never use `wt switch --clobber` to resolve a path collision.
 
 ## Step 1: Detect State
 
@@ -238,6 +228,7 @@ After creating or updating a PR, enter a **fix loop** -- keep watching until CI 
 ### Guidelines
 
 - Fix issues in **new commits** (don't amend) so reviewers can see incremental fixes.
+- If Step 0 selected a worktree, keep every fix and check there.
 - After each push, restart from step 1 of the loop.
 - **Never post a reply to a review comment yourself.** Fixing the code and pushing is your move; talking to a reviewer is not. If a comment is a question or non-actionable, draft the reply, show it to the user, and let them post it. Continue the loop while you wait; do not block on it.
 - If stuck after 3 failed attempts on the same issue, stop the loop and ask the user for guidance.
@@ -247,11 +238,10 @@ After creating or updating a PR, enter a **fix loop** -- keep watching until CI 
 If the PR was created from a worktree (Step 0), clean up:
 
 ```bash
-wt switch main
-wt delete BRANCH_NAME
+wt remove BRANCH_NAME
 ```
 
-`wt delete` removes the worktree directory and deletes the local branch.
+`wt remove` removes the worktree. It deletes the local branch only when the branch is integrated. Never use `--force` or `--force-delete` to bypass this check.
 
 ## Related review skill
 

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -35,7 +35,7 @@ git status --short
 git branch --show-current
 ```
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 
@@ -50,7 +50,7 @@ If another agent is active in the repository:
 5. Run `wt list --format=json` again. Read the branch's absolute `path`.
 6. Pass that path as `workdir` to every later command, including CI repairs.
 
-If this task's changes already exist in a shared checkout, leave that checkout untouched. Copy only verified task-owned changes into the new worktree. Use `git diff --binary` for tracked files and copy owned untracked files individually. Verify the destination diff before continuing. Never reset, clean, stash, or overwrite the source checkout.
+If this task's changes already exist in a shared checkout, leave that checkout untouched. List every verified task-owned path. Export `git diff --cached --binary -- PATHS` and `git diff --binary -- PATHS` separately. Apply the cached patch with `git apply --index`, then apply the unstaged patch. Copy owned untracked files individually. Compare every owned source path with its destination before continuing. Never reset, clean, stash, or overwrite the source checkout.
 
 Never share a mutation worktree between tasks. Never use `wt switch --clobber` to resolve a path collision.
 

--- a/harlan-agent-kit/skills/release-notes/SKILL.md
+++ b/harlan-agent-kit/skills/release-notes/SKILL.md
@@ -11,7 +11,7 @@ Generate Nuxt-style release notes with highlights, categorized changelog, and LL
 
 ## Worktree isolation
 
-Before writing a repository file, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before writing a repository file, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/release-notes/SKILL.md
+++ b/harlan-agent-kit/skills/release-notes/SKILL.md
@@ -9,6 +9,12 @@ effort: high
 
 Generate Nuxt-style release notes with highlights, categorized changelog, and LLM upgrade prompts for breaking changes.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` before writing a repository file only when another agent is actively modifying the same repository. Otherwise keep the current checkout. For concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## Current State
 
 - **Repo:** !`gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo 'unknown'`

--- a/harlan-agent-kit/skills/release-notes/SKILL.md
+++ b/harlan-agent-kit/skills/release-notes/SKILL.md
@@ -11,6 +11,8 @@ Generate Nuxt-style release notes with highlights, categorized changelog, and LL
 
 ## Worktree isolation
 
+Before writing a repository file, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` before writing a repository file only when another agent is actively modifying the same repository. Otherwise keep the current checkout. For concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/ripast/SKILL.md
+++ b/harlan-agent-kit/skills/ripast/SKILL.md
@@ -8,6 +8,8 @@ user_invocable: true
 
 ## Worktree isolation
 
+Before a mutating `--apply`, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` before a mutating `--apply` command only when another agent is actively modifying the same repository. Otherwise keep the current checkout. For concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/ripast/SKILL.md
+++ b/harlan-agent-kit/skills/ripast/SKILL.md
@@ -6,6 +6,12 @@ user_invocable: true
 
 `ripast` is published on npm as `@ripast/cli`. Repo: <https://github.com/harlan-zw/ripast>
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` before a mutating `--apply` command only when another agent is actively modifying the same repository. Otherwise keep the current checkout. For concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## Invocation
 
 ```bash

--- a/harlan-agent-kit/skills/ripast/SKILL.md
+++ b/harlan-agent-kit/skills/ripast/SKILL.md
@@ -8,7 +8,7 @@ user_invocable: true
 
 ## Worktree isolation
 
-Before a mutating `--apply`, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before a mutating `--apply`, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -9,6 +9,8 @@ Turn the complete open Sentry backlog into one verified PR per affected site. Ac
 
 ## Worktree isolation
 
+Before site edits, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the site task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` for a site only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse a worktree only when it belongs to the same frozen site task. Otherwise create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command.

--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -9,7 +9,7 @@ Turn the complete open Sentry backlog into one verified PR per affected site. Ac
 
 ## Worktree isolation
 
-Before site edits, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the site task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before site edits, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: sentry-checkin
-description: Triage and repair every open Sentry issue across Harlan's site inventory. Use when asked to check Sentry, run a Sentry check-in, fix production errors, or clear site error backlogs. Discovers every Sentry project, groups projects by site, delegates one site per agent, requires complete issue coverage, keeps each site's fixes in one worktree, and opens one PR through $harlan-agent-kit:pr when fixes exist.
+description: Triage and repair every open Sentry issue across Harlan's site inventory. Use when asked to check Sentry, run a Sentry check-in, fix production errors, or clear site error backlogs. Discovers every Sentry project, groups projects by site, delegates one site per agent, requires complete issue coverage, isolates concurrent same-repository work with wt, and opens one PR through $harlan-agent-kit:pr when fixes exist.
 ---
 
 # Sentry Check-in
 
 Turn the complete open Sentry backlog into one verified PR per affected site. Account for every issue present at discovery time.
+
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` for a site only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse a worktree only when it belongs to the same frozen site task. Otherwise create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command.
 
 ## Load the contracts
 
@@ -78,7 +84,7 @@ Pass each agent:
 - The absolute path to this skill directory.
 - The full contract from `references/site-agent-contract.md`.
 
-Site agents may inspect other repositories for context. They must change only their assigned checkout and its single worktree.
+Site agents may inspect other repositories for context. They must change only their selected task checkout or worktree.
 
 ## Enforce complete coverage
 
@@ -97,9 +103,9 @@ Require the site agent to run `scripts/ledger.py audit` against every project ma
 
 ## PR and Sentry state
 
-Each site with code fixes gets one branch, one worktree, and one PR. The site agent invokes `$harlan-agent-kit:pr` only after focused and repository-required checks pass. The PR skill owns push, metadata, CI, and review follow-up.
+Each site with code fixes gets one branch and one PR. If another agent is active in that repository, it also gets one `wt` worktree. The site agent invokes `$harlan-agent-kit:pr` only after focused and repository-required checks pass. The PR skill owns push, metadata, CI, and review follow-up.
 
-If a complete ledger produces no diff, do not create an empty PR. Confirm the branch is clean, remove its temporary worktree, and return the verified ledger. If the repository has no PR workflow, state that explicitly and use the complete local gate as evidence.
+If a complete ledger produces no diff, do not create an empty PR. Confirm the branch is clean. If this task created a worktree, run `wt remove <branch>`. Return the verified ledger. If the repository has no PR workflow, state that explicitly and use the complete local gate as evidence.
 
 Do not resolve or mute Sentry issues when opening a PR. Code is not live yet. Let a verified release resolve issues, unless the user explicitly asks for a Sentry state change after production verification.
 

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -6,7 +6,7 @@ Own one site from frozen Sentry snapshot through one verified PR. Do not delegat
 
 1. Read repository-local `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and `GLOSSARY.md` before edits.
 2. Inspect the main checkout status without changing it. Preserve all existing changes.
-3. Check whether another agent is actively modifying this repository. An existing worktree alone does not prove activity.
+3. Acquire the controller's atomic site claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as active. Release the claim when the site task ends. If ownership is ambiguous, do not edit the shared checkout. An existing worktree alone does not prove activity.
 4. If none is active, keep the current checkout. Run `git switch -c fix/sentry-checkin-YYYYMMDD-SITE` before the first edit when no task branch exists.
 5. If another agent is active, run `wt list --format=json`. Reuse an open `fix/sentry-checkin-*` PR worktree only when it targets the same frozen issues. Otherwise run `wt switch --create fix/sentry-checkin-YYYYMMDD-SITE --base BASE`. Read its absolute `path` from the JSON and pass it as `workdir` to every later command.
 

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -6,7 +6,7 @@ Own one site from frozen Sentry snapshot through one verified PR. Do not delegat
 
 1. Read repository-local `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and `GLOSSARY.md` before edits.
 2. Inspect the main checkout status without changing it. Preserve all existing changes.
-3. Acquire the controller's atomic site claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as active. Release the claim when the site task ends. If ownership is ambiguous, do not edit the shared checkout. An existing worktree alone does not prove activity.
+3. Follow the [worktree isolation contract](../../../references/worktree-isolation.md). Acquire its atomic claim before checking for another active agent. An existing worktree alone does not prove activity.
 4. If none is active, keep the current checkout. Run `git switch -c fix/sentry-checkin-YYYYMMDD-SITE` before the first edit when no task branch exists.
 5. If another agent is active, run `wt list --format=json`. Reuse an open `fix/sentry-checkin-*` PR worktree only when it targets the same frozen issues. Otherwise run `wt switch --create fix/sentry-checkin-YYYYMMDD-SITE --base BASE`. Read its absolute `path` from the JSON and pass it as `workdir` to every later command.
 

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -6,11 +6,11 @@ Own one site from frozen Sentry snapshot through one verified PR. Do not delegat
 
 1. Read repository-local `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and `GLOSSARY.md` before edits.
 2. Inspect the main checkout status without changing it. Preserve all existing changes.
-3. Check for an open `fix/sentry-checkin-*` PR for this site. Reuse its branch and worktree only when it targets the same frozen issues.
-4. Otherwise create one branch and one worktree before the first edit. Use `fix/sentry-checkin-YYYYMMDD-SITE`.
-5. Resolve the new worktree's absolute path with `git worktree list`. Pass that path as `workdir` to every later command.
+3. Check whether another agent is actively modifying this repository. An existing worktree alone does not prove activity.
+4. If none is active, keep the current checkout. Run `git switch -c fix/sentry-checkin-YYYYMMDD-SITE` before the first edit when no task branch exists.
+5. If another agent is active, run `wt list --format=json`. Reuse an open `fix/sentry-checkin-*` PR worktree only when it targets the same frozen issues. Otherwise run `wt switch --create fix/sentry-checkin-YYYYMMDD-SITE --base BASE`. Read its absolute `path` from the JSON and pass it as `workdir` to every later command.
 
-All fixes, tests, commits, and PR actions for this site happen in that worktree. Never edit the main checkout. Never create a worktree per issue.
+All fixes, tests, commits, and PR actions for this site happen in the selected task checkout or worktree. Never use a checkout owned by another active task. Never create a worktree per issue.
 
 ## Inspect every issue
 
@@ -77,7 +77,7 @@ python3 SKILL_DIR/scripts/ledger.py audit \
 
 Repeat `--manifest` for every project. Invoke `$harlan-agent-kit:pr` from the worktree after the audit and local checks pass. Include the Sentry short IDs in the PR description only when they help reviewers. Let the PR skill create or update the PR and monitor CI and review feedback.
 
-If the audited ledger produces no code diff, do not create an empty PR. Confirm the worktree is clean, delete the temporary worktree and branch, then return the ledger checksum. If GitHub registers no PR checks, report `no PR workflow` after confirming the PR remains mergeable.
+If the audited ledger produces no code diff, do not create an empty PR. Confirm the selected checkout is clean. If this task created a worktree, run `wt remove <branch>`. Then return the ledger checksum. If GitHub registers no PR checks, report `no PR workflow` after confirming the PR remains mergeable.
 
 Do not deploy. Do not resolve or mute Sentry issues.
 

--- a/harlan-agent-kit/skills/take-ownership/SKILL.md
+++ b/harlan-agent-kit/skills/take-ownership/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: take-ownership
+description: >
+  Own current work through its intended delivery result.
+  Use for end-to-end closure, landing, merging, CI monitoring, deployment monitoring, or smoke verification.
+  Resume from local changes, a branch, a pull request, a merged change, or a pushed revision.
+  Repair attributable failures and continue until verified, blocked, or cancelled.
+---
+
+# Take Ownership
+
+Own one current work item until its intended delivery result is verified or visibly blocked.
+
+A commit, green CI, or merge is intermediate when later delivery stages apply.
+
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
+## Load contracts
+
+Read these completely:
+
+1. `../pr/SKILL.md` before creating or updating a pull request.
+2. `../adversarial-review/SKILL.md` before deciding merge readiness.
+3. `../adversarial-review/references/mutation-authority.md` before any mutation.
+4. `../adversarial-review/references/review-contract.md` before updating the bot status.
+5. `../unit-tests/SKILL.md` before repairing behavior or validation.
+
+Read repository instructions, required workflows, release configuration, deployment configuration, and smoke commands.
+
+Use `dev-browser` for browser smoke tests.
+
+## Resolve the work item
+
+Inspect local Git state and GitHub state. Record exactly one subject:
+
+- `LocalWork`: uncommitted or unpushed work for the current request.
+- `PullRequest`: an open pull request with its exact head revision.
+- `Revision`: a pushed commit without an open pull request.
+
+Ask for a target only when multiple subjects remain plausible.
+
+Record the repository, subject, initial revision, default branch, canonical checkout, and intended result.
+
+Also record required CI, merge policy, production targets, release targets, and smoke assertions.
+
+Treat configured delivery stages as required. Never silently shorten the intended result.
+
+If `harlan-github-agent` already controls the repository, resume its existing worker and journal. Do not start another watcher.
+
+## Establish authority
+
+Apply the mutation authority contract before every code, branch, metadata, comment, or merge mutation.
+
+Explicit `$take-ownership`, `/take-ownership`, `get this merged`, or `land this` authorizes an eligible merge.
+
+Other ownership requests activate tracking and eligible repair authority. They do not authorize a merge.
+
+For example, `watch this through deploy` permits eligible repairs for the exact subject. Wait for the human merge decision.
+
+Merge only repositories owned by the authenticated GitHub user. Never merge maintained or external repositories.
+
+Require `READY` for the exact pull request head. Recheck every gate immediately before merging.
+
+Honor branch protection, required approvals, merge queues, and repository merge methods. Never bypass them.
+
+Never approve the pull request, use administrator privileges, force push, or amend a published commit.
+
+## Lifecycle
+
+Run each applicable phase in order. Resume the same durable session when new evidence arrives.
+
+### 1. Finish the change
+
+For `LocalWork`, complete the requested implementation and its required verification.
+
+Load any domain skill required by the change. Keep unrelated work outside the ownership subject.
+
+Use `pr` to create or update the pull request when code needs review.
+
+For a feature branch `Revision`, create or resolve its pull request. For a default branch revision, continue to delivery tracking.
+
+### 2. Reach readiness
+
+Use `pr` for metadata, publication, CI monitoring, and review feedback repairs.
+
+Run `adversarial-review` against the complete remote head. Resume until the exact head becomes `READY`.
+
+Restart readiness checks after every pushed repair or remote head change.
+
+### 3. Land the change
+
+If merge authority exists, refetch the pull request and confirm the exact `READY` head.
+
+Use the repository's normal merge method. If GitHub queues the merge, track the queue until it lands.
+
+Without merge authority, wait for the human merge decision and keep ownership active.
+
+When merged, record the merge commit and exact default branch head. Treat a pull request closed unmerged as `CANCELLED`.
+
+### 4. Track delivery
+
+For already pushed code, start from this phase when earlier phases do not apply.
+
+Track required checks, workflows, deployments, releases, and provider jobs for the owned revision.
+
+For a pull request, follow the merge commit and only its proven default branch descendants.
+
+Match the revision, workflow identity, environment, target, and delivery source. Ignore unrelated green jobs.
+
+Do not infer deployment or publication success from CI success.
+
+### 5. Repair failures
+
+Prove the failure belongs to the owned revision before editing.
+
+Read the failing logs and classify the cause. Distinguish subject failures, baseline failures, and transient provider failures.
+
+Retry one proven transient failure once. Repair deterministic failures.
+
+If another agent is active in the repository, create the repair worktree with `wt switch --create <branch> --base <current-writable-branch>`. Otherwise keep the current checkout. Add a failing test first for behavior or validation regressions.
+
+Use `chore: <specific problem>` for every CI or delivery pipeline repair. Never use the generic `chore: fix ci`.
+
+Use a precise `fix:` subject when deployed product behavior is wrong.
+
+Apply the smallest repair and run focused verification. Let required CI provide broad verification.
+
+Recheck the remote target revision before pushing. Rebuild the repair when the target changed.
+
+Use a normal repair pull request when direct repair is ineligible or branch protection rejects the push.
+
+Never weaken protection, bypass hooks, force push, or hide a failed repair.
+
+Stop after three failed repairs for the same cause. Mark ownership `BLOCKED` with exact evidence.
+
+### 6. Smoke the result
+
+Wait for the matched deployment or release to succeed. Then test the configured target.
+
+For browser targets, check HTTP health, changed behavior, console errors, and one critical path.
+
+For packages or services, run the configured consumer, release, or protocol smoke command.
+
+Choose assertions from the request, changed files, pull request description, and repository configuration.
+
+If smoke finds a regression, return to Repair failures.
+
+Never claim verification without a meaningful target and assertion. Keep ownership active while evidence can still arrive.
+
+Use `BLOCKED` when required evidence is unavailable and no safe discovery path remains.
+
+### 7. Close ownership
+
+For a pull request, update and confirm the existing marked bot comment.
+
+Preserve review evidence. Append the owned revision, delivery target, delivery outcome, and smoke evidence.
+
+For a direct revision, preserve the same evidence in the durable journal or final ownership record.
+
+Close only as `VERIFIED`, `BLOCKED`, or `CANCELLED`. If this task created a worktree, run `wt remove <branch>` after closure. Do not force removal.
+
+Do not stop at an intermediate state while an expected CI, merge, deployment, release, or smoke event can progress.
+
+## Examples
+
+Input: `Take ownership of the current work`
+
+Output:
+
+```text
+owner/repo#42 · VERIFIED · MERGE_SHA · https://example.com/path · COMMENT_URL
+```
+
+Input: `The code is pushed, watch it through deploy`
+
+Output:
+
+```text
+owner/repo@REVISION · BLOCKED · chore: correct Linux artifact path failed three times
+```

--- a/harlan-agent-kit/skills/take-ownership/SKILL.md
+++ b/harlan-agent-kit/skills/take-ownership/SKILL.md
@@ -15,6 +15,8 @@ A commit, green CI, or merge is intermediate when later delivery stages apply.
 
 ## Worktree isolation
 
+Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when ownership closes. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` only when another agent is actively modifying the same repository. Otherwise keep the current checkout. Before concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
@@ -63,7 +65,7 @@ For example, `watch this through deploy` permits eligible repairs for the exact 
 
 Merge only repositories owned by the authenticated GitHub user. Never merge maintained or external repositories.
 
-Require `READY` for the exact pull request head. Recheck every gate immediately before merging.
+Require `PASS` for the exact pull request head. Recheck every gate immediately before merging.
 
 Honor branch protection, required approvals, merge queues, and repository merge methods. Never bypass them.
 
@@ -87,13 +89,13 @@ For a feature branch `Revision`, create or resolve its pull request. For a defau
 
 Use `pr` for metadata, publication, CI monitoring, and review feedback repairs.
 
-Run `adversarial-review` against the complete remote head. Resume until the exact head becomes `READY`.
+Run `adversarial-review` against the complete remote head. Resume until the exact head receives `PASS`.
 
 Restart readiness checks after every pushed repair or remote head change.
 
 ### 3. Land the change
 
-If merge authority exists, refetch the pull request and confirm the exact `READY` head.
+If merge authority exists, refetch the pull request and confirm `PASS` for the exact head.
 
 Use the repository's normal merge method. If GitHub queues the merge, track the queue until it lands.
 
@@ -121,7 +123,9 @@ Read the failing logs and classify the cause. Distinguish subject failures, base
 
 Retry one proven transient failure once. Repair deterministic failures.
 
-If another agent is active in the repository, create the repair worktree with `wt switch --create <branch> --base <current-writable-branch>`. Otherwise keep the current checkout. Add a failing test first for behavior or validation regressions.
+After merge, fetch the remote default branch and record its exact head. Never build a repair from the merged feature checkout.
+
+Create a repair branch from that remote default head. If another agent is active, use `wt switch --create <repair-branch> --base <remote>/<default-branch>`. Otherwise use `git switch -c <repair-branch> <remote>/<default-branch>`. Add a failing test first for behavior or validation regressions.
 
 Use `chore: <specific problem>` for every CI or delivery pipeline repair. Never use the generic `chore: fix ci`.
 
@@ -129,9 +133,9 @@ Use a precise `fix:` subject when deployed product behavior is wrong.
 
 Apply the smallest repair and run focused verification. Let required CI provide broad verification.
 
-Recheck the remote target revision before pushing. Rebuild the repair when the target changed.
+Recheck the remote default head before pushing. Rebuild the repair on its new head when it changed.
 
-Use a normal repair pull request when direct repair is ineligible or branch protection rejects the push.
+If the default branch repair contract permits a direct push, push the verified repair commit to the unchanged remote default branch. Otherwise open a normal repair pull request. Use a repair pull request when branch protection rejects the direct push.
 
 Never weaken protection, bypass hooks, force push, or hide a failed repair.
 

--- a/harlan-agent-kit/skills/take-ownership/SKILL.md
+++ b/harlan-agent-kit/skills/take-ownership/SKILL.md
@@ -15,7 +15,7 @@ A commit, green CI, or merge is intermediate when later delivery stages apply.
 
 ## Worktree isolation
 
-Before any edit, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when ownership closes. If ownership is ambiguous, do not edit the shared checkout.
+Before any edit, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 
@@ -57,7 +57,9 @@ If `harlan-github-agent` already controls the repository, resume its existing wo
 
 Apply the mutation authority contract before every code, branch, metadata, comment, or merge mutation.
 
-Explicit `$take-ownership`, `/take-ownership`, `get this merged`, or `land this` authorizes an eligible merge.
+Only an explicit, unnegated merge instruction for the resolved pull request authorizes an eligible merge. Examples include `get PR #42 merged` and `land this pull request`.
+
+Skill selection, `$take-ownership`, `/take-ownership`, `finish this`, or `make the PR` does not authorize a merge. Confirm the instruction still applies immediately before merging.
 
 Other ownership requests activate tracking and eligible repair authority. They do not authorize a merge.
 

--- a/harlan-agent-kit/skills/take-ownership/agents/openai.yaml
+++ b/harlan-agent-kit/skills/take-ownership/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Take Ownership
+  short_description: Finish current work through delivery verification
+  default_prompt: Use $take-ownership to finish this work through delivery and smoke verification.

--- a/harlan-agent-kit/skills/unit-tests/SKILL.md
+++ b/harlan-agent-kit/skills/unit-tests/SKILL.md
@@ -11,6 +11,8 @@ A unit test exercises an API. Input goes in, output gets asserted. Everything el
 
 ## Worktree isolation
 
+Before writing or deleting tests, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+
 An existing worktree alone does not prove another agent is active.
 
 Use `wt` before writing or deleting tests only when another agent is actively modifying the same repository. Otherwise keep the current checkout. For concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.

--- a/harlan-agent-kit/skills/unit-tests/SKILL.md
+++ b/harlan-agent-kit/skills/unit-tests/SKILL.md
@@ -11,7 +11,7 @@ A unit test exercises an API. Input goes in, output gets asserted. Everything el
 
 ## Worktree isolation
 
-Before writing or deleting tests, acquire the controller's atomic task claim for the intended checkout. If no controller exists, acquire an atomic session-owned lock keyed by the repository and absolute checkout path. Treat another live claim in the repository as an active agent. Release the claim when the task ends. If ownership is ambiguous, do not edit the shared checkout.
+Before writing or deleting tests, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
 
 An existing worktree alone does not prove another agent is active.
 

--- a/harlan-agent-kit/skills/unit-tests/SKILL.md
+++ b/harlan-agent-kit/skills/unit-tests/SKILL.md
@@ -9,6 +9,12 @@ argument-hint: "[file or directory to test or review]"
 
 A unit test exercises an API. Input goes in, output gets asserted. Everything else is a fact check against the source file and should be deleted.
 
+## Worktree isolation
+
+An existing worktree alone does not prove another agent is active.
+
+Use `wt` before writing or deleting tests only when another agent is actively modifying the same repository. Otherwise keep the current checkout. For concurrent edits, run `wt list --format=json`. Reuse the task's worktree with `wt switch <branch>`, or create one with `wt switch --create <branch> --base <base>`. Read its absolute `path` from the JSON, then pass that path as `workdir` to every later command. Never share a mutation worktree between tasks.
+
 ## The failure mode this exists to stop
 
 Fact-check tests restate what the file already says. They pass by construction, break on harmless refactors, and prove nothing.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "check:context": "scripts/check-agent-context.sh",
+    "test:worktree-claim": "bash harlan-agent-kit/scripts/worktree-claim.test.sh",
     "release": "node --experimental-strip-types scripts/release.ts"
   },
   "dependencies": {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`take-ownership` carries the current work item through PR, delivery, and smoke verification. Repository-mutating skills now use `wt` only while another agent is active in the same repository; solo work stays in the current checkout. PR and Sentry cleanup uses `wt remove`, and shared changes remain untouched during a handoff.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).