### PR TITLE
fix(github-agent): identify a publication by content, not patch text

### DIFF
--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -243,6 +243,21 @@ function runGitDigest(checkout: string, args: string[], signal: AbortSignal): Pr
   })
 }
 
+/**
+ * The `git diff` arguments that identify one change by content alone.
+ *
+ * A change is verified in a checkout and published from the controller mirror,
+ * so its digest must read the same in both. Patch text does not: `git` scales
+ * index line abbreviation with the object count of the repository, so a large
+ * checkout wrote 11 character blob names where the mirror wrote 9, and every
+ * publication of that repository failed on a digest that described the same
+ * commit. Raw lines carry full blob names, the mode, and the path, and no diff
+ * setting, `.gitattributes` driver, or object count can change them.
+ */
+function contentDiffArgs(...args: string[]): string[] {
+  return ['diff', '--raw', '--no-abbrev', '--no-renames', ...args]
+}
+
 function repositoryGitDirectory(root: string, repository: string): string {
   return join(root, 'repositories', `${repository.replace('/', '__')}.git`)
 }
@@ -645,10 +660,10 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
     if (unmerged.exitCode !== 0 || unmerged.stdout.length > 0)
       return err(`Merge conflicts remain: ${unmerged.stdout || unmerged.stderr}`)
 
-    const patch = await runGitDigest(worktree.path, ['diff', '--binary', 'HEAD'], signal)
+    const patch = await runGitDigest(worktree.path, contentDiffArgs('--cached', 'HEAD'), signal)
     if (patch.exitCode !== 0)
       return err(`Could not read the conflict resolution patch: ${patch.stderr}`)
-    const changed = await runGit(worktree.path, ['diff', '--name-only', 'HEAD'], signal)
+    const changed = await runGit(worktree.path, ['diff', '--cached', '--name-only', 'HEAD'], signal)
     const changedPaths = changed.stdout.split('\n').filter(Boolean).sort()
     const changedFiles = changedPaths.length
 
