### PR TITLE
fix(github-agent): repair approved workflows and bundle icons

### DIFF
--- a/packages/harlan-github-agent/dashboard/nuxt.config.ts
+++ b/packages/harlan-github-agent/dashboard/nuxt.config.ts
@@ -11,7 +11,18 @@ export default defineNuxtConfig({
   },
   icon: {
     serverBundle: 'local',
-    clientBundle: { scan: true },
+    clientBundle: {
+      scan: true,
+      // WorkChip resolves these names at runtime. Static scanning cannot find them.
+      icons: [
+        'lucide:scan-eye',
+        'lucide:wrench',
+        'lucide:git-merge',
+        'lucide:heart-pulse',
+        'lucide:inbox',
+        'lucide:hammer',
+      ],
+    },
   },
   ui: {
     theme: {

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -67,6 +67,15 @@ const outputSchema = {
 
 const aiDisclosure = '> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).'
 
+function withAiDisclosure(body: string): string {
+  const content = body
+    .split(/\r?\n/)
+    .filter(line => !/^>\s*🤖 AI disclosure:/.test(line))
+    .join('\n')
+    .trimEnd()
+  return `${content}\n\n${aiDisclosure}`
+}
+
 function templateStructure(body: string): string[] {
   return [
     ...body.matchAll(/<!--.*?-->/gs),
@@ -100,13 +109,13 @@ function parseAgentResponse(text: string, issueNumber: number, template: PullReq
         return ok({ outcome: 'blocked', summary: value.summary, checks: value.checks as string[] })
       if (value.outcome !== 'implemented' || typeof value.commitMessage !== 'string' || value.commitMessage.trim().length === 0 || typeof value.pullRequestTitle !== 'string' || typeof value.pullRequestBody !== 'string')
         return err('The agent returned an invalid issue work result.')
+      const pullRequestBody = withAiDisclosure(value.pullRequestBody)
       if (
         !/^(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?:\([^)]+\))?: \S/.test(value.pullRequestTitle)
         || value.pullRequestTitle.length >= 70
-        || !new RegExp(`(?:closes|fixes|resolves)\\s+#${issueNumber}\\b`, 'i').test(value.pullRequestBody)
-        || !value.pullRequestBody.includes(aiDisclosure)
-        || /^#{1,6} (?:checks?|testing|verification|qa)\b/im.test(value.pullRequestBody)
-        || !preservesTemplate(value.pullRequestBody, template)
+        || !new RegExp(`(?:closes|fixes|resolves)\\s+#${issueNumber}\\b`, 'i').test(pullRequestBody)
+        || /^#{1,6} (?:checks?|testing|verification|qa)\b/im.test(pullRequestBody)
+        || !preservesTemplate(pullRequestBody, template)
       ) {
         return err('The agent returned pull request metadata that does not follow the PR skill.')
       }
@@ -116,7 +125,7 @@ function parseAgentResponse(text: string, issueNumber: number, template: PullReq
         checks: value.checks as string[],
         commitMessage: value.commitMessage.replaceAll(/[\r\n]/g, ' ').replaceAll(/\s+/g, ' ').trim().slice(0, 240),
         pullRequestTitle: value.pullRequestTitle,
-        pullRequestBody: value.pullRequestBody,
+        pullRequestBody,
       })
     })
     .catch(() => err('The agent returned malformed issue work JSON.'))

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -22,6 +22,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { formatProgressBar } from './agent-progress.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { issueTriageComment } from './issue-triage-comment.ts'
+import { canWritePullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
 import { cleanLine, updatedAtLabel } from './text.ts'
@@ -548,7 +549,7 @@ function hasReviewMutationAuthority(mapping: RepositoryMapping): boolean {
 }
 
 function hasRepairAuthority(task: ClaimedAdversarialReviewTask, snapshot: PullRequestReviewSnapshot, repairsBaseline: boolean): boolean {
-  return task.repositoryMapping.ownership === 'owned'
+  return canWritePullRequestHead(task.repositoryMapping)
     && (repairsBaseline || checksGate(snapshot.baseChecks, 'base-ci', 'Pending')._tag === 'Passed')
     && task.pullRequest.headRef !== task.repositoryMapping.defaultBranch
     && task.repositoryMapping.writablePullRequestHeadPrefixes.some(prefix => task.pullRequest.headRef.startsWith(prefix))

--- a/packages/harlan-github-agent/src/repository-policy.ts
+++ b/packages/harlan-github-agent/src/repository-policy.ts
@@ -35,11 +35,12 @@ export function canRepairBaseline(mapping: RepositoryMapping): boolean {
 /**
  * True when the controller may write to a pull request head branch here.
  *
- * That branch belongs to whoever opened the pull request, so this needs a
- * repository Harlan owns outright.
+ * Approval and branch checks run before publication.
  */
 export function canWritePullRequestHead(mapping: RepositoryMapping): boolean {
-  return mapping.ownership === 'owned'
+  return mapping.enabled
+    && canPushBranch(mapping)
+    && (mapping.pullRequestReview || mapping.conflictResolution)
 }
 
 /**

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -67,7 +67,7 @@ import { dirname } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { CODEX_AGENT_PROFILE, parseAgentSelection, providerAgentSelection, resolveAgentProfile, resolveAgentSelection } from './agent-profile.ts'
 import { classifyFailure, isTransientFailure, MAXIMUM_RECOVERY_ATTEMPTS, mayRetryFailure, nextRecoveryAt, REVIEW_REPAIR_REFUSALS } from './failure.ts'
-import { canRepairBaseline } from './repository-policy.ts'
+import { canRepairBaseline, canWritePullRequestHead as canWriteConfiguredPullRequestHead } from './repository-policy.ts'
 
 export interface RecordIncidentInput {
   scope: IncidentScope
@@ -2056,7 +2056,7 @@ function canWritePullRequestHead(mapping: RepositoryMapping, subject: GitHubPull
 }
 
 function canRepairPullRequestHead(mapping: RepositoryMapping, subject: GitHubPullRequestItem): boolean {
-  return mapping.ownership === 'owned'
+  return canWriteConfiguredPullRequestHead(mapping)
     && (subject.headRepository.toLowerCase() === mapping.github.toLowerCase() || subject.maintainerCanModify === true)
     && mapping.writablePullRequestHeadPrefixes.some(prefix => subject.headRef.startsWith(prefix))
     && subject.headRef !== mapping.defaultBranch

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -1106,7 +1106,7 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
           return err('An open pull request already uses this branch.')
       }
       else {
-        // Writing to a branch someone else opened needs a repository Harlan owns.
+        // Approval and the repository policy decide whether this head is writable.
         if (!canWritePullRequestHead(command.repositoryMapping))
           return err('Repository policy does not authorize writing this pull request head.')
         const headRepository = publicationTargetRepository(command)

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -23,7 +23,7 @@ describe('issue work worker', () => {
 
 Fixed the parser.
 
-> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
+> 🤖 AI disclosure: [Codex](https://openai.com/codex) modified this description.
 
 ### Linked Issues
 
@@ -84,6 +84,12 @@ Closes #12.`,
         pullRequestBody: expect.stringContaining('Closes #12.'),
       }),
     }))
+    expect(result).toEqual(ok(expect.objectContaining({
+      publication: expect.objectContaining({
+        pullRequestBody: expect.stringContaining('> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).'),
+      }),
+    })))
+    expect(JSON.stringify(result)).not.toContain('[Codex]')
   })
 
   /** One worker whose stack decisions the caller controls. */

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -219,7 +219,7 @@ describe('subject Workers', () => {
   })
 
   it('repairs findings during the review turn and stages their publication', async () => {
-    const repository = repositoryMapping()
+    const repository = repositoryMapping({ ownership: 'maintained' })
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     let attempt: RecordReviewRunInput | undefined
     let claimed = false

--- a/packages/harlan-github-agent/test/poller.test.ts
+++ b/packages/harlan-github-agent/test/poller.test.ts
@@ -103,7 +103,9 @@ describe('abandoned pass containment', () => {
       await vi.advanceTimersByTimeAsync(5_000)
       expect(started).toBeGreaterThan(2)
 
-      poller.stop().catch(() => undefined)
+      poller.stop().catch(() => {
+        // This teardown cannot affect the overlap assertions above.
+      })
     }
     finally {
       vi.useRealTimers()

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -191,7 +191,11 @@ describe('git publication remote', () => {
 
   it('authorizes an approved repair while the pull request remains clean', async () => {
     const { bare, command, root } = fixture()
-    const repair = { ...command, taskKind: 'review_fix' as const }
+    const repair = {
+      ...command,
+      repositoryMapping: { ...command.repositoryMapping, ownership: 'maintained' as const },
+      taskKind: 'review_fix' as const,
+    }
     const remote = createGitPublicationRemote({
       github: {
         getPullRequest: () => Promise.resolve(ok(pullRequestItem({

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1567,9 +1567,9 @@ describe('journal store', () => {
     }))
   })
 
-  it('claims an owned repair inside its active review', () => {
+  it('claims a maintained repair inside its active review', () => {
     const store = createStore()
-    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.syncRepositories([repositoryMapping({ ownership: 'maintained' })], '2026-08-13T00:00:00.000Z')
     const observed = store.recordObservation({
       externalId: 'owned-pr-findings',
       observedAt: '2026-08-13T01:00:00.000Z',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

This showed up as a failed issue work run on `harlan-zw/nuxt-link-checker#105` and a blocked approved review on `skilld-dev/skilld#95`. The dashboard also left runtime WorkChip icons blank because their fallback request could not pass its CSP. WorkChip icons are bundled now, issue work descriptions use one disclosure, and Approval permits review repairs in maintained repositories.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).