### PR TITLE
fix(github-agent): explain a queued Task on its comment

### DIFF
--- a/packages/harlan-github-agent/src/approval-controller.ts
+++ b/packages/harlan-github-agent/src/approval-controller.ts
@@ -80,7 +80,7 @@ export function createApprovalController(options: ApprovalControllerOptions): Ap
         // went on asking after the label arrived, because no Task exists yet to
         // own it. Recording it hands it to the sweep that corrects stale
         // comments once the review joins the Queue.
-        options.store.recordApprovalPromptComment({
+        const recorded = options.store.recordApprovalPromptComment({
           repository: repository.github,
           pullRequestNumber: pullRequest.number,
           revisionId,
@@ -88,6 +88,8 @@ export function createApprovalController(options: ApprovalControllerOptions): Ap
           body,
           at: options.now().toISOString(),
         })
+        if (!recorded)
+          return err(`The REVIEW PAUSED prompt for ${repository.github}#${pullRequest.number} could not be recorded.`)
         return ok(undefined)
       }
 

--- a/packages/harlan-github-agent/src/approval-controller.ts
+++ b/packages/harlan-github-agent/src/approval-controller.ts
@@ -13,7 +13,7 @@ export interface ApprovalController {
 export interface ApprovalControllerOptions {
   github: Pick<GitHubAgentSource, 'consumeApprovalLabel' | 'ensureApprovalLabel' | 'upsertReviewStatus'>
   now: () => Date
-  store: Pick<JournalStore, 'approveIssueWork' | 'approvePullRequest' | 'getSelectionMode' | 'hasPullRequestApproval' | 'isIssueWorkApprovalReady'>
+  store: Pick<JournalStore, 'approveIssueWork' | 'approvePullRequest' | 'getSelectionMode' | 'hasPullRequestApproval' | 'isIssueWorkApprovalReady' | 'recordApprovalPromptComment'>
 }
 
 function approvalPrompt(label: string, headSha: string): string {
@@ -72,7 +72,23 @@ export function createApprovalController(options: ApprovalControllerOptions): Ap
         const available = await options.github.ensureApprovalLabel(repository, label, signal)
         if (available._tag === 'Err')
           return available
-        return options.github.upsertReviewStatus(repository, pullRequest.number, null, approvalPrompt(label, pullRequest.headSha), false, signal).then(result => result._tag === 'Err' ? result : ok(undefined))
+        const body = approvalPrompt(label, pullRequest.headSha)
+        const posted = await options.github.upsertReviewStatus(repository, pullRequest.number, null, body, false, signal)
+        if (posted._tag === 'Err')
+          return posted
+        // This comment asks for a label and then has nothing left to say. It
+        // went on asking after the label arrived, because no Task exists yet to
+        // own it. Recording it hands it to the sweep that corrects stale
+        // comments once the review joins the Queue.
+        options.store.recordApprovalPromptComment({
+          repository: repository.github,
+          pullRequestNumber: pullRequest.number,
+          revisionId,
+          commentId: posted.value.commentId,
+          body,
+          at: options.now().toISOString(),
+        })
+        return ok(undefined)
       }
 
       const approved = options.store.approvePullRequest({

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -157,6 +157,11 @@ export interface PublishedReviewStatus {
   url: string
 }
 
+/** `Missing` means a person deleted the comment, so there is nothing to correct. */
+export type EditedReviewStatus
+  = | { _tag: 'Edited', commentId: number, url: string }
+    | { _tag: 'Missing' }
+
 export interface GitHubAgentSource {
   consumeApprovalLabel: (repository: RepositoryMapping, subjectKind: 'issue' | 'pull_request', itemNumber: number, label: string, signal: AbortSignal) => Promise<Result<void, string>>
   ensureApprovalLabel: (repository: RepositoryMapping, label: string, signal: AbortSignal) => Promise<Result<void, string>>
@@ -166,6 +171,15 @@ export interface GitHubAgentSource {
   /** Every file one open pull request changes, which decides whether new work stacks on it. */
   listPullRequestFiles: (repository: RepositoryMapping, pullRequestNumber: number, signal: AbortSignal) => Promise<Result<string[], string>>
   upsertIssueTriageComment: (repository: RepositoryMapping, issueNumber: number, commentId: number | null, body: string, signal: AbortSignal) => Promise<Result<PublishedReviewStatus, string>>
+  /**
+   * Rewrites one comment this service already posted, and only that.
+   *
+   * `upsertReviewStatus` opens a comment when the stored identifier is gone,
+   * which is right for a review that owns its comment and wrong for a sweep
+   * correcting an old one: deleting the comment would bring it straight back.
+   * A missing comment is an outcome here, not a failure.
+   */
+  editReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, body: string, signal: AbortSignal) => Promise<Result<EditedReviewStatus, string>>
   upsertReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number | null, body: string, replacePriorReview: boolean, signal: AbortSignal) => Promise<Result<PublishedReviewStatus, string>>
 }
 
@@ -185,6 +199,10 @@ function repositoryParts(repository: string): { owner: string, repo: string } {
 
 function message(error: unknown): string {
   return error instanceof Error ? error.message : 'GitHub request failed.'
+}
+
+function isMissingComment(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'status' in error && (error as { status: unknown }).status === 404
 }
 
 /** GitHub's own app slug for Actions. Only its check run id is also a job id. */
@@ -515,6 +533,29 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
             : [{ body: review.body, createdAt: review.submitted_at ?? '' }])),
         })
       }).catch((error: unknown) => err(message(error)))
+    },
+
+    async editReviewStatus(repository, pullRequestNumber, commentId, body, signal) {
+      const octokit = await client(repository.github, 'item_write', signal)
+      if (octokit._tag === 'Err')
+        return octokit
+      const { owner, repo } = repositoryParts(repository.github)
+      const requestOptions = { request: { signal } }
+      const actor = options.actorLogin(repository).toLowerCase()
+      return octokit.value.rest.issues.getComment({ owner, repo, comment_id: commentId, ...requestOptions })
+        .then(async (existing) => {
+          if (existing.data.user?.login.toLowerCase() !== actor)
+            return err('The stored automated review comment belongs to another GitHub actor.')
+          if (existing.data.issue_url !== undefined && !existing.data.issue_url.endsWith(`/${pullRequestNumber}`))
+            return err('The stored automated review comment belongs to another pull request.')
+          if (existing.data.body === body && existing.data.html_url !== undefined)
+            return ok({ _tag: 'Edited' as const, commentId: existing.data.id, url: existing.data.html_url })
+          const written = await octokit.value.rest.issues.updateComment({ owner, repo, comment_id: commentId, body, ...requestOptions })
+          if (written.data.user?.login.toLowerCase() !== actor || written.data.body !== body)
+            return err('GitHub did not confirm the edited automated review comment.')
+          return ok({ _tag: 'Edited' as const, commentId: written.data.id, url: written.data.html_url })
+        })
+        .catch((error: unknown) => isMissingComment(error) ? ok({ _tag: 'Missing' as const }) : err(message(error)))
     },
 
     async upsertReviewStatus(repository, pullRequestNumber, commentId, body, replacePriorReview, signal) {

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -183,11 +183,14 @@ export interface GitHubAgentSource {
    * correcting an old one: deleting the comment would bring it straight back.
    * A missing comment is an outcome here, not a failure.
    *
-   * The write is a compare and swap against `expectedBody`. A sweep reads the
-   * Queue, then spends two round trips reaching this call, and an agent can
-   * claim the Task and publish its own progress inside that window. Comparing
-   * what GitHub holds is the only check that cannot be overtaken, because
-   * GitHub applies it at the moment of the write.
+   * The write is a compare and swap against `expectedBody`, but GitHub's REST
+   * API applies no precondition at write time, so the swap is a client side
+   * read then write. A sweep reads the Queue, then spends round trips reaching
+   * this call, and an agent that claims the Task can publish its own progress
+   * inside that window; this call would overwrite it without knowing. The read
+   * back after the write reports `Changed` when the comment no longer holds
+   * what was written, which catches a writer that landed after the edit, but
+   * the window between the read and the write cannot be closed here.
    */
   editReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, expectedBody: string, body: string, signal: AbortSignal) => Promise<Result<EditedReviewStatus, string>>
   upsertReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number | null, body: string, replacePriorReview: boolean, signal: AbortSignal) => Promise<Result<PublishedReviewStatus, string>>
@@ -562,10 +565,16 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
             return ok({ _tag: 'Edited' as const, commentId: existing.data.id, url: existing.data.html_url })
           if (existing.data.body !== expectedBody)
             return ok({ _tag: 'Changed' as const })
-          const written = await octokit.value.rest.issues.updateComment({ owner, repo, comment_id: commentId, body, ...requestOptions })
-          if (written.data.user?.login.toLowerCase() !== actor || written.data.body !== body)
+          await octokit.value.rest.issues.updateComment({ owner, repo, comment_id: commentId, body, ...requestOptions })
+          // The compare and swap above is a client side read then write, so a
+          // concurrent writer can land between the two. Reading back is the
+          // only way to see that the written body no longer holds.
+          const confirmed = await octokit.value.rest.issues.getComment({ owner, repo, comment_id: commentId, ...requestOptions })
+          if (confirmed.data.user?.login.toLowerCase() !== actor)
             return err('GitHub did not confirm the edited automated review comment.')
-          return ok({ _tag: 'Edited' as const, commentId: written.data.id, url: written.data.html_url })
+          if (confirmed.data.body !== body)
+            return ok({ _tag: 'Changed' as const })
+          return ok({ _tag: 'Edited' as const, commentId: confirmed.data.id, url: confirmed.data.html_url })
         })
         .catch((error: unknown) => isMissingComment(error) ? ok({ _tag: 'Missing' as const }) : err(message(error)))
     },

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -157,9 +157,13 @@ export interface PublishedReviewStatus {
   url: string
 }
 
