### PR TITLE
fix(github-agent): block repair for wrong premises

### DIFF
--- a/harlan-agent-kit/skills/adversarial-review/SKILL.md
+++ b/harlan-agent-kit/skills/adversarial-review/SKILL.md
@@ -105,13 +105,15 @@ Record every material finding. Never cap the finding count.
 
 Give each finding a stable identity, exact location, proof, next action, and resolution.
 
-Use resolution `Repair` when the pull request premise is sound. Name the regression test Repair must write first.
+Decide the pull request premise once before classifying findings.
 
-Use resolution `Dismissal` when the premise is wrong and Repair would replace the pull request intent. Recommend Dismissal for an unrelated root architecture rewrite. Never Dismiss or close the pull request.
+Use a sound premise only when safe fixes preserve the pull request intent. Every finding then uses resolution `Repair`. Name the regression test Repair must write first.
+
+Use a wrong premise when safe fixes must reverse the intent, remove a safeguard, or add unrelated root architecture. Every finding then uses resolution `Dismissal` and records no regression test. Never mix Repair and Dismissal findings. Never Dismiss or close the pull request.
 
 ### 7. Hand off Repair and restart
 
-When every finding uses resolution `Repair`, queue one fresh Repair Agent with all exact findings. Never reuse the Review session.
+When the premise is sound and findings remain, queue one fresh Repair Agent with all exact findings. Never reuse the Review session.
 
 For an outside contributor, use the existing Approval. A new external Revision invalidates Approval. The exact controller repair commit continues the workflow.
 

--- a/harlan-agent-kit/skills/adversarial-review/references/review-contract.md
+++ b/harlan-agent-kit/skills/adversarial-review/references/review-contract.md
@@ -127,11 +127,13 @@ Record every material Review finding. Never cap the finding count.
 
 Each finding records a stable fingerprint, exact path and line, proof, summary, next action, and resolution.
 
-A `Repair` finding also records the regression test the fresh Repair Agent must write first.
+Decide the pull request premise once before classifying findings.
 
-A `Dismissal` finding records no regression test. Use it only when the premise is wrong and Repair would replace the pull request intent.
+A sound premise means safe fixes preserve the pull request intent. Every finding uses `Repair` and records the regression test the fresh Repair Agent must write first.
 
-When any finding recommends Dismissal, queue no Repair. Publish `BLOCKED` with Action required. Harlan decides whether to Dismiss.
+A wrong premise means safe fixes must reverse the intent, remove a safeguard, or add unrelated root architecture. Every finding uses `Dismissal` and records no regression test.
+
+Never mix `Repair` and `Dismissal` findings. For a wrong premise, queue no Repair. Publish `BLOCKED` with Action required. Harlan decides whether to Dismiss.
 
 ## Deployment extension
 

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -231,6 +231,10 @@ A dismissed Item leaves the Queue. It stays visible under `Dismissed` in the Wat
 
 A Review Agent may write **Dismissal recommended** when the pull request premise is wrong. Use it when Repair would replace the pull request intent or require an unrelated root architecture rewrite.
 
+Review decides the premise once for the whole pull request. A wrong premise makes every Review finding a Dismissal recommendation. It never starts Repair.
+
+GitHub status, comments, and labels are durable workflow truth. The Journal stores local coordination and observability data.
+
 A recommendation never creates a Dismissal. Harlan decides whether to use `Dismiss`.
 
 Restoring queues nothing by itself. The next observation replans the Item from its current state.

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -63,7 +63,9 @@ The triage agent resumes its own session, selects the matching installed skills,
 
 Review stays read only. Repair starts fresh with every structured finding. It writes each failing regression test before its fix.
 
-If the pull request premise is wrong, Review recommends Dismissal. It never attempts an unrelated root architecture rewrite.
+Review decides the pull request premise once. A sound premise permits Repair. A wrong premise recommends Dismissal and never starts Repair.
+
+GitHub status, comments, and labels hold durable workflow truth. The local journal coordinates leases, Agent sessions, Recovery, and Review usage.
 
 Every published Repair head SHA gets a fresh Review. A repeated finding stops with Action required.
 

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -41,10 +41,13 @@ interface ReviewResponse {
     path: string
     proof: string
     regressionTest: string | null
-    resolution: 'repair' | 'dismiss'
     summary: string
   }>
   metadata: GateResponse
