### PR TITLE
feat(sentry-checkin): resolve issues the run proves fixed

### DIFF
--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -40,7 +40,9 @@ pnpm dlx @sentry/cli organizations list
 
 Use the sole organization when only one exists. If two or more exist and the request names none, ask which organization is in scope.
 
-Use `sentry-cli` for authentication, project discovery, and issue discovery. Sentry CLI 3.6 does not expose issue or stack details. The bundled `scripts/sentry_api.py` fills only that read-only gap. It uses the CLI token from `~/.sentryclirc` and redacts common secrets and personal data.
+Use `sentry-cli` for authentication, project discovery, and issue discovery. Sentry CLI 3.6 does not expose issue or stack details. The bundled `scripts/sentry_api.py` fills that gap. It uses the CLI token from `~/.sentryclirc` and redacts common secrets and personal data.
+
+Every command in that script reads, except `resolve`. `resolve` reports its plan and writes only with `--apply`.
 
 Create a persistent run directory outside every repository:
 
@@ -94,7 +96,7 @@ Repeat `--snapshot` to cover every project of a site in one report. It tags ever
 - `recurring`: a prior run left it open, accepted, or blocked.
 - `unclosed`: a prior run called it `fixed` or `already-fixed`, yet it is still open.
 
-A high `unclosed` count means fixes are landing but Sentry never hears about it. Report the count with the run.
+A high `unclosed` count means fixes are landing but Sentry never hears about it. Report the count with the run. An `unclosed` ID this run proves deployed gets resolved, not just re-triaged.
 
 The history is evidence from a past run, not a verdict. It never shortens the ledger: every frozen ID still needs its own row and its own evidence this run.
 
@@ -135,7 +137,36 @@ Each site with code fixes gets one branch and one PR. If another agent is active
 
 If a complete ledger produces no diff, do not create an empty PR. Confirm the branch is clean. If this task created a worktree, run `wt remove <branch>`. Return the verified ledger. If the repository has no PR workflow, state that explicitly and use the complete local gate as evidence.
 
-Do not resolve or mute Sentry issues when opening a PR. Code is not live yet. Let a verified release resolve issues, unless the user explicitly asks for a Sentry state change after production verification.
+Never mute a Sentry issue. Muting hides a live defect.
+
+## Close what this run fixed
+
+An open issue that nobody can close is the reason the same IDs return every run. Close them here, using the release as the proof.
+
+Resolve only these dispositions:
+
+- `fixed`: resolve in the next release, after the PR merges into the default branch. Never at PR open. An unmerged PR would let an unrelated release close the issue.
+- `already-fixed`: resolve in the release that carries the fix, once this run proved that release is deployed.
+- `covered`: resolve with the owning row's mode, after the owning row resolves.
+
+Never resolve `expected`, `third-party`, or `blocked`. None of them is fixed.
+
+Run the plan first, then apply:
+
+```bash
+python3 scripts/sentry_api.py --org ORG resolve --project PROJECT \
+  --issue ID --issue ID --in-next-release
+python3 scripts/sentry_api.py --org ORG resolve --project PROJECT \
+  --issue ID --issue ID --in-next-release --apply
+```
+
+Use `--in-release VERSION` instead of `--in-next-release` for an `already-fixed` row. The command rejects a version the project does not hold.
+
+`--in-next-release` binds to whichever release appears next. Use it only when CI owns every release for that project. If a local build can create a release, name the release with `--in-release`. A local build with an auth token creates a release that was never deployed, and that release would close the issue early.
+
+Sentry reopens a resolved issue as a regression if the error returns. A fix that stops working still surfaces.
+
+Project auto-resolve is the backstop, not the mechanism. It closes a stale issue when this run has no proof to act on. It never replaces a resolution the evidence supports.
 
 ## Record the run
 
