### PR TITLE
feat(sentry-checkin): carry dispositions across runs

### DIFF
--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -77,6 +77,26 @@ The CLI paginates a live query, so one issue can appear on two pages. The wrappe
 
 The snapshot is the run contract. New issues after discovery belong to the next run. Disappearing issues still need a ledger disposition.
 
+## Read the prior dispositions
+
+Every completed run appends to one append-only history at
+`${XDG_STATE_HOME:-$HOME/.local/state}/sentry-checkin/history.tsv`. Read it before delegating:
+
+```bash
+python3 scripts/ledger.py history --snapshot "$SENTRY_CHECKIN_RUN_DIR/PROJECT.snapshot.json" \
+  --output "$SENTRY_CHECKIN_RUN_DIR/PROJECT.history.json"
+```
+
+Repeat `--snapshot` to cover every project of a site in one report. It tags every frozen ID:
+
+- `new`: no prior run saw this issue.
+- `recurring`: a prior run left it open, accepted, or blocked.
+- `unclosed`: a prior run called it `fixed` or `already-fixed`, yet it is still open.
+
+A high `unclosed` count means fixes are landing but Sentry never hears about it. Report the count with the run.
+
+The history is evidence from a past run, not a verdict. It never shortens the ledger: every frozen ID still needs its own row and its own evidence this run.
+
 ## Delegate one agent per site
 
 Spawn exactly one agent for every mapped inventory site, including sites with zero open issues. Queue agents when concurrency slots are full. Never spawn two agents for one checkout.
@@ -86,6 +106,7 @@ Pass each agent:
 - The site name and absolute main checkout path.
 - The organization and all project slugs for that site.
 - The snapshot paths and frozen numeric and short IDs.
+- The history report path for its projects.
 - A site artifact directory under the run directory.
 - The absolute path to this skill directory.
 - The full contract from `references/site-agent-contract.md`.
@@ -115,6 +136,17 @@ If a complete ledger produces no diff, do not create an empty PR. Confirm the br
 
 Do not resolve or mute Sentry issues when opening a PR. Code is not live yet. Let a verified release resolve issues, unless the user explicitly asks for a Sentry state change after production verification.
 
+## Record the run
+
+After every site returns a complete audited ledger, append the run to the history:
+
+```bash
+python3 scripts/ledger.py record --ledger SITE_ARTIFACTS/ledger.tsv \
+  --run-id "$(basename "$SENTRY_CHECKIN_RUN_DIR")" --run-date YYYY-MM-DD
+```
+
+Repeat `--ledger` for every site. `record` refuses a ledger with any empty disposition, so run it only after each audit passes. It skips rows already recorded for the same run, so a repeat is safe.
+
 ## Return the run
 
-Report each site with its issue count, ledger coverage, PR URL, CI state, and confidence. List zero-issue sites and unmatched projects. Keep blocked rows explicit.
+Report each site with its issue count, ledger coverage, PR URL, CI state, and confidence. List zero-issue sites and unmatched projects. Keep blocked rows explicit. Give the run's `new`, `recurring`, and `unclosed` counts, and name the history path.

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -43,12 +43,23 @@ Repeat `--manifest` for sites with several projects. Fill every row. Preserve th
 
 Cluster issues only after stack and release evidence proves one root cause. Keep every issue as its own ledger row.
 
+Read the history report handed to you. It tags each frozen ID `new`, `recurring`, or `unclosed`.
+
+Treat a prior disposition as a lead, never as an answer. It tells you where a past run looked, so you can reach the same evidence faster or find it no longer holds. It never substitutes for this run's evidence, and it never removes a row.
+
+An `unclosed` ID needs care. A past run already proved a commit fixes it, and the issue is open anyway. Do not repeat that proof. Establish which of these is true, and record it as the evidence:
+
+- The fix is deployed and the issue is stale in Sentry. Disposition `already-fixed`, and name the release that carries the fix plus the last-seen time that precedes it.
+- The fix is merged but never deployed. Disposition `blocked`, naming the missing deploy.
+- The fix does not hold. Treat it as a live defect and fix the category, not the instance.
+
 ## Decide each disposition
 
 - Reproduce local defects when practical.
 - For bugs and validation logic, write the failing exported-API test first.
 - Design out the failure category when a type or boundary change can make recurrence impossible.
 - Confirm `already-fixed` against a specific commit and the event's release or last-seen time.
