### PR TITLE
fix(github-agent): read a lost runner as PENDING, not a failed check

### DIFF
--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -80,6 +80,7 @@ knows GitHub already knows them.
 | merge queue | GitHub's merge queue feature | queue, unqualified |
 | workflow, job, step | GitHub Actions units | pipeline, stage |
 | re-run | GitHub's re-run of a workflow or check | retry, replay |
+| runner | the machine one job runs on | executor, box, build agent |
 
 Collisions
 
@@ -88,6 +89,7 @@ Collisions
 - "approval" means this service's local Approval. A GitHub pull request review is always "review" or "approving review".
 - "check" means a GitHub check run. This service's own conditions are always "Review gate", never bare "check".
 - "job" means a GitHub Actions job. This service's unit of work is a Task.
+- "runner" means GitHub's job machine. The Owner column of the Map above uses "Runner" for the internal owner of agent sessions, which is never user-visible.
 - "worker" sits on two axes. As the thing that answers a turn it is an Agent. As `worker_id`, the scheduler instance holding a Task lease, it is a Lease holder and keeps the word.
 - Storage lags three terms on purpose: Item is stored in `subjects`, Agent in `worker_sessions`, and Lease holder in `worker_id`. Renaming those columns would migrate every foreign key in the journal for a word no user reads.
 

--- a/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
@@ -165,6 +165,7 @@ const incidentKindLabels: Record<IncidentKind, string> = {
   network: 'Network',
   policy: 'Repository policy',
   rate_limit: 'Rate limit',
+  runner_lost: 'Runner lost',
   subject_changed: 'Item changed',
   unknown: 'Unclassified',
 }

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -9,12 +9,60 @@ import { AUTOMATED_ISSUE_TRIAGE_MARKER } from './issue-triage-comment.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedReviewHead, priorAutomatedReviewForHead } from './review-comment.ts'
 