@@ -803,7 +818,7 @@ export function createReviewFixWorktreeManager(options: ConflictWorktreeManagerO
       const add = await runGit(worktree.path, ['add', '--all'], signal)
       if (add.exitCode !== 0)
         return err(`Could not stage the verified repair: ${add.stderr}`)
-      const patch = await runGitDigest(worktree.path, ['diff', '--cached', '--binary', 'HEAD'], signal)
+      const patch = await runGitDigest(worktree.path, contentDiffArgs('--cached', 'HEAD'), signal)
       if (patch.exitCode !== 0)
         return err(`Could not read the verified repair: ${patch.stderr}`)
       const changed = await runGit(worktree.path, ['diff', '--cached', '--name-only', '-z', 'HEAD'], signal)
@@ -873,7 +888,7 @@ export function createBaselineRepairWorktreeManager(options: ConflictWorktreeMan
       const add = await runGit(worktree.path, ['add', '--all'], signal)
       if (add.exitCode !== 0)
         return err(`Could not stage the verified Baseline repair: ${add.stderr}`)
-      const patch = await runGitDigest(worktree.path, ['diff', '--cached', '--binary', 'HEAD'], signal)
+      const patch = await runGitDigest(worktree.path, contentDiffArgs('--cached', 'HEAD'), signal)
       if (patch.exitCode !== 0)
         return err(`Could not read the verified Baseline repair: ${patch.stderr}`)
       const changed = await runGit(worktree.path, ['diff', '--cached', '--name-only', '-z', 'HEAD'], signal)
@@ -933,7 +948,7 @@ export function createIssueWorktreeManager(options: ConflictWorktreeManagerOptio
       const add = await runGit(worktree.path, ['add', '--all'], signal)
       if (add.exitCode !== 0)
         return err(`Could not stage the verified change: ${add.stderr}`)
-      const patch = await runGitDigest(worktree.path, ['diff', '--cached', '--binary', 'HEAD'], signal)
+      const patch = await runGitDigest(worktree.path, contentDiffArgs('--cached', 'HEAD'), signal)
       if (patch.exitCode !== 0)
         return err(`Could not read the verified change: ${patch.stderr}`)
       const changed = await runGit(worktree.path, ['diff', '--cached', '--name-only', '-z', 'HEAD'], signal)
@@ -1011,7 +1026,7 @@ export function createIssueWorktreeManager(options: ConflictWorktreeManagerOptio
         const restored = await restore()
         return restored._tag === 'Err' ? restored : ok({ _tag: 'Unstacked', reason })
       }
-      const patch = await runGitDigest(worktree.path, ['diff', '--cached', '--binary', 'HEAD'], signal)
+      const patch = await runGitDigest(worktree.path, contentDiffArgs('--cached', 'HEAD'), signal)
       if (patch.exitCode !== 0)
         return err(`Could not read the restacked change: ${patch.stderr}`)
       const changed = await runGit(worktree.path, ['diff', '--cached', '--name-only', '-z', 'HEAD'], signal)
@@ -1186,7 +1201,7 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
         : command.expectedHeadSha
       if (parents.exitCode !== 0 || parents.stdout !== expectedParents)
         return err('The publication artifact has unexpected parents.')
-      const patch = await runGitDigest(repository, ['diff', '--binary', command.expectedHeadSha, command.commitSha], signal)
+      const patch = await runGitDigest(repository, contentDiffArgs(command.expectedHeadSha, command.commitSha), signal)
       if (patch.exitCode !== 0 || patch.digest !== command.patchDigest)
         return err('The publication artifact patch digest does not match.')
       const changed = await runGit(repository, ['diff', '--name-only', command.expectedHeadSha, command.commitSha], signal)

--- a/packages/harlan-github-agent/test/conflict-worktree.test.ts
+++ b/packages/harlan-github-agent/test/conflict-worktree.test.ts
@@ -4,7 +4,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { createConflictWorktreeManager } from '../src/worktree.ts'
+import { ok } from '../src/result.ts'
+import { createConflictWorktreeManager, createGitPublicationRemote } from '../src/worktree.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
 const temporaryDirectories: string[] = []
@@ -147,5 +148,63 @@ describe('conflict worktree', () => {
     expect(committed).toEqual(expect.objectContaining({ _tag: 'Ok' }))
     expect(git(prepared.value.path, 'show', '--no-patch', '--format=%an <%ae>')).toBe('Harlan Wilton <harlan@harlanzw.com>')
     expect(git(prepared.value.path, 'show', '--no-patch', '--format=%s')).toBe('merge: reconcile parser changes')
+  })
+  it('publishes a resolution whose digest was read where blob names abbreviate differently', async () => {
+    // Git scales blob name abbreviation with the object count of a repository,
+    // so the checkout that resolves a conflict and the controller mirror that
+    // publishes it disagreed on the same commit and every publication failed.
+    const { remote, root, task } = fixture()
+    const options = {
+      gitIdentity: { name: 'Harlan Wilton', email: 'harlan@harlanzw.com' },
+      remoteUrl: () => remote,
+      root,
+      tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
+    }
+    const manager = createConflictWorktreeManager(options)
+    const prepared = await manager.prepare(task, new AbortController().signal)
+    if (prepared._tag === 'Err')
+      throw new Error(prepared.error)
+    git(prepared.value.path, 'config', 'core.abbrev', '20')
+    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
+    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    if (verified._tag === 'Err')
+      throw new Error(verified.error)
+    const committed = await manager.commit(task, prepared.value, verified.value, 'merge: resolve conflicts', new AbortController().signal)
+    if (committed._tag === 'Err')
+      throw new Error(committed.error)
+    git(join(root, 'repositories', `${task.repository.replace('/', '__')}.git`), 'config', 'core.abbrev', '7')
+
+    const publication = createGitPublicationRemote({
+      github: {
+        getPullRequest: () => Promise.reject(new Error('This publication reads no pull request.')),
+        hasOpenPullRequestForBranch: () => Promise.resolve(ok(false)),
+        isBranchProtected: () => Promise.resolve(ok(false)),
+      },
+      ...options,
+    })
+    const pushed = await publication.push({
+      _tag: 'UpdatePullRequest',
+      id: 'publication-1',
+      taskId: task.id,
+      taskKind: 'resolve_conflict',
+      repository: task.repository,
+      pullRequestNumber: 1,
+      commitSha: committed.value.commitSha,
+      baseSha: committed.value.baseSha,
+      baseRef: 'main',
+      expectedHeadSha: task.pullRequest.headSha,
+      headRef: 'fix/conflict',
+      artifactRef: committed.value.artifactRef,
+      patchDigest: committed.value.digest,
+      changedFiles: committed.value.changedFiles,
+      outcomeUnknown: false,
+      workerId: 'publisher-1',
+      fence: 1,
+      leaseExpiresAt: '2026-08-13T02:00:00.000Z',
+      repositoryMapping: task.repositoryMapping,
+    }, new AbortController().signal)
+
+    expect(pushed).toEqual(ok(undefined))
+    expect(git(remote, 'rev-parse', 'refs/heads/fix/conflict')).toBe(committed.value.commitSha)
   })
 })

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -27,6 +27,11 @@ function git(checkout: string, ...args: string[]): string {
   }).trim()
 }
 