+- Never answer an `unclosed` ID with `already-fixed` on the same commit a past run already cited. Name why it stayed open.
 - Use `expected` only when the behavior is intended. Improve filtering or context when Sentry still reports it as an error.
 - Use `third-party` only after locating the external frame or service boundary. Add a safe local mitigation when one exists.
 - Use `blocked` only after exhausting repository, Sentry, history, and dependency evidence.

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/ledger.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/ledger.py
@@ -5,8 +5,10 @@ import argparse
 import csv
 import hashlib
 import json
+import os
 import sys
 from collections import Counter
+from datetime import date
 from pathlib import Path
 
 
@@ -126,6 +128,177 @@ def audit_ledger(args):
     }
 
 
+HISTORY_FIELDS = (
+    "run_id",
+    "run_date",
+    "numeric_id",
+    "short_id",
+    "project",
+    "disposition",
+    "owning_fix",
+    "root_cause",
+)
+# These dispositions claim the issue is closed in code. If a later snapshot
+# still lists the issue, the claim never reached Sentry: either the release
+# never resolved it or the fix does not hold. Re-proving the same commit is
+# wasted work, so the site agent must answer why it stayed open instead.
+CLOSING_DISPOSITIONS = {"fixed", "already-fixed"}
+
+
+def default_history_path():
+    state = os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+    return Path(state) / "sentry-checkin" / "history.tsv"
+
+
+def history_rows_from_ledger(ledger_rows, run_id, run_date):
+    """Project complete ledger rows into history rows. Raises on an incomplete ledger."""
+    if not run_id:
+        raise ValueError("run_id is required.")
+    date.fromisoformat(run_date)
+    rows = []
+    for row in ledger_rows:
+        disposition = row.get("disposition", "")
+        if disposition not in DISPOSITIONS:
+            raise RuntimeError(
+                f"{row.get('numeric_id')}: cannot record disposition {disposition!r}"
+            )
+        rows.append(
+            {
+                "run_id": run_id,
+                "run_date": run_date,
+                "numeric_id": row["numeric_id"],
+                "short_id": row.get("short_id", ""),
+                "project": row.get("project", ""),
+                "disposition": disposition,
+                "owning_fix": row.get("owning_fix", ""),
+                "root_cause": row.get("root_cause", ""),
+            }
+        )
+    return rows
+
+
+def read_history(path):
+    path = Path(path)
+    if not path.exists():
+        return []
+    with path.open(newline="") as file:
+        reader = csv.DictReader(file, delimiter="\t")
+        if tuple(reader.fieldnames or ()) != HISTORY_FIELDS:
+            raise RuntimeError("History header does not match the contract.")
+        return list(reader)
+
+
+def append_history(path, rows):
+    """Append rows not already recorded for their run. Returns the number written."""
+    path = Path(path)
+    existing = read_history(path)
+    seen = {(row["run_id"], row["numeric_id"]) for row in existing}
+    fresh = [row for row in rows if (row["run_id"], row["numeric_id"]) not in seen]
+    if not fresh:
+        return 0
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=HISTORY_FIELDS, delimiter="\t")
+        if not existing:
+            writer.writeheader()
+        writer.writerows(fresh)
+    return len(fresh)
+
+
+def latest_priors(history_rows):
+    """The most recent history row per numeric ID, with how many runs saw it."""
+    priors = {}
+    for row in sorted(history_rows, key=lambda item: (item["run_date"], item["run_id"])):
+        issue_id = row["numeric_id"]
+        seen = priors[issue_id]["runs_seen"] + 1 if issue_id in priors else 1
+        priors[issue_id] = {"row": row, "runs_seen": seen}
+    return priors
+
+
+def classify_snapshot(numeric_ids, history_rows, exclude_runs=frozenset()):
+    """Tag every frozen ID as new, recurring, or regressed against prior runs.
+
+    Pass the current run in exclude_runs so a re-read after `record` does not
+    compare a run against itself.
+    """
+    priors = latest_priors(
+        [row for row in history_rows if row["run_id"] not in exclude_runs]
+    )
+    classified = {}
+    for issue_id in numeric_ids:
+        prior = priors.get(str(issue_id))
+        if prior is None:
+            classified[str(issue_id)] = {
+                "state": "new",
+                "prior_disposition": None,
+                "prior_run_id": None,
+                "prior_run_date": None,
+                "runs_seen": 0,
+            }
+            continue
+        row = prior["row"]
+        state = (
+            "unclosed"
+            if row["disposition"] in CLOSING_DISPOSITIONS
+            else "recurring"
+        )
+        classified[str(issue_id)] = {
+            "state": state,
+            "prior_disposition": row["disposition"],
+            "prior_run_id": row["run_id"],
+            "prior_run_date": row["run_date"],
+            "runs_seen": prior["runs_seen"],
+        }
+    return classified
+
+
+def snapshot_ids(paths):
+    ids = []
+    for raw_path in paths:
+        snapshot = json.loads(Path(raw_path).read_text())
+        ids.extend(str(issue["id"]) for issue in snapshot.get("issues", []))
+    return ids
+
+
+def record_history(args):
+    history_path = Path(args.history) if args.history else default_history_path()
+    rows = []
+    for raw_path in args.ledger:
+        rows.extend(
+            history_rows_from_ledger(
+                read_ledger(Path(raw_path)), args.run_id, args.run_date
+            )
+        )
+    appended = append_history(history_path, rows)
+    return {
+        "appended": appended,
+        "skipped": len(rows) - appended,
+        "rows_read": len(rows),
+        "history": str(history_path.resolve()),
+    }
+
+
+def history_report(args):
+    history_path = Path(args.history) if args.history else default_history_path()
+    ids = snapshot_ids(args.snapshot)
+    classified = classify_snapshot(
+        ids, read_history(history_path), exclude_runs=set(args.exclude_run or ())
+    )
+    result = {
+        "history": str(history_path.resolve()),
+        "counts": dict(
+            sorted(Counter(item["state"] for item in classified.values()).items())
+        ),
+        "issues": classified,
+    }
+    for state in ("new", "recurring", "unclosed"):
+        result["counts"].setdefault(state, 0)
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(json.dumps(result, indent=2, sort_keys=True))
+    return result
+
+
 def build_parser():
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -135,13 +308,30 @@ def build_parser():
     audit = subparsers.add_parser("audit")
     audit.add_argument("--manifest", action="append", required=True)
     audit.add_argument("--ledger", required=True)
