### PR TITLE
docs(skills): add a shared code comment contract

### DIFF
--- a/harlan-agent-kit/references/code-comments.md
+++ b/harlan-agent-kit/references/code-comments.md
@@ -1,0 +1,16 @@
+# Code comment contract
+
+This contract applies to every skill that writes, fixes, or reviews code.
+
+## Rules
+
+- Write one line by default. Three lines is the maximum.
+- Never explain what the logic does. The code already shows that.
+- State only a constraint the code cannot show: a protocol quirk, an ordering requirement, a deliberate workaround.
+- Link a GitHub issue or a design document instead of writing inline prose.
+- Delete a comment that repeats the line below it.
+- Function docs (JSDoc, TSDoc) are fine. This cap does not apply to them.
+
+## Review
+
+If a comment breaks these rules, report it. Treat it as non-blocking unless the comment states something false.

--- a/harlan-agent-kit/skills/adversarial-review/SKILL.md
+++ b/harlan-agent-kit/skills/adversarial-review/SKILL.md
@@ -27,6 +27,7 @@ Read these completely before reviewing:
 
 1. `references/mutation-authority.md` for repository and mutation authority.
 2. `references/review-contract.md` for review gates, confidence, comment format, and idempotent posting.
+3. `../../references/code-comments.md` for the code comment contract.
 
 Read `../pr/SKILL.md` before changing PR metadata. Read `../humanize-writing/SKILL.md` before changing its prose.
 

--- a/harlan-agent-kit/skills/adversarial-review/references/review-contract.md
+++ b/harlan-agent-kit/skills/adversarial-review/references/review-contract.md
@@ -15,6 +15,7 @@ Check:
 - Performance regressions on hot or scaling-sensitive paths.
 - Tests that would fail before the change and cover realistic regressions.
 - Documentation for user-visible behavior.
+- Code comments against `../../../references/code-comments.md`.
 - Repository architecture and local instructions.
 
 Treat style-only preferences as non-blocking. Treat correctness, security, data loss, public API breakage, and missing regression coverage as material.

--- a/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/improve-ts-pkg-architecture/SKILL.md
@@ -27,6 +27,7 @@ Use `wt` only when another agent is actively modifying the same repository. Othe
 - [TS-PKG-SEAMS.md](TS-PKG-SEAMS.md) — catalogue of TS-package-native seams (`exports`, conditional exports, `packages/*`, catalogs, `bin`, hookable, unplugin, citty).
 - [PKG-CONVENTIONS.md](PKG-CONVENTIONS.md) — package conventions (factory shape, options + hooks, error modes, CLI shape, treeshake invariants, fixture layout, runtime portability).
 - [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md) — design-it-twice with parallel sub-agents for chosen candidates.
+- [code-comments.md](../../references/code-comments.md) — the comment contract for any code this skill writes.
 
 ## Process
 

--- a/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-improve-codebase-architecture/SKILL.md
@@ -42,6 +42,7 @@ This skill is _informed_ by the project's domain model (`CONTEXT.md`, `docs/adr/
 - [VUE-CONVENTIONS.md](VUE-CONVENTIONS.md) — framework-agnostic Vue patterns (service composables as factory + `provide` + `use`, component thinness).
 - [NUXT-APP-CONVENTIONS.md](NUXT-APP-CONVENTIONS.md) — Nuxt-specific app layer (`$fetch` as port, async resource composables, `useState` for SSR-safe app-wide state, client policy mirror).
 - [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md) — design-it-twice with parallel sub-agents for chosen candidates.
+- [code-comments.md](../../references/code-comments.md) — the comment contract for any code this skill writes.
 
 ## Process
 

--- a/harlan-agent-kit/skills/pkg-conform/SKILL.md
+++ b/harlan-agent-kit/skills/pkg-conform/SKILL.md
@@ -133,6 +133,7 @@ See `references/nuxt-module-structure.md` for directory layout and runtime rules
 ## References
 
 See `references/` for detailed templates:
+- `../../references/code-comments.md` - the comment contract for any code this skill writes
 - `references/pkg-package-json.md` - single repo and monorepo package.json templates
 - `references/catalogs.md` - pnpm workspace catalogs
 - `references/configs.md` - package config file templates (eslint, vitest, tsconfig, obuild)

--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -25,6 +25,7 @@ Read these files completely before discovery:
 2. `../unit-tests/SKILL.md`, for bug fix tests.
 3. `../pr/SKILL.md`, for worktree, PR, CI, and review rules.
 4. `references/site-agent-contract.md`, for the exact delegated workflow.
+5. `../../references/code-comments.md`, for the code comment contract.
 
 If no inventory exists, stop before spawning agents or editing repositories. Report every path checked.
 

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -59,7 +59,7 @@ When a release resembles a commit SHA, verify it with `git cat-file -e RELEASE^{
 
 ## Implement the complete site fix
 
-Fix every actionable root cause in the same worktree. Keep unrelated user changes out of the branch. Use repository skills and current framework guidance when they match the code touched.
+Fix every actionable root cause in the same worktree. Keep unrelated user changes out of the branch. Use repository skills and current framework guidance when they match the code touched. Follow `../../../references/code-comments.md` for every comment you write.
 
 Run focused tests after each root-cause fix. Then run every check required by repository instructions and CI. Record exact commands and results.
 


### PR DESCRIPTION
### Description

My comment rule only lives in my global `CLAUDE.md`. Any subagent a skill spawns with its own brief never sees it, so long explanatory comments keep coming back. This puts the rule in the kit as `references/code-comments.md`, loaded the same way as the worktree isolation contract.

Wired into the skills that write or review code:

- `sentry-checkin`, both the skill and `site-agent-contract.md`, since the delegated site agent is the one writing the fix
- `adversarial-review`, plus a check line in the review contract
- `pkg-conform`
- `nuxt-improve-codebase-architecture` and `improve-ts-pkg-architecture`

Comment findings stay non-blocking unless the comment states something false, so this should not turn reviews into style nits.

### Additional context

I left out `ripast`, `unit-tests`, and `nuxt-frontend-design`. They touch code too, but they run in the main loop where `CLAUDE.md` is already loaded, so the pointer felt redundant. Say the word if you would rather every code-touching skill carry it.

Unrelated, but `references/auto-merge.md` is missing from the published 5.0.0 plugin cache while `skills/pr/SKILL.md` links to it. Did not touch it here.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).