### PR TITLE
feat(github-agent): support Ox Alpha Free

### DIFF
--- a/packages/harlan-github-agent/src/agent-profile.ts
+++ b/packages/harlan-github-agent/src/agent-profile.ts
@@ -74,6 +74,7 @@ export const AGENT_MODELS = {
     'opencode-go/mimo-v2.5-pro',
     'opencode-go/minimax-m2.7',
     'opencode-go/minimax-m3',
+    'opencode-go/ox-alpha-free',
     'opencode-go/qwen3.6-plus',
     'opencode-go/qwen3.7-max',
     'opencode-go/qwen3.7-plus',

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -638,6 +638,7 @@ export type OpencodeAgentModel
     | 'opencode-go/mimo-v2.5-pro'
     | 'opencode-go/minimax-m2.7'
     | 'opencode-go/minimax-m3'
+    | 'opencode-go/ox-alpha-free'
     | 'opencode-go/qwen3.6-plus'
     | 'opencode-go/qwen3.7-max'
     | 'opencode-go/qwen3.7-plus'

--- a/packages/harlan-github-agent/test/agent-selection.test.ts
+++ b/packages/harlan-github-agent/test/agent-selection.test.ts
@@ -33,6 +33,12 @@ describe('agent selection parsing', () => {
     expect(parsed).toEqual({ _tag: 'Ok', value: { _tag: 'Pinned', provider: 'codex', model: 'gpt-5.6-luna', reasoningEffort: 'max' } })
   })
 
+  it('accepts Ox Alpha Free from OpenCode Go', () => {
+    const parsed = parseAgentSelection({ _tag: 'Pinned', provider: 'opencode', model: 'opencode-go/ox-alpha-free', reasoningEffort: 'high' })
+
+    expect(parsed).toEqual({ _tag: 'Ok', value: { _tag: 'Pinned', provider: 'opencode', model: 'opencode-go/ox-alpha-free', reasoningEffort: 'high' } })
+  })
+
   it('rejects a model that belongs to the other provider', () => {
     const parsed = parseAgentSelection({ _tag: 'Pinned', provider: 'codex', model: 'opencode-go/deepseek-v4-pro' })
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Ox Alpha Free is available through OpenCode Go, but the Agent selector rejects it. The model can now be pinned for every Agent role.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).