### PR TITLE
fix(github-agent): stop an unapproved repair spinning the claim path

### DIFF
--- a/packages/harlan-github-agent/src/failure.ts
+++ b/packages/harlan-github-agent/src/failure.ts
@@ -228,6 +228,9 @@ const agentResultPatterns: RegExp[] = [
   /\breturned an invalid\b/i,
   /\breturned malformed\b/i,
   /\bomitted confidence\b/i,
+  // Metadata that ignores the PR skill is the same kind of wrong shape as the
+  // three above. It waited for a person while the work behind it was redoable.
+  /\bdoes not follow the PR skill\b/i,
 ]
 
 function matches(patterns: RegExp[], message: string): boolean {

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4306,6 +4306,20 @@ export function openJournalStore(
             OR (tasks.kind = 'baseline_repair' AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1)
             OR (tasks.kind = 'issue_work' AND json_extract(repositories.policy_json, '$.issueWork') = 1)
           )
+          -- Approval is a live condition of the claim, not something checked
+          -- after one is picked. A repair whose Approval went away used to be
+          -- selected anyway, throw, roll back, and be selected again on the very
+          -- next pass. One repair spent a day doing that. It becomes claimable
+          -- again by itself if Harlan approves this same head commit again.
+          AND (
+            tasks.kind != 'review_fix'
+            OR EXISTS (
+              SELECT 1 FROM pull_request_approvals
+              WHERE pull_request_approvals.subject_id = subjects.id
+                AND pull_request_approvals.revision_id = tasks.revision_id
+                AND pull_request_approvals.kind = 'fixes'
+            )
+          )
         ORDER BY tasks.updated_at, tasks.id
         LIMIT 1
       `).get(kind, exactTaskId ?? null, exactTaskId ?? null) as ClaimRow | undefined
@@ -4320,13 +4334,19 @@ export function openJournalStore(
       if (kind !== 'issue_work' && subject.kind !== 'pull_request')
         throw new Error(`Pull request Task ${row.id} does not reference a pull request.`)
       const repositoryMapping = JSON.parse(row.policy_json) as RepositoryMapping
+      // The query above cannot return an unapproved repair. This stays as the
+      // second half of the boundary that decides who may write a contributor's
+      // branch, and it declines the claim rather than throwing, so a broken
+      // guard above can never spin the claim path again.
       if (kind === 'review_fix') {
         const approved = database.prepare(`
           SELECT 1 FROM pull_request_approvals
           WHERE subject_id = ? AND revision_id = ? AND kind = 'fixes'
         `).get(row.subject_id, row.revision_id)
-        if (approved === undefined)
-          throw new Error(`Repair Task ${row.id} lost Approval for its pull request head commit.`)
+        if (approved === undefined) {
+          database.exec('COMMIT')
+          return null
+        }
       }
       const fence = row.fence + 1
       const leaseExpiresAt = new Date(new Date(now).getTime() + leaseMilliseconds).toISOString()

--- a/packages/harlan-github-agent/test/failure.test.ts
+++ b/packages/harlan-github-agent/test/failure.test.ts
@@ -22,6 +22,7 @@ describe('classifyFailure', () => {
     ['The pull request changed before the review completed.', 'subject_changed'],
     ['The agent returned an invalid adversarial review result.', 'agent_result'],
     ['The agent returned malformed adversarial review JSON.', 'agent_result'],
+    ['The agent returned pull request metadata that does not follow the PR skill.', 'agent_result'],
   ])('treats %s as a transient %s failure', (message, kind) => {
     expect(classifyFailure({ message })).toEqual({ _tag: 'Transient', kind })
   })


### PR DESCRIPTION
Found in the service logs, which produce failures the journal never records as a task failure.

## An unapproved repair spun the claim path

`claimMutationTask` selected a Queued `review_fix` Task, then read `pull_request_approvals`, found none, and **threw**. The catch rolls back, so the Task stayed Queued and the next pass selected the same row again.

```
52  Review Task <id> lost Approval for its pull request head commit.
```

One Task, three hours, today. Because the claim orders by `updated_at, id` and takes `LIMIT 1`, it also sat at the front of the queue the whole time.

Approval is now a condition of the claim query, so an unapproved repair is never selected. Approving that same head commit again makes it claimable with nothing to clean up.

The read that used to throw stays, as the second half of the boundary that decides who may write a contributor's branch, and declines the claim instead of throwing. A broken guard above can no longer spin the claim path.

## PR metadata that ignores the skill is an agent result failure

`The agent returned pull request metadata that does not follow the PR skill.` classified as unknown, so it waited for a person. It is the same wrong shape as `returned an invalid` and `returned malformed`, and the work behind it is redoable. It now retries inside the recovery budget.

## Checked and left alone

- **`Review rerun command: Not Found`, 348 times.** All on 17 and 18 August, none since. Already fixed.
- **`Resource not accessible by integration`, ~300 times.** All in the 17 August GitHub window the taxonomy already documents, plus a batch on 13 August. Nothing current.
- **`One poll pass exceeded 600 seconds`, 3 times in 7 days.** The poller abandons the pass, counts it, backs off, and keeps running. Working as designed. The `This operation was aborted` errors around each one are that abort, not separate faults.
- **`The controller cannot write this pull request branch`, 6 times.** Correct. Sampled `nuxtseo.com#311`, head `pro-integrations-page`, which matches no configured prefix, and `mdream#213`, a fork with `maintainerCanModify: false`.

## Test

`classifyFailure` covers the new agent result wording.

The claim guard has no direct test. A Queued `review_fix` without its Approval is not reachable through the store API: the Approval is inserted before the Task is created, and a refused repair supersedes the Task. Existing coverage proves the approved path still claims. Calling that out rather than fabricating the row.

548 tests, typecheck, and lint pass.

🤖 Written by Claude Code.