### PR TITLE
feat(github-agent): remove persisted controller state

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3498,7 +3498,8 @@ export function openJournalStore(
   /** Issue work stops above this many open pull requests. Matches the configuration default. */
   maxOpenPullRequests = 8,
 ): JournalStore {
-  const database = openDatabase(path)
+  void path
+  const database = openDatabase(':memory:')
   const configuredSelection = providerAgentSelection(profile.provider)
 
   const getAgentSelection = (): AgentSelection => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [x] ⚠️ Breaking change

### 📚 Description

GitHub remains the source of truth, so Harlan GitHub Agent should rebuild its state after every restart. Queue entries, Approvals, Dismissals, Review history, and Recovery records no longer need disk persistence.

The service now keeps controller state in memory.

### ⚠️ Breaking Changes

Restarting Harlan GitHub Agent clears its Queue, Approvals, Dismissals, Review history, Recovery, and active Task history.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).