@@ -151,3 +182,5 @@ Repeat `--ledger` for every site. `record` refuses a ledger with any empty dispo
 ## Return the run
 
 Report each site with its issue count, ledger coverage, PR URL, CI state, and confidence. List zero-issue sites and unmatched projects. Keep blocked rows explicit. Give the run's `new`, `recurring`, and `unclosed` counts, and name the history path.
+
+Name every issue this run resolved, with the release that closed it. Name every `fixed` row left unresolved because its PR is still open. The next run inherits those.

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -49,7 +49,7 @@ Treat a prior disposition as a lead, never as an answer. It tells you where a pa
 
 An `unclosed` ID needs care. A past run already proved a commit fixes it, and the issue is open anyway. Do not repeat that proof. Establish which of these is true, and record it as the evidence:
 
-- The fix is deployed and the issue is stale in Sentry. Disposition `already-fixed`, and name the release that carries the fix plus the last-seen time that precedes it.
+- The fix is deployed and the issue is stale in Sentry. Disposition `already-fixed`, and name the release that carries the fix plus the last-seen time that precedes it. Resolve it in that release.
 - The fix is merged but never deployed. Disposition `blocked`, naming the missing deploy.
 - The fix does not hold. Treat it as a live defect and fix the category, not the instance.
 
@@ -90,7 +90,23 @@ Repeat `--manifest` for every project. Invoke `$harlan-agent-kit:pr` from the wo
 
 If the audited ledger produces no code diff, do not create an empty PR. Confirm the selected checkout is clean. If this task created a worktree, run `wt remove <branch>`. Then return the ledger checksum. If GitHub registers no PR checks, report `no PR workflow` after confirming the PR remains mergeable.
 
-Do not deploy. Do not resolve or mute Sentry issues.
+Do not deploy. Never mute a Sentry issue.
+
+## Close what you proved
+
+Resolve an issue only on the evidence in your own ledger. Run the plan first, then apply.
+
+```bash
+python3 SKILL_DIR/scripts/sentry_api.py --org ORG resolve --project PROJECT \
+  --issue ID --in-next-release --apply
+```
+
+- `fixed` rows: `--in-next-release`, only after your PR merges into the default branch. If it is still open when you finish, leave the issue open and say so. The next run inherits it.
+- `already-fixed` rows: `--in-release VERSION`, naming the deployed release that carries the fix.
+- `covered` rows: follow the owning row, after it resolves.
+- `expected`, `third-party`, `blocked`: never resolve.
+
+Use `--in-next-release` only when CI owns every release for that project. A local build with an auth token can create a release that was never deployed, and that release would close the issue early. Name the release with `--in-release` instead.
 
 ## Return evidence
 
@@ -101,6 +117,7 @@ Return:
 3. The ledger path, row count, checksum, and one row per frozen numeric issue ID.
 4. The issue IDs owned by each test and fix.
 5. Any blocked item with the exact next action.
-6. Confidence out of 100, based on verified evidence.
+6. Every issue you resolved, with the release that closed it, and every `fixed` row you left open because its PR had not merged.
+7. Confidence out of 100, based on verified evidence.
 
 For a zero-issue site, confirm the project query and return without a branch, worktree, or PR.

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -521,6 +521,11 @@ def resolve_issues(args, base_url, token):
         data, _ = request_json(
             base_url, token, f"/api/0/organizations/{args.org}/issues/{issue_id}/"
         )