+  premise: {
+    reason: string
+    verdict: 'sound' | 'wrong'
+  }
   review: GateResponse
   verification: GateResponse
 }
@@ -100,14 +103,20 @@ Keep the worktree read only. Do not edit, stage, commit, push, or post comments.
 Return only the required JSON.
 
 Report the result this way:
+Decide the pull request premise before listing defects.
+A premise is sound only when safe fixes preserve the pull request's stated intent.
+A premise is wrong when safe work must reverse that intent, remove a safeguard, or add unrelated root architecture.
+Return premise verdict wrong when Repair would deepen the harmful premise or rewrite root architecture to compensate for it.
+Treat GitHub status, comments, and labels as durable workflow truth.
+Local state may still coordinate leases, Agent sessions, Recovery, and Review usage.
+Do not call GitHub-first workflow state a wrong premise by itself.
+Call the premise wrong when the pull request removes local coordination before the required GitHub-backed replacement exists.
+Return one evidence-based finding for every material consequence of a wrong premise.
 Return every material defect.
 Each finding needs a stable identity, exact path and line, proof, summary, and next action.
 Keep the identity stable across line changes.
-For resolution repair, describe one test that fails before Repair and passes after it.
-For resolution dismiss, return null for regressionTest.
-Use resolution dismiss only when the pull request has a wrong premise and Repair would replace its intent.
-Recommend Dismissal when Repair would require a root architecture rewrite outside that intent.
-Use resolution repair for every finding that can be fixed without replacing the pull request intent.
+For a sound premise, describe one test that fails before Repair and passes after it.
+For a wrong premise, return null for every regressionTest. The controller will recommend Dismissal.
 Return confidence as an integer from 0 to 100 when every gate you report passes.
 Return every field the schema names, including empty arrays and null.`
 const issuePolicy = `Work as a normal local agent session inside the prepared Git worktree. Use the user's global agent context, installed skills, environment, and authenticated GitHub CLI.
