### PR TITLE
feat: add close-off skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ the skills only; the Claude hook config is not portable to Codex as-is.
 | Skill | Description |
 |-------|-------------|
 | `adversarial-review` | Review and repair one PR, then post its bot status |
+| `close-off` | Finish loose ends, verify delivery, and clean task-owned Git state |
 | `email-triage` | Triage inbox email with himalaya |
 | `humanize-writing` | Strip AI tells from prose before publishing |
 | `improve-ts-pkg-architecture` | Find architecture improvements in TS packages and monorepos |

--- a/harlan-agent-kit/skills/close-off/SKILL.md
+++ b/harlan-agent-kit/skills/close-off/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: close-off
+description: "Finish remaining task work, verify delivery, reconcile records, and safely clean task-owned worktrees and branches. Use after a merge or deploy, or when the user asks what remains, asks for follow-up, or says close off, wrap up, or finish up."
+user_invocable: true
+argument-hint: "[work item, pull request, or branch]"
+---
+
+# Close Off
+
+Close one current work item completely.
+
+Finish required loose ends before reconciling records and cleaning task-owned state.
+
+## Use existing contracts
+
+Read these contracts completely when they apply:
+
+1. `../take-ownership/SKILL.md` for an open pull request, revision, delivery, release, or smoke path.
+2. `../pr/SKILL.md` when local changes need review or an existing pull request needs updates.
+3. `../adversarial-review/SKILL.md` before any readiness or merge decision.
+4. `../unit-tests/SKILL.md` before repairing behavior or validation.
+5. `../../references/worktree-isolation.md` before local mutation or cleanup.
+
+Use the matching domain skill for repairs. Do not copy loaded workflows here.
+
+## Authority
+
+Closing off authorizes safe cleanup of task-owned integrated Git state.
+
+This includes the exact merged pull request branch in an owned repository.
+
+It grants no merge, issue mutation, publication, or unrelated delivery authority.
+
+Existing user instructions can grant those actions for the current work item.
+
+## 1. Fix the closure target
+
+Start from the current conversation. Resolve one work item and its named repositories.
+
+Use `$ARGUMENTS` when it names a work item, pull request, branch, issue, or work brief.
+
+Record its closure contract:
+
+1. The intended result.
+2. Every promise made during the task.
+3. Every reported failure or untested path.
+4. Every explicit deferral.
+5. Exact repositories, revisions, pull requests, issues, and work briefs.
+6. Existing authority for external actions.
+
+Inspect the current summary when conversation compaction occurred.
+
+Use durable Git and GitHub evidence when earlier detail is unavailable.
+
+Search local session history only when the work item identifies the missing session.
+
+Never run a broad history search by default.
+
+Ask once only when plausible targets require materially different or destructive actions.
+
+## 2. Build the closure ledger
+
+Inspect applicable state before editing. Run independent read-only checks in parallel.
+
+### Conversation state
+
+Find unfinished promises, workarounds, follow-ups, and blockers.
+
+Collect unfinished task-owned agent or background command results before cleanup.
+
+### Local state
+
+Inspect branches, changes, divergence, unpushed commits, live claims, task worktrees, processes, and temporary files.
+
+Never infer file ownership from location alone.
+
+### Remote and delivery state
+
+Fetch current state and prune stale tracking references.
+
+Inspect the exact pull request head, gates, linked records, superseding work, and remote head branch.
+
+Check whether another open pull request uses that branch.
+
+Determine whether deployment, migration, release, smoke verification, or monitoring applies.
+
+Never infer delivery from a merged pull request or unrelated green check.
+
+### Durable records
+
+Inspect each work brief, plan, status document, marked review comment, or task ledger.
+
+## 3. Classify every loose end
+
+Classify each item:
+
+1. `Required`: needed for the intended result.
+2. `RelatedDefect`: the same failure category in a directly adjacent consumer.
+3. `Superseded`: replaced by newer verified work.
+4. `Deferred`: useful work outside the intended result.
+5. `UnknownOwnership`: ownership cannot be proved.
+
+Finish every `Required` item.
+
+Preserve `UnknownOwnership` items. Record `Deferred` items without starting them.
+
+Prove replacement delivery before closing `Superseded` items.
+
+## 4. Run one related defect sweep
+
+Perform this step only when the work fixed a defect category.
+
+Check directly adjacent surfaces once:
+
+1. Consumers of the changed export or contract.
+2. Call sites of the repaired helper.
+3. Equivalent routes, components, jobs, or configuration paths.
+4. Tests and documentation tied to the behavior.
+
+Fix confirmed instances of the same defect category.
+
+Use a failing test first when required. Stop after one bounded pass.
+
+Do not begin unrelated polish, architecture work, or backlog items.
+
+## 5. Finish required work
+
+For task-owned local changes, separate exact paths from unknown work.
+
+Complete them, run applicable checks, then use `pr` when review is required.
+
+For an open pull request or revision, resume `take-ownership`.
+
+For a merged pull request, verify its revision on the default branch.
+
+Complete every applicable delivery stage already inside the intended result.
+
+Repair attributable failures through the loaded contracts.
+
+Wait while CI, review, deployment, release, or smoke work can still progress.
+
+Do not stop at an intermediate state.
+
+## 6. Reconcile durable records
+
+Update existing work briefs and ledgers with current evidence.
+
+Move briefs to shipped only after delivery verification.
+
+Preserve exact revisions, commands, URLs, and smoke assertions for handoffs.
+
+Issue comments, issue closure, review replies, and publications keep normal approval requirements.
+
+Draft the exact text when publication approval is missing.
+
+## 7. Clean task-owned state
+
+Cleanup starts only after the work reaches `VERIFIED`, `BLOCKED`, or `CANCELLED`.
+
+Before deleting a task worktree or branch, prove:
+
+1. No live agent or process owns it.
+2. The worktree is clean.
+3. Every intended commit exists on the verified destination.
+4. Its pull request merged, or Git proves the branch fully integrated.
+5. No open pull request uses the branch.
+6. It is not a default, protected, shared, or unknown branch.
+
+Then clean in this order:
+
+1. Stop only task-owned temporary processes.
+2. Remove only task-owned temporary files.
+3. Release the task's worktree claim.
+4. Run `wt remove <branch>` for each eligible worktree.
+5. Safely delete an eligible local branch when it remains.
+6. Delete the eligible remote head branch in an owned repository when it remains.
+7. Fetch and prune stale tracking references again.
+
+`wt remove` may delete the integrated local branch itself.
+
+Never pass `--force`, `--force-delete`, or `--clobber`.
+
+Never use raw `git worktree` mutation commands.
+
+Never delete a branch with unique commits.
+
+If safe deletion fails, preserve the state and report why.
+
+Fast-forward a canonical default checkout only when it is clean and unclaimed.
+
+Never switch or rewrite a checkout during cleanup.
+
+## 8. Close with evidence
+
+Use one terminal state from `take-ownership`:
+
+1. `VERIFIED`: the intended result works and no actionable task-owned loose end remains.
+2. `BLOCKED`: progress needs new authority or external state. Name the blocker and next action.
+3. `CANCELLED`: the user abandoned the result. Preserve useful work and complete safe cleanup.
+
+For `VERIFIED`, required records must match reality.
+
+Cleanup must complete or preserve each item for a stated safety reason.
+
+## Final response
+
+Lead with the terminal state and outcome.
+
+List only unresolved items requiring the user.
+
+Name any preserved worktree or branch. Report end-to-end confidence.
+
+Do not repeat the work log.
+
+## Boundaries
+
+Default scope is the current conversation and current repository.
+
+Include another repository only when the intended result already names it.
+
+This skill does not triage the general backlog.
+
+It does not inspect unrelated worktrees across the machine.
+
+It does not start the next work item.
+
+It does not force cleanup.

--- a/harlan-agent-kit/skills/close-off/agents/openai.yaml
+++ b/harlan-agent-kit/skills/close-off/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: Close Off
+  short_description: Finish loose ends and clean completed task state
+  default_prompt: Use $close-off to finish remaining task work, verify delivery, and clean task-owned Git state.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Long tasks can end while Git, delivery, and work records disagree about what is done. `/close-off` checks the current task against that evidence, finishes any loose ends, then removes its integrated branches and worktrees.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.