+/** The change identity the controller signs: raw lines, full blob names. */
+function contentDigest(checkout: string, from: string, to: string): string {
+  return createHash('sha256').update(git(checkout, 'diff', '--raw', '--no-abbrev', '--no-renames', from, to)).digest('hex')
+}
+
 function fixture(): { bare: string, checkout: string, command: Extract<ClaimedPublicationCommand, { _tag: 'UpdatePullRequest' }>, expectedHeadSha: string, root: string } {
   const root = mkdtempSync(join(tmpdir(), 'harlan-publication-'))
   temporaryDirectories.push(root)
@@ -56,7 +61,7 @@ function fixture(): { bare: string, checkout: string, command: Extract<ClaimedPu
   mkdirSync(join(root, 'repositories'))
   execFileSync('git', ['clone', '--bare', checkout, controller])
   git(controller, 'update-ref', artifactRef, commitSha)
-  const patchDigest = createHash('sha256').update(git(controller, 'diff', '--binary', expectedHeadSha, commitSha)).digest('hex')
+  const patchDigest = contentDigest(controller, expectedHeadSha, commitSha)
   return {
     bare,
     checkout,
@@ -171,7 +176,7 @@ describe('git publication remote', () => {
       expectedHeadSha: command.baseSha,
       headRef: 'fix/baseline-ci',
       artifactRef,
-      patchDigest: createHash('sha256').update(git(controller, 'diff', '--binary', command.baseSha, repairSha)).digest('hex'),
+      patchDigest: contentDigest(controller, command.baseSha, repairSha),
       changedFiles: 1,
     }
     const remote = createGitPublicationRemote({


### PR DESCRIPTION
## Problem

Every publication in `harlan-zw/nuxtseo.com` failed with `The publication artifact patch digest does not match.`, after burning three agent turns each. PR #380's conflict resolution is the latest.

All 13 recorded digest mismatches belong to that one repository.

## Cause

The digest is taken over `git diff --binary` patch text. Git scales the index line blob abbreviation with the object count of the repository. The checkout that verifies a change and the controller mirror that publishes it hold different object counts, so they wrote 11 and 9 character blob names for the same commit.

Reproduced on the failed artifact:

```
recorded         311919fb…
source  plain    311919fb…   ← matches
mirror  plain    6c59c4db…   ← the publication check
```

## Fix

Digest `git diff --raw --no-abbrev --no-renames`. Raw lines carry the full blob names, the mode, and the path, so no diff setting, `.gitattributes` driver, or object count can change them. It is also a stricter content check than patch text.

Same artifact, after the change: both repositories return `d0998f4a…`.

The conflict verify now digests the index rather than the working tree, so the digest and the changed file count read the same place. Everything the worker may change is already staged at that point.

## Test

`publishes a resolution whose digest was read where blob names abbreviate differently` drives the real path: prepare, resolve, verify, commit, publish, with the checkout and the controller mirror on different `core.abbrev`. It fails on `main` with the exact production message.

544 tests, typecheck, and lint pass.

🤖 Written by Claude Code.