+    record = subparsers.add_parser("record")
+    record.add_argument("--ledger", action="append", required=True)
+    record.add_argument("--run-id", required=True)
+    record.add_argument("--run-date", required=True)
+    record.add_argument("--history")
+    history = subparsers.add_parser("history")
+    history.add_argument("--snapshot", action="append", required=True)
+    history.add_argument("--history")
+    history.add_argument("--exclude-run", action="append")
+    history.add_argument("--output")
     return parser
+
+
+COMMANDS = {
+    "init": init_ledger,
+    "audit": audit_ledger,
+    "record": record_history,
+    "history": history_report,
+}
 
 
 def main():
     args = build_parser().parse_args()
-    result = init_ledger(args) if args.command == "init" else audit_ledger(args)
-    print(json.dumps(result, indent=2, sort_keys=True))
+    print(json.dumps(COMMANDS[args.command](args), indent=2, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_history.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_history.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import ledger
+
+
+def ledger_row(numeric_id, disposition, **overrides):
+    row = {
+        "numeric_id": numeric_id,
+        "short_id": f"SITE-{numeric_id}",
+        "project": "site",
+        "root_cause": "root",
+        "disposition": disposition,
+        "owning_issue": "",
+        "owning_fix": "",
+        "evidence": "event stack",
+    }
+    row.update(overrides)
+    return row
+
+
+class HistoryRowsTest(unittest.TestCase):
+    def test_projects_complete_rows_with_the_run_identity(self):
+        rows = ledger.history_rows_from_ledger(
+            [ledger_row("7", "third-party", owning_fix="ignoreErrors")],
+            run_id="run-A",
+            run_date="2026-08-19",
+        )
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "run_id": "run-A",
+                    "run_date": "2026-08-19",
+                    "numeric_id": "7",
+                    "short_id": "SITE-7",
+                    "project": "site",
+                    "disposition": "third-party",
+                    "owning_fix": "ignoreErrors",
+                    "root_cause": "root",
+                }
+            ],
+        )
+
+    def test_rejects_a_ledger_row_with_no_disposition(self):
+        with self.assertRaises(RuntimeError) as caught:
+            ledger.history_rows_from_ledger(
+                [ledger_row("7", "")], run_id="run-A", run_date="2026-08-19"
+            )
+        self.assertIn("7", str(caught.exception))
+
+    def test_rejects_a_run_date_that_is_not_an_iso_date(self):
+        with self.assertRaises(ValueError):
+            ledger.history_rows_from_ledger(
+                [ledger_row("7", "fixed")], run_id="run-A", run_date="19 Aug 2026"
+            )
+
+
+class ClassifySnapshotTest(unittest.TestCase):
+    def history(self, *triples):
+        return [
+            {
+                "run_id": run_id,
+                "run_date": run_date,
+                "numeric_id": numeric_id,
+                "short_id": f"SITE-{numeric_id}",
+                "project": "site",
+                "disposition": disposition,
+                "owning_fix": "",
+                "root_cause": "root",
+            }
+            for run_id, run_date, numeric_id, disposition in triples
+        ]
+
+    def test_an_unseen_id_is_new(self):
+        result = ledger.classify_snapshot(["7"], [])
+        self.assertEqual(result["7"]["state"], "new")
+        self.assertIsNone(result["7"]["prior_disposition"])
+
+    def test_an_id_last_seen_as_third_party_is_recurring(self):
+        result = ledger.classify_snapshot(
+            ["7"], self.history(("run-A", "2026-08-16", "7", "third-party"))
+        )
+        self.assertEqual(result["7"]["state"], "recurring")
+        self.assertEqual(result["7"]["prior_disposition"], "third-party")
+
+    def test_an_id_last_seen_as_fixed_is_unclosed(self):
+        result = ledger.classify_snapshot(
+            ["7"], self.history(("run-A", "2026-08-16", "7", "fixed"))
+        )
+        self.assertEqual(result["7"]["state"], "unclosed")
+
+    def test_an_id_last_seen_as_already_fixed_is_unclosed(self):
+        result = ledger.classify_snapshot(
+            ["7"], self.history(("run-A", "2026-08-16", "7", "already-fixed"))
+        )
+        self.assertEqual(result["7"]["state"], "unclosed")
+
+    def test_an_excluded_run_is_not_its_own_prior(self):
+        history = self.history(("run-A", "2026-08-19", "7", "fixed"))
+        self.assertEqual(
+            ledger.classify_snapshot(["7"], history, exclude_runs={"run-A"})["7"]["state"],
+            "new",
+        )
+
+    def test_the_most_recent_run_decides_the_state(self):
+        result = ledger.classify_snapshot(
+            ["7"],
+            self.history(
+                ("run-A", "2026-08-14", "7", "fixed"),
+                ("run-B", "2026-08-17", "7", "blocked"),
+            ),
+        )
+        self.assertEqual(result["7"]["state"], "recurring")
+        self.assertEqual(result["7"]["prior_disposition"], "blocked")
+        self.assertEqual(result["7"]["prior_run_id"], "run-B")
+        self.assertEqual(result["7"]["runs_seen"], 2)
+
+
+class AppendHistoryTest(unittest.TestCase):
+    def test_re_recording_the_same_run_adds_nothing(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "history.tsv"
+            rows = ledger.history_rows_from_ledger(
+                [ledger_row("7", "blocked")], run_id="run-A", run_date="2026-08-19"
+            )
+            self.assertEqual(ledger.append_history(path, rows), 1)
+            self.assertEqual(ledger.append_history(path, rows), 0)
+            self.assertEqual(len(ledger.read_history(path)), 1)
+
+    def test_a_later_run_appends_a_second_row_for_the_same_issue(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "history.tsv"
+            ledger.append_history(
+                path,
+                ledger.history_rows_from_ledger(
+                    [ledger_row("7", "fixed")], run_id="run-A", run_date="2026-08-16"
+                ),
+            )
+            ledger.append_history(
+                path,
+                ledger.history_rows_from_ledger(
+                    [ledger_row("7", "blocked")], run_id="run-B", run_date="2026-08-19"
+                ),
+            )
+            self.assertEqual(len(ledger.read_history(path)), 2)
+
+
+class HistoryCommandTest(unittest.TestCase):
+    def test_record_then_history_reports_an_unclosed_issue(self):
+        script = Path(__file__).with_name("ledger.py")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            history = root / "history.tsv"
+            ledger.write_ledger(root / "ledger.tsv", [ledger_row("7", "fixed")])
+            recorded = subprocess.run(
+                [
+                    sys.executable, str(script), "record",
+                    "--ledger", str(root / "ledger.tsv"),
+                    "--run-id", "run-A",
+                    "--run-date", "2026-08-16",
+                    "--history", str(history),
+                ],
+                capture_output=True, check=False, text=True,
+            )
+            self.assertEqual(recorded.returncode, 0, recorded.stderr)
+            self.assertEqual(json.loads(recorded.stdout)["appended"], 1)
+
+            snapshot = root / "snapshot.json"
+            snapshot.write_text(json.dumps({"project": "site", "issues": [{"id": "7"}]}))
+            reported = subprocess.run(
+                [
+                    sys.executable, str(script), "history",
+                    "--snapshot", str(snapshot),
+                    "--history", str(history),
+                ],
+                capture_output=True, check=False, text=True,
+            )
+            self.assertEqual(reported.returncode, 0, reported.stderr)
+            payload = json.loads(reported.stdout)
+            self.assertEqual(payload["counts"]["unclosed"], 1)
+            self.assertEqual(payload["issues"]["7"]["prior_disposition"], "fixed")
+
+    def test_record_refuses_an_incomplete_ledger(self):
+        script = Path(__file__).with_name("ledger.py")
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ledger.write_ledger(root / "ledger.tsv", [ledger_row("7", "")])
+            recorded = subprocess.run(
+                [
+                    sys.executable, str(script), "record",
+                    "--ledger", str(root / "ledger.tsv"),
+                    "--run-id", "run-A",
+                    "--run-date", "2026-08-16",
+                    "--history", str(root / "history.tsv"),
+                ],
+                capture_output=True, check=False, text=True,
+            )
+            self.assertEqual(recorded.returncode, 1)
+            self.assertIn("7", recorded.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "service:status": "bash scripts/service.sh status",
     "test:worktree-claim": "bash harlan-agent-kit/scripts/worktree-claim.test.sh",
     "test:wt-only": "bash harlan-agent-kit/hooks/wt-only.test.sh",
+    "test:sentry-checkin": "python3 -m unittest discover -s harlan-agent-kit/skills/sentry-checkin/scripts -p 'test_*.py'",
     "release": "node --experimental-strip-types scripts/release.ts"
   },
   "dependencies": {


### PR DESCRIPTION
### Description

Every check-in re-derived its dispositions from nothing. I ran today's snapshot against the four run directories already sitting in `~/.local/state/sentry-checkin/` and only 60 of 351 issues were new. 210 already had a disposition from an earlier run, and 81 had been called `fixed` or `already-fixed` by a run that had proved a commit closed them.

60 of those 81 got `already-fixed` a second time, two days later, citing the same commits. That is what having no memory between runs costs.

`ledger.py` gains two commands:

- `record` appends a completed run to one append-only TSV. It refuses a ledger with any empty disposition, so only audited runs land.
- `history` tags every frozen ID as `new` (no prior run saw it), `recurring` (a prior run left it open, accepted, or blocked), or `unclosed` (a prior run called it fixed, and it is open anyway).

I named the third state `unclosed` rather than `regressed` deliberately. The usual cause is not a broken fix. The skill forbids resolving issues in Sentry and waits for a release to do it, so a fix can land and the issue stays open regardless. `regressed` would send the next agent hunting a bug that isn't there. The site contract now makes an `unclosed` ID choose between "deployed, stale in Sentry", "merged but never deployed", and "the fix does not hold", and name which.

The history is a lead, not an answer. It never shortens the ledger; every frozen ID still needs its own row and its own evidence.

Backfilled the four existing run directories, 977 rows. Run dates come from directory mtimes, so they mark the day a run finished rather than started.

### Additional context

The Python tests under `skills/sentry-checkin/scripts/` were not wired into anything, so `pnpm test:sentry-checkin` now runs them. This repo has no CI workflows, so that only helps locally.

`pnpm lint` reports 40 errors on this branch. All 40 are on `main` too, in files this PR does not touch.

Open question worth your call: `history` only reads the most recent prior run, so an issue that has alternated fixed/open across four runs looks identical to one that did it once. I left it there because I could not decide what an agent should do differently with that, but the full sequence is in the TSV if it turns out to matter.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).