-/** `Missing` means a person deleted the comment, so there is nothing to correct. */
+/**
+ * `Missing` means a person deleted the comment, so there is nothing to correct.
+ * `Changed` means somebody wrote it after the caller last read it.
+ */
 export type EditedReviewStatus
   = | { _tag: 'Edited', commentId: number, url: string }
+    | { _tag: 'Changed' }
     | { _tag: 'Missing' }
 
 export interface GitHubAgentSource {
@@ -178,8 +182,14 @@ export interface GitHubAgentSource {
    * which is right for a review that owns its comment and wrong for a sweep
    * correcting an old one: deleting the comment would bring it straight back.
    * A missing comment is an outcome here, not a failure.
+   *
+   * The write is a compare and swap against `expectedBody`. A sweep reads the
+   * Queue, then spends two round trips reaching this call, and an agent can
+   * claim the Task and publish its own progress inside that window. Comparing
+   * what GitHub holds is the only check that cannot be overtaken, because
+   * GitHub applies it at the moment of the write.
    */
-  editReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, body: string, signal: AbortSignal) => Promise<Result<EditedReviewStatus, string>>
+  editReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, expectedBody: string, body: string, signal: AbortSignal) => Promise<Result<EditedReviewStatus, string>>
   upsertReviewStatus: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number | null, body: string, replacePriorReview: boolean, signal: AbortSignal) => Promise<Result<PublishedReviewStatus, string>>
 }
 
@@ -535,7 +545,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
       }).catch((error: unknown) => err(message(error)))
     },
 