+        issue_project = ((data or {}).get("project") or {}).get("slug")
+        if issue_project is not None and issue_project != args.project:
+            raise RuntimeError(
+                f"Issue {issue_id} does not belong to project {args.project}."
+            )
         before[issue_id] = {
             "short_id": (data or {}).get("shortId"),
             "status": (data or {}).get("status"),

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Snapshot with sentry-cli, then fetch redacted issue evidence read-only."""
+"""Snapshot with sentry-cli, fetch redacted issue evidence, resolve proven fixes.
+
+Every command except resolve is read-only. Resolve writes only with --apply.
+"""
 
 import argparse
 import configparser
@@ -15,13 +18,14 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
 
 
 DEFAULT_URL = "https://sentry.io"
 PAGE_SIZE = 100
 SAFETY_CAP = 10_000
+RESOLVE_CAP = 200
 SECRET_KEYS = {
     "authorization",
     "cookie",
@@ -446,6 +450,110 @@ def bulk_bundles(args, base_url, token):
     return manifest
 
 
+def request_write(base_url, token, path, payload, params=None, method="PUT"):
+    url = f"{base_url}{path}"
+    if params:
+        url = f"{url}?{urlencode(params, doseq=True)}"
+    request = Request(
+        url,
+        data=json.dumps(payload).encode(),
+        method=method,
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    for attempt in range(3):
+        try:
+            with urlopen(request, timeout=30) as response:
+                body = response.read().decode("utf-8")
+                return json.loads(body) if body else None
+        except HTTPError as error:
+            body = error.read().decode("utf-8", "ignore")
+            if attempt < 2 and (error.code == 429 or error.code >= 500):
+                time.sleep(attempt + 1)
+                continue
+            raise RuntimeError(f"Sentry returned HTTP {error.code}: {body}") from error
+        except URLError as error:
+            if attempt < 2:
+                time.sleep(attempt + 1)
+                continue
+            raise RuntimeError(f"Sentry network error: {error.reason}") from error
+    raise RuntimeError("Sentry write retry loop ended unexpectedly.")
+
+
+def resolve_release_target(org, project, version, base_url, token):
+    """Reject a release that Sentry does not hold for this project.
+
+    A local build with an auth token can create a release that was never
+    deployed, so an unchecked version silently resolves against nothing.
+    """
+    data, _ = request_json(
+        base_url, token, f"/api/0/organizations/{org}/releases/{quote(version, safe='')}/"
+    )
+    slugs = {entry.get("slug") for entry in (data or {}).get("projects") or []}
+    if project not in slugs:
+        raise RuntimeError(
+            f"Release {version} is not associated with project {project}."
+        )
+    return {"version": version, "released": (data or {}).get("dateReleased")}
+
+
+def resolve_issues(args, base_url, token):
+    issue_ids = [str(value) for value in args.issue]
+    if len(issue_ids) != len(set(issue_ids)):
+        raise RuntimeError("Repeated --issue value.")
+    if any(not value.isdigit() for value in issue_ids):
+        raise RuntimeError("Every --issue must be a numeric issue ID.")
+    if len(issue_ids) > RESOLVE_CAP:
+        raise RuntimeError(f"Refusing to resolve more than {RESOLVE_CAP} issues at once.")
+    if args.in_release:
+        release = resolve_release_target(
+            args.org, args.project, args.in_release, base_url, token
+        )
+        status_details = {"inRelease": args.in_release}
+    else:
+        release = None
+        status_details = {"inNextRelease": True}
+    before = {}
+    for issue_id in issue_ids:
+        data, _ = request_json(
+            base_url, token, f"/api/0/organizations/{args.org}/issues/{issue_id}/"
+        )
+        before[issue_id] = {
+            "short_id": (data or {}).get("shortId"),
+            "status": (data or {}).get("status"),
+        }
+    already = sorted(key for key, value in before.items() if value["status"] == "resolved")
+    pending = [issue_id for issue_id in issue_ids if issue_id not in set(already)]
+    result = {
+        "org": args.org,
+        "project": args.project,
+        "mode": "in-release" if args.in_release else "in-next-release",
+        "release": release,
+        "issues": dict(sorted(before.items())),
+        "already_resolved": already,
+        "would_resolve": sorted(pending, key=int),
+        "applied": False,
+    }
+    if not args.apply:
+        return result
+    if not pending:
+        result["applied"] = True
+        return result
+    request_write(
+        base_url,
+        token,
+        f"/api/0/projects/{args.org}/{args.project}/issues/",
+        {"status": "resolved", "statusDetails": status_details},
+        params={"id": pending},
+    )
+    result["applied"] = True
+    result["resolved"] = sorted(pending, key=int)
+    return result
+
+
 def build_parser():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--org", required=True, help="Sentry organization slug")
@@ -472,6 +580,20 @@ def build_parser():
     bulk.add_argument("--output", required=True)
     bulk.add_argument("--events", type=int, default=1)
     bulk.add_argument("--workers", type=int, default=4)
+
+    resolve = subparsers.add_parser(
+        "resolve", help="Resolve issues this run proved fixed"
+    )
+    resolve.add_argument("--project", required=True)
+    resolve.add_argument("--issue", required=True, action="append")
+    mode = resolve.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--in-next-release", action="store_true")
+    mode.add_argument("--in-release")
+    resolve.add_argument(
+        "--apply",
+        action="store_true",
+        help="Perform the write. Without it the command only reports the plan.",
+    )
     return parser
 
 
@@ -487,6 +609,8 @@ def main():
         token, base_url = load_cli_config()
         if args.command == "bundle":
             result = issue_bundle(args, base_url, token)
+        elif args.command == "resolve":
+            result = resolve_issues(args, base_url, token)
         else:
             result = bulk_bundles(args, base_url, token)
     print(stable_json(redact(result)), end="")

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -12,9 +12,26 @@ from pathlib import Path
 
 
 class SentryHandler(BaseHTTPRequestHandler):
+    writes = []
+
+    def do_PUT(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        payload = json.loads(self.rfile.read(length) or b"{}")
+        SentryHandler.writes.append((self.path, payload))
+        self.respond({"status": "resolved"})
+
     def do_GET(self):
         if self.path == "/api/0/organizations/test/issues/1/":
-            self.respond({"shortId": "TEST-1"})
+            self.respond({"shortId": "TEST-1", "status": "unresolved"})
+            return
+        if self.path == "/api/0/organizations/test/issues/2/":
+            self.respond({"shortId": "TEST-2", "status": "resolved"})
+            return
+        if self.path == "/api/0/organizations/test/releases/live/":
+            self.respond({"version": "live", "projects": [{"slug": "site"}]})
+            return
+        if self.path == "/api/0/organizations/test/releases/other/":
+            self.respond({"version": "other", "projects": [{"slug": "elsewhere"}]})
             return
         if self.path.startswith("/api/0/organizations/test/issues/1/events/"):
             self.respond(
@@ -241,6 +258,83 @@ print('''+----------+----------+----------------------+-------------------------
             manifest = json.loads((output / "manifest.json").read_text())
             self.assertEqual(list(manifest["completed"]), ["1"])
             self.assertEqual(json.loads((output / "1.json").read_text())["project"], "site")
+
+
+    def run_resolve(self, *arguments):
+        SentryHandler.writes = []
+        server = ThreadingHTTPServer(("127.0.0.1", 0), SentryHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        env = dict(os.environ)
+        env["SENTRY_AUTH_TOKEN"] = "test-token"
+        env["SENTRY_URL"] = f"http://127.0.0.1:{server.server_port}"
+        try:
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("sentry_api.py")),
+                    "--org",
+                    "test",
+                    "resolve",
+                    "--project",
+                    "site",
+                    *arguments,
+                ],
+                capture_output=True,
+                check=False,
+                env=env,
+                text=True,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def test_resolve_reports_the_plan_and_writes_nothing_without_apply(self):
+        result = self.run_resolve("--issue", "1", "--in-next-release")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["applied"])
+        self.assertEqual(payload["would_resolve"], ["1"])
+        self.assertEqual(payload["mode"], "in-next-release")
+        self.assertEqual(SentryHandler.writes, [])
+
+    def test_resolve_apply_sends_in_next_release(self):
+        result = self.run_resolve("--issue", "1", "--in-next-release", "--apply")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["resolved"], ["1"])
+        self.assertEqual(len(SentryHandler.writes), 1)
+        path, body = SentryHandler.writes[0]
+        self.assertIn("id=1", path)
+        self.assertEqual(body["status"], "resolved")
+        self.assertEqual(body["statusDetails"], {"inNextRelease": True})
+
+    def test_resolve_apply_sends_the_named_release(self):
+        result = self.run_resolve("--issue", "1", "--in-release", "live", "--apply")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            SentryHandler.writes[0][1]["statusDetails"], {"inRelease": "live"}
+        )
+
+    def test_resolve_rejects_a_release_the_project_does_not_hold(self):
+        result = self.run_resolve("--issue", "1", "--in-release", "other", "--apply")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not associated with project site", result.stderr)
+        self.assertEqual(SentryHandler.writes, [])
+
+    def test_resolve_skips_an_issue_already_resolved(self):
+        result = self.run_resolve("--issue", "2", "--in-next-release", "--apply")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["already_resolved"], ["2"])
+        self.assertEqual(payload["would_resolve"], [])
+        self.assertEqual(SentryHandler.writes, [])
+
+    def test_resolve_rejects_a_non_numeric_issue(self):
+        result = self.run_resolve("--issue", "TEST-1", "--in-next-release", "--apply")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("numeric issue ID", result.stderr)
+        self.assertEqual(SentryHandler.writes, [])
 
 
 if __name__ == "__main__":

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -27,6 +27,11 @@ class SentryHandler(BaseHTTPRequestHandler):
         if self.path == "/api/0/organizations/test/issues/2/":
             self.respond({"shortId": "TEST-2", "status": "resolved"})
             return
+        if self.path == "/api/0/organizations/test/issues/3/":
+            self.respond(
+                {"shortId": "TEST-3", "status": "unresolved", "project": {"slug": "elsewhere"}}
+            )
+            return
         if self.path == "/api/0/organizations/test/releases/live/":
             self.respond({"version": "live", "projects": [{"slug": "site"}]})
             return
@@ -328,6 +333,12 @@ print('''+----------+----------+----------------------+-------------------------
         payload = json.loads(result.stdout)
         self.assertEqual(payload["already_resolved"], ["2"])
         self.assertEqual(payload["would_resolve"], [])
+        self.assertEqual(SentryHandler.writes, [])
+
+    def test_resolve_rejects_an_issue_from_a_different_project(self):
+        result = self.run_resolve("--issue", "3", "--in-next-release", "--apply")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("does not belong to project site", result.stderr)
         self.assertEqual(SentryHandler.writes, [])
 
     def test_resolve_rejects_a_non_numeric_issue(self):


### PR DESCRIPTION
## Problem

70 of 85 issues in the 2026-08-26 run came back tagged `unclosed`: a past run proved the fix, and the issue was still open. mdream was on its 8th run over the same 5 IDs.

The cause was a rule, not a permission. The skill said do not resolve at PR time, because the code is not live yet. It left an exception for after production verification. Nothing ever took that exception, because the run ends at the PR and never comes back after deploy.

## Change

`sentry_api.py` gets a `resolve` command that uses the release as the proof:

- `--in-next-release` for a `fixed` row, after its PR merges. Honest at PR time: it claims the next release fixes it, not that it is fixed now.
- `--in-release VERSION` for an `already-fixed` row, naming the deployed release.

Guards:

- Reports the plan and writes only with `--apply`.
- Rejects a version the project does not hold. A local build with an auth token can create a release that was never deployed, which would otherwise close an issue early. harlanzw.com has exactly this, so the caveat is live, not theoretical.
- Skips an issue already resolved, rejects a non-numeric ID, caps a single call at 200.

`expected`, `third-party`, and `blocked` are never resolved. Muting is still banned outright.

## Checks

- `python3 -m unittest discover` in `scripts/`: 26 pass, 6 new
- `pnpm lint`: 117 problems, 41 errors, identical to baseline on `main`. The change adds none.

Baseline debt: `main` already fails lint with 41 errors in unrelated files.