@@ -217,9 +226,18 @@ const gateSchema = {
 const reviewSchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['metadata', 'review', 'verification', 'findings', 'confidence'],
+  required: ['metadata', 'premise', 'review', 'verification', 'findings', 'confidence'],
   properties: {
     metadata: gateSchema,
+    premise: {
+      type: 'object',
+      additionalProperties: false,
+      required: ['verdict', 'reason'],
+      properties: {
+        verdict: { type: 'string', enum: ['sound', 'wrong'] },
+        reason: { type: 'string' },
+      },
+    },
     review: gateSchema,
     verification: gateSchema,
     findings: {
@@ -227,14 +245,13 @@ const reviewSchema = {
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['identity', 'path', 'line', 'proof', 'regressionTest', 'resolution', 'summary', 'nextAction'],
+        required: ['identity', 'path', 'line', 'proof', 'regressionTest', 'summary', 'nextAction'],
         properties: {
           identity: { type: 'string' },
           path: { type: 'string' },
           line: { type: ['integer', 'null'], minimum: 1 },
           proof: { type: 'string' },
           regressionTest: { type: ['string', 'null'] },
-          resolution: { type: 'string', enum: ['repair', 'dismiss'] },
           summary: { type: 'string' },
           nextAction: { type: 'string' },
         },
@@ -293,13 +310,19 @@ function parseReviewResponse(text: string): Promise<Result<ReviewResponse, strin
     .then(value => JSON.parse(value) as Record<string, unknown>)
     .then((value): Result<ReviewResponse, string> => {
       const metadata = parseGate(value.metadata)
+      const premise = typeof value.premise === 'object' && value.premise !== null
+        ? value.premise as Partial<ReviewResponse['premise']>
+        : undefined
       const review = parseGate(value.review)
       const verification = parseGate(value.verification)
       const findings = Array.isArray(value.findings) ? value.findings : undefined
       const confidence = value.confidence
       if (
-        metadata === undefined || review === undefined || verification === undefined
+        metadata === undefined || premise === undefined || review === undefined || verification === undefined
+        || (premise.verdict !== 'sound' && premise.verdict !== 'wrong')
+        || typeof premise.reason !== 'string' || cleanLine(premise.reason).length === 0
         || findings === undefined
+        || (premise.verdict === 'wrong' && findings.length === 0)
         || !findings.every((finding) => {
           if (typeof finding !== 'object' || finding === null)
             return false
@@ -308,8 +331,7 @@ function parseReviewResponse(text: string): Promise<Result<ReviewResponse, strin
             && typeof candidate.path === 'string' && cleanLine(candidate.path).length > 0
             && (candidate.line === null || (Number.isInteger(candidate.line) && (candidate.line ?? 0) >= 1))
             && typeof candidate.proof === 'string' && cleanLine(candidate.proof).length > 0
-            && (candidate.resolution === 'repair' || candidate.resolution === 'dismiss')
-            && (candidate.resolution === 'repair'
+            && (premise.verdict === 'sound'
               ? typeof candidate.regressionTest === 'string' && cleanLine(candidate.regressionTest).length > 0
               : candidate.regressionTest === null)
             && typeof candidate.summary === 'string' && cleanLine(candidate.summary).length > 0
@@ -322,6 +344,7 @@ function parseReviewResponse(text: string): Promise<Result<ReviewResponse, strin
       const reviewed = findings as ReviewResponse['findings']
       return ok({
         metadata,
+        premise: { verdict: premise.verdict, reason: cleanLine(premise.reason) },
         review,
         verification,
         confidence: typeof confidence === 'number' ? confidence : null,
@@ -333,7 +356,6 @@ function parseReviewResponse(text: string): Promise<Result<ReviewResponse, strin
           path: cleanLine(finding.path),
           proof: cleanLine(finding.proof),
           regressionTest: finding.regressionTest === null ? null : cleanLine(finding.regressionTest),
-          resolution: finding.resolution,
         })),
       })
     })
@@ -830,8 +852,8 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       let findings: ReviewFinding[] = response.findings.map(finding => ({
         _tag: 'Open',
         summary: finding.summary,
-        nextAction: finding.nextAction,
-        resolution: finding.resolution === 'dismiss' ? 'Dismissal' : 'Repair',
+        nextAction: response.premise.verdict === 'wrong' ? 'Dismiss this pull request.' : finding.nextAction,
+        resolution: response.premise.verdict === 'wrong' ? 'Dismissal' : 'Repair',
         details: {
           fingerprint: reviewFindingFingerprint(finding.identity),
           identity: finding.identity,

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -43,6 +43,7 @@ describe('subject Workers', () => {
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        premise: { verdict: 'sound', reason: 'The change can be repaired without replacing its intent.' },
         review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
         verification: { state: 'passed', reason: '', evidence: 'focused tests passed' },
         findings: [],
@@ -216,6 +217,7 @@ describe('subject Workers', () => {
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        premise: { verdict: 'sound', reason: 'The parser change remains valid after a focused fix.' },
         review: { state: 'failed', reason: 'The parser drops data.', evidence: 'focused reproduction proves the defect' },
         verification: { state: 'passed', reason: '', evidence: 'the regression test is specified' },
         findings: [{
@@ -224,7 +226,6 @@ describe('subject Workers', () => {
           line: 42,
           proof: 'A split UTF-8 sequence loses its first byte.',
           regressionTest: 'Split one UTF-8 sequence across two chunks and assert the original string.',
-          resolution: 'repair',
           summary: 'The parser drops data.',
           nextAction: 'Preserve the buffered bytes.',
         }],
@@ -310,6 +311,103 @@ describe('subject Workers', () => {
     expect(worktreeVerified).toBe(true)
   })
 
+  it('stamps a wrong premise for Dismissal without queuing Repair', async () => {
+    const repository = repositoryMapping({ ownership: 'maintained' })
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const comments: string[] = []
+    let attempt: RecordReviewRunInput | undefined
+    const worker = createReviewWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        review: { state: 'failed', reason: 'The premise removes required durability.', evidence: 'cross-process cleanup reads the persisted lease journal' },
+        verification: { state: 'passed', reason: '', evidence: 'the persistence boundary proves the premise is unsafe' },
+        premise: {
+          verdict: 'wrong',
+          reason: 'Safe worktree cleanup requires controller state shared across processes and restarts.',
+        },
+        findings: [{
+          identity: 'persisted-controller-state-removal',
+          path: 'src/store.ts',
+          line: 42,
+          proof: 'A second process sees no active leases when the journal uses private memory.',
+          regressionTest: null,
+          summary: 'The pull request removes state required for safe worktree cleanup.',
+          nextAction: 'Restore persistent journal storage.',
+        }],
+        confidence: null,
+      }))),
+      github: {
+        consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+        listPullRequestFiles: () => Promise.resolve(ok([])),
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [] },
+          body: 'Remove persisted controller state.',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' as const },
+          reviews: [],
+        })),
+        upsertIssueTriageComment: () => Promise.reject(new Error('Unexpected issue comment.')),
+        upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      store: {
+        queueReviewFixTaskForReview: () => { throw new Error('A wrong premise must not queue Repair work.') },
+        getRepairedHeadFindings: () => [],
+        getWorkerSession: () => null,
+        isBaselineRepairPullRequest: () => false,
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
+        queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
+        retireBaselineRepairForReview: () => 0,
+        recordReviewRun: (input) => {
+          attempt = input
+          return { _tag: 'Inserted', reviewRunId: input.id }
+        },
+        recordReviewPublication: input => ({ _tag: 'Inserted', publicationId: input.id }),
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      status: {
+        publish: (_task, _phase, body) => {
+          comments.push(body)
+          return Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      triageStatus: { publish: () => Promise.reject(new Error('Unexpected issue triage.')) },
+      workspaces: {
+        prepareIssue: () => Promise.reject(new Error('Unexpected issue workspace.')),
+        prepareReview: () => Promise.resolve(ok({ path: '/tmp/review-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+        verifyReview: () => Promise.resolve(ok(undefined)),
+      },
+    })
+
+    const result = await worker.run({
+      id: 'review-task',
+      kind: 'adversarial_review',
+      repository: repository.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-wrong-premise',
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: repository,
+      pullRequest,
+      rerun: { _tag: 'NotRequested' },
+    }, new AbortController().signal)
+
+    expect(result).toEqual(ok({ evidence: expect.any(String) }))
+    expect(attempt?.findings).toEqual([expect.objectContaining({
+      _tag: 'Open',
+      resolution: 'Dismissal',
+      nextAction: 'Dismiss this pull request.',
+    })])
+    expect(comments.at(-1)).toContain('Dismissal recommended')
+  })
+
   it('gives a fresh Review the identities its repaired head already reported', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const capture: ProviderCapture = { requests: [] }
@@ -317,6 +415,7 @@ describe('subject Workers', () => {
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        premise: { verdict: 'sound', reason: 'The parser change remains valid after a focused fix.' },
         review: { state: 'failed', reason: 'The parser drops data.', evidence: 'focused reproduction proves the defect' },
         verification: { state: 'passed', reason: '', evidence: 'the regression test is specified' },
         findings: [{
@@ -325,7 +424,6 @@ describe('subject Workers', () => {
           line: 42,
           proof: 'A split UTF-8 sequence loses its first byte.',
           regressionTest: 'Split one UTF-8 sequence across two chunks and assert the original string.',
-          resolution: 'repair',
           summary: 'The parser still drops data on split UTF-8 sequences.',
           nextAction: 'Preserve the buffered bytes.',
         }],
@@ -492,6 +590,7 @@ describe('subject Workers', () => {
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        premise: { verdict: 'sound', reason: 'The change can remain intact.' },
         review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
         verification: { state: 'passed', reason: '', evidence: 'build passes' },
         findings: [],
@@ -574,6 +673,7 @@ describe('subject Workers', () => {
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        premise: { verdict: 'sound', reason: 'The change can remain intact.' },
         review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
         verification: { state: 'passed', reason: '', evidence: 'build passes' },
         findings: [],
@@ -653,6 +753,7 @@ describe('subject Workers', () => {
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+        premise: { verdict: 'sound', reason: 'The change can remain intact.' },
         review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
         verification: { state: 'passed', reason: '', evidence: 'build passes with the fix' },
         findings: [],

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -10,6 +10,7 @@ import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEve
 
 const cleanReview = {
   metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+  premise: { verdict: 'sound', reason: 'The change can remain intact.' },
   review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
   verification: { state: 'passed', reason: '', evidence: 'focused tests passed' },
   findings: [],

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -10,17 +10,17 @@ import { err, ok } from '../src/result.ts'
 import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
 const passingGate = { state: 'passed' as const, reason: '', evidence: 'checked' }
+const soundPremise = { verdict: 'sound' as const, reason: 'The change can be repaired without replacing its intent.' }
 
-function materialFinding(resolution: 'repair' | 'dismiss' = 'repair') {
+function materialFinding() {
   return {
     identity: 'unsafe-parser-boundary',
     path: 'src/parser.ts',
     line: 42,
     proof: 'Malformed input reaches the unsafe parser branch.',
-    regressionTest: resolution === 'dismiss' ? null : 'Pass malformed input and assert a tagged rejection.',
-    resolution,
+    regressionTest: 'Pass malformed input and assert a tagged rejection.',
     summary: 'Malformed input crosses the parser boundary.',
-    nextAction: resolution === 'dismiss' ? 'Dismiss this pull request.' : 'Parse input before use.',
+    nextAction: 'Parse input before use.',
   }
 }
 
@@ -80,7 +80,11 @@ function harness(input: {
   let read = 0
 
   const options: ReviewWorkerOptions = {
-    runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(input.response), provider)),
+    runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(
+      typeof input.response === 'object' && input.response !== null
+        ? { premise: soundPremise, ...input.response }
+        : input.response,
+    ), provider)),
     github: {
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
@@ -493,15 +497,37 @@ describe('review resilience', () => {
     expect(test.comments.at(-1)).toContain(refusal)
   })
 
+  it('rejects a wrong premise that still asks for Repair', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const test = harness({
+      pullRequest,
+      response: {
+        premise: { verdict: 'wrong', reason: 'Safe repair would reverse the pull request intent.' },
+        metadata: passingGate,
+        review: { state: 'failed', reason: 'The pull request premise is wrong.', evidence: 'architecture trace' },
+        verification: passingGate,
+        findings: [materialFinding()],
+        confidence: null,
+      },
+    })
+
+    const result = await createReviewWorker(test.options).run(reviewTask(pullRequest), new AbortController().signal)
+
+    expect(result).toEqual(err('The agent returned an invalid adversarial review result.'))
+    expect(test.queued).toBe(0)
+    expect(test.attempts).toEqual([])
+  })
+
   it('recommends Dismissal instead of repairing a wrong premise', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const test = harness({
       pullRequest,
       response: {
+        premise: { verdict: 'wrong', reason: 'Safe repair would restore the architecture this pull request removes.' },
         metadata: passingGate,
         review: { state: 'failed', reason: 'The pull request premise is wrong.', evidence: 'architecture trace' },
         verification: passingGate,
-        findings: [materialFinding('dismiss')],
+        findings: [{ ...materialFinding(), regressionTest: null }],
         confidence: null,
       },
     })

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -11,6 +11,7 @@ import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEve
 
 const cleanReview = {
   metadata: { state: 'passed', reason: '', evidence: 'metadata aligned' },
+  premise: { verdict: 'sound', reason: 'The change can remain intact.' },
   review: { state: 'passed', reason: '', evidence: 'full diff reviewed' },
   verification: { state: 'passed', reason: '', evidence: 'focused tests passed' },
   findings: [],


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Review chose Repair per finding. Live dogfood showed that a wrong pull request premise could still start Repair.

Review now decides the premise once. A sound premise permits Repair. A wrong premise forces Dismissal and blocks Repair. GitHub status, comments, and labels remain the durable workflow truth.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