-    async editReviewStatus(repository, pullRequestNumber, commentId, body, signal) {
+    async editReviewStatus(repository, pullRequestNumber, commentId, expectedBody, body, signal) {
       const octokit = await client(repository.github, 'item_write', signal)
       if (octokit._tag === 'Err')
         return octokit
@@ -550,6 +560,8 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
             return err('The stored automated review comment belongs to another pull request.')
           if (existing.data.body === body && existing.data.html_url !== undefined)
             return ok({ _tag: 'Edited' as const, commentId: existing.data.id, url: existing.data.html_url })
+          if (existing.data.body !== expectedBody)
+            return ok({ _tag: 'Changed' as const })
           const written = await octokit.value.rest.issues.updateComment({ owner, repo, comment_id: commentId, body, ...requestOptions })
           if (written.data.user?.login.toLowerCase() !== actor || written.data.body !== body)
             return err('GitHub did not confirm the edited automated review comment.')

--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -1,0 +1,115 @@
+import type { GitHubAgentSource } from './github-agent-source.ts'
+import type { Result } from './result.ts'
+import type { JournalStore, QueuedReviewStatus } from './store.ts'
+import type { RepositoryMapping } from './types.ts'
+import { formatProgressBar } from './agent-progress.ts'
+import { err, ok } from './result.ts'
+import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
+
+const workLabel: Record<QueuedReviewStatus['taskKind'], string> = {
+  adversarial_review: 'Review',
+  review_fix: 'Repair',
+}
+
+function ordinal(position: number): string {
+  const teen = position % 100
+  if (teen >= 11 && teen <= 13)
+    return `${position}th`
+  const suffix = { 1: 'st', 2: 'nd', 3: 'rd' }[position % 10] ?? 'th'
+  return `${position}${suffix}`
+}
+
+/**
+ * The canonical comment while its Task waits in the Queue.
+ *
+ * No timestamp and no estimate. The comment carries one changing fact, the
+ * Queue position, so an unchanged position renders an identical body and the
+ * sweep writes nothing. A timestamp here would edit every comment every pass.
+ */
+export function queuePositionComment(status: QueuedReviewStatus): string {
+  const work = workLabel[status.taskKind]
+  const ahead = status.position - 1
+  const next = ahead === 0
+    ? `${work} starts as soon as an agent is free.`
+    : ahead === 1
+      ? `${work} starts after the 1 Task ahead of it finishes.`
+      : `${work} starts after the ${ahead} Tasks ahead of it finish.`
+  return `${AUTOMATED_REVIEW_MARKER}
+<!-- reviewed-sha: ${status.headSha} -->
+### 🤖 QUEUED · ${ordinal(status.position)} of ${status.total}
+
+> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). This comment updates as the Queue moves.
+
+\`${formatProgressBar(0)}\`
+
+Next: ${next}`
+}
+
+export interface QueuePositionSweepOptions {
+  github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
+  now: () => Date
+  repositories: RepositoryMapping[]
+  store: Pick<JournalStore, 'listQueuedReviewStatuses' | 'recordQueuedReviewStatus'>
+}
+
+export type QueuePositionOutcome
+  = | { _tag: 'Published', repository: string, pullRequestNumber: number, position: number, total: number }
+    | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
+
+/**
+ * Tells a waiting pull request where its Task sits in the Queue.
+ *
+ * A Review that queues a Repair leaves its comment reading "Repair queued" and
+ * says nothing more, so a pull request behind six other Tasks looked identical
+ * to one an agent was about to pick up. The position comes from the claim
+ * predicate itself, so it is the count of Tasks that must finish first.
+ *
+ * Only a comment this service already published is rewritten. The edit cannot
+ * open a comment, so a quiet pull request stays quiet and a comment a person
+ * deleted stays deleted.
+ */
+export async function publishQueuePositions(
+  options: QueuePositionSweepOptions,
+  signal: AbortSignal,
+): Promise<Array<Result<QueuePositionOutcome, string>>> {
+  const mappings = new Map(options.repositories.map(mapping => [mapping.github.toLowerCase(), mapping]))
+  const changed = options.store.listQueuedReviewStatuses()
+    .filter(status => queuePositionComment(status) !== status.publishedBody)
+  return Promise.all(changed.map(async (status): Promise<Result<QueuePositionOutcome, string>> => {
+    const mapping = mappings.get(status.repository.toLowerCase())
+    if (mapping === undefined)
+      return err(`${status.repository}: the repository is no longer configured.`)
+    const current = await options.github.getPullRequestReviewSnapshot(mapping, status.pullRequestNumber, signal)
+    if (current._tag === 'Err')
+      return err(`${status.repository}#${status.pullRequestNumber}: ${current.error}`)
+    if (current.value.pullRequest.state !== 'open' || current.value.pullRequest.headSha !== status.headSha)
+      return err(`${status.repository}#${status.pullRequestNumber}: the pull request changed before the Queue position comment.`)
+
+    const at = options.now().toISOString()
+    const body = queuePositionComment(status)
+    const edited = await options.github.editReviewStatus(mapping, status.pullRequestNumber, status.commentId, body, signal)
+    if (edited._tag === 'Err')
+      return err(`${status.repository}#${status.pullRequestNumber}: ${edited.error}`)
+    if (edited.value._tag === 'Missing')
+      return ok({ _tag: 'CommentGone', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
+    const recorded = options.store.recordQueuedReviewStatus({
+      taskId: status.taskId,
+      taskKind: status.taskKind,
+      revisionId: status.revisionId,
+      expectedHeadSha: status.headSha,
+      body,
+      at,
+      commentId: edited.value.commentId,
+      url: edited.value.url,
+    })
+    return recorded
+      ? ok({
+          _tag: 'Published',
+          repository: status.repository,
+          pullRequestNumber: status.pullRequestNumber,
+          position: status.position,
+          total: status.total,
+        })
+      : err(`${status.repository}#${status.pullRequestNumber}: the Queue position comment could not be saved.`)
+  }))
+}

--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -49,12 +49,13 @@ export interface QueuePositionSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listQueuedReviewStatuses' | 'recordQueuedReviewStatus'>
+  store: Pick<JournalStore, 'isQueuedReviewStatus' | 'listQueuedReviewStatuses' | 'recordQueuedReviewStatus'>
 }
 
 export type QueuePositionOutcome
   = | { _tag: 'Published', repository: string, pullRequestNumber: number, position: number, total: number }
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
+    | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
 
 /**
  * Tells a waiting pull request where its Task sits in the Queue.
@@ -67,6 +68,11 @@ export type QueuePositionOutcome
  * Only a comment this service already published is rewritten. The edit cannot
  * open a comment, so a quiet pull request stays quiet and a comment a person
  * deleted stays deleted.
+ *
+ * An agent can claim the Task between the Queue read and the comment write,
+ * because both GitHub round trips sit in between. The claim is re-checked
+ * synchronously before the write, and a claim lost during the write is reported
+ * as Superseded, so an active review's comment never keeps a stale QUEUED body.
  */
 export async function publishQueuePositions(
   options: QueuePositionSweepOptions,
@@ -79,6 +85,8 @@ export async function publishQueuePositions(
     const mapping = mappings.get(status.repository.toLowerCase())
     if (mapping === undefined)
       return err(`${status.repository}: the repository is no longer configured.`)
+    if (!options.store.isQueuedReviewStatus({ taskId: status.taskId, taskKind: status.taskKind }))
+      return ok({ _tag: 'Superseded', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
     const current = await options.github.getPullRequestReviewSnapshot(mapping, status.pullRequestNumber, signal)
     if (current._tag === 'Err')
       return err(`${status.repository}#${status.pullRequestNumber}: ${current.error}`)
@@ -110,6 +118,8 @@ export async function publishQueuePositions(
           position: status.position,
           total: status.total,
         })
-      : err(`${status.repository}#${status.pullRequestNumber}: the Queue position comment could not be saved.`)
+      // The claim was lost while the edit was in flight, so the claimed agent
+      // now owns the comment. Nothing was saved and nothing needs to be.
+      : ok({ _tag: 'Superseded', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
   }))
 }

--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -70,9 +70,10 @@ export type QueuePositionOutcome
  * deleted stays deleted.
  *
  * An agent can claim the Task between the Queue read and the comment write,
- * because both GitHub round trips sit in between. The claim is re-checked
- * synchronously before the write, and a claim lost during the write is reported
- * as Superseded, so an active review's comment never keeps a stale QUEUED body.
+ * because both GitHub round trips sit in between. No local check closes that
+ * window: whatever it reads can go stale before the write lands. The edit is a
+ * compare and swap against the body the Queue read saw, so a claimed agent that
+ * published first keeps its comment and this sweep reports Superseded.
  */
 export async function publishQueuePositions(
   options: QueuePositionSweepOptions,
@@ -95,11 +96,13 @@ export async function publishQueuePositions(
 
     const at = options.now().toISOString()
     const body = queuePositionComment(status)
-    const edited = await options.github.editReviewStatus(mapping, status.pullRequestNumber, status.commentId, body, signal)
+    const edited = await options.github.editReviewStatus(mapping, status.pullRequestNumber, status.commentId, status.publishedBody, body, signal)
     if (edited._tag === 'Err')
       return err(`${status.repository}#${status.pullRequestNumber}: ${edited.error}`)
     if (edited.value._tag === 'Missing')
       return ok({ _tag: 'CommentGone', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
+    if (edited.value._tag === 'Changed')
+      return ok({ _tag: 'Superseded', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
     const recorded = options.store.recordQueuedReviewStatus({
       taskId: status.taskId,
       taskKind: status.taskKind,

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -10,6 +10,7 @@ import { cleanLine, updatedAtLabel } from './text.ts'
 export type StoppedReviewOutcome
   = | { _tag: 'Published', repository: string, pullRequestNumber: number }
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
+    | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
 
 export interface ReviewStopSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
@@ -75,11 +76,13 @@ export async function publishStoppedReviews(
 
     const at = options.now().toISOString()
     const body = stoppedReviewComment(review, at)
-    const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, body, signal)
+    const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, review.publishedBody, body, signal)
     if (edited._tag === 'Err')
       return err(`${review.repository}#${review.pullRequestNumber}: ${edited.error}`)
     if (edited.value._tag === 'Missing')
       return ok({ _tag: 'CommentGone', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
+    if (edited.value._tag === 'Changed')
+      return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     const recorded = options.store.recordStoppedReviewStatus({
       taskId: review.taskId,
       taskKind: review.taskKind,

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -7,8 +7,12 @@ import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
 import { cleanLine, updatedAtLabel } from './text.ts'
 
+export type StoppedReviewOutcome
+  = | { _tag: 'Published', repository: string, pullRequestNumber: number }
+    | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
+
 export interface ReviewStopSweepOptions {
-  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'upsertReviewStatus'>
+  github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
   store: Pick<JournalStore, 'listStoppedReviews' | 'recordStoppedReviewStatus'>
@@ -49,14 +53,17 @@ Push a new commit or ask for a review rerun to start a new review.`
  *
  * A review writes one canonical comment as it works. When its Task dies, that
  * comment keeps claiming a review is running, so the controller closes it out.
+ *
+ * The write is an edit, never an open. A person who deletes the stale comment
+ * has answered it, and posting it again would overrule them.
  */
 export async function publishStoppedReviews(
   options: ReviewStopSweepOptions,
   signal: AbortSignal,
-): Promise<Array<Result<{ repository: string, pullRequestNumber: number }, string>>> {
+): Promise<Array<Result<StoppedReviewOutcome, string>>> {
   const mappings = new Map(options.repositories.map(mapping => [mapping.github.toLowerCase(), mapping]))
   const reviews = options.store.listStoppedReviews()
-  return Promise.all(reviews.map(async (review): Promise<Result<{ repository: string, pullRequestNumber: number }, string>> => {
+  return Promise.all(reviews.map(async (review): Promise<Result<StoppedReviewOutcome, string>> => {
     const mapping = mappings.get(review.repository.toLowerCase())
     if (mapping === undefined)
       return err(`${review.repository}: the repository is no longer configured.`)
@@ -68,9 +75,11 @@ export async function publishStoppedReviews(
 
     const at = options.now().toISOString()
     const body = stoppedReviewComment(review, at)
-    const published = await options.github.upsertReviewStatus(mapping, review.pullRequestNumber, review.commentId, body, false, signal)
-    if (published._tag === 'Err')
-      return err(`${review.repository}#${review.pullRequestNumber}: ${published.error}`)
+    const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, body, signal)
+    if (edited._tag === 'Err')
+      return err(`${review.repository}#${review.pullRequestNumber}: ${edited.error}`)
+    if (edited.value._tag === 'Missing')
+      return ok({ _tag: 'CommentGone', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     const recorded = options.store.recordStoppedReviewStatus({
       taskId: review.taskId,
       taskKind: review.taskKind,
@@ -78,11 +87,11 @@ export async function publishStoppedReviews(
       expectedHeadSha: review.headSha,
       body,
       at,
-      commentId: published.value.commentId,
-      url: published.value.url,
+      commentId: edited.value.commentId,
+      url: edited.value.url,
     })
     return recorded
-      ? ok({ repository: review.repository, pullRequestNumber: review.pullRequestNumber })
+      ? ok({ _tag: 'Published', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
       : err(`${review.repository}#${review.pullRequestNumber}: the final review comment could not be saved.`)
   }))
 }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -31,6 +31,7 @@ import { createOpencodeProvider } from './opencode-provider.ts'
 import { createPoller } from './poller.ts'
 import { createPublicationScheduler } from './publication-scheduler.ts'
 import { createPullRequestStatusController } from './pull-request-status-controller.ts'
+import { publishQueuePositions } from './queue-position-sweep.ts'
 import { reconcileAllRepositories } from './reconcile.ts'
 import { buildRepositoryMappings, discoverGitHubAppRepositories, discoverLocalCheckouts, discoverUserRepositories, installedWithoutCheckout } from './repository-discovery.ts'
 import { err, ok } from './result.ts'
@@ -505,11 +506,30 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         }, signal)
         stopped.forEach((result) => {
           if (result._tag === 'Ok') {
-            options.logger.info(`${result.value.repository}#${result.value.pullRequestNumber}: closed the stopped review comment.`)
+            options.logger.info(result.value._tag === 'CommentGone'
+              ? `${result.value.repository}#${result.value.pullRequestNumber}: the stopped review comment was deleted, so nothing was written.`
+              : `${result.value.repository}#${result.value.pullRequestNumber}: closed the stopped review comment.`)
           }
           else {
             options.logger.error(`Stopped review comment: ${result.error}`)
             recordServiceIncident('stopped_review_comment', result.error)
+          }
+        })
+        const positions = await publishQueuePositions({
+          github: workerGithub,
+          now,
+          repositories: config.repositories,
+          store,
+        }, signal)
+        positions.forEach((result) => {
+          if (result._tag === 'Ok') {
+            options.logger.info(result.value._tag === 'CommentGone'
+              ? `${result.value.repository}#${result.value.pullRequestNumber}: the automated comment was deleted, so nothing was written.`
+              : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.position} of ${result.value.total}.`)
+          }
+          else {
+            options.logger.error(`Queue position comment: ${result.error}`)
+            recordServiceIncident('queue_position_comment', result.error)
           }
         })
       }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -525,7 +525,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           if (result._tag === 'Ok') {
             options.logger.info(result.value._tag === 'CommentGone'
               ? `${result.value.repository}#${result.value.pullRequestNumber}: the automated comment was deleted, so nothing was written.`
-              : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.position} of ${result.value.total}.`)
+              : result.value._tag === 'Superseded'
+                ? `${result.value.repository}#${result.value.pullRequestNumber}: an agent claimed the Task, so the Queue position comment was left to it.`
+                : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.position} of ${result.value.total}.`)
           }
           else {
             options.logger.error(`Queue position comment: ${result.error}`)

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -508,7 +508,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           if (result._tag === 'Ok') {
             options.logger.info(result.value._tag === 'CommentGone'
               ? `${result.value.repository}#${result.value.pullRequestNumber}: the stopped review comment was deleted, so nothing was written.`
-              : `${result.value.repository}#${result.value.pullRequestNumber}: closed the stopped review comment.`)
+              : result.value._tag === 'Superseded'
+                ? `${result.value.repository}#${result.value.pullRequestNumber}: another writer took the comment, so it was left alone.`
+                : `${result.value.repository}#${result.value.pullRequestNumber}: closed the stopped review comment.`)
           }
           else {
             options.logger.error(`Stopped review comment: ${result.error}`)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -520,6 +520,14 @@ export interface JournalStore {
     commentId: number
     url: string
   }) => boolean
+  /**
+   * True while the Task is still Queued, so a sweep may still write for it.
+   *
+   * The Queue read and the comment write are separated by GitHub round trips,
+   * during which an agent can claim the Task. This check is synchronous, so a
+   * sweep that sees false here has lost the comment to the claimed agent.
+   */
+  isQueuedReviewStatus: (input: { taskId: string, taskKind: 'adversarial_review' | 'review_fix' }) => boolean
   recordStoppedReviewStatus: (input: {
     taskId: string
     taskKind: 'adversarial_review' | 'review_fix'
@@ -6874,6 +6882,14 @@ export function openJournalStore(
     findings: JSON.parse(row.findings) as ReviewFinding[],
   }))
 
+  const isQueuedReviewStatus: JournalStore['isQueuedReviewStatus'] = (input) => {
+    const taskTable = input.taskKind === 'adversarial_review' ? 'worker_tasks' : 'tasks'
+    return database.prepare(`
+      SELECT 1 FROM ${taskTable}
+      WHERE id = ? AND kind = ? AND state_tag = 'Queued'
+    `).get(input.taskId, input.taskKind) !== undefined
+  }
+
   const recordStoppedReviewStatus: JournalStore['recordStoppedReviewStatus'] = (input) => {
     const bodySha256 = digest(input.body)
     const commandId = digest(`${input.taskKind}:${input.taskId}:stopped:${bodySha256}`)
@@ -7044,6 +7060,7 @@ export function openJournalStore(
     recordApprovalPromptComment,
     listStoppedReviews,
     recordQueuedReviewStatus,
+    isQueuedReviewStatus,
     recordStoppedReviewStatus,
     approvePullRequest,
     authorizePublication,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -326,6 +326,35 @@ export interface StoppedReview {
   findings: ReviewFinding[]
 }
 
+interface QueuedReviewStatusRow {
+  task_id: string
+  task_kind: 'adversarial_review' | 'review_fix'
+  repository: string
+  github_number: number
+  revision_id: string
+  head_sha: string
+  position: number
+  total: number
+  github_comment_id: number
+  published_body: string
+}
+
+export interface QueuedReviewStatus {
+  taskId: string
+  taskKind: 'adversarial_review' | 'review_fix'
+  repository: string
+  pullRequestNumber: number
+  revisionId: string
+  headSha: string
+  /** 1 for the Task the next free agent claims. */
+  position: number
+  /** Claimable queued Tasks of the same kind, this one included. */
+  total: number
+  commentId: number
+  /** What the canonical comment holds now, so an unchanged position writes nothing. */
+  publishedBody: string
+}
+
 export type RecordObservationResult
   = | { _tag: 'Inserted', revisionId: string }
     | { _tag: 'Duplicate', revisionId: string }
@@ -457,8 +486,40 @@ export interface JournalStore {
    * worktree still in use from one nothing will touch again.
    */
   listActiveTaskLeases: () => AgentWorktreeLease[]
+  /**
+   * Queued Tasks whose pull request already carries a canonical comment.
+   *
+   * Position comes from the same predicate and order the claim uses, so the
+   * number a person reads is the number of Tasks that must finish first.
+   */
+  listQueuedReviewStatuses: () => QueuedReviewStatus[]
   /** Reviews that stopped without a final comment, so the pull request still claims one is running. */
   listStoppedReviews: () => StoppedReview[]
+  /**
+   * Records the Approval prompt comment, so a sweep can correct it later.
+   *
+   * No Task exists while a pull request waits for Approval, so this comment has
+   * no Task to own it and nothing to hang a review status command on.
+   */
+  recordApprovalPromptComment: (input: {
+    repository: string
+    pullRequestNumber: number
+    revisionId: string
+    commentId: number
+    body: string
+    at: string
+  }) => boolean
+  /** Records the Queue position this service published on the canonical comment. */
+  recordQueuedReviewStatus: (input: {
+    taskId: string
+    taskKind: 'adversarial_review' | 'review_fix'
+    revisionId: string
+    expectedHeadSha: string
+    body: string
+    at: string
+    commentId: number
+    url: string
+  }) => boolean
   recordStoppedReviewStatus: (input: {
     taskId: string
     taskKind: 'adversarial_review' | 'review_fix'
@@ -3109,6 +3170,71 @@ const reviewUsageMigration = `
   PRAGMA user_version = 31;
 `
 
+/**
+ * Adds the queued phase to the canonical review comment.
+ *
+ * A Task can wait hours behind other Tasks. The comment it already owns went on
+ * claiming a review was under way the whole time, so a person read progress
+ * where there was none. The comment now states the Queue position instead, and
+ * that publication needs a phase of its own to be recorded under.
+ *
+ * The Approval prompt is recorded for the same reason. It asks a person to add
+ * a label, and it went on asking after they added it, because no Task existed
+ * yet to own that comment and nothing else ever came back to correct it.
+ */
+const queuedReviewStatusMigration = `
+  DROP INDEX IF EXISTS review_status_commands_state;
+  CREATE TABLE review_status_commands_v32 (
+    id TEXT PRIMARY KEY,
+    task_kind TEXT NOT NULL CHECK (task_kind IN ('adversarial_review', 'review_fix')),
+    task_id TEXT NOT NULL,
+    task_fence INTEGER NOT NULL,
+    revision_id TEXT NOT NULL REFERENCES revisions(id),
+    expected_head_sha TEXT NOT NULL,
+    phase TEXT NOT NULL CHECK (phase IN ('snapshot', 'review', 'repair', 'terminal', 'queued')),
+    body TEXT NOT NULL,
+    body_sha256 TEXT NOT NULL CHECK (length(body_sha256) = 64),
+    state_tag TEXT NOT NULL CHECK (state_tag IN ('Pending', 'Running', 'Published', 'Superseded')),
+    outcome_unknown INTEGER NOT NULL DEFAULT 0 CHECK (outcome_unknown IN (0, 1)),
+    reason TEXT,
+    github_comment_id INTEGER,
+    github_url TEXT,
+    worker_id TEXT,
+    fence INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (task_kind, task_id, task_fence, phase, body_sha256),
+    CHECK (
+      (task_kind = 'adversarial_review' AND phase IN ('snapshot', 'review', 'terminal', 'queued'))
+      OR (task_kind = 'review_fix' AND phase IN ('repair', 'terminal', 'queued'))
+    ),
+    CHECK (
+      (state_tag = 'Running' AND worker_id IS NOT NULL AND lease_expires_at IS NOT NULL)
+      OR (state_tag != 'Running' AND worker_id IS NULL AND lease_expires_at IS NULL)
+    ),
+    CHECK (
+      (state_tag = 'Published' AND github_comment_id IS NOT NULL AND github_url IS NOT NULL)
+      OR state_tag != 'Published'
+    )
+  );
+  INSERT INTO review_status_commands_v32 SELECT * FROM review_status_commands;
+  DROP TABLE review_status_commands;
+  ALTER TABLE review_status_commands_v32 RENAME TO review_status_commands;
+  CREATE INDEX review_status_commands_state ON review_status_commands(state_tag, updated_at);
+
+  DROP TABLE IF EXISTS approval_prompt_comments;
+  CREATE TABLE approval_prompt_comments (
+    subject_id INTEGER NOT NULL REFERENCES subjects(id),
+    revision_id TEXT NOT NULL REFERENCES revisions(id),
+    github_comment_id INTEGER NOT NULL,
+    body TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (subject_id, revision_id)
+  );
+  PRAGMA user_version = 32;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -3134,7 +3260,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 31)
+  if (version === 32)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -3259,6 +3385,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 30) {
     applyForeignKeyMigration(database, reviewUsageMigration)
+    version = 31
+  }
+  if (version === 31) {
+    applyForeignKeyMigration(database, queuedReviewStatusMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -6473,6 +6603,197 @@ export function openJournalStore(
     SELECT id AS taskId, fence FROM worker_tasks WHERE state_tag NOT IN ('Completed', 'Failed', 'Superseded')
   `).all() as unknown as AgentWorktreeLease[]
 
+  const recordApprovalPromptComment: JournalStore['recordApprovalPromptComment'] = (input) => {
+    const subject = database.prepare(`
+      SELECT subjects.id
+      FROM subjects
+      JOIN repositories ON repositories.id = subjects.repository_id
+      WHERE repositories.github = ? AND subjects.github_number = ? AND subjects.kind = 'pull_request'
+        AND subjects.current_revision_id = ?
+    `).get(input.repository, input.pullRequestNumber, input.revisionId) as { id: number } | undefined
+    if (subject === undefined)
+      return false
+    database.prepare(`
+      INSERT INTO approval_prompt_comments (subject_id, revision_id, github_comment_id, body, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT (subject_id, revision_id) DO UPDATE SET
+        github_comment_id = excluded.github_comment_id,
+        body = excluded.body,
+        updated_at = excluded.updated_at
+    `).run(subject.id, input.revisionId, input.commentId, input.body, input.at)
+    return true
+  }
+
+  const listQueuedReviewStatuses: JournalStore['listQueuedReviewStatuses'] = () => (database.prepare(`
+    WITH claimable AS (
+      SELECT
+        worker_tasks.id AS task_id,
+        'adversarial_review' AS task_kind,
+        worker_tasks.subject_id,
+        worker_tasks.revision_id,
+        worker_tasks.updated_at
+      FROM worker_tasks
+      JOIN subjects ON subjects.id = worker_tasks.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
+      WHERE worker_tasks.kind = 'adversarial_review' AND worker_tasks.state_tag = 'Queued'
+        AND worker_tasks.revision_id = subjects.current_revision_id
+        AND repositories.enabled = 1
+        AND repositories.paused = 0
+        AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
+      UNION ALL
+      SELECT
+        tasks.id AS task_id,
+        'review_fix' AS task_kind,
+        tasks.subject_id,
+        tasks.revision_id,
+        tasks.updated_at
+      FROM tasks
+      JOIN subjects ON subjects.id = tasks.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
+      WHERE tasks.kind = 'review_fix' AND tasks.state_tag = 'Queued'
+        AND tasks.revision_id = subjects.current_revision_id
+        AND repositories.enabled = 1
+        AND repositories.paused = 0
+        AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
+        AND EXISTS (
+          SELECT 1 FROM pull_request_approvals
+          WHERE pull_request_approvals.subject_id = subjects.id
+            AND pull_request_approvals.revision_id = tasks.revision_id
+            AND pull_request_approvals.kind = 'fixes'
+        )
+    )
+    SELECT
+      claimable.task_id,
+      claimable.task_kind,
+      repositories.github AS repository,
+      subjects.github_number,
+      claimable.revision_id,
+      json_extract(revisions.payload, '$.headSha') AS head_sha,
+      (
+        SELECT COUNT(*) + 1 FROM claimable AS ahead
+        WHERE ahead.task_kind = claimable.task_kind
+          AND (
+            ahead.updated_at < claimable.updated_at
+            OR (ahead.updated_at = claimable.updated_at AND ahead.task_id < claimable.task_id)
+          )
+      ) AS position,
+      (
+        SELECT COUNT(*) FROM claimable AS peer WHERE peer.task_kind = claimable.task_kind
+      ) AS total,
+      COALESCE(published.github_comment_id, prompt.github_comment_id) AS github_comment_id,
+      COALESCE(published.body, prompt.body) AS published_body
+    FROM claimable
+    JOIN subjects ON subjects.id = claimable.subject_id
+    JOIN repositories ON repositories.id = subjects.repository_id
+    JOIN revisions ON revisions.id = claimable.revision_id
+    -- The Approval prompt is the canonical comment until a Task publishes one.
+    LEFT JOIN approval_prompt_comments AS prompt
+      ON prompt.subject_id = claimable.subject_id AND prompt.revision_id = claimable.revision_id
+    LEFT JOIN review_status_commands AS published ON published.id = COALESCE(
+      (
+        SELECT candidate.id FROM review_status_commands AS candidate
+        WHERE candidate.task_kind = claimable.task_kind AND candidate.task_id = claimable.task_id
+          AND candidate.state_tag = 'Published'
+        ORDER BY candidate.updated_at DESC, candidate.id DESC
+        LIMIT 1
+      ),
+      -- A Repair queued straight after a Review has published nothing of its
+      -- own. It inherits the canonical comment of the Review for the same
+      -- revision, which is the comment left reading "Repair queued".
+      (
+        SELECT candidate.id FROM review_status_commands AS candidate
+        JOIN worker_tasks AS sibling ON sibling.id = candidate.task_id
+        WHERE candidate.task_kind = 'adversarial_review' AND candidate.state_tag = 'Published'
+          AND sibling.subject_id = claimable.subject_id
+          AND candidate.revision_id = claimable.revision_id
+        ORDER BY candidate.updated_at DESC, candidate.id DESC
+        LIMIT 1
+      )
+    )
+    WHERE json_extract(revisions.payload, '$.state') = 'open'
+      AND COALESCE(published.github_comment_id, prompt.github_comment_id) IS NOT NULL
+      AND (
+        published.id IS NULL
+        OR (
+          published.phase != 'terminal'
+          AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
+        )
+      )
+      -- A final status for this exact head is a complete statement. Writing a
+      -- Queue position over it would delete the review a person still needs.
+      AND NOT EXISTS (
+        SELECT 1 FROM review_status_commands AS final
+        WHERE final.phase = 'terminal' AND final.state_tag = 'Published'
+          AND final.revision_id = claimable.revision_id
+          AND final.expected_head_sha = json_extract(revisions.payload, '$.headSha')
+      )
+  `).all() as unknown as QueuedReviewStatusRow[]).map(row => ({
+    taskId: row.task_id,
+    taskKind: row.task_kind,
+    repository: row.repository,
+    pullRequestNumber: row.github_number,
+    revisionId: row.revision_id,
+    headSha: row.head_sha,
+    position: row.position,
+    total: row.total,
+    commentId: row.github_comment_id,
+    publishedBody: row.published_body,
+  }))
+
+  const recordQueuedReviewStatus: JournalStore['recordQueuedReviewStatus'] = (input) => {
+    const bodySha256 = digest(input.body)
+    const taskTable = input.taskKind === 'adversarial_review' ? 'worker_tasks' : 'tasks'
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      const authorized = database.prepare(`
+        SELECT ${taskTable}.fence
+        FROM ${taskTable}
+        JOIN subjects ON subjects.id = ${taskTable}.subject_id
+        WHERE ${taskTable}.id = ? AND ${taskTable}.kind = ?
+          AND ${taskTable}.state_tag = 'Queued'
+          AND ${taskTable}.revision_id = ? AND subjects.current_revision_id = ?
+      `).get(input.taskId, input.taskKind, input.revisionId, input.revisionId) as { fence: number } | undefined
+      if (authorized === undefined) {
+        database.exec('COMMIT')
+        return false
+      }
+      const commandId = digest(`${input.taskKind}:${input.taskId}:${authorized.fence}:queued:${bodySha256}`)
+      // A position can return to a number this comment already held, because a
+      // Task ahead of it can leave the Queue and another can join behind it.
+      // Rewriting the row keeps the newest publication the newest row, so the
+      // next pass compares against what GitHub actually shows.
+      database.prepare(`
+        INSERT INTO review_status_commands (
+          id, task_kind, task_id, task_fence, revision_id, expected_head_sha, phase, body, body_sha256,
+          state_tag, github_comment_id, github_url, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'queued', ?, ?, 'Published', ?, ?, ?, ?)
+        ON CONFLICT (id) DO UPDATE SET
+          github_comment_id = excluded.github_comment_id,
+          github_url = excluded.github_url,
+          updated_at = excluded.updated_at
+      `).run(
+        commandId,
+        input.taskKind,
+        input.taskId,
+        authorized.fence,
+        input.revisionId,
+        input.expectedHeadSha,
+        input.body,
+        bodySha256,
+        input.commentId,
+        input.url,
+        input.at,
+        input.at,
+      )
+      database.exec('COMMIT')
+      return true
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
   const listStoppedReviews: JournalStore['listStoppedReviews'] = () => (database.prepare(`
     WITH stopped AS (
       SELECT id, subject_id, revision_id, kind AS task_kind, state_tag, reason
@@ -6719,7 +7040,10 @@ export function openJournalStore(
     isIssueWorkApprovalReady,
     listOpenAgentPullRequests,
     listActiveTaskLeases,
+    listQueuedReviewStatuses,
+    recordApprovalPromptComment,
     listStoppedReviews,
+    recordQueuedReviewStatus,
     recordStoppedReviewStatus,
     approvePullRequest,
     authorizePublication,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -311,6 +311,7 @@ interface StoppedReviewRow {
   head_sha: string
   reason: string
   github_comment_id: number
+  published_body: string
   findings: string
 }
 
@@ -323,6 +324,8 @@ export interface StoppedReview {
   headSha: string
   reason: string
   commentId: number
+  /** What the canonical comment holds now, so the edit can compare and swap. */
+  publishedBody: string
   findings: ReviewFinding[]
 }
 
@@ -6819,6 +6822,7 @@ export function openJournalStore(
       json_extract(revisions.payload, '$.headSha') AS head_sha,
       COALESCE(stopped.reason, 'The automated review stopped.') AS reason,
       published.github_comment_id,
+      published.body AS published_body,
       COALESCE((
         SELECT review_runs.findings FROM review_runs
         WHERE review_runs.subject_id = stopped.subject_id
@@ -6879,6 +6883,7 @@ export function openJournalStore(
     headSha: row.head_sha,
     reason: row.reason,
     commentId: row.github_comment_id,
+    publishedBody: row.published_body,
     findings: JSON.parse(row.findings) as ReviewFinding[],
   }))
 

--- a/packages/harlan-github-agent/test/approval-controller.test.ts
+++ b/packages/harlan-github-agent/test/approval-controller.test.ts
@@ -29,6 +29,7 @@ describe('approval controller', () => {
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       store: {
         ...unusedIssueApproval,
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => false,
         approvePullRequest: () => {
@@ -54,7 +55,7 @@ describe('approval controller', () => {
         },
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
-      store: { ...unusedIssueApproval, getSelectionMode: () => 'auto' as const, hasPullRequestApproval: () => false, approvePullRequest: () => { throw new Error('Unexpected Approval.') } },
+      store: { ...unusedIssueApproval, recordApprovalPromptComment: () => true, getSelectionMode: () => 'auto' as const, hasPullRequestApproval: () => false, approvePullRequest: () => { throw new Error('Unexpected Approval.') } },
     })
 
     expect(await controller.reconcile(repositoryMapping(), pullRequestItem({ author: 'contributor' }), 'a'.repeat(64), new AbortController().signal)).toEqual(ok(undefined))
@@ -79,6 +80,7 @@ describe('approval controller', () => {
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       store: {
         ...unusedIssueApproval,
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => false,
         approvePullRequest(input) {
@@ -110,6 +112,7 @@ describe('approval controller', () => {
       now: () => new Date('2026-08-14T01:00:00.000Z'),
       store: {
         ...unusedIssueApproval,
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: (_repository, _number, revisionId) => approvals.has(revisionId),
         approvePullRequest(input) {
@@ -139,6 +142,7 @@ describe('approval controller', () => {
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       store: {
         ...unusedIssueApproval,
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => false,
         approvePullRequest: () => {
@@ -162,6 +166,7 @@ describe('approval controller', () => {
       now: () => new Date('2026-08-14T01:00:00.000Z'),
       store: {
         ...unusedIssueApproval,
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => true,
         approvePullRequest: () => { throw new Error('Unexpected Approval.') },
@@ -187,6 +192,7 @@ describe('approval controller', () => {
       },
       now: () => new Date('2026-08-14T01:00:00.000Z'),
       store: {
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => false,
         isIssueWorkApprovalReady: () => false,
@@ -213,6 +219,7 @@ describe('approval controller', () => {
       },
       now: () => new Date('2026-08-14T01:00:00.000Z'),
       store: {
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => false,
         isIssueWorkApprovalReady: () => true,
@@ -241,6 +248,7 @@ describe('approval controller', () => {
       },
       now: () => new Date('2026-08-14T01:00:00.000Z'),
       store: {
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => 'auto' as const,
         hasPullRequestApproval: () => false,
         isIssueWorkApprovalReady: () => true,

--- a/packages/harlan-github-agent/test/approval-controller.test.ts
+++ b/packages/harlan-github-agent/test/approval-controller.test.ts
@@ -232,6 +232,27 @@ describe('approval controller', () => {
     expect(calls).toEqual(['ensure'])
   })
 
+  it('fails when the prompt comment cannot be recorded', async () => {
+    const controller = createApprovalController({
+      github: {
+        consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label consumption.')),
+        ensureApprovalLabel: () => Promise.resolve(ok(undefined)),
+        upsertReviewStatus: () => Promise.resolve(ok({ commentId: 1, url: 'url' })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      store: {
+        ...unusedIssueApproval,
+        recordApprovalPromptComment: () => false,
+        getSelectionMode: () => 'auto' as const,
+        hasPullRequestApproval: () => false,
+        approvePullRequest: () => { throw new Error('Unexpected Approval.') },
+      },
+    })
+
+    const result = await controller.reconcile(repositoryMapping(), pullRequestItem({ author: 'contributor' }), 'a'.repeat(64), new AbortController().signal)
+    expect(result._tag).toBe('Err')
+  })
+
   it('consumes the shared label before approving the exact outside issue state', async () => {
     const calls: string[] = []
     let consumedItemKind: unknown

--- a/packages/harlan-github-agent/test/edit-review-status.test.ts
+++ b/packages/harlan-github-agent/test/edit-review-status.test.ts
@@ -1,0 +1,88 @@
+import type { Octokit } from 'octokit'
+import { describe, expect, it, vi } from 'vitest'
+import { ok } from '../src/result.ts'
+import { repositoryMapping } from './fixtures.ts'
+
+const hoisted = vi.hoisted(() => {
+  const state = {
+    remoteBody: '',
+    reads: 0,
+    writes: 0,
+  }
+  const octokit = {
+    rest: {
+      issues: {
+        getComment: () => Promise.resolve({
+          data: {
+            id: 5,
+            html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
+            issue_url: 'https://github.com/harlan-zw/example/issues/24',
+            user: { login: 'harlan-agent[bot]' },
+            body: state.remoteBody,
+          },
+        }),
+        updateComment: (input: { body: string }) => {
+          state.writes += 1
+          state.remoteBody = input.body
+          return Promise.resolve({
+            data: {
+              id: 5,
+              user: { login: 'harlan-agent[bot]' },
+              body: input.body,
+              html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
+            },
+          })
+        },
+      },
+    },
+  }
+  return { state, octokit }
+})
+
+vi.mock('../src/github-auth.ts', () => ({
+  createAuthenticatedClient: () => hoisted.octokit as unknown as Octokit,
+}))
+
+const { createGitHubAgentSource } = await import('../src/github-agent-source.ts')
+
+const publishedBody = '<!-- harlan-agent-review --> published review'
+const progressBody = '<!-- harlan-agent-progress --> claimed agent progress'
+
+function source() {
+  return createGitHubAgentSource({
+    actorLogin: () => 'harlan-agent[bot]',
+    tokens: {
+      getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T02:00:00.000Z' })),
+      invalidate: () => undefined,
+    },
+  })
+}
+
+describe('editReviewStatus compare and swap', () => {
+  it('reports Edited when the written body survives', async () => {
+    hoisted.state.remoteBody = publishedBody
+    hoisted.state.reads = 0
+    const result = await source().editReviewStatus(repositoryMapping(), 24, 5, publishedBody, 'updated body', new AbortController().signal)
+    expect(hoisted.state.writes).toBe(1)
+    expect(result).toEqual(ok({ _tag: 'Edited', commentId: 5, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5' }))
+  })
+
+  it('reports Changed when a concurrent writer replaces the comment around the edit', async () => {
+    hoisted.state.remoteBody = publishedBody
+    hoisted.octokit.rest.issues.updateComment = (input: { body: string }) => {
+      // The write lands, then a claimed agent publishes its own progress over it.
+      hoisted.state.writes += 1
+      hoisted.state.remoteBody = progressBody
+      return Promise.resolve({
+        data: {
+          id: 5,
+          user: { login: 'harlan-agent[bot]' },
+          body: input.body,
+          html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
+        },
+      })
+    }
+    const result = await source().editReviewStatus(repositoryMapping(), 24, 5, publishedBody, 'updated body', new AbortController().signal)
+    expect(result).toEqual(ok({ _tag: 'Changed' }))
+  })
+})

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -51,6 +51,7 @@ describe('subject Workers', () => {
       }), capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -137,6 +138,7 @@ describe('subject Workers', () => {
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([], capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -233,6 +235,7 @@ describe('subject Workers', () => {
       }))),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -338,6 +341,7 @@ describe('subject Workers', () => {
       }))),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -431,6 +435,7 @@ describe('subject Workers', () => {
       }), capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -521,6 +526,7 @@ describe('subject Workers', () => {
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([], capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -598,6 +604,7 @@ describe('subject Workers', () => {
       }), capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -681,6 +688,7 @@ describe('subject Workers', () => {
       }), capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -761,6 +769,7 @@ describe('subject Workers', () => {
       }), capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -842,6 +851,7 @@ describe('subject Workers', () => {
       }), capture)),
       github: {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         getIssueTriageSnapshot: () => Promise.resolve(ok({ body: 'Reproduction', comments: [], state: 'open', title: issue.title, updatedAt: issue.updatedAt })),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -78,6 +78,7 @@ describe('publishQueuePositions', () => {
       repositories: [repositoryMapping()],
       store: {
         listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: (input) => {
           recorded = { taskId: input.taskId, body: input.body }
           return true
@@ -107,6 +108,7 @@ describe('publishQueuePositions', () => {
       repositories: [repositoryMapping()],
       store: {
         listQueuedReviewStatuses: () => [{ ...unchanged, publishedBody: queuePositionComment(unchanged) }],
+        isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => true,
       },
     }, new AbortController().signal)
@@ -126,6 +128,7 @@ describe('publishQueuePositions', () => {
       repositories: [repositoryMapping()],
       store: {
         listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => {
           recorded += 1
           return true
@@ -151,6 +154,7 @@ describe('publishQueuePositions', () => {
       repositories: [repositoryMapping()],
       store: {
         listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => true,
       },
     }, new AbortController().signal)
@@ -160,5 +164,57 @@ describe('publishQueuePositions', () => {
       _tag: 'Err',
       error: 'harlan-zw/example#24: the pull request changed before the Queue position comment.',
     }])
+  })
+
+  it('skips the edit once an agent claimed the Task before the comment was written', async () => {
+    let writes = 0
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => {
+          writes += 1
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        // An agent claimed the Task between the Queue read and the write.
+        isQueuedReviewStatus: () => false,
+        recordQueuedReviewStatus: () => false,
+      },
+    }, new AbortController().signal)
+
+    expect(writes).toBe(0)
+    expect(results).toEqual([ok({ _tag: 'Superseded', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+  })
+
+  it('reports the lost claim as Superseded instead of an unsaved comment once an agent claims the Task mid-edit', async () => {
+    let claimed = false
+    let recorded = 0
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => new Promise((resolve) => {
+          // The claim lands while the comment edit is in flight.
+          claimed = true
+          resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        }),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => !claimed,
+        recordQueuedReviewStatus: () => {
+          recorded += 1
+          return false
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(recorded).toBe(1)
+    expect(results).toEqual([ok({ _tag: 'Superseded', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
   })
 })

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -1,0 +1,164 @@
+import type { QueuedReviewStatus } from '../src/store.ts'
+import { describe, expect, it } from 'vitest'
+import { publishQueuePositions, queuePositionComment } from '../src/queue-position-sweep.ts'
+import { err, ok } from '../src/result.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+function queuedRepair(overrides: Partial<QueuedReviewStatus> = {}): QueuedReviewStatus {
+  return {
+    taskId: 'repair-task',
+    taskKind: 'review_fix',
+    repository: 'harlan-zw/example',
+    pullRequestNumber: 24,
+    revisionId: 'revision-1',
+    headSha: 'abc123',
+    position: 3,
+    total: 7,
+    commentId: 42,
+    publishedBody: '### 🤖 REVIEWING · Repair queued',
+    ...overrides,
+  }
+}
+
+function snapshot(overrides: Parameters<typeof pullRequestItem>[0] = {}) {
+  return ok({
+    baseChecks: { _tag: 'Available' as const, checks: [] },
+    body: '',
+    checks: { _tag: 'Available' as const, checks: [] },
+    comments: [],
+    priorAutomatedReview: { _tag: 'None' as const },
+    pullRequest: pullRequestItem({ headSha: 'abc123', ...overrides }),
+    requiredChecks: { _tag: 'None' as const },
+    reviews: [],
+  })
+}
+
+describe('queuePositionComment', () => {
+  it('states the exact position and how many Tasks come first', () => {
+    const body = queuePositionComment(queuedRepair())
+
+    expect(body).toContain('### 🤖 QUEUED · 3rd of 7')
+    expect(body).toContain('Next: Repair starts after the 2 Tasks ahead of it finish.')
+    expect(body).toContain('░░░░░ 0%')
+  })
+
+  it('says an agent is the only thing left to wait for at the head of the Queue', () => {
+    expect(queuePositionComment(queuedRepair({ position: 1, total: 4 })))
+      .toContain('Next: Repair starts as soon as an agent is free.')
+  })
+
+  it('names the work the Queue is holding', () => {
+    expect(queuePositionComment(queuedRepair({ taskKind: 'adversarial_review', position: 2, total: 2 })))
+      .toContain('Next: Review starts after the 1 Task ahead of it finishes.')
+  })
+
+  it('renders the same body for the same position, so an idle Queue writes nothing', () => {
+    expect(queuePositionComment(queuedRepair())).toBe(queuePositionComment(queuedRepair()))
+  })
+
+  it('writes an ordinal a person reads, not a number with a wrong suffix', () => {
+    expect(queuePositionComment(queuedRepair({ position: 11, total: 20 }))).toContain('11th of 20')
+    expect(queuePositionComment(queuedRepair({ position: 22, total: 30 }))).toContain('22nd of 30')
+  })
+})
+
+describe('publishQueuePositions', () => {
+  it('rewrites the canonical comment and records the position it published', async () => {
+    let edited: { commentId: number, body: string } | undefined
+    let recorded: { taskId: string, body: string } | undefined
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: (_repository, _number, commentId, body) => {
+          edited = { commentId, body }
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        recordQueuedReviewStatus: (input) => {
+          recorded = { taskId: input.taskId, body: input.body }
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24, position: 3, total: 7 })])
+    expect(edited?.commentId).toBe(42)
+    expect(edited?.body).toContain('### 🤖 QUEUED · 3rd of 7')
+    expect(recorded?.taskId).toBe('repair-task')
+    expect(recorded?.body).toBe(edited?.body)
+  })
+
+  it('writes nothing while the position has not moved', async () => {
+    let writes = 0
+    const unchanged = queuedRepair()
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(err('Unexpected snapshot read.')),
+        editReviewStatus: () => {
+          writes += 1
+          return Promise.resolve(err('Unexpected comment write.'))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [{ ...unchanged, publishedBody: queuePositionComment(unchanged) }],
+        recordQueuedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([])
+    expect(writes).toBe(0)
+  })
+
+  it('writes nothing when a person deleted the comment, rather than posting it again', async () => {
+    let recorded = 0
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Missing' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        recordQueuedReviewStatus: () => {
+          recorded += 1
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'CommentGone', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(recorded).toBe(0)
+  })
+
+  it('leaves the comment alone once the head commit moves', async () => {
+    let writes = 0
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({ headSha: 'def456' })),
+        editReviewStatus: () => {
+          writes += 1
+          return Promise.resolve(err('Unexpected comment write.'))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        recordQueuedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(writes).toBe(0)
+    expect(results).toEqual([{
+      _tag: 'Err',
+      error: 'harlan-zw/example#24: the pull request changed before the Queue position comment.',
+    }])
+  })
+})

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -69,7 +69,7 @@ describe('publishQueuePositions', () => {
     const results = await publishQueuePositions({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
-        editReviewStatus: (_repository, _number, commentId, body) => {
+        editReviewStatus: (_repository, _number, commentId, _expectedBody, body) => {
           edited = { commentId, body }
           return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
         },
@@ -187,6 +187,53 @@ describe('publishQueuePositions', () => {
     }, new AbortController().signal)
 
     expect(writes).toBe(0)
+    expect(results).toEqual([ok({ _tag: 'Superseded', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+  })
+
+  it('offers the body it read as the compare and swap, so a claimed agent cannot be overwritten', async () => {
+    let expected: string | undefined
+    await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: (_repository, _number, _commentId, expectedBody) => {
+          expected = expectedBody
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => true,
+        recordQueuedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(expected).toBe(queuedRepair().publishedBody)
+  })
+
+  it('leaves the comment to the agent that published first, and saves nothing', async () => {
+    let recorded = 0
+    const results = await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        // The claimed agent published its own progress, so GitHub no longer
+        // holds the body the Queue read saw and the swap declines.
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Changed' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => true,
+        recordQueuedReviewStatus: () => {
+          recorded += 1
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(recorded).toBe(0)
     expect(results).toEqual([ok({ _tag: 'Superseded', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
   })
 

--- a/packages/harlan-github-agent/test/queue-position.test.ts
+++ b/packages/harlan-github-agent/test/queue-position.test.ts
@@ -245,3 +245,21 @@ describe('recordQueuedReviewStatus', () => {
     })).toBe(false)
   })
 })
+
+describe('isQueuedReviewStatus', () => {
+  it('holds while the Task is Queued and breaks the moment an agent claims it', () => {
+    const store = createStore()
+    queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    const status = store.listQueuedReviewStatuses()[0]!
+
+    expect(store.isQueuedReviewStatus({ taskId: status.taskId, taskKind: status.taskKind })).toBe(true)
+    store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:04:00.000Z', 60_000)
+    expect(store.isQueuedReviewStatus({ taskId: status.taskId, taskKind: status.taskKind })).toBe(false)
+  })
+
+  it('answers for the exact Task, not any Task of the same kind', () => {
+    const store = createStore()
+
+    expect(store.isQueuedReviewStatus({ taskId: 'missing-task', taskKind: 'review_fix' })).toBe(false)
+  })
+})

--- a/packages/harlan-github-agent/test/queue-position.test.ts
+++ b/packages/harlan-github-agent/test/queue-position.test.ts
@@ -1,0 +1,247 @@
+import type { ReviewGates } from '../src/types.ts'
+import { afterEach, describe, expect, it } from 'vitest'
+import { openJournalStore } from '../src/store.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const stores: Array<ReturnType<typeof openJournalStore>> = []
+
+afterEach(() => {
+  stores.splice(0).forEach(store => store.close())
+})
+
+function createStore() {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+  return store
+}
+
+function passedReviewGates(): ReviewGates {
+  return {
+    head: { _tag: 'Passed', evidence: [{ label: 'head', sha256: 'a'.repeat(64) }] },
+    merge: { _tag: 'Passed', evidence: [{ label: 'mergeability', sha256: 'b'.repeat(64) }] },
+    metadata: { _tag: 'Passed', evidence: [] },
+    review: { _tag: 'Failed', reason: 'A material finding remains.', evidence: [] },
+    verification: { _tag: 'Passed', evidence: [{ label: 'tests', sha256: 'd'.repeat(64) }] },
+    ci: { _tag: 'Passed', evidence: [{ label: 'required-ci', sha256: 'e'.repeat(64) }] },
+  }
+}
+
+/**
+ * One pull request carried to the exact state the sweep reads: a Review that
+ * published its canonical comment, then queued a Repair behind it.
+ */
+function queuedRepair(store: ReturnType<typeof openJournalStore>, number: number, at: string): { commentId: number, body: string } {
+  const observed = store.recordObservation({
+    externalId: `queue-position-${number}`,
+    observedAt: at,
+    source: 'poll',
+    subject: pullRequestItem({
+      number,
+      headRef: `fix/thing-${number}`,
+      headSha: `head${number}`,
+      mergeState: 'clean',
+      url: `https://github.com/harlan-zw/example/pull/${number}`,
+    }),
+  })
+  if (observed._tag !== 'Inserted')
+    throw new Error('Expected a new pull request revision.')
+  const review = store.claimNextAdversarialReviewTask(`review-agent-${number}`, at, 600_000)
+  if (review === null)
+    throw new Error('Expected the review Task.')
+
+  const body = `### 🤖 REVIEWING · Repair queued for ${number}`
+  const staged = store.stageReviewStatus({
+    taskKind: 'adversarial_review',
+    phase: 'review',
+    taskId: review.id,
+    workerId: review.state.workerId,
+    fence: review.state.fence,
+    at,
+    revisionId: observed.revisionId,
+    expectedHeadSha: review.pullRequest.headSha,
+    body,
+  })
+  if (staged._tag === 'Rejected')
+    throw new Error(staged.reason)
+  const command = store.claimReviewStatus(staged.commandId, `status-worker-${number}`, at, 60_000)
+  if (command === null)
+    throw new Error('Expected the review status command.')
+  const commentId = 100 + number
+  store.completeReviewStatus({
+    commandId: command.id,
+    workerId: command.workerId,
+    fence: command.fence,
+    at,
+    commentId,
+    url: `https://github.com/harlan-zw/example/pull/${number}#issuecomment-${commentId}`,
+  })
+
+  store.recordReviewRun({
+    id: `review-run-${number}`,
+    repository: 'harlan-zw/example',
+    pullRequestNumber: number,
+    revisionId: observed.revisionId,
+    headSha: review.pullRequest.headSha,
+    provider: 'codex',
+    sessionId: `queue-position-session-${number}`,
+    model: 'gpt-5.6',
+    agentVersion: '1.2.3',
+    skillDigest: 'f'.repeat(64),
+    startedAt: at,
+    completedAt: at,
+    gates: passedReviewGates(),
+    findings: [{
+      _tag: 'Open',
+      summary: 'Unsafe parser input.',
+      nextAction: 'Parse input before use.',
+      resolution: 'Repair',
+      details: {
+        fingerprint: 'f'.repeat(64),
+        identity: 'unsafe-parser-input',
+        location: { path: 'src/parser.ts', line: 42 },
+        proof: 'Malformed input reaches the unsafe parser branch.',
+        regressionTest: 'Pass malformed input and assert a tagged rejection.',
+      },
+    }],
+  })
+  const queued = store.queueReviewFixTaskForReview({
+    taskId: review.id,
+    workerId: review.state.workerId,
+    fence: review.state.fence,
+    at,
+  })
+  if (queued._tag !== 'Queued')
+    throw new Error(`Expected a queued Repair, received ${queued._tag}.`)
+  store.completeWorkerTask({
+    taskId: review.id,
+    workerId: review.state.workerId,
+    fence: review.state.fence,
+    at,
+    evidence: `review-run-${number}`,
+  })
+  return { commentId, body }
+}
+
+describe('listQueuedReviewStatuses', () => {
+  it('numbers every queued Repair in the order an agent claims them', () => {
+    const store = createStore()
+    const first = queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    const second = queuedRepair(store, 25, '2026-08-13T02:00:00.000Z')
+
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({ pullRequestNumber: 24, position: 1, total: 2, commentId: first.commentId, publishedBody: first.body }),
+      expect.objectContaining({ pullRequestNumber: 25, position: 2, total: 2, commentId: second.commentId, publishedBody: second.body }),
+    ])
+  })
+
+  it('agrees with the claim, so position 1 is the Task the next agent takes', () => {
+    const store = createStore()
+    queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    queuedRepair(store, 25, '2026-08-13T02:00:00.000Z')
+
+    const claimed = store.claimNextReviewFixTask('repair-agent', '2026-08-13T03:00:00.000Z', 60_000)
+    expect(claimed?.pullRequestNumber).toBe(24)
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({ pullRequestNumber: 25, position: 1, total: 1 }),
+    ])
+  })
+
+  it('takes over an Approval prompt the person has already answered', () => {
+    const store = createStore()
+    const observed = store.recordObservation({
+      externalId: 'approval-prompt-30',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 30,
+        author: 'contributor',
+        headRef: 'fix/from-contributor',
+        headSha: 'head30',
+        mergeState: 'clean',
+        url: 'https://github.com/harlan-zw/example/pull/30',
+      }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    // No Task exists while the pull request waits for Approval, so the prompt
+    // is the only comment on it and nothing owns it yet.
+    expect(store.listQueuedReviewStatuses()).toEqual([])
+    expect(store.recordApprovalPromptComment({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 30,
+      revisionId: observed.revisionId,
+      commentId: 900,
+      body: '### 🤖 REVIEW PAUSED',
+      at: '2026-08-13T01:00:01.000Z',
+    })).toBe(true)
+
+    expect(store.approvePullRequest({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 30,
+      revisionId: observed.revisionId,
+      kind: 'review',
+      at: '2026-08-13T01:00:02.000Z',
+    })._tag).toBe('Approved')
+
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({
+        taskKind: 'adversarial_review',
+        pullRequestNumber: 30,
+        position: 1,
+        total: 1,
+        commentId: 900,
+        publishedBody: '### 🤖 REVIEW PAUSED',
+      }),
+    ])
+  })
+
+  it('says nothing about a Task no agent can claim', () => {
+    const store = createStore()
+    queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    store.setRepositoryPaused('harlan-zw/example', true)
+
+    expect(store.listQueuedReviewStatuses()).toEqual([])
+    expect(store.claimNextReviewFixTask('repair-agent', '2026-08-13T03:00:00.000Z', 60_000)).toBeNull()
+  })
+})
+
+describe('recordQueuedReviewStatus', () => {
+  it('becomes what the next pass compares against, so a still Queue writes nothing', () => {
+    const store = createStore()
+    queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    const status = store.listQueuedReviewStatuses()[0]!
+
+    expect(store.recordQueuedReviewStatus({
+      taskId: status.taskId,
+      taskKind: status.taskKind,
+      revisionId: status.revisionId,
+      expectedHeadSha: status.headSha,
+      body: '### 🤖 QUEUED · 1st of 1',
+      at: '2026-08-13T01:05:00.000Z',
+      commentId: status.commentId,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-124',
+    })).toBe(true)
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({ publishedBody: '### 🤖 QUEUED · 1st of 1', commentId: 124 }),
+    ])
+  })
+
+  it('refuses once an agent has claimed the Task, because the comment is the agent to write', () => {
+    const store = createStore()
+    queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    const status = store.listQueuedReviewStatuses()[0]!
+    store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:04:00.000Z', 60_000)
+
+    expect(store.recordQueuedReviewStatus({
+      taskId: status.taskId,
+      taskKind: status.taskKind,
+      revisionId: status.revisionId,
+      expectedHeadSha: status.headSha,
+      body: '### 🤖 QUEUED · 1st of 1',
+      at: '2026-08-13T01:05:00.000Z',
+      commentId: status.commentId,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-124',
+    })).toBe(false)
+  })
+})

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -61,6 +61,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], requiredChecks: Required
     runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(cleanReview))),
     github: {
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       listPullRequestFiles: () => Promise.reject(new Error('Unexpected file listing.')),

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -87,6 +87,7 @@ function harness(input: {
     ), provider)),
     github: {
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -62,14 +62,14 @@ describe('stoppedReviewComment', () => {
 
 describe('publishStoppedReviews', () => {
   it('rewrites the canonical comment and records it once', async () => {
-    let upserted: { commentId: number | null, body: string } | undefined
+    let edited: { commentId: number, body: string } | undefined
     let recorded = 0
     const results = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
-        upsertReviewStatus: (_repository, _number, commentId, body) => {
-          upserted = { commentId, body }
-          return Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        editReviewStatus: (_repository, _number, commentId, body) => {
+          edited = { commentId, body }
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
         },
       },
       now: () => new Date('2026-08-15T04:00:00.000Z'),
@@ -83,19 +83,41 @@ describe('publishStoppedReviews', () => {
       },
     }, new AbortController().signal)
 
-    expect(results).toEqual([ok({ repository: 'harlan-zw/example', pullRequestNumber: 24 })])
-    expect(upserted?.commentId).toBe(42)
-    expect(upserted?.body).toContain('### 🤖 STOPPED')
+    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(edited?.commentId).toBe(42)
+    expect(edited?.body).toContain('### 🤖 STOPPED')
     expect(recorded).toBe(1)
   })
 
+  it('writes nothing when a person deleted the comment, rather than posting it again', async () => {
+    let recorded = 0
+    const results = await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Missing' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listStoppedReviews: () => [stopped],
+        recordStoppedReviewStatus: () => {
+          recorded += 1
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'CommentGone', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(recorded).toBe(0)
+  })
+
   it('leaves the comment alone once the pull request moves on', async () => {
-    let upserts = 0
+    let writes = 0
     const results = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({ headSha: 'def456' })),
-        upsertReviewStatus: () => {
-          upserts += 1
+        editReviewStatus: () => {
+          writes += 1
           return Promise.resolve(err('Unexpected comment write.'))
         },
       },
@@ -107,7 +129,7 @@ describe('publishStoppedReviews', () => {
       },
     }, new AbortController().signal)
 
-    expect(upserts).toBe(0)
+    expect(writes).toBe(0)
     expect(results).toEqual([{ _tag: 'Err', error: 'harlan-zw/example#24: the pull request changed before the final comment.' }])
   })
 })

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -13,6 +13,7 @@ const stopped: StoppedReview = {
   headSha: 'abc123',
   reason: 'The pull request is not ready for review.',
   commentId: 42,
+  publishedBody: '### 🤖 REVIEWING · Reviewing changed files',
   findings: [],
 }
 
@@ -67,7 +68,7 @@ describe('publishStoppedReviews', () => {
     const results = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
-        editReviewStatus: (_repository, _number, commentId, body) => {
+        editReviewStatus: (_repository, _number, commentId, _expectedBody, body) => {
           edited = { commentId, body }
           return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
         },

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -69,6 +69,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], baseChecks?: GitHubCheck
     runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(cleanReview))),
     github: {
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       listPullRequestFiles: () => Promise.reject(new Error('Unexpected file listing.')),

--- a/packages/harlan-github-agent/test/selection-mode.test.ts
+++ b/packages/harlan-github-agent/test/selection-mode.test.ts
@@ -138,6 +138,7 @@ describe('selection mode approval controller', () => {
       store: {
         approveIssueWork: () => { throw new Error('Unexpected issue Approval.') },
         isIssueWorkApprovalReady: () => false,
+        recordApprovalPromptComment: () => true,
         getSelectionMode: () => mode,
         hasPullRequestApproval: () => false,
         approvePullRequest: () => {

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -253,7 +253,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(31)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(32)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

A Review that queues a Repair leaves its comment reading `REVIEWING · Repair queued` at 95% and then says nothing for as long as the Repair waits. A pull request sitting behind six Tasks looks exactly like one an agent is about to pick up. Same for a review Task that fails and gets requeued: the bar freezes wherever it stopped.

The comment now states the Queue position, and updates as the Queue moves:

```
### 🤖 QUEUED · 3rd of 7

`░░░░░ 0%`

Next: Repair starts after the 2 Tasks ahead of it finish.
```

The position comes from the claim query's own predicate and order, so position 1 really is the Task the next free agent takes. There is no timestamp in the body, so an unmoved Queue renders an identical body and nothing is written.

Two other things came out of this:

The `REVIEW PAUSED` prompt kept asking for a label after the label arrived, because no Task exists while a pull request waits for Approval and nothing ever came back to correct it. It is recorded when posted now, so the same sweep takes it over once the review joins the Queue.

`upsertReviewStatus` opens a comment when the stored identifier is gone, which is right for a review that owns its comment and wrong for a sweep correcting an old one: deleting the stale comment brought it straight back. Both sweeps use an edit-only path now, and a missing comment is an outcome rather than a failure. The stop sweep had this bug already.

Loose end I did not take: a Running Task's comment can also drift when a progress publish fails, since that failure is logged and swallowed. It self-heals on the next progress event, so I left it alone rather than have the sweep and the worker write the same comment.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).