+/**
+ * What the job steps say about a check run GitHub reports as failed.
+ *
+ * A self-hosted runner that restarts kills its container mid-job. GitHub then
+ * reports the job as `failure`, no step reports failure, and every step after
+ * the kill keeps a null conclusion. That shape is `RunnerLost`.
+ *
+ * The controller resolves this only for a failing GitHub Actions check run.
+ * Every other check keeps `NotAsked`. `NotAsked` and `Unknown` both keep the
+ * check failing, so a lookup the controller skipped or could not finish never
+ * reads as a lost runner.
+ */
+export type CheckFailureEvidence
+  = | { _tag: 'NotAsked' }
+    | { _tag: 'Unknown', reason: string }
+    | { _tag: 'StepFailed' }
+    | { _tag: 'RunnerLost', incompleteSteps: number }
+
 export interface GitHubCheck {
   conclusion: string | null
+  /** What the job steps say, for a check run GitHub reports as failed. */
+  failure: CheckFailureEvidence
   id: number
   name: string
   source: { _tag: 'CheckRun', appId: number | null } | { _tag: 'CommitStatus' }
   status: string
+}
+
+/** One GitHub Actions job step, reduced to the field that decides the class. */
+export interface GitHubJobStep {
+  conclusion: string | null
+}
+
+/**
+ * Reads one failing GitHub Actions job as a real failure or a lost runner.
+ *
+ * A killed container leaves no failed step, because the kill lands between
+ * steps. It leaves incomplete steps, because GitHub never gets their result.
+ *
+ * A container killed during a step is a different shape. That step reports
+ * failure, and from here it is identical to a genuine failure. So one failed
+ * step always means a genuine failure. Do not relax this rule: an OOM kill
+ * inside a step was verified to look exactly like a broken build.
+ *
+ * A job with no failed step and no incomplete step is neither shape, so it
+ * stays `Unknown` and keeps failing.
+ */
+export function classifyFailedJob(steps: GitHubJobStep[]): CheckFailureEvidence {
+  if (steps.some(step => step.conclusion === 'failure'))
+    return { _tag: 'StepFailed' }
+  const incompleteSteps = steps.filter(step => step.conclusion === null).length
+  return incompleteSteps === 0
+    ? { _tag: 'Unknown', reason: 'The job reports no failed step and no incomplete step.' }
+    : { _tag: 'RunnerLost', incompleteSteps }
 }
 
 function checkContext(check: GitHubCheck): string {
@@ -131,6 +179,44 @@ function repositoryParts(repository: string): { owner: string, repo: string } {
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : 'GitHub request failed.'
+}
+
+/** GitHub's own app slug for Actions. Only its check run id is also a job id. */
+const ACTIONS_APP_SLUG = 'github-actions'
+
+/**
+ * How many failing Actions jobs one checks read resolves.
+ *
+ * Each job costs one request. A runner outage turns every check red at once,
+ * which is the moment the controller sits nearest its rate limit. So the read
+ * is capped. A job past the cap keeps `NotAsked`, so it still reads as failed.
+ */
+const FAILED_JOB_LOOKUP_LIMIT = 12
+
+/**
+ * Asks GitHub what the steps of each failing job say.
+ *
+ * For a GitHub Actions check run, the check run id is also the job id.
+ * Verified on 2026-08-19: check run 96051144474 carries a `details_url` ending
+ * `/job/96051144474`. A third-party check run id is not a job id, so the caller
+ * passes Actions jobs only.
+ *
+ * A lookup that fails returns `Unknown`, which keeps the check failing.
+ */
+async function resolveFailedJobs(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  jobIds: number[],
+  signal: AbortSignal,
+): Promise<Map<number, CheckFailureEvidence>> {
+  const resolved = await Promise.all(jobIds.slice(0, FAILED_JOB_LOOKUP_LIMIT).map(async (jobId): Promise<[number, CheckFailureEvidence]> => {
+    const job = await octokit.rest.actions.getJobForWorkflowRun({ owner, repo, job_id: jobId, request: { signal } })
+      .then(response => ok(response.data.steps ?? []))
+      .catch((error: unknown) => err(message(error)))
+    return [jobId, job._tag === 'Err' ? { _tag: 'Unknown', reason: job.error } : classifyFailedJob(job.value)]
+  }))
+  return new Map(resolved)
 }
 
 function errorStatus(error: unknown): number | undefined {
@@ -344,11 +430,11 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
           : Promise.all([
               checksClient.value.paginate(checksClient.value.rest.checks.listForRef, { owner, repo, ref, per_page: 100, request: { signal } }),
               checksClient.value.rest.repos.getCombinedStatusForRef({ owner, repo, ref, per_page: 100, request: { signal } }),
-            ]).then(([runs, statuses]): GitHubChecksSnapshot => ({
-              _tag: 'Available',
-              checks: currentGitHubChecks([
+            ]).then(async ([runs, statuses]): Promise<GitHubChecksSnapshot> => {
+              const current = currentGitHubChecks([
                 ...runs.map(check => ({
                   id: check.id,
+                  failure: { _tag: 'NotAsked' as const },
                   source: { _tag: 'CheckRun' as const, appId: check.app?.id ?? null },
                   name: check.name,
                   status: check.status,
@@ -356,13 +442,31 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
                 })),
                 ...statuses.data.statuses.map(status => ({
                   id: status.id,
+                  failure: { _tag: 'NotAsked' as const },
                   source: { _tag: 'CommitStatus' as const },
                   name: status.context,
                   status: status.state === 'pending' ? 'in_progress' : 'completed',
                   conclusion: status.state,
                 })),
-              ]),
-            })).catch((error: unknown): GitHubChecksSnapshot => ({ _tag: 'Unavailable', reason: message(error) }))
+              ])
+              // Only a failing Actions check run can have lost its runner, and
+              // only the `failure` conclusion can. GitHub reports a job a person
+              // cancelled as `cancelled` with no failed step, which is the same
+              // step shape for a different reason. Reading that one here would
+              // report every cancelled job as a lost runner.
+              const currentCheckRunIds = new Set(current.flatMap(check => check.source._tag === 'CheckRun' ? [check.id] : []))
+              const failedActionsJobs = runs.flatMap(check => check.conclusion === 'failure'
+                && check.app?.slug === ACTIONS_APP_SLUG
+                && currentCheckRunIds.has(check.id)
+                ? [check.id]
+                : [])
+              const evidence = await resolveFailedJobs(checksClient.value, owner, repo, failedActionsJobs, signal)
+              // A commit status id and a check run id come from different
+              // sequences, so the evidence is keyed back onto check runs only.
+              return { _tag: 'Available', checks: current.map(check => check.source._tag === 'CheckRun'
+                ? { ...check, failure: evidence.get(check.id) ?? check.failure }
+                : check) }
+            }).catch((error: unknown): GitHubChecksSnapshot => ({ _tag: 'Unavailable', reason: message(error) }))
         const requiredChecksFor = (branch: string): Promise<RequiredChecks> => octokit.value.rest.repos
           .getBranchRules({ owner, repo, branch, per_page: 100, request: { signal } })
           .then((rules): RequiredChecks => {

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1,6 +1,6 @@
 import type { AgentActivityLog } from './agent-activity.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
-import type { GitHubAgentSource, GitHubCheck, PullRequestReviewSnapshot, RequiredChecks } from './github-agent-source.ts'
+import type { GitHubAgentSource, GitHubCheck, GitHubChecksSnapshot, PullRequestReviewSnapshot, RequiredChecks } from './github-agent-source.ts'
 import type { IssueTriageCommentController } from './issue-triage-comment-controller.ts'
 import type { Result } from './result.ts'
 import type { ReviewStatusController } from './review-status-controller.ts'
@@ -80,7 +80,7 @@ export interface ItemAgentOptions {
 export interface ReviewWorkerOptions extends ItemAgentOptions {
   repairs: Pick<ReviewFixWorktreeManager, 'commit' | 'verify'>
   status: Pick<ReviewStatusController, 'publish' | 'publishRepair'>
-  store: Pick<JournalStore, 'claimReviewFixTaskForReview' | 'failTask' | 'getWorkerSession' | 'isBaselineRepairPullRequest' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'stagePublication' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'updateAgentProgress'>
+  store: Pick<JournalStore, 'claimReviewFixTaskForReview' | 'failTask' | 'getWorkerSession' | 'isBaselineRepairPullRequest' | 'recordIncident' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'stagePublication' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'updateAgentProgress'>
 }
 
 const reviewPolicy = `Work as a normal local agent session inside the prepared Git worktree. Use the user's global agent context, installed skills, environment, and authenticated GitHub CLI.
@@ -295,12 +295,47 @@ function gate(response: GateResponse, label: string): ReviewGateState {
 
 const FAILED_CONCLUSIONS = new Set(['action_required', 'cancelled', 'error', 'failure', 'stale', 'timed_out'])
 
+/**
+ * True when a failing check run lost its runner instead of finding a defect.
+ *
+ * The evidence is GitHub's own job steps, read once where the checks snapshot
+ * is built. Only the `RunnerLost` shape qualifies. A lookup the controller
+ * skipped or could not finish stays failed, so silence never clears a check.
+ */
+function checkRunnerLost(check: GitHubCheck): boolean {
+  return check.failure._tag === 'RunnerLost'
+}
+
+/**
+ * True when a check run says the change is broken.
+ *
+ * A restarted self-hosted runner kills its container, and GitHub reports every
+ * lost job as failed. Ten healthy pull requests read as BLOCKED on 2026-08-19
+ * for that reason alone. A lost runner reports nothing about the change, so it
+ * is not a failure here.
+ */
 function checkFailed(check: GitHubCheck): boolean {
-  return FAILED_CONCLUSIONS.has(check.conclusion ?? '')
+  return !checkRunnerLost(check) && FAILED_CONCLUSIONS.has(check.conclusion ?? '')
 }
 
 function checkRunning(check: GitHubCheck): boolean {
   return check.status !== 'completed' || check.conclusion === null || check.conclusion === 'pending'
+}
+
+/** A check run that has not decided yet, because it runs or lost its runner. */
+function checkUndecided(check: GitHubCheck): boolean {
+  return checkRunning(check) || checkRunnerLost(check)
+}
+
+function undecidedReason(check: GitHubCheck): string {
+  return checkRunnerLost(check)
+    ? `${cleanLine(check.name)} lost its runner, so it has not reported.`
+    : `${cleanLine(check.name)} is still running.`
+}
+
+/** True when any check run in one snapshot lost its runner. */
+function checksLostRunner(checks: GitHubChecksSnapshot): boolean {
+  return checks._tag === 'Available' && checks.checks.some(checkRunnerLost)
 }
 
 function checksGate(
@@ -316,10 +351,10 @@ function checksGate(
   const failed = checks.checks.find(checkFailed)
   if (failed !== undefined)
     return { _tag: failedTag, reason: `${label === 'base-ci' ? 'Base branch CI: ' : ''}${cleanLine(failed.name)} failed.`, evidence: checkEvidence }
-  const pending = checks.checks.find(checkRunning)
+  const pending = checks.checks.find(checkUndecided)
   return pending === undefined
     ? { _tag: 'Passed', evidence: checkEvidence }
-    : { _tag: 'Pending', reason: `${label === 'base-ci' ? 'Base branch CI: ' : ''}${cleanLine(pending.name)} is still running.`, evidence: checkEvidence }
+    : { _tag: 'Pending', reason: `${label === 'base-ci' ? 'Base branch CI: ' : ''}${undecidedReason(pending)}`, evidence: checkEvidence }
 }
 
 /**
@@ -363,9 +398,9 @@ function headChecksGate(checks: PullRequestReviewSnapshot['checks'], required: R
   const failed = requiredChecks.find(checkFailed)
   if (failed !== undefined)
     return { state: { _tag: 'Failed', reason: `${cleanLine(failed.name)} failed.`, evidence: checkEvidence }, reported }
-  const running = requiredChecks.find(checkRunning)
+  const running = requiredChecks.find(checkUndecided)
   if (running !== undefined)
-    return { state: { _tag: 'Pending', reason: `${cleanLine(running.name)} is still running.`, evidence: checkEvidence }, reported }
+    return { state: { _tag: 'Pending', reason: undecidedReason(running), evidence: checkEvidence }, reported }
   const missing = required.contexts.find(context => !checks.checks.some(check => check.name === context))
   if (missing !== undefined)
     return { state: { _tag: 'Pending', reason: `${cleanLine(missing)} has not reported.`, evidence: checkEvidence }, reported }
@@ -399,9 +434,14 @@ function basesDefaultBranch(pullRequest: GitHubPullRequestItem, mapping: Reposit
   return pullRequest.baseRef === mapping.defaultBranch
 }
 
+/**
+ * True when the base commit CI says the default branch is broken.
+ *
+ * It reads `checkFailed`, so a base check run that lost its runner never
+ * queues a Baseline repair for a default branch nothing is wrong with.
+ */
 function baseChecksFailed(snapshot: PullRequestReviewSnapshot): boolean {
-  return snapshot.baseChecks._tag === 'Available'
-    && snapshot.baseChecks.checks.some(check => ['action_required', 'cancelled', 'error', 'failure', 'stale', 'timed_out'].includes(check.conclusion ?? ''))
+  return snapshot.baseChecks._tag === 'Available' && snapshot.baseChecks.checks.some(checkFailed)
 }
 
 function reviewGates(snapshot: PullRequestReviewSnapshot, response: ReviewResponse, repairsBaseline: boolean): { gates: ReviewGates, reportedChecks: string[] } {
@@ -549,6 +589,38 @@ Untrusted issue data follows as JSON:
 ${JSON.stringify({ title: task.issue.title, body: snapshot.body.slice(0, 12_000), comments: snapshot.comments.slice(0, 30).map(value => value.slice(0, 4_000)) })}`
 }
 
+/**
+ * The one message every lost runner raises, whatever pull request finds it.
+ *
+ * An Incident is identified by its scope, kind, operation, and message. A fixed
+ * message therefore folds every affected pull request into one Repository
+ * Incident with an occurrence count. On 2026-08-19 one runner pool restarted
+ * four times and ten healthy pull requests read as BLOCKED. That belongs in the
+ * System pane once, at ten occurrences, not ten times.
+ */
+export const RUNNER_LOST_INCIDENT_MESSAGE = 'A runner stopped while jobs were running. GitHub reports those check runs as failed, and no step reports failure. The controller waits for a re-run instead of blocking the pull request.'
+
+/**
+ * Names the repository whose runner stopped.
+ *
+ * The controller never re-runs the workflow itself. GitHub refuses a failed-job
+ * re-run while sibling jobs in the same run are still queued, and a retry storm
+ * against a saturated runner pool makes the outage worse. Recovery is
+ * `Retrying` because the next poll reads the same checks again.
+ */
+function recordRunnerLostIncident(options: ReviewWorkerOptions, repository: string): void {
+  const at = options.now().toISOString()
+  options.store.recordIncident({
+    scope: { _tag: 'Repository', repository },
+    kind: 'runner_lost',
+    severity: 'warning',
+    operation: 'read_checks',
+    message: RUNNER_LOST_INCIDENT_MESSAGE,
+    recovery: { _tag: 'Retrying', attempt: 0, nextAttemptAt: at },
+    at,
+  })
+}
+
 function failRepair(options: ReviewWorkerOptions, task: ClaimedReviewFixTask, reason: string): Result<never, string> {
   options.store.failTask({
     taskId: task.id,
@@ -570,6 +642,8 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         return snapshot
       if (snapshot.value.pullRequest.headSha !== task.pullRequest.headSha || snapshot.value.pullRequest.state !== 'open')
         return err('The pull request changed before review started.')
+      if (checksLostRunner(snapshot.value.checks) || checksLostRunner(snapshot.value.baseChecks))
+        recordRunnerLostIncident(options, task.repository)
       if (snapshot.value.priorAutomatedReview._tag === 'Found' && task.rerun._tag === 'NotRequested')
         return ok({ evidence: `Existing automated review by @${snapshot.value.priorAutomatedReview.authorLogin}: ${snapshot.value.priorAutomatedReview.url}` })
       const repairsBaseline = options.store.isBaselineRepairPullRequest(task.repository, task.pullRequest.headRef)

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -707,6 +707,13 @@ export type IncidentScope
     | { _tag: 'Repository', repository: string }
     | { _tag: 'Task', taskId: string, repository: string, itemNumber: number | null }
 
+/**
+ * What one Incident is about.
+ *
+ * Every kind except `runner_lost` comes from `classifyFailure`, which reads a
+ * failure message. `runner_lost` comes from GitHub's own job steps instead, so
+ * it is raised where the checks snapshot is built.
+ */
 export type IncidentKind
   = | 'github_unavailable'
     | 'github_access'
@@ -719,6 +726,13 @@ export type IncidentKind
     | 'context_budget'
     | 'policy'
     | 'installation_access'
+    /**
+     * A runner stopped while its jobs were running.
+     *
+     * GitHub reports the job as failed, and no step reports failure. The change
+     * under review is not broken, so its check runs read as PENDING.
+     */
+    | 'runner_lost'
     | 'unknown'
 
 /** What the controller will do about an Incident without being asked. */

--- a/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
+++ b/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
@@ -23,7 +23,7 @@ describe('baseline repair worker', () => {
       github: {
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
           body: '',
           checks: { _tag: 'Available', checks: [] },
           comments: [],
@@ -90,7 +90,7 @@ describe('baseline repair worker', () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const baseChecks = scenario.green === true
       ? []
-      : [{ id: 1, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed' as const, conclusion: 'failure' }]
+      : [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed' as const, conclusion: 'failure' }]
     const preparedHead = scenario.moved === true ? 'f'.repeat(40) : pullRequest.baseSha
     const worker = createBaselineRepairWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({}))),

--- a/packages/harlan-github-agent/test/github-worker-source.test.ts
+++ b/packages/harlan-github-agent/test/github-worker-source.test.ts
@@ -4,14 +4,14 @@ import { currentGitHubChecks } from '../src/github-agent-source.ts'
 describe('current GitHub checks', () => {
   it('uses the latest run when one check context ran more than once', () => {
     const checks = currentGitHubChecks([
-      { id: 20, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' },
-      { id: 10, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'cancelled' },
-      { id: 30, source: { _tag: 'CheckRun', appId: 15368 }, name: 'release', status: 'completed', conclusion: 'success' },
+      { id: 20, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' },
+      { id: 10, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'cancelled' },
+      { id: 30, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'release', status: 'completed', conclusion: 'success' },
     ])
 
     expect(checks).toEqual([
-      { id: 20, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' },
-      { id: 30, source: { _tag: 'CheckRun', appId: 15368 }, name: 'release', status: 'completed', conclusion: 'success' },
+      { id: 20, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' },
+      { id: 30, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'release', status: 'completed', conclusion: 'success' },
     ])
   })
 })

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -26,7 +26,7 @@ describe('subject Workers', () => {
     })).toBe(reviewSnapshotDigest(snapshot))
     expect(reviewSnapshotDigest({
       ...snapshot,
-      checks: { _tag: 'Available' as const, checks: [{ id: 1, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+      checks: { _tag: 'Available' as const, checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
     })).toBe(reviewSnapshotDigest(snapshot))
     expect(reviewSnapshotDigest({
       ...snapshot,
@@ -56,9 +56,9 @@ describe('subject Workers', () => {
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
           body: 'Fixes the bug.',
-          checks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          checks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
           comments: [],
           priorAutomatedReview: {
             _tag: 'Found',
@@ -79,6 +79,7 @@ describe('subject Workers', () => {
         failTask: () => { throw new Error('A clean review must not fail repair work.') },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
         saveWorkerSession: () => undefined,
@@ -146,7 +147,7 @@ describe('subject Workers', () => {
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
           body: 'Fixes the bug.',
           checks: { _tag: 'Available', checks: [] },
           comments: [],
@@ -169,6 +170,7 @@ describe('subject Workers', () => {
         failTask: () => { throw new Error('A second review must not fail repair work.') },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('A second review must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
         saveWorkerSession: () => undefined,
@@ -249,9 +251,9 @@ describe('subject Workers', () => {
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
           body: 'Fixes the parser.',
-          checks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          checks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
           comments: [],
           priorAutomatedReview: { _tag: 'None' },
           pullRequest,
@@ -269,6 +271,7 @@ describe('subject Workers', () => {
         },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
         failTask: () => { throw new Error('A verified repair must not fail.') },
@@ -340,9 +343,9 @@ describe('subject Workers', () => {
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
           body: 'Fixes the parser.',
-          checks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
+          checks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
           comments: [],
           priorAutomatedReview: { _tag: 'None' },
           pullRequest,
@@ -358,6 +361,7 @@ describe('subject Workers', () => {
         failTask: () => { throw new Error('No repair Task should exist.') },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => {
           baselineQueued = true
           return { _tag: 'Queued', taskId: 'baseline-task' }
@@ -421,9 +425,9 @@ describe('subject Workers', () => {
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
           body: 'Fixes the parser.',
-          checks: { _tag: 'Available', checks: [{ id: 2, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
+          checks: { _tag: 'Available', checks: [{ id: 2, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
           comments: [],
           priorAutomatedReview: { _tag: 'None' },
           pullRequest,
@@ -439,6 +443,7 @@ describe('subject Workers', () => {
         failTask: () => { throw new Error('No repair Task should exist.') },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => ({
           _tag: 'NotAuthorized',
           reason: 'Repository policy does not authorize Baseline repair for this base commit.',
@@ -509,9 +514,9 @@ describe('subject Workers', () => {
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
           // The parent pull request is red. That is the parent's problem.
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
           body: 'Builds on the parent pull request.',
-          checks: { _tag: 'Available', checks: [{ id: 2, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
+          checks: { _tag: 'Available', checks: [{ id: 2, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
           comments: [],
           priorAutomatedReview: { _tag: 'None' },
           pullRequest,
@@ -527,6 +532,7 @@ describe('subject Workers', () => {
         failTask: () => { throw new Error('No repair Task should exist.') },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('A stacked pull request must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
         recordReviewRun: () => ({ _tag: 'Inserted', reviewRunId: 'attempt-1' }),
@@ -593,9 +599,9 @@ describe('subject Workers', () => {
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
           // The default branch is red. That failure is what this pull request repairs.
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
           body: 'Repairs the default branch build.',
-          checks: { _tag: 'Available', checks: [{ id: 2, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
+          checks: { _tag: 'Available', checks: [{ id: 2, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
           comments: [],
           priorAutomatedReview: { _tag: 'None' },
           pullRequest,
@@ -611,6 +617,7 @@ describe('subject Workers', () => {
         failTask: () => { throw new Error('No repair Task should exist.') },
         getWorkerSession: () => null,
         isBaselineRepairPullRequest: () => true,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('A Baseline repair must not queue another Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
         recordReviewRun: () => ({ _tag: 'Inserted', reviewRunId: 'attempt-1' }),

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -18,7 +18,7 @@ const cleanReview = {
 }
 
 function check(id: number, name: string, conclusion: string): GitHubCheck {
-  return { id, source: { _tag: 'CheckRun', appId: 15368 }, name, status: 'completed', conclusion }
+  return { id, failure: { _tag: 'NotAsked' }, source: { _tag: 'CheckRun', appId: 15368 }, name, status: 'completed', conclusion }
 }
 
 const passingBaseCheck = check(1, 'ci / test', 'success')
@@ -75,6 +75,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], requiredChecks: Required
       failTask: () => { throw new Error('Unexpected repair failure.') },
       getWorkerSession: () => null,
       isBaselineRepairPullRequest: () => false,
+      recordIncident: () => { throw new Error('Unexpected Incident.') },
       queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
       retireBaselineRepairForReview: () => 0,
       saveWorkerSession: () => undefined,

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -10,7 +10,7 @@ import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEve
 const passingGate = { state: 'passed' as const, reason: '', evidence: 'checked' }
 
 function reviewSnapshot(pullRequest: GitHubPullRequestItem, comments: string[] = []) {
-  const check = { id: 1, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }
+  const check = { id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }
   return {
     baseChecks: { _tag: 'Available' as const, checks: [check] },
     body: 'Fixes the bug.',
@@ -98,6 +98,7 @@ function harness(input: {
       failTask: () => { throw new Error('Unexpected repair failure.') },
       getWorkerSession: () => null,
       isBaselineRepairPullRequest: () => false,
+      recordIncident: () => { throw new Error('Unexpected Incident.') },
       queueBaselineRepairForReview: () => { throw new Error('Unexpected Baseline repair.') },
       retireBaselineRepairForReview: () => 0,
       saveWorkerSession: () => undefined,

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -1,0 +1,247 @@
+import type { GitHubCheck, PullRequestReviewSnapshot } from '../src/github-agent-source.ts'
+import type { ReviewWorkerOptions } from '../src/item-agent.ts'
+import type { RecordIncidentInput } from '../src/store.ts'
+import type { ClaimedAdversarialReviewTask, GitHubPullRequestItem, Incident, RecordReviewRunInput } from '../src/types.ts'
+import { describe, expect, it } from 'vitest'
+import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
+import { classifyFailedJob } from '../src/github-agent-source.ts'
+import { createReviewWorker, RUNNER_LOST_INCIDENT_MESSAGE } from '../src/item-agent.ts'
+import { ok } from '../src/result.ts'
+import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
+
+const cleanReview = {
+  metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+  review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
+  verification: { state: 'passed', reason: '', evidence: 'focused tests passed' },
+  findings: [],
+  repair: { outcome: 'not_needed', summary: 'No repair needed.', checks: [], commitMessage: '' },
+  confidence: 96,
+}
+
+function check(id: number, name: string, conclusion: string, failure: GitHubCheck['failure'] = { _tag: 'NotAsked' }): GitHubCheck {
+  return { id, failure, source: { _tag: 'CheckRun', appId: 15368 }, name, status: 'completed', conclusion }
+}
+
+/** GitHub reports a lost container as a failed job whose steps never finished. */
+const lostRunner = check(2, 'ci / test', 'failure', { _tag: 'RunnerLost', incompleteSteps: 4 })
+
+function reviewTask(pullRequest: GitHubPullRequestItem): ClaimedAdversarialReviewTask {
+  return {
+    id: 'review-task',
+    kind: 'adversarial_review',
+    repository: 'harlan-zw/example',
+    pullRequestNumber: 24,
+    revisionId: 'revision-1',
+    state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-19T02:00:00.000Z' },
+    updatedAt: '2026-08-19T01:00:00.000Z',
+    repositoryMapping: repositoryMapping(),
+    pullRequest,
+    rerun: { _tag: 'Requested' },
+  }
+}
+
+interface ReviewProbe {
+  comments: string[]
+  incidents: RecordIncidentInput[]
+  baselineRepairs: number
+  runs: RecordReviewRunInput[]
+  run: () => Promise<unknown>
+}
+
+/** One review worker whose only moving parts are the head and base check runs. */
+function reviewWith(input: { headChecks: GitHubCheck[], baseChecks?: GitHubCheck[] }): ReviewProbe {
+  const pullRequest = pullRequestItem({ mergeState: 'clean' })
+  const comments: string[] = []
+  const incidents: RecordIncidentInput[] = []
+  const runs: RecordReviewRunInput[] = []
+  let baselineRepairs = 0
+  const snapshot: PullRequestReviewSnapshot = {
+    baseChecks: { _tag: 'Available', checks: input.baseChecks ?? [check(1, 'ci / test', 'success')] },
+    body: 'Fixes the bug.',
+    checks: { _tag: 'Available', checks: input.headChecks },
+    comments: [],
+    priorAutomatedReview: { _tag: 'None' },
+    pullRequest,
+    requiredChecks: { _tag: 'Declared', contexts: ['ci / test'] },
+    reviews: [],
+  }
+  const options: ReviewWorkerOptions = {
+    runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(cleanReview))),
+    github: {
+      consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
+      listPullRequestFiles: () => Promise.reject(new Error('Unexpected file listing.')),
+      getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+      getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot)),
+      upsertIssueTriageComment: () => Promise.reject(new Error('Review must not post issue triage.')),
+      upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
+    },
+    now: () => new Date('2026-08-19T01:00:00.000Z'),
+    store: {
+      claimReviewFixTaskForReview: () => { throw new Error('Unexpected repair claim.') },
+      failTask: () => { throw new Error('Unexpected repair failure.') },
+      getWorkerSession: () => null,
+      isBaselineRepairPullRequest: () => false,
+      recordIncident: (incident) => {
+        incidents.push(incident)
+        return { ...incident, id: 'incident-1', occurrences: 1, firstSeenAt: incident.at, lastSeenAt: incident.at } satisfies Incident
+      },
+      queueBaselineRepairForReview: () => {
+        baselineRepairs += 1
+        return { _tag: 'Queued', taskId: 'baseline-task' }
+      },
+      retireBaselineRepairForReview: () => 0,
+      saveWorkerSession: () => undefined,
+      stagePublication: () => { throw new Error('Unexpected publication.') },
+      updateAgentProgress: () => true,
+      recordReviewRun: (run) => {
+        runs.push(run)
+        return { _tag: 'Inserted', reviewRunId: run.id }
+      },
+      recordReviewPublication: publication => ({ _tag: 'Inserted', publicationId: publication.id }),
+    },
+    status: {
+      publish: (_task, _phase, body) => {
+        comments.push(body)
+        return Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+      },
+      publishRepair: () => Promise.reject(new Error('Unexpected repair progress.')),
+    },
+    triageStatus: { publish: () => Promise.reject(new Error('Review must not publish issue triage.')) },
+    workspaces: {
+      prepareIssue: () => Promise.reject(new Error('Unexpected issue workspace.')),
+      prepareReview: () => Promise.resolve(ok({ path: '/tmp/review-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+    },
+    repairs: {
+      commit: () => Promise.reject(new Error('Unexpected repair commit.')),
+      verify: () => Promise.reject(new Error('Unexpected repair verification.')),
+    },
+  }
+  const worker = createReviewWorker(options)
+  return {
+    comments,
+    incidents,
+    runs,
+    run: () => worker.run(reviewTask(pullRequest), new AbortController().signal),
+    get baselineRepairs() {
+      return baselineRepairs
+    },
+  }
+}
+
+function terminal(comments: string[]): string {
+  return comments[comments.length - 1] ?? ''
+}
+
+describe('a failing job with no failed step', () => {
+  it('reads a killed container as a lost runner', () => {
+    expect(classifyFailedJob([
+      { conclusion: 'success' },
+      { conclusion: null },
+      { conclusion: null },
+    ])).toEqual({ _tag: 'RunnerLost', incompleteSteps: 2 })
+  })
+
+  it('reads a failed step as a genuine failure', () => {
+    expect(classifyFailedJob([
+      { conclusion: 'success' },
+      { conclusion: 'failure' },
+      { conclusion: null },
+    ])).toEqual({ _tag: 'StepFailed' })
+  })
+
+  it('reads a container killed during a step as a genuine failure', () => {
+    // An OOM kill inside a step leaves one failed step and no incomplete step.
+    // GitHub also loses the log. From here that is a broken build, and it must
+    // stay one. Do not widen the lost runner shape to cover it.
+    expect(classifyFailedJob([
+      { conclusion: 'success' },
+      { conclusion: 'failure' },
+    ])).toEqual({ _tag: 'StepFailed' })
+  })
+
+  it('refuses to guess when no step failed and no step is incomplete', () => {
+    expect(classifyFailedJob([{ conclusion: 'success' }])._tag).toBe('Unknown')
+    expect(classifyFailedJob([])._tag).toBe('Unknown')
+  })
+})
+
+describe('a required check that lost its runner', () => {
+  it('waits instead of blocking the pull request', async () => {
+    const test = reviewWith({ headChecks: [lostRunner] })
+
+    await test.run()
+
+    expect(terminal(test.comments)).toContain('PENDING')
+    expect(test.runs[0]?.gates.ci._tag).toBe('Pending')
+  })
+
+  it('says the check lost its runner', async () => {
+    const test = reviewWith({ headChecks: [lostRunner] })
+
+    await test.run()
+
+    expect(terminal(test.comments)).toContain('ci / test lost its runner')
+  })
+
+  it('raises one warning Incident against the repository', async () => {
+    const test = reviewWith({ headChecks: [lostRunner] })
+
+    await test.run()
+
+    expect(test.incidents).toEqual([{
+      scope: { _tag: 'Repository', repository: 'harlan-zw/example' },
+      kind: 'runner_lost',
+      severity: 'warning',
+      operation: 'read_checks',
+      message: RUNNER_LOST_INCIDENT_MESSAGE,
+      recovery: { _tag: 'Retrying', attempt: 0, nextAttemptAt: '2026-08-19T01:00:00.000Z' },
+      at: '2026-08-19T01:00:00.000Z',
+    }])
+  })
+
+  it('does not queue a Baseline repair for a base check that lost its runner', async () => {
+    const test = reviewWith({
+      headChecks: [check(3, 'ci / test', 'success')],
+      baseChecks: [check(1, 'ci / test', 'failure', { _tag: 'RunnerLost', incompleteSteps: 4 })],
+    })
+
+    await test.run()
+
+    expect(test.baselineRepairs).toBe(0)
+    expect(test.incidents).toHaveLength(1)
+  })
+})
+
+describe('a required check that really failed', () => {
+  it('blocks when a step reports failure', async () => {
+    const test = reviewWith({ headChecks: [check(2, 'ci / test', 'failure', { _tag: 'StepFailed' })] })
+
+    await test.run()
+
+    expect(terminal(test.comments)).toContain('BLOCKED')
+    expect(test.runs[0]?.gates.ci._tag).toBe('Failed')
+    expect(test.incidents).toEqual([])
+  })
+
+  it('blocks when GitHub does not answer what the steps say', async () => {
+    const test = reviewWith({ headChecks: [check(2, 'ci / test', 'failure', { _tag: 'Unknown', reason: 'GitHub returned 500.' })] })
+
+    await test.run()
+
+    expect(terminal(test.comments)).toContain('BLOCKED')
+    expect(test.runs[0]?.gates.ci._tag).toBe('Failed')
+    expect(test.incidents).toEqual([])
+  })
+
+  it('blocks when the controller never read the steps', async () => {
+    const test = reviewWith({ headChecks: [check(2, 'ci / test', 'failure')] })
+
+    await test.run()
+
+    expect(terminal(test.comments)).toContain('BLOCKED')
+    expect(test.runs[0]?.gates.ci._tag).toBe('Failed')
+    expect(test.incidents).toEqual([])
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Yesterday a self-hosted runner pool serving 8 repos restarted four times in 90 minutes. Every restart SIGKILLed the in-flight containers, and GitHub reports each lost job as `conclusion: "failure"`. `checkFailed()` matches on the conclusion alone, so ten open pull requests read as BLOCKED with nothing wrong with them. I burned several agent runs proving that one at a time.

A lost container has a signature: the job says `failure`, no step says `failure`, several steps still have a null conclusion, and the log endpoint 404s because the container never uploaded it. So the checks snapshot now resolves the job steps for a failing Actions check run, and that shape reads as PENDING plus one `runner_lost` Incident scoped to the repository. Yesterday's ten pull requests would have been one Incident at ×10.

Three shapes, only one of them clears the check:

| Job steps | Reads as |
| --- | --- |
| no failed step, some incomplete | `RunnerLost`, gate PENDING |
| any failed step | `StepFailed`, gate BLOCKED |
| no failed step, none incomplete | `Unknown`, gate BLOCKED |

That middle row matters. I found a job whose container was OOM-killed *during* a step: `failedSteps=1, nullSteps=0`, log also unavailable. The step legitimately reports failure and from the controller's side it is identical to a broken build, so it stays BLOCKED. There is a comment on `classifyFailedJob` saying not to widen the rule, because "the log is missing too" is the obvious next thing someone reaches for.

Where it hooks in: the lookup happens in `github-agent-source.ts` where `checksFor` already fans out, so `checkFailed` stays a pure predicate usable in `.find()`. For an Actions check run the check run id *is* the job id (check run `96051144474` has a `details_url` ending `/job/96051144474`), so no extra resolution step is needed.

Cost is one `GET /actions/jobs/{id}` per failing Actions check run, which is free when things are green and most expensive during exactly the outage that triggers it. Bounded three ways: check runs only, the `github-actions` app only, and `conclusion === 'failure'` only. That last one is not tidiness. A job a person cancelled is also "no failed step, some incomplete", so reading `cancelled` here would report every cancelled job as a lost runner. There is a hard cap of 12 lookups per checks read on top; anything past it keeps `NotAsked`, which keeps it failing.

The failure evidence is a tagged union rather than a boolean, so a lookup that failed (`Unknown`) and one the controller never made (`NotAsked`) both keep the check red. Silence can't clear a check.

No auto-rerun. `gh run rerun --failed` gets refused while sibling jobs in the same run are still queued, which I hit repeatedly yesterday, and hammering a saturated pool makes it worse. Recovery is `Retrying` only in the sense that the next poll re-reads the checks.

Loose ends I did not take:

- Only the review worker raises the Incident. `review-status-controller` and `review-stop-sweep` read the same snapshots and get the corrected gate behaviour, but stay silent. Felt right to have one place raise it rather than four, but I could be talked out of it.
- The 12-lookup cap is a guess. I have no data on how many Actions checks a single pull request realistically has here.
- A *non-required* check that lost its runner now disappears from the `reported` list in the review comment, since it is no longer a failure. Arguably it should still be mentioned.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).