### PR TITLE
fix(github-agent): stop three failure categories stranding agent work

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -2467,25 +2467,31 @@ function planConflictResolution(
 
   supersedeTasks(database, subjectId, observedAt, 'A newer pull request head commit replaced this task.', revisionId)
   const existing = database.prepare(`
-    SELECT id, state_tag, reason, fence,
+    SELECT id, state_tag, reason, fence, recovery_attempts,
       EXISTS (SELECT 1 FROM task_cancellations WHERE task_id = tasks.id) AS cancelled
     FROM tasks
     WHERE subject_id = ? AND kind = 'resolve_conflict' AND revision_id = ?
-  `).get(subjectId, revisionId) as { id: string, state_tag: TaskRow['state_tag'], reason: string | null, fence: number, cancelled: number } | undefined
+  `).get(subjectId, revisionId) as { id: string, state_tag: TaskRow['state_tag'], reason: string | null, fence: number, recovery_attempts: number, cancelled: number } | undefined
   // Recovery used to match two exact reasons collected from past incidents, so
   // every new transient failure left the conflict dead until someone added its
   // wording. The failure taxonomy decides instead: a transient failure can
   // succeed unchanged, and a permanent one still waits for a person.
+  // Spending recovery budget is what stops a repeating transient failure from
+  // spinning. One conflict task started twenty one agent turns on the same
+  // unreadable worktree listing, because this path requeued it free of charge.
+  // A pull request that conflicts again is not a failure and stays unbudgeted.
   const recoverableFailure = existing?.state_tag === 'Failed'
     && existing.reason !== null
+    && existing.recovery_attempts < MAXIMUM_RECOVERY_ATTEMPTS
     && isTransientFailure({ message: existing.reason })
   if ((existing?.state_tag === 'Superseded' && existing.cancelled === 0) || recoverableFailure) {
     database.prepare(`
       UPDATE tasks
       SET state_tag = 'Queued', reason = NULL, attempts = 0, worker_id = NULL,
-        command_id = NULL, lease_expires_at = NULL, updated_at = ?
+        command_id = NULL, lease_expires_at = NULL, updated_at = ?,
+        recovery_attempts = recovery_attempts + ?
       WHERE id = ? AND state_tag = ?
-    `).run(observedAt, existing.id, existing.state_tag)
+    `).run(observedAt, recoverableFailure ? 1 : 0, existing.id, existing.state_tag)
     recordTransition(database, {
       taskId: existing.id,
       from: existing.state_tag,
@@ -2813,19 +2819,21 @@ function planAdversarialReview(
 
   supersedeWorkerTasks(database, subjectId, 'adversarial_review', observedAt, 'A newer pull request head commit replaced this review.', revisionId)
   const existing = database.prepare(`
-    SELECT id, state_tag, reason, fence FROM worker_tasks
+    SELECT id, state_tag, reason, fence, recovery_attempts FROM worker_tasks
     WHERE subject_id = ? AND kind = 'adversarial_review' AND revision_id = ?
-  `).get(subjectId, revisionId) as { id: string, state_tag: TaskRow['state_tag'], reason: string | null, fence: number } | undefined
-  const recoverableFailure = existing?.state_tag === 'Failed' && (
-    existing.reason === 'The agent returned an invalid adversarial review result.'
-    || existing.reason === 'The agent returned malformed adversarial review JSON.'
-    || existing.reason === 'Fetched base branch no longer matches the claimed review base commit SHA.'
-  )
+  `).get(subjectId, revisionId) as { id: string, state_tag: TaskRow['state_tag'], reason: string | null, fence: number, recovery_attempts: number } | undefined
+  // The failure taxonomy decides, never a list of exact wordings. The list this
+  // replaces was collected from past incidents, so rewording any one of those
+  // messages silently left a recoverable review dead until someone noticed.
+  const recoverableFailure = existing?.state_tag === 'Failed'
+    && existing.reason !== null
+    && existing.recovery_attempts < MAXIMUM_RECOVERY_ATTEMPTS
+    && isTransientFailure({ message: existing.reason })
   if (recoverableFailure) {
     database.prepare(`
       UPDATE worker_tasks
       SET state_tag = 'Queued', reason = NULL, attempts = 0, worker_id = NULL,
-        lease_expires_at = NULL, updated_at = ?
+        lease_expires_at = NULL, updated_at = ?, recovery_attempts = recovery_attempts + 1
       WHERE id = ? AND state_tag = 'Failed'
     `).run(observedAt, existing.id)
     recordWorkerTransition(database, { taskId: existing.id, from: 'Failed', to: 'Queued', reason: 'Retrying a recoverable review failure.', fence: existing.fence, at: observedAt })

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -269,32 +269,39 @@ function publicationArtifactRef(taskId: string): string {
 /**
  * Reads `wt list --format=json` into the branch worktrees the controller can claim.
  *
- * A detached worktree reports a null branch. That is a normal wt state, not
- * malformed data, so it is dropped rather than failing the whole list. One
- * detached worktree used to strand every agent task in the repository.
+ * An entry only names a claimable worktree when it carries a branch name and an
+ * absolute path. Everything else describes something the controller cannot use:
+ * a detached head, a pruned directory, or a listing field `wt` grew after this
+ * code was written. Those are skipped. A reader that failed the whole list on
+ * one of them stranded every agent task in the repository, and one conflict
+ * task restarted twenty one times behind it.
+ *
+ * Output that is not a list of entries at all is still a broken contract, so it
+ * still fails rather than reporting an empty repository.
  */
 export function parseWtWorktrees(stdout: string): Result<WtWorktree[], string> {
+  let value: unknown
   try {
-    const value: unknown = JSON.parse(stdout)
-    if (!Array.isArray(value))
-      return err('wt list returned an invalid worktree list.')
-    const worktrees: WtWorktree[] = []
-    for (const entry of value) {
-      if (typeof entry !== 'object' || entry === null || !('branch' in entry) || !('path' in entry))
-        return err('wt list returned an invalid worktree entry.')
-      if (typeof entry.path !== 'string' || !isAbsolute(entry.path))
-        return err('wt list returned an invalid worktree entry.')
-      if (entry.branch === null)
-        continue
-      if (typeof entry.branch !== 'string')
-        return err('wt list returned an invalid worktree entry.')
-      worktrees.push({ branch: entry.branch, path: entry.path })
-    }
-    return ok(worktrees)
+    value = JSON.parse(stdout)
   }
   catch {
     return err('wt list returned invalid JSON.')
   }
+  if (!Array.isArray(value))
+    return err('wt list returned an invalid worktree list.')
+  const worktrees: WtWorktree[] = []
+  for (const entry of value) {
+    if (typeof entry !== 'object' || entry === null)
+      continue
+    const branch: unknown = 'branch' in entry ? entry.branch : undefined
+    const path: unknown = 'path' in entry ? entry.path : undefined
+    if (typeof branch !== 'string' || branch.length === 0)
+      continue
+    if (typeof path !== 'string' || !isAbsolute(path))
+      continue
+    worktrees.push({ branch, path })
+  }
+  return ok(worktrees)
 }
 
 async function listWtWorktrees(checkout: string, signal: AbortSignal): Promise<Result<WtWorktree[], string>> {
@@ -640,9 +647,21 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
     if (workerChanged.exitCode !== 0)
       return err(`Could not inspect the conflict fix: ${workerChanged.stderr}`)
     const workerChangedPaths = workerChanged.stdout.split('\n').filter(Boolean).sort()
-    const unexpectedPath = workerChangedPaths.find(path => !worktree.conflictedFiles.includes(path))
+    // The merge, not the conflict list, bounds what a resolution may touch. A
+    // marker is only where two edits met: reconciling them often means the test
+    // or the call site the base branch moved, and refusing those killed correct
+    // resolutions outright. Anything the merge did not touch is still unrelated
+    // work that has no place in a merge commit.
+    const mergeBase = await runGit(worktree.path, ['merge-base', worktree.headSha, worktree.baseSha], signal)
+    if (mergeBase.exitCode !== 0)
+      return err(`Could not resolve the merge base: ${mergeBase.stderr}`)
+    const merged = await runGit(worktree.path, ['diff', '--name-only', mergeBase.stdout, worktree.baseSha], signal)
+    if (merged.exitCode !== 0)
+      return err(`Could not inspect what the base branch changed: ${merged.stderr}`)
+    const writablePaths = new Set([...worktree.conflictedFiles, ...merged.stdout.split('\n').filter(Boolean)])
+    const unexpectedPath = workerChangedPaths.find(path => !writablePaths.has(path))
     if (unexpectedPath !== undefined)
-      return err(`The worker changed a file that was not conflicted: ${unexpectedPath}.`)
+      return err(`The worker changed a file the merge did not touch: ${unexpectedPath}.`)
     const untracked = await runGit(worktree.path, ['ls-files', '--others', '--exclude-standard'], signal)
     if (untracked.exitCode !== 0)
       return err(`Could not inspect untracked files: ${untracked.stderr}`)
@@ -653,7 +672,9 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
     if (diffCheck.exitCode !== 0)
       return err(`Resolved patch failed git diff check: ${diffCheck.stdout || diffCheck.stderr}`)
 
-    const staged = await runGit(worktree.path, ['add', '--', ...worktree.conflictedFiles], signal)
+    // Conflicted files stage even when the worker left one side untouched, or
+    // the merge stays unresolved. Everything the worker touched stages with them.
+    const staged = await runGit(worktree.path, ['add', '--', ...new Set([...worktree.conflictedFiles, ...workerChangedPaths])], signal)
     if (staged.exitCode !== 0)
       return err(`Could not stage the conflict fix: ${staged.stderr}`)
     const unmerged = await runGit(worktree.path, ['diff', '--name-only', '--diff-filter=U'], signal)

--- a/packages/harlan-github-agent/test/conflict-worktree.test.ts
+++ b/packages/harlan-github-agent/test/conflict-worktree.test.ts
@@ -26,7 +26,7 @@ function git(checkout: string, ...args: string[]): string {
   }).trim()
 }
 
-function fixture(): { currentBaseSha: string, remote: string, root: string, task: ClaimedConflictResolutionTask } {
+function fixture(): { checkout: string, currentBaseSha: string, remote: string, root: string, task: ClaimedConflictResolutionTask } {
   const directory = mkdtempSync(join(tmpdir(), 'harlan-conflict-worktree-'))
   temporaryDirectories.push(directory)
   const remote = join(directory, 'remote.git')
@@ -38,7 +38,11 @@ function fixture(): { currentBaseSha: string, remote: string, root: string, task
   git(checkout, 'config', 'user.email', 'agent@example.com')
   git(checkout, 'checkout', '-b', 'main')
   writeFileSync(join(checkout, 'file.txt'), 'original\n')
-  git(checkout, 'add', 'file.txt')
+  // `helper.ts` is what the base branch moves under a resolution. `keep.ts` is
+  // what neither side touches, so nothing may edit it.
+  writeFileSync(join(checkout, 'helper.ts'), 'export const limit = 1\n')
+  writeFileSync(join(checkout, 'keep.ts'), 'export const kept = true\n')
+  git(checkout, 'add', '--all')
   git(checkout, 'commit', '-m', 'initial')
   git(checkout, 'push', 'origin', 'main')
   const staleBaseSha = git(checkout, 'rev-parse', 'HEAD')
@@ -56,6 +60,7 @@ function fixture(): { currentBaseSha: string, remote: string, root: string, task
   const currentBaseSha = git(checkout, 'rev-parse', 'HEAD')
   const mapping = repositoryMapping({ checkout, defaultBranch: 'main' })
   return {
+    checkout,
     currentBaseSha,
     remote,
     root,
@@ -206,5 +211,49 @@ describe('conflict worktree', () => {
 
     expect(pushed).toEqual(ok(undefined))
     expect(git(remote, 'rev-parse', 'refs/heads/fix/conflict')).toBe(committed.value.commitSha)
+  })
+  it('lets a resolution follow the base branch into a file that never conflicted', async () => {
+    const { checkout, remote, root, task } = fixture()
+    // The base branch moves `helper.ts` under the pull request. Reconciling the
+    // conflict means following it, and that file never carried a marker.
+    writeFileSync(join(checkout, 'helper.ts'), 'export const limit = 2\n')
+    git(checkout, 'commit', '-am', 'raise the limit')
+    git(checkout, 'push', 'origin', 'main')
+    const manager = createConflictWorktreeManager({
+      gitIdentity: { name: 'Harlan Wilton', email: 'harlan@harlanzw.com' },
+      remoteUrl: () => remote,
+      root,
+      tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
+    })
+    const prepared = await manager.prepare(task, new AbortController().signal)
+    if (prepared._tag === 'Err')
+      throw new Error(prepared.error)
+    expect(prepared.value.conflictedFiles).toEqual(['file.txt'])
+    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
+    writeFileSync(join(prepared.value.path, 'helper.ts'), 'export const limit = 3\n')
+
+    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+
+    expect(verified).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ changedFiles: 2 }) }))
+    expect(git(prepared.value.path, 'diff', '--cached', '--name-only', 'HEAD').split('\n').sort()).toEqual(['file.txt', 'helper.ts'])
+  })
+
+  it('refuses a resolution that edits a file the merge never touched', async () => {
+    const { remote, root, task } = fixture()
+    const manager = createConflictWorktreeManager({
+      gitIdentity: { name: 'Harlan Wilton', email: 'harlan@harlanzw.com' },
+      remoteUrl: () => remote,
+      root,
+      tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
+    })
+    const prepared = await manager.prepare(task, new AbortController().signal)
+    if (prepared._tag === 'Err')
+      throw new Error(prepared.error)
+    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
+    writeFileSync(join(prepared.value.path, 'keep.ts'), 'export const kept = false\n')
+
+    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+
+    expect(verified).toEqual({ _tag: 'Err', error: 'The worker changed a file the merge did not touch: keep.ts.' })
   })
 })

--- a/packages/harlan-github-agent/test/failure.test.ts
+++ b/packages/harlan-github-agent/test/failure.test.ts
@@ -47,7 +47,7 @@ describe('classifyFailure', () => {
   })
 
   it('keeps the attempts of a failure nobody has classified', () => {
-    expect(mayRetryFailure({ message: 'The worker changed a file that was not conflicted: src/main.rs.' })).toBe(true)
+    expect(mayRetryFailure({ message: 'The worker changed a file the merge did not touch: src/main.rs.' })).toBe(true)
   })
 
   it.each([
@@ -90,7 +90,7 @@ describe('classifyFailure', () => {
   })
 
   it('treats an unrecognised failure as permanent so it surfaces instead of spinning', () => {
-    expect(classifyFailure({ message: 'The worker changed a file that was not conflicted: src/main.rs.' }))
+    expect(classifyFailure({ message: 'The worker changed a file the merge did not touch: src/main.rs.' }))
       .toEqual({ _tag: 'Permanent', kind: 'unknown' })
   })
 })

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -291,7 +291,7 @@ describe('task incidents from the mutation journal', () => {
         workerId: task.state.workerId,
         fence: task.state.fence,
         at,
-        reason: 'The worker changed a file that was not conflicted: src/main.rs.',
+        reason: 'The worker changed a file the merge did not touch: src/main.rs.',
       })
     }
 

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -303,7 +303,7 @@ describe('journal store', () => {
 
   it.each([
     ['a transient failure', 'wt list returned an invalid worktree entry.', true],
-    ['a permanent failure', 'The worker changed a file that was not conflicted: src/index.ts.', false],
+    ['a permanent failure', 'The worker changed a file the merge did not touch: src/index.ts.', false],
   ])('requeues a failed conflict task on the next poll only after %s', (_name, reason, requeued) => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
@@ -412,6 +412,34 @@ describe('journal store', () => {
       _tag: 'Queued',
       work: 'conflict_resolution',
     })
+  })
+
+  it('stops requeueing a conflict that keeps failing for the same transient reason', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const subject = pullRequestItem({ mergeState: 'conflicting' })
+    let elapsed = 0
+    const at = (): string => new Date(Date.parse('2026-08-13T01:00:00.000Z') + (elapsed += 1000)).toISOString()
+    store.recordObservation({ externalId: 'spinning-conflict', observedAt: at(), source: 'poll', subject })
+    // One round more than the recovery budget. Without a budget the planner
+    // requeued this free of charge and the same failure ran forever.
+    for (let round = 0; round < 6; round += 1) {
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const task = store.claimNextConflictTask('worker-1', at(), 600_000)
+        if (task === null)
+          break
+        store.failTask({
+          taskId: task.id,
+          workerId: task.state.workerId,
+          fence: task.state.fence,
+          at: at(),
+          reason: 'Could not list wt worktrees: spawn wt ENOENT',
+        })
+      }
+      store.recordObservation({ externalId: 'spinning-conflict', observedAt: at(), source: 'poll', subject })
+    }
+
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
   })
 
   it('retries an invalid agent review result without asking for attention', () => {

--- a/packages/harlan-github-agent/test/wt-list.test.ts
+++ b/packages/harlan-github-agent/test/wt-list.test.ts
@@ -22,15 +22,23 @@ describe('parseWtWorktrees', () => {
     })
   })
 
-  it('rejects an entry that carries neither a branch nor a detached head', () => {
-    const parsed = parseWtWorktrees(JSON.stringify([{ branch: 7, path: '/home/harlan/pkg/repo' }]))
+  it('keeps the claimable worktrees around an entry it cannot use', () => {
+    const parsed = parseWtWorktrees(JSON.stringify([
+      { branch: 7, path: '/home/harlan/pkg/repo' },
+      { path: '/home/harlan/pkg/repo.pruned' },
+      entry('main', 'pkg/repo.relative'),
+      { kind: 'session', name: 'something wt grew later' },
+      entry('harlan-agent/conflict-1', '/home/harlan/pkg/repo.conflict-1'),
+    ]))
 
-    expect(parsed._tag).toBe('Err')
+    expect(parsed).toEqual({
+      _tag: 'Ok',
+      value: [{ branch: 'harlan-agent/conflict-1', path: '/home/harlan/pkg/repo.conflict-1' }],
+    })
   })
 
-  it('rejects a relative worktree path', () => {
-    const parsed = parseWtWorktrees(JSON.stringify([entry('main', 'pkg/repo')]))
-
-    expect(parsed._tag).toBe('Err')
+  it('rejects output that is not a list of worktrees', () => {
+    expect(parseWtWorktrees('{"worktrees":[]}')._tag).toBe('Err')
+    expect(parseWtWorktrees('not json')._tag).toBe('Err')
   })
 })


### PR DESCRIPTION
Four fixes, each traced to a count in the journal rather than found by reading.

## `wt list` fails a whole repository on one unreadable entry

`parseWtWorktrees` refused the entire listing when any entry lacked a string branch or an absolute path. Every agent task in that repository then failed. Task `d802819f` entered `Running` **21 times** on `wt list returned an invalid worktree entry`.

It now keeps the worktrees it can claim and skips the rest: a detached head, a pruned directory, or a field `wt` grew later. Output that is not a list of entries at all still fails, because that is a broken contract, not an unusable entry. `prepareWtWorktree` already recreates a missing worktree and reports a clear error if `wt` still will not produce it.

## Planner recovery had no budget and no backoff

Both planners requeued a transiently failed task with `attempts = 0` and no change to `recovery_attempts`, bypassing `MAXIMUM_RECOVERY_ATTEMPTS` and `nextRecoveryAt` entirely. That is the other half of the 21 restarts.

They now spend recovery budget, so a repeat surfaces as an Incident. A pull request that conflicts again is not a failure and stays unbudgeted. `restoreRecoveryBudget` still gives the budget back after a GitHub outage.

## The review planner still allowlisted exact wordings

`planAdversarialReview` recovered from three exact strings collected from past incidents. Rewording any one of them silently left a recoverable review dead. It now asks `isTransientFailure`, which is what `planConflictResolution` already does.

## Conflict resolution could only touch conflicted files

`The worker changed a file that was not conflicted: crates/core/tests/max_node_bytes.rs.` A marker is only where two edits met. Reconciling them often means the test or the call site the base branch moved, and that was refused outright.

The merge bounds the resolution now: conflicted files plus what the base brought in since the merge base. Anything the merge did not touch is still unrelated work with no place in a merge commit.

## Tests

- `keeps the claimable worktrees around an entry it cannot use`
- `stops requeueing a conflict that keeps failing for the same transient reason`
- `lets a resolution follow the base branch into a file that never conflicted`
- `refuses a resolution that edits a file the merge never touched`

Each was confirmed to fail on `main` before the change. 547 tests, typecheck, and lint pass.

## Not fixed here

21 `Resource not accessible by integration` failures on `baseline_repair`, all reading pull request comments and reviews. That is App installation scope, not code.

🤖 Written by Claude Code.