### PR TITLE
fix(agent): enforce write authority before agent work

### DIFF
--- a/packages/harlan-github-agent/src/github-write-gate.ts
+++ b/packages/harlan-github-agent/src/github-write-gate.ts
@@ -1,57 +1,73 @@
-import type { GitHubAgentSource } from './github-agent-source.ts'
-import type { RepositoryMapping } from './types.ts'
-import { err } from './result.ts'
+import type { GitHubTokenProvider } from './github-auth.ts'
+import type { Result } from './result.ts'
+import type { GitHubRepositoryAccess } from './types.ts'
+import { err, ok } from './result.ts'
 
 export interface GitHubWriteGateOptions {
   /** True when a person has trusted the controller to write to this repository. */
   mayWrite: (github: string) => boolean
   /** Called once for each refused write, so a person sees why nothing happened. */
   onRefused: (github: string) => void
-  source: GitHubAgentSource
+  source: GitHubTokenProvider
 }
 
-/**
- * The reason a quarantined repository refuses every write.
- *
- * One wording, so the failure taxonomy and the dashboard both recognise it.
- */
+/** The reason every write credential is refused for one quarantined repository. */
 export function repositoryQuarantineReason(github: string): string {
   return `The controller has never been trusted to write to ${github}. Enable writes for it first.`
 }
 
+const writeAccess = new Set<GitHubRepositoryAccess>(['contents_write', 'item_write'])
+
 /**
- * Refuses every GitHub write to a repository nobody has enabled writes for.
+ * Refuses every write credential to a repository nobody enabled.
  *
- * Discovery decides what the controller can see, and until now nothing decided
- * what it could write to. Widening `allowed_owners` by one organization put
- * four repositories in reach, and the controller published ninety eight
- * automated comments across them under Harlan's own account within the hour.
- *
- * The gate sits here, around the source itself, rather than at the command
- * tables. Two callers already write straight through this interface without
- * staging a command, which is why the journal held no record of those ninety
- * eight. Anything that can write has to come through this object, so this is
- * the only place that can refuse all of it, including callers not yet written.
+ * Every GitHub mutation needs one of the two write access levels. Keeping the
+ * gate at that shared boundary covers comments, labels, branches, pull requests,
+ * and future writers without each caller remembering a separate policy check.
  */
-export function createGitHubWriteGate(options: GitHubWriteGateOptions): GitHubAgentSource {
-  const refuse = (repository: RepositoryMapping) => {
-    options.onRefused(repository.github)
-    return Promise.resolve(err(repositoryQuarantineReason(repository.github)))
-  }
-  const source = options.source
+export function createGitHubWriteGate(options: GitHubWriteGateOptions): GitHubTokenProvider {
   return {
-    ...source,
-    consumeApprovalLabel: (repository, subjectKind, itemNumber, label, signal) => options.mayWrite(repository.github)
-      ? source.consumeApprovalLabel(repository, subjectKind, itemNumber, label, signal)
-      : refuse(repository),
-    ensureApprovalLabel: (repository, label, signal) => options.mayWrite(repository.github)
-      ? source.ensureApprovalLabel(repository, label, signal)
-      : refuse(repository),
-    upsertIssueTriageComment: (repository, issueNumber, commentId, body, signal) => options.mayWrite(repository.github)
-      ? source.upsertIssueTriageComment(repository, issueNumber, commentId, body, signal)
-      : refuse(repository),
-    upsertReviewStatus: (repository, pullRequestNumber, commentId, body, replacePriorReview, signal) => options.mayWrite(repository.github)
-      ? source.upsertReviewStatus(repository, pullRequestNumber, commentId, body, replacePriorReview, signal)
-      : refuse(repository),
+    getToken(repository, access, signal) {
+      if (!writeAccess.has(access) || options.mayWrite(repository))
+        return options.source.getToken(repository, access, signal)
+      options.onRefused(repository)
+      return Promise.resolve(err({
+        repository,
+        message: repositoryQuarantineReason(repository),
+      }))
+    },
+    invalidate: (repository, access) => options.source.invalidate(repository, access),
+  }
+}
+
+export async function preflightGitHubWriteAccess(
+  source: GitHubTokenProvider,
+  repository: string,
+  accesses: readonly GitHubRepositoryAccess[],
+  signal?: AbortSignal,
+): Promise<Result<void, string>> {
+  for (const access of accesses) {
+    const token = await source.getToken(repository, access, signal)
+    if (token._tag === 'Err')
+      return err(token.error.message)
+  }
+  return ok(undefined)
+}
+
+interface RepositoryWorker<Task extends { repository: string }, Value> {
+  run: (task: Task, signal: AbortSignal) => Promise<Result<Value, string>>
+}
+
+/** Refuses work before an Agent turn when its required GitHub access is absent. */
+export function withGitHubWritePreflight<Task extends { repository: string }, Value>(options: {
+  accesses: readonly GitHubRepositoryAccess[]
+  source: GitHubTokenProvider
+  worker: RepositoryWorker<Task, Value>
+}): RepositoryWorker<Task, Value> {
+  return {
+    async run(task, signal) {
+      const access = await preflightGitHubWriteAccess(options.source, task.repository, options.accesses, signal)
+      return access._tag === 'Err' ? access : options.worker.run(task, signal)
+    },
   }
 }

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -84,6 +84,7 @@ export interface ItemAgentOptions {
 }
 
 export interface ReviewWorkerOptions extends Omit<ItemAgentOptions, 'workspaces'> {
+  preflightRepair: (repository: string, signal: AbortSignal) => Promise<Result<void, string>>
   store: Pick<JournalStore, 'getRepairedHeadFindings' | 'getWorkerSession' | 'isBaselineRepairPullRequest' | 'queueReviewFixTaskForReview' | 'recordIncident' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'updateAgentProgress'>
   workspaces: Pick<AgentWorkspaceManager, 'prepareIssue' | 'prepareReview' | 'verifyReview'>
 }
@@ -661,9 +662,11 @@ type RepairPreflight
   = | { _tag: 'Authorized' }
     | { _tag: 'ActionRequired', reason: string }
 
-function repairPreflight(task: ClaimedAdversarialReviewTask, snapshot: PullRequestReviewSnapshot, repairsBaseline: boolean): RepairPreflight {
+function repairPreflight(task: ClaimedAdversarialReviewTask, snapshot: PullRequestReviewSnapshot, repairsBaseline: boolean, access: Result<void, string>): RepairPreflight {
   if (!canRepairPullRequestHead(task.repositoryMapping, task.pullRequest))
     return { _tag: 'ActionRequired', reason: 'The controller cannot write this pull request branch.' }
+  if (access._tag === 'Err')
+    return { _tag: 'ActionRequired', reason: access.error }
   const baseAllowsRepair = snapshot.baseChecks._tag === 'Available'
     && (snapshot.baseChecks.checks.length === 0 || checksGate(snapshot.baseChecks, 'base-ci', 'Pending')._tag === 'Passed')
   if (!repairsBaseline && !baseAllowsRepair)
@@ -762,14 +765,17 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       if (snapshot.value.priorAutomatedReview._tag === 'Found' && task.rerun._tag === 'NotRequested')
         return ok({ evidence: `Existing automated review by @${snapshot.value.priorAutomatedReview.authorLogin}: ${snapshot.value.priorAutomatedReview.url}` })
       const repairsBaseline = options.store.isBaselineRepairPullRequest(task.repository, task.pullRequest.headRef)
+      const repairAccess = await options.preflightRepair(task.repository, signal)
       if (!repairsBaseline && baseChecksFailed(snapshot.value) && basesDefaultBranch(snapshot.value.pullRequest, task.repositoryMapping)) {
-        const baseline = options.store.queueBaselineRepairForReview({
-          taskId: task.id,
-          workerId: task.state.workerId,
-          fence: task.state.fence,
-          baseSha: snapshot.value.pullRequest.baseSha,
-          at: options.now().toISOString(),
-        })
+        const baseline = repairAccess._tag === 'Ok'
+          ? options.store.queueBaselineRepairForReview({
+              taskId: task.id,
+              workerId: task.state.workerId,
+              fence: task.state.fence,
+              baseSha: snapshot.value.pullRequest.baseSha,
+              at: options.now().toISOString(),
+            })
+          : { _tag: 'NotAuthorized' as const }
         if (baseline._tag === 'Rejected')
           return err(baseline.reason)
         // A repository Harlan only watches cannot get a Baseline repair. The
@@ -801,7 +807,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       // The Review run records which Agent provider and model answered, so the
       // runtime is read once and reused for the whole review.
       const reviewRuntime = options.runtime()
-      const preflight = repairPreflight(task, snapshot.value, repairsBaseline)
+      const preflight = repairPreflight(task, snapshot.value, repairsBaseline, repairAccess)
       const repairedHeadFindings = options.store.getRepairedHeadFindings(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
       const turn = await runParsedAgentTurn({ ...options, parse: parseReviewResponse, runtime: () => reviewRuntime }, {
         number: task.pullRequestNumber,

--- a/packages/harlan-github-agent/src/reconcile.ts
+++ b/packages/harlan-github-agent/src/reconcile.ts
@@ -52,7 +52,8 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
   dependencies.store.recordPollAttempt(repository.github, observedAt)
   const result = await dependencies.github.listOpenItems(repository, dependencies.signal)
   if (result._tag === 'Err') {
-    dependencies.store.recordPollFailure(repository.github, observedAt, result.error.message)
+    if (dependencies.signal?.aborted !== true)
+      dependencies.store.recordPollFailure(repository.github, observedAt, result.error.message)
     return err({ repository: repository.github, message: result.error.message })
   }
 
@@ -82,7 +83,8 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     }))
     const failed = approvals.find(approval => approval._tag === 'Err')
     if (failed?._tag === 'Err') {
-      dependencies.store.recordPollFailure(repository.github, observedAt, failed.error)
+      if (dependencies.signal?.aborted !== true)
+        dependencies.store.recordPollFailure(repository.github, observedAt, failed.error)
       return err({ repository: repository.github, message: failed.error })
     }
   }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -22,7 +22,7 @@ import { classifyFailure } from './failure.ts'
 import { createGitHubAgentSource } from './github-agent-source.ts'
 import { createGitHubAppTokenProvider, createRoutedTokenProvider, createUserTokenProvider } from './github-auth.ts'
 import { createGitHubUserAccess } from './github-user-access.ts'
-import { createGitHubWriteGate, repositoryQuarantineReason } from './github-write-gate.ts'
+import { createGitHubWriteGate, preflightGitHubWriteAccess, repositoryQuarantineReason, withGitHubWritePreflight } from './github-write-gate.ts'
 import { createGitHubPullRequestMerger, createGitHubPullRequestPublisher, createGitHubSource } from './github.ts'
 import { createIssueTriageCommentController } from './issue-triage-comment-controller.ts'
 import { createIssueWorkWorker } from './issue-work-worker.ts'
@@ -171,13 +171,30 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   }
   // A repository the App cannot reach is answered with Harlan's own account.
   const actorLogin = (repository: RepositoryMapping): string => repository.authentication === 'user' ? userLogin : AGENT_ACTOR_LOGIN
-  const tokens = createRoutedTokenProvider({
+  const routedTokens = createRoutedTokenProvider({
     app: createGitHubAppTokenProvider({
       appId: config.github.appId,
       privateKey: options.githubPrivateKey,
     }),
     user: createUserTokenProvider({ readToken: signal => userAccess.token(signal) }),
     usesUserToken: repository => userRepositoryNames.has(repository.toLowerCase()),
+  })
+  // Write authority belongs at the credential boundary. Every current and
+  // future mutation needs one of these write credentials before it can leave.
+  const tokens = createGitHubWriteGate({
+    mayWrite: github => store.mayWriteRepository(github),
+    onRefused: (github) => {
+      store.recordIncident({
+        scope: { _tag: 'Repository', repository: github },
+        kind: 'policy',
+        severity: 'warning',
+        message: repositoryQuarantineReason(github),
+        operation: 'write',
+        recovery: { _tag: 'ActionRequired' },
+        at: now().toISOString(),
+      })
+    },
+    source: routedTokens,
   })
   const github = createGitHubSource({ actorLogin, tokens, issueCutoff: config.issueCutoff })
   const pullRequestStatuses = createPullRequestStatusController({
@@ -194,23 +211,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   })
   // Ephemeral: what each running agent is doing right now, never persisted.
   const activityLog = createAgentActivityLog()
-  // Every GitHub write leaves through this object, so quarantine sits on it
-  // rather than on the callers. Two of them write without staging a command.
-  const workerGithub = createGitHubWriteGate({
-    mayWrite: github => store.mayWriteRepository(github),
-    onRefused: (github) => {
-      store.recordIncident({
-        scope: { _tag: 'Repository', repository: github },
-        kind: 'policy',
-        severity: 'warning',
-        message: repositoryQuarantineReason(github),
-        operation: 'write',
-        recovery: { _tag: 'ActionRequired' },
-        at: now().toISOString(),
-      })
-    },
-    source: createGitHubAgentSource({ actorLogin, tokens }),
-  })
+  const workerGithub = createGitHubAgentSource({ actorLogin, tokens })
   const mutationSchedulers = await (async () => {
     if (!config.mutationsEnabled)
       return undefined
@@ -233,14 +234,18 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       const current = validated.value.repositories[0]
       return current === undefined ? err('Repository mapping disappeared during validation.') : ok(current)
     }
-    const conflictWorker = createConflictWorker({
-      activityLog,
-      github,
-      now,
-      runtime,
-      store,
-      worktrees,
-      validateMapping,
+    const conflictWorker = withGitHubWritePreflight({
+      accesses: ['item_write', 'contents_write'],
+      source: tokens,
+      worker: createConflictWorker({
+        activityLog,
+        github,
+        now,
+        runtime,
+        store,
+        worktrees,
+        validateMapping,
+      }),
     })
     const reviewStatus = createReviewStatusController({
       github: workerGithub,
@@ -266,6 +271,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           at: now().toISOString(),
         })
       },
+      preflightRepair: (repository: string, signal: AbortSignal) => preflightGitHubWriteAccess(tokens, repository, ['contents_write'], signal),
       store,
       runtime,
       status: reviewStatus,
@@ -311,14 +317,18 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onTaskSettled: activityLog.clear,
         permits,
         store,
-        worker: createBaselineRepairWorker({
-          activityLog,
-          github: workerGithub,
-          now,
-          runtime,
-          store,
-          validateMapping,
-          worktrees: baselineWorktrees,
+        worker: withGitHubWritePreflight({
+          accesses: ['item_write', 'contents_write'],
+          source: tokens,
+          worker: createBaselineRepairWorker({
+            activityLog,
+            github: workerGithub,
+            now,
+            runtime,
+            store,
+            validateMapping,
+            worktrees: baselineWorktrees,
+          }),
         }),
         workerId: randomUUID(),
       }),
@@ -334,7 +344,11 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onError: error => options.logger.error(error),
         onTaskSettled: activityLog.clear,
         permits,
-        worker: createIssueTriageWorker(subjectWorkerOptions),
+        worker: withGitHubWritePreflight({
+          accesses: ['item_write'],
+          source: tokens,
+          worker: createIssueTriageWorker(subjectWorkerOptions),
+        }),
         workerId: randomUUID(),
       }),
       publications: createPublicationScheduler({
@@ -361,16 +375,20 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onTaskSettled: activityLog.clear,
         permits,
         store,
-        worker: createReviewFixWorker({
-          activityLog,
-          github: workerGithub,
-          now,
-          onProgressPublishFailure: subjectWorkerOptions.onProgressPublishFailure,
-          runtime,
-          status: reviewStatus,
-          store,
-          validateMapping,
-          worktrees: fixWorktrees,
+        worker: withGitHubWritePreflight({
+          accesses: ['item_write', 'contents_write'],
+          source: tokens,
+          worker: createReviewFixWorker({
+            activityLog,
+            github: workerGithub,
+            now,
+            onProgressPublishFailure: subjectWorkerOptions.onProgressPublishFailure,
+            runtime,
+            status: reviewStatus,
+            store,
+            validateMapping,
+            worktrees: fixWorktrees,
+          }),
         }),
         workerId: randomUUID(),
       })),
@@ -386,7 +404,11 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onError: error => options.logger.error(error),
         onTaskSettled: activityLog.clear,
         permits,
-        worker: createReviewWorker(subjectWorkerOptions),
+        worker: withGitHubWritePreflight({
+          accesses: ['item_write'],
+          source: tokens,
+          worker: createReviewWorker(subjectWorkerOptions),
+        }),
         workerId: randomUUID(),
       })),
       issueWork: createTaskScheduler({
@@ -403,14 +425,18 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onTaskSettled: activityLog.clear,
         permits,
         store,
-        worker: createIssueWorkWorker({
-          github: workerGithub,
-          activityLog,
-          now,
-          runtime,
-          store,
-          validateMapping,
-          worktrees: issueWorktrees,
+        worker: withGitHubWritePreflight({
+          accesses: ['item_write', 'contents_write'],
+          source: tokens,
+          worker: createIssueWorkWorker({
+            github: workerGithub,
+            activityLog,
+            now,
+            runtime,
+            store,
+            validateMapping,
+            worktrees: issueWorktrees,
+          }),
         }),
         workerId: randomUUID(),
       }),
@@ -446,6 +472,11 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     })
   }
 
+  function replaceServiceIncidents(operation: string, messages: string[]): void {
+    messages.forEach(message => recordServiceIncident(operation, message))
+    store.resolveIncidents({ _tag: 'Service' }, now().toISOString(), operation, messages)
+  }
+
   const poller = createPoller({
     intervalMilliseconds: config.pollIntervalSeconds * 1_000,
     timeoutMilliseconds: Math.max(5 * 60_000, config.pollIntervalSeconds * 4_000),
@@ -459,6 +490,8 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         now,
         signal,
       })
+      if (signal.aborted)
+        return
       results.forEach((result) => {
         if (result._tag === 'Ok')
           options.logger.info(`${result.value.repository}: observed ${result.value.subjects} open pull requests and issues.`)
@@ -486,17 +519,17 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       reruns.forEach((result) => {
         if (result._tag === 'Err') {
           options.logger.error(`Review rerun command: ${result.error}`)
-          recordServiceIncident('review_rerun', result.error)
         }
         else if (result.value.results.some(item => item._tag === 'Queued')) {
           options.logger.info(`${result.value.repository}: queued a requested review rerun.`)
         }
       })
+      replaceServiceIncidents('review_rerun', reruns.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       const statusSync = await pullRequestStatuses.sync(store.getDashboardSnapshot(now().toISOString()), signal)
       statusSync.errors.forEach((error) => {
         options.logger.error(`Pull request status: ${error}`)
-        recordServiceIncident('pull_request_status', error)
       })
+      replaceServiceIncidents('pull_request_status', statusSync.errors)
       if (mutationSchedulers !== undefined) {
         const stopped = await publishStoppedReviews({
           github: workerGithub,
@@ -514,9 +547,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           }
           else {
             options.logger.error(`Stopped review comment: ${result.error}`)
-            recordServiceIncident('stopped_review_comment', result.error)
           }
         })
+        replaceServiceIncidents('stopped_review_comment', stopped.flatMap(result => result._tag === 'Err' ? [result.error] : []))
         const positions = await publishQueuePositions({
           github: workerGithub,
           now,
@@ -533,9 +566,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           }
           else {
             options.logger.error(`Queue position comment: ${result.error}`)
-            recordServiceIncident('queue_position_comment', result.error)
           }
         })
+        replaceServiceIncidents('queue_position_comment', positions.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       }
       // Only a pass where nothing succeeded describes an outage. Throwing for a
       // partial failure backed the poller off to its 15 minute ceiling and held
@@ -543,11 +576,8 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       const failed = results.filter(result => result._tag === 'Err').length
       if (failed > 0 && failed === results.length)
         throw new Error(`Every repository reconciliation failed (${failed}).`)
-      if (failed > 0) {
+      if (failed > 0)
         options.logger.info(`${failed} of ${results.length} repositories failed this pass. The rest reconciled.`)
-        return
-      }
-      store.resolveIncidents({ _tag: 'Service' }, now().toISOString())
     },
     onError: error => options.logger.error(error),
   })

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -184,6 +184,9 @@ function recordTaskIncident(database: DatabaseSync, taskId: string, reason: stri
   `).get(taskId, taskId) as { repository: string, github_number: number, kind: string, recovery_attempts: number } | undefined
   if (row === undefined)
     return
+  // A Task has one current failure. A later failure replaces the earlier cause
+  // instead of leaving several contradictory recovery instructions visible.
+  resolveTaskIncidents(database, taskId, at)
   const failure = classifyFailure({ message: reason })
   const exhausted = row.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS
   upsertIncident(database, {
@@ -572,7 +575,7 @@ export interface JournalStore {
   /** Names one failure for the system pane. Repeats raise `occurrences`. */
   recordIncident: (input: RecordIncidentInput) => Incident
   /** Clears every open Incident for one scope once the work behind it succeeds. */
-  resolveIncidents: (scope: IncidentScope, at: string) => number
+  resolveIncidents: (scope: IncidentScope, at: string, operation?: string, exceptMessages?: readonly string[]) => number
   listIncidents: () => Incident[]
   recordReviewRun: (input: RecordReviewRunInput) => RecordReviewRunResult
   recordReviewPublication: (input: RecordReviewPublicationInput) => RecordReviewPublicationResult
@@ -3730,6 +3733,12 @@ export function openJournalStore(
         at,
         'Repository policy no longer permits this Worker.',
       ))
+      database.prepare(`
+        UPDATE incidents SET resolved_at = ?
+        WHERE resolved_at IS NULL AND scope_tag = 'Repository' AND repository IN (
+          SELECT github FROM repositories WHERE enabled = 0
+        )
+      `).run(at)
       database.exec('COMMIT')
     }
     catch (error) {
@@ -4244,20 +4253,24 @@ export function openJournalStore(
 
   const recordIncident: JournalStore['recordIncident'] = input => upsertIncident(database, input)
 
-  const resolveIncidents: JournalStore['resolveIncidents'] = (scope, at) => {
+  const resolveIncidents: JournalStore['resolveIncidents'] = (scope, at, operation, exceptMessages = []) => {
+    const operationClause = operation === undefined ? '' : ' AND operation = ?'
+    const operationArgs = operation === undefined ? [] : [operation]
+    const exceptClause = exceptMessages.length === 0 ? '' : ` AND message NOT IN (${exceptMessages.map(() => '?').join(', ')})`
+    const filterArgs = [...operationArgs, ...exceptMessages]
     const changes = scope._tag === 'Service'
       ? database.prepare(`
-        UPDATE incidents SET resolved_at = ? WHERE resolved_at IS NULL AND scope_tag = 'Service'
-      `).run(at).changes
+        UPDATE incidents SET resolved_at = ? WHERE resolved_at IS NULL AND scope_tag = 'Service'${operationClause}${exceptClause}
+      `).run(at, ...filterArgs).changes
       : scope._tag === 'Repository'
         ? database.prepare(`
           UPDATE incidents SET resolved_at = ?
-          WHERE resolved_at IS NULL AND scope_tag = 'Repository' AND repository = ?
-        `).run(at, scope.repository).changes
+          WHERE resolved_at IS NULL AND scope_tag = 'Repository' AND repository = ?${operationClause}${exceptClause}
+        `).run(at, scope.repository, ...filterArgs).changes
         : database.prepare(`
           UPDATE incidents SET resolved_at = ?
-          WHERE resolved_at IS NULL AND scope_tag = 'Task' AND task_id = ?
-        `).run(at, scope.taskId).changes
+          WHERE resolved_at IS NULL AND scope_tag = 'Task' AND task_id = ?${operationClause}${exceptClause}
+        `).run(at, scope.taskId, ...filterArgs).changes
     return Number(changes)
   }
 
@@ -4291,20 +4304,43 @@ export function openJournalStore(
   }
 
   const resolveStaleTaskIncidents: JournalStore['resolveStaleTaskIncidents'] = (at) => {
-    // An Incident belongs to work the controller still intends to do. A Task
-    // that completed, was superseded, or belongs to an older Revision is none
-    // of those, so its Incident is only noise in the System pane.
+    // An Incident belongs to the current failure of work that can still run.
+    // Startup repairs journals written before that invariant was enforced.
     const stale = (table: 'tasks' | 'worker_tasks') => `
       UPDATE incidents SET resolved_at = ?
       WHERE resolved_at IS NULL AND scope_tag = 'Task' AND task_id IN (
         SELECT ${table}.id FROM ${table}
         JOIN subjects ON subjects.id = ${table}.subject_id
-        WHERE ${table}.state_tag IN ('Completed', 'Superseded')
+        WHERE (${table}.state_tag IN ('Completed', 'Superseded')
           OR ${table}.revision_id != subjects.current_revision_id
+          OR (${table}.state_tag = 'Failed' AND incidents.message != ${table}.reason))
       )
     `
-    return (['tasks', 'worker_tasks'] as const)
+    const resolved = (['tasks', 'worker_tasks'] as const)
       .reduce((total, table) => total + Number(database.prepare(stale(table)).run(at).changes), 0)
+
+    for (const table of ['tasks', 'worker_tasks'] as const) {
+      const missing = database.prepare(`
+        SELECT ${table}.id, ${table}.reason
+        FROM ${table}
+        JOIN subjects ON subjects.id = ${table}.subject_id
+        JOIN repositories ON repositories.id = subjects.repository_id
+        WHERE ${table}.state_tag = 'Failed'
+          AND ${table}.reason IS NOT NULL
+          AND ${table}.revision_id = subjects.current_revision_id
+          AND repositories.enabled = 1
+          AND NOT EXISTS (
+            SELECT 1 FROM incidents
+            WHERE incidents.resolved_at IS NULL
+              AND incidents.scope_tag = 'Task'
+              AND incidents.task_id = ${table}.id
+              AND incidents.message = ${table}.reason
+          )
+      `).all() as unknown as Array<{ id: string, reason: string }>
+      for (const task of missing)
+        recordTaskIncident(database, task.id, task.reason, at)
+    }
+    return resolved
   }
 
   const restoreOutageRecoveryBudget: JournalStore['restoreOutageRecoveryBudget'] = (at) => {
@@ -6341,19 +6377,22 @@ export function openJournalStore(
         at: input.at,
       })
       if (!retry) {
-        database.prepare(`
+        const task = database.prepare(`
           UPDATE tasks
           SET state_tag = 'Failed', reason = ?, command_id = NULL, updated_at = ?
           WHERE id = ? AND state_tag = 'Publishing' AND command_id = ?
         `).run(input.reason, input.at, row.task_id, input.commandId)
-        recordTransition(database, {
-          taskId: row.task_id,
-          from: 'Publishing',
-          to: 'Failed',
-          reason: input.reason,
-          fence: row.task_fence,
-          at: input.at,
-        })
+        if (task.changes === 1) {
+          recordTransition(database, {
+            taskId: row.task_id,
+            from: 'Publishing',
+            to: 'Failed',
+            reason: input.reason,
+            fence: row.task_fence,
+            at: input.at,
+          })
+          recordTaskIncident(database, row.task_id, input.reason, input.at)
+        }
       }
       database.exec('COMMIT')
       return retry ? 'Retrying' : 'Failed'

--- a/packages/harlan-github-agent/test/github-write-gate.test.ts
+++ b/packages/harlan-github-agent/test/github-write-gate.test.ts
@@ -1,67 +1,90 @@
-import type { GitHubAgentSource } from '../src/github-agent-source.ts'
+import type { GitHubRepositoryAccess } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
-import { createGitHubWriteGate, repositoryQuarantineReason } from '../src/github-write-gate.ts'
-import { ok } from '../src/result.ts'
-import { repositoryMapping } from './fixtures.ts'
-
-function source(calls: string[]): GitHubAgentSource {
-  const record = (name: string) => {
-    calls.push(name)
-    return Promise.resolve(ok({ commentId: 1, url: 'url' }))
-  }
-  return {
-    consumeApprovalLabel: () => {
-      calls.push('consumeApprovalLabel')
-      return Promise.resolve(ok(undefined))
-    },
-    ensureApprovalLabel: () => {
-      calls.push('ensureApprovalLabel')
-      return Promise.resolve(ok(undefined))
-    },
-    upsertIssueTriageComment: () => record('upsertIssueTriageComment'),
-    upsertReviewStatus: () => record('upsertReviewStatus'),
-  } as unknown as GitHubAgentSource
-}
+import { createGitHubWriteGate, repositoryQuarantineReason, withGitHubWritePreflight } from '../src/github-write-gate.ts'
+import { err, ok } from '../src/result.ts'
 
 describe('gitHub write gate', () => {
-  it('refuses every write to a repository nobody enabled writes for', async () => {
-    const calls: string[] = []
+  it('refuses every write credential to a repository nobody enabled', async () => {
+    const requested: GitHubRepositoryAccess[] = []
     const refused: string[] = []
     const gate = createGitHubWriteGate({
       mayWrite: () => false,
       onRefused: github => refused.push(github),
-      source: source(calls),
+      source: {
+        getToken: (_repository, access) => {
+          requested.push(access)
+          return Promise.resolve(ok({ token: 'token', expiresAt: '2126-01-01T00:00:00.000Z' }))
+        },
+        invalidate: () => undefined,
+      },
     })
-    const repository = repositoryMapping()
-    const signal = new AbortController().signal
 
-    const results = [
-      await gate.upsertReviewStatus(repository, 1, null, 'body', false, signal),
-      await gate.upsertIssueTriageComment(repository, 1, null, 'body', signal),
-      await gate.ensureApprovalLabel(repository, 'harlan-agent-review', signal),
-      await gate.consumeApprovalLabel(repository, 'pull_request', 1, 'harlan-agent-review', signal),
-    ]
+    const results = await Promise.all([
+      gate.getToken('harlan-zw/example', 'item_write'),
+      gate.getToken('harlan-zw/example', 'contents_write'),
+    ])
 
-    expect(results).toEqual(Array.from({ length: 4 }, () => ({
+    expect(results).toEqual(Array.from({ length: 2 }, () => ({
       _tag: 'Err',
-      error: repositoryQuarantineReason('harlan-zw/example'),
+      error: {
+        repository: 'harlan-zw/example',
+        message: repositoryQuarantineReason('harlan-zw/example'),
+      },
     })))
-    expect(calls).toEqual([])
-    expect(refused).toEqual(Array.from({ length: 4 }).fill('harlan-zw/example'))
+    expect(requested).toEqual([])
+    expect(refused).toEqual(['harlan-zw/example', 'harlan-zw/example'])
   })
 
-  it('passes every write through once a person enables the repository', async () => {
-    const calls: string[] = []
+  it('passes reads and trusted writes through unchanged', async () => {
+    const requested: GitHubRepositoryAccess[] = []
     const gate = createGitHubWriteGate({
       mayWrite: github => github === 'harlan-zw/example',
       onRefused: () => { throw new Error('An enabled repository must not be refused.') },
-      source: source(calls),
+      source: {
+        getToken: (_repository, access) => {
+          requested.push(access)
+          return Promise.resolve(ok({ token: access, expiresAt: '2126-01-01T00:00:00.000Z' }))
+        },
+        invalidate: () => undefined,
+      },
     })
-    const signal = new AbortController().signal
 
-    await gate.upsertReviewStatus(repositoryMapping(), 1, null, 'body', false, signal)
-    await gate.ensureApprovalLabel(repositoryMapping(), 'harlan-agent-review', signal)
+    expect(await gate.getToken('outside/example', 'read')).toEqual(ok({
+      token: 'read',
+      expiresAt: '2126-01-01T00:00:00.000Z',
+    }))
+    expect(await gate.getToken('harlan-zw/example', 'item_write')).toEqual(ok({
+      token: 'item_write',
+      expiresAt: '2126-01-01T00:00:00.000Z',
+    }))
+    expect(requested).toEqual(['read', 'item_write'])
+  })
 
-    expect(calls).toEqual(['upsertReviewStatus', 'ensureApprovalLabel'])
+  it('stops before agent work when GitHub refuses required access', async () => {
+    const requested: GitHubRepositoryAccess[] = []
+    let runs = 0
+    const worker = withGitHubWritePreflight({
+      accesses: ['item_write', 'contents_write'],
+      source: {
+        getToken: (repository, access) => {
+          requested.push(access)
+          return Promise.resolve(access === 'contents_write'
+            ? err({ repository, message: 'The GitHub App needs Contents write permission.' })
+            : ok({ token: access, expiresAt: '2126-01-01T00:00:00.000Z' }))
+        },
+        invalidate: () => undefined,
+      },
+      worker: {
+        run: () => {
+          runs += 1
+          return Promise.resolve(ok({ evidence: 'Agent ran.' }))
+        },
+      },
+    })
+
+    expect(await worker.run({ repository: 'harlan-zw/example' }, new AbortController().signal))
+      .toEqual(err('The GitHub App needs Contents write permission.'))
+    expect(requested).toEqual(['item_write', 'contents_write'])
+    expect(runs).toBe(0)
   })
 })

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -40,6 +40,63 @@ describe('incident log', () => {
     expect(store.listIncidents().map(incident => incident.kind).sort()).toEqual(['github_access', 'rate_limit'])
   })
 
+  it('clears only the service operation that recovered', () => {
+    const store = createStore()
+    store.recordIncident({
+      scope: { _tag: 'Service' },
+      kind: 'network',
+      severity: 'warning',
+      operation: 'review_rerun',
+      message: 'fetch failed',
+      recovery: { _tag: 'Retrying', attempt: 0, nextAttemptAt: '2026-08-18T00:01:00.000Z' },
+      at: '2026-08-18T00:01:00.000Z',
+    })
+    store.recordIncident({
+      scope: { _tag: 'Service' },
+      kind: 'network',
+      severity: 'warning',
+      operation: 'pull_request_status',
+      message: 'fetch failed',
+      recovery: { _tag: 'Retrying', attempt: 0, nextAttemptAt: '2026-08-18T00:01:00.000Z' },
+      at: '2026-08-18T00:01:00.000Z',
+    })
+
+    store.resolveIncidents({ _tag: 'Service' }, '2026-08-18T00:02:00.000Z', 'review_rerun')
+
+    expect(store.listIncidents().map(incident => incident.operation)).toEqual(['pull_request_status'])
+  })
+
+  it('keeps the current service failure while clearing the prior failure', () => {
+    const store = createStore()
+    for (const [message, at] of [
+      ['first failure', '2026-08-18T00:01:00.000Z'],
+      ['current failure', '2026-08-18T00:02:00.000Z'],
+      ['current failure', '2026-08-18T00:03:00.000Z'],
+    ] as const) {
+      store.recordIncident({
+        scope: { _tag: 'Service' },
+        kind: 'network',
+        severity: 'warning',
+        operation: 'review_rerun',
+        message,
+        recovery: { _tag: 'Retrying', attempt: 0, nextAttemptAt: at },
+        at,
+      })
+    }
+
+    store.resolveIncidents(
+      { _tag: 'Service' },
+      '2026-08-18T00:03:00.000Z',
+      'review_rerun',
+      ['current failure'],
+    )
+
+    expect(store.listIncidents()).toMatchObject([{
+      message: 'current failure',
+      occurrences: 2,
+    }])
+  })
+
   it('clears a repository incident once the repository polls cleanly', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
@@ -434,6 +491,130 @@ describe('recovery budget after a GitHub outage', () => {
 })
 
 describe('stale task incidents', () => {
+  it('restores a missing incident for the current failed task', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'missing-incident-pr',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    let taskId = ''
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextAdversarialReviewTask(`worker-${attempt}`, `2026-08-18T00:00:0${attempt}.000Z`, 10_000)
+      if (task === null)
+        throw new Error(`Expected failure attempt ${attempt}.`)
+      taskId = task.id
+      store.failWorkerTask({
+        taskId,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-18T00:00:0${attempt}.000Z`,
+        reason: 'The GitHub App needs Contents write permission.',
+      })
+    }
+    store.resolveIncidents({ _tag: 'Task', taskId, repository: 'harlan-zw/example', itemNumber: 24 }, '2026-08-18T00:00:04.000Z')
+    expect(store.listIncidents()).toEqual([])
+
+    store.resolveStaleTaskIncidents('2026-08-18T00:00:05.000Z')
+
+    expect(store.listIncidents()).toMatchObject([{
+      message: 'The GitHub App needs Contents write permission.',
+      scope: { _tag: 'Task', taskId },
+    }])
+  })
+
+  it('closes an incident that no longer matches the task failure', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'old-incident-pr',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    let taskId = ''
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextAdversarialReviewTask(`worker-${attempt}`, `2026-08-18T00:00:0${attempt}.000Z`, 10_000)
+      if (task === null)
+        throw new Error(`Expected failure attempt ${attempt}.`)
+      taskId = task.id
+      store.failWorkerTask({
+        taskId,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-18T00:00:0${attempt}.000Z`,
+        reason: 'The current failure.',
+      })
+    }
+    store.recordIncident({
+      scope: { _tag: 'Task', taskId, repository: 'harlan-zw/example', itemNumber: 24 },
+      kind: 'policy',
+      severity: 'error',
+      operation: 'adversarial_review',
+      message: 'An old failure.',
+      recovery: { _tag: 'ActionRequired' },
+      at: '2026-08-18T00:00:04.000Z',
+    })
+    expect(store.listIncidents()).toHaveLength(2)
+
+    expect(store.resolveStaleTaskIncidents('2026-08-18T00:00:05.000Z')).toBe(1)
+
+    expect(store.listIncidents()).toMatchObject([{ message: 'The current failure.' }])
+  })
+
+  it('keeps only the current failure for one task', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'changed-failure-pr',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextAdversarialReviewTask(`worker-a-${attempt}`, `2026-08-18T00:00:0${attempt}.000Z`, 10_000)
+      if (task === null)
+        throw new Error(`Expected first failure attempt ${attempt}.`)
+      store.failWorkerTask({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-18T00:00:0${attempt}.000Z`,
+        reason: 'fetch failed',
+      })
+    }
+    expect(store.retryRecoverableWorkerFailures('2026-08-18T00:00:05.000Z')).toBe(1)
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextAdversarialReviewTask(`worker-b-${attempt}`, `2026-08-18T01:00:0${attempt}.000Z`, 10_000)
+      if (task === null)
+        throw new Error(`Expected second failure attempt ${attempt}.`)
+      store.failWorkerTask({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-18T01:00:0${attempt}.000Z`,
+        reason: 'The agent returned malformed review JSON.',
+      })
+    }
+
+    expect(store.listIncidents()).toMatchObject([{
+      kind: 'agent_result',
+      message: 'The agent returned malformed review JSON.',
+    }])
+  })
+
+  it('clears incidents for a repository removed from the service', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordPollFailure('harlan-zw/example', '2026-08-18T00:01:00.000Z', 'fetch failed')
+
+    store.syncRepositories([], '2026-08-18T00:02:00.000Z')
+
+    expect(store.listIncidents()).toEqual([])
+  })
+
   it('closes an incident once a newer revision supersedes its task', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -75,6 +75,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('A clean review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
@@ -162,6 +163,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('A second comment must not be posted.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('A second review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
@@ -254,6 +256,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => {
           queued = true
@@ -360,6 +363,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('A wrong premise must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
@@ -454,6 +458,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => {
           // The store refuses once the reused identity matches its guard.
@@ -545,6 +550,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('Base CI failure must prevent Repair work.') },
         getRepairedHeadFindings: () => [],
@@ -623,6 +629,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
@@ -708,6 +715,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
@@ -789,6 +797,7 @@ describe('subject Workers', () => {
         upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -132,6 +132,26 @@ describe('gitHub reconciliation', () => {
     store.close()
   })
 
+  it('does not report shutdown cancellation as repository failure', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    const controller = new AbortController()
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    controller.abort()
+
+    const result = await reconcileRepository(repository, {
+      github: { listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'This operation was aborted' })) },
+      store,
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      signal: controller.signal,
+    })
+
+    expect(result).toEqual({ _tag: 'Err', error: { repository: repository.github, message: 'This operation was aborted' } })
+    expect(store.getDashboardSnapshot('2026-08-13T01:00:00.000Z').repositories[0]?.lastError).toBeNull()
+    expect(store.listIncidents()).toEqual([])
+    store.close()
+  })
+
   it('does not reuse legacy observation identities after revision schema changes', async () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -71,6 +71,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], requiredChecks: Required
       upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
     },
     now: () => new Date('2026-08-13T01:00:00.000Z'),
+    preflightRepair: () => Promise.resolve(ok(undefined)),
     store: {
       queueReviewFixTaskForReview: () => { throw new Error('Unexpected Repair queue.') },
       getRepairedHeadFindings: () => [],

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -68,6 +68,7 @@ function harness(input: {
   response: unknown
   snapshots?: Array<ReturnType<typeof reviewSnapshot>>
   publish?: () => ReturnType<ReviewWorkerOptions['status']['publish']>
+  preflightRepair?: ReviewWorkerOptions['preflightRepair']
   queueRepair?: () => ReviewFixQueueResult
   verifyReview?: () => ReturnType<ReviewWorkerOptions['workspaces']['verifyReview']>
 }): Harness {
@@ -102,6 +103,7 @@ function harness(input: {
     },
     now: () => new Date('2026-08-13T01:00:00.000Z'),
     onProgressPublishFailure: (_task, reason) => progressFailures.push(reason),
+    preflightRepair: input.preflightRepair ?? (() => Promise.resolve(ok(undefined))),
     store: {
       queueReviewFixTaskForReview: input.queueRepair ?? (() => {
         repairs.queued += 1
@@ -448,6 +450,27 @@ describe('review resilience', () => {
 
     expect(test.queued).toBe(0)
     expect(test.comments.at(-1)).toContain('The base branch must pass CI before Repair starts.')
+  })
+
+  it('does not queue Repair when GitHub refuses write access', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const reason = 'The GitHub App needs Contents write permission.'
+    const test = harness({
+      pullRequest,
+      preflightRepair: () => Promise.resolve(err(reason)),
+      response: {
+        metadata: passingGate,
+        review: { state: 'failed', reason: 'A material finding remains.', evidence: 'proof' },
+        verification: passingGate,
+        findings: [materialFinding()],
+        confidence: null,
+      },
+    })
+
+    await createReviewWorker(test.options).run(reviewTask(pullRequest), new AbortController().signal)
+
+    expect(test.queued).toBe(0)
+    expect(test.comments.at(-1)).toContain(reason)
   })
 
   it('hands every material finding to Repair without a count cap', async () => {

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -79,6 +79,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], baseChecks?: GitHubCheck
       upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
     },
     now: () => new Date('2026-08-19T01:00:00.000Z'),
+    preflightRepair: () => Promise.resolve(ok(undefined)),
     store: {
       queueReviewFixTaskForReview: () => { throw new Error('Unexpected Repair queue.') },
       getRepairedHeadFindings: () => [],


### PR DESCRIPTION
## Description

`skilld-dev/skilld.dev` spent six Agent attempts before publication found a missing GitHub App permission. Issue #138 lost a finished patch because its PR text was malformed. Write access now fails before an Agent starts, and a valid patch gets safe controller metadata before Review and Repair take over.

## AI disclosure

This pull request was generated by an AI agent. The agent verified the changes with the repository test suite, typecheck, and build.
