### PR TITLE
fix(agent): preserve Baseline repair patches

### DIFF
--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -107,7 +107,9 @@ function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
       if (value.outcome === 'blocked') {
         return ok({
           outcome: 'blocked',
-          summary: typeof value.summary === 'string' ? value.summary : '',
+          summary: typeof value.summary === 'string' && cleanLine(value.summary).length > 0
+            ? value.summary
+            : 'The Agent reported that it could not safely repair Baseline CI.',
           checks: Array.isArray(value.checks) ? value.checks.filter((check): check is string => typeof check === 'string') : [],
         })
       }

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -5,7 +5,7 @@ import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedBaselineRepairTask, MutationWorkerOutcome, RepositoryMapping } from './types.ts'
 import type { BaselineRepairWorktreeManager } from './worktree.ts'
-import { truncateOutput } from './agent-activity.ts'
+import { redactSecrets, truncateOutput } from './agent-activity.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { canRepairBaseline } from './repository-policy.ts'
 import { err, ok } from './result.ts'
@@ -101,10 +101,18 @@ function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
   return Promise.resolve(text)
     .then(value => JSON.parse(value) as AgentResponsePayload)
     .then((value): Result<AgentResponse, string> => {
+      // A blocked intent is a completed turn, even when its metadata fields are
+      // malformed. Surface it so the caller returns ActionRequired instead of
+      // substituting metadata and publishing a patch.
+      if (value.outcome === 'blocked') {
+        return ok({
+          outcome: 'blocked',
+          summary: typeof value.summary === 'string' ? value.summary : '',
+          checks: Array.isArray(value.checks) ? value.checks.filter((check): check is string => typeof check === 'string') : [],
+        })
+      }
       if (typeof value.summary !== 'string' || !Array.isArray(value.checks) || !value.checks.every(check => typeof check === 'string'))
         return err('The agent returned an invalid Baseline repair result.')
-      if (value.outcome === 'blocked')
-        return ok({ outcome: 'blocked', summary: value.summary, checks: value.checks as string[] })
       if (
         value.outcome !== 'repaired'
         || typeof value.commitMessage !== 'string'
@@ -205,7 +213,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
         options.activityLog?.record(task.id, {
           _tag: 'Reasoning',
           at: options.now().toISOString(),
-          text: `The agent response could not be parsed (${parsed.error}) and the controller substituted the pull request metadata. Raw response: ${truncateOutput(turn.value.response)}`,
+          text: `The agent response could not be parsed (${parsed.error}) and the controller substituted the pull request metadata. Raw response: ${truncateOutput(redactSecrets(turn.value.response))}`,
         })
         response = controllerBaselineMetadata(template.value)
       }

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -5,6 +5,7 @@ import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedBaselineRepairTask, MutationWorkerOutcome, RepositoryMapping } from './types.ts'
 import type { BaselineRepairWorktreeManager } from './worktree.ts'
+import { truncateOutput } from './agent-activity.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { canRepairBaseline } from './repository-policy.ts'
 import { err, ok } from './result.ts'
@@ -80,6 +81,20 @@ function withDisclosure(body: string): string {
     .join('\n')
     .trimEnd()
   return `${description}\n\n${disclosure}`
+}
+
+function controllerBaselineMetadata(template: PullRequestTemplate): RepairedResponse {
+  const title = 'fix: repair default branch CI'
+  return {
+    outcome: 'repaired',
+    summary: 'The controller published the verified Baseline repair patch.',
+    checks: [],
+    commitMessage: title,
+    pullRequestTitle: title,
+    pullRequestBody: template._tag === 'Found'
+      ? `${template.body.trimEnd()}\n\nRepairs failing default branch CI.`
+      : 'Repairs failing default branch CI.',
+  }
 }
 
 function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
@@ -182,10 +197,23 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
       if (turn._tag === 'Err')
         return turn
       const parsed = await parseResponse(turn.value.response)
-      if (parsed._tag === 'Err')
-        return parsed
-      if (parsed.value.outcome === 'blocked')
-        return ok({ _tag: 'ActionRequired', reason: cleanLine(parsed.value.summary), evidence: JSON.stringify(parsed.value) })
+      // A bad metadata envelope must not discard a finished patch. Review and
+      // Repair own code quality after publication, so the controller supplies
+      // safe PR metadata and keeps the Agent's work moving.
+      let response: RepairedResponse
+      if (parsed._tag === 'Err') {
+        options.activityLog?.record(task.id, {
+          _tag: 'Reasoning',
+          at: options.now().toISOString(),
+          text: `The agent response could not be parsed (${parsed.error}) and the controller substituted the pull request metadata. Raw response: ${truncateOutput(turn.value.response)}`,
+        })
+        response = controllerBaselineMetadata(template.value)
+      }
+      else {
+        if (parsed.value.outcome === 'blocked')
+          return ok({ _tag: 'ActionRequired', reason: cleanLine(parsed.value.summary), evidence: JSON.stringify(parsed.value) })
+        response = parsed.value
+      }
       const verified = await options.worktrees.verify(task, prepared.value, signal)
       if (verified._tag === 'Err')
         return verified
@@ -194,7 +222,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
         return frozen
       if (frozen.value.pullRequest.baseSha !== prepared.value.baseSha)
         return err('Default branch changed before the controller committed the Baseline repair.')
-      const committed = await options.worktrees.commit(task, prepared.value, verified.value, parsed.value.commitMessage, signal)
+      const committed = await options.worktrees.commit(task, prepared.value, verified.value, response.commitMessage, signal)
       if (committed._tag === 'Err')
         return committed
       return ok({
@@ -203,8 +231,8 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
           _tag: 'OpenPullRequest',
           taskKind: 'baseline_repair',
           pullRequestNumber: task.pullRequestNumber,
-          pullRequestTitle: parsed.value.pullRequestTitle,
-          pullRequestBody: withDisclosure(parsed.value.pullRequestBody),
+          pullRequestTitle: response.pullRequestTitle,
+          pullRequestBody: withDisclosure(response.pullRequestBody),
           commitSha: committed.value.commitSha,
           baseSha: committed.value.baseSha,
           // A Baseline repair fixes the default branch, so it never stacks.

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -5,7 +5,7 @@ import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedIssueWorkTask, MutationWorkerOutcome, OpenAgentPullRequest, PullRequestBase, RepositoryMapping } from './types.ts'
 import type { IssueWorktreeManager, PreparedWorkerWorkspace, VerifiedIssuePatch } from './worktree.ts'
-import { truncateOutput } from './agent-activity.ts'
+import { redactSecrets, truncateOutput } from './agent-activity.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { issueSnapshotDigest } from './item-agent.ts'
 import { canWorkIssues } from './repository-policy.ts'
@@ -140,11 +140,11 @@ function parseAgentResponse(text: string, issueNumber: number, template: PullReq
     .then(value => JSON.parse(value) as AgentResponsePayload)
     .then((value): Result<AgentResponse, string> => {
       if (value.outcome === 'blocked') {
-        if (typeof value.summary !== 'string')
-          return err('The agent returned an invalid issue work result.')
         return ok({
           outcome: 'blocked',
-          summary: value.summary,
+          summary: typeof value.summary === 'string' && cleanLine(value.summary).length > 0
+            ? value.summary
+            : 'The Agent reported that it could not safely complete the issue work.',
           checks: Array.isArray(value.checks) && value.checks.every(check => typeof check === 'string') ? value.checks : [],
         })
       }
@@ -321,7 +321,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
         options.activityLog?.record(task.id, {
           _tag: 'Reasoning',
           at: options.now().toISOString(),
-          text: `The agent response could not be parsed (${parsed.error}) and the controller substituted the pull request metadata. Raw response: ${truncateOutput(turn.value.response)}`,
+          text: `The agent response could not be parsed (${parsed.error}) and the controller substituted the pull request metadata. Raw response: ${truncateOutput(redactSecrets(turn.value.response))}`,
         })
         response = controllerIssueMetadata(task, template.value)
       }

--- a/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
+++ b/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
@@ -94,7 +94,7 @@ describe('baseline repair worker', () => {
       },
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([
         { _tag: 'SessionStarted', sessionId: 'session-1' },
-        { _tag: 'Message', text: '{' },
+        { _tag: 'Message', text: '{ broken ghp_Abcdefghijklmnopqrstuvwx' },
         { _tag: 'TurnCompleted' },
       ])),
       github: {
@@ -150,15 +150,71 @@ describe('baseline repair worker', () => {
       taskId: 'baseline-task',
       item: expect.objectContaining({
         _tag: 'Reasoning',
-        text: expect.stringMatching(/malformed Baseline repair JSON[\s\S]*\{/),
+        text: expect.stringMatching(/malformed Baseline repair JSON[\s\S]*ghp_\*\*\*/),
       }),
     }])
+    expect(JSON.stringify(recorded)).not.toContain('ghp_Abcdefghijklmnopqrstuvwx')
     expect(result).toEqual(ok({
       _tag: 'Publish',
       publication: expect.objectContaining({
         pullRequestTitle: 'fix: repair default branch CI',
         pullRequestBody: expect.stringMatching(/### Description[\s\S]*### Linked Issues[\s\S]*Repairs failing default branch CI\./),
       }),
+    }))
+  })
+
+  it('surfaces ActionRequired when a blocked result carries malformed metadata', async () => {
+    const mapping = repositoryMapping()
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const worker = createBaselineRepairWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([
+        { _tag: 'SessionStarted', sessionId: 'session-1' },
+        { _tag: 'Message', text: JSON.stringify({ outcome: 'blocked' }) },
+        { _tag: 'TurnCompleted' },
+      ])),
+      github: {
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' as const },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      store: {
+        getWorkerSession: () => null,
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: value => Promise.resolve(ok(value)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/baseline-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.baseSha })),
+        verify: () => Promise.resolve(ok({ digest: 'patch-digest', changedFiles: 2 })),
+        commit: () => Promise.reject(new Error('A blocked result must not publish a patch.')),
+      },
+    })
+
+    const result = await worker.run({
+      id: 'baseline-task',
+      kind: 'baseline_repair',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'baseline-agent', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+    }, new AbortController().signal)
+
+    expect(result).toEqual(ok({
+      _tag: 'ActionRequired',
+      reason: '',
+      evidence: expect.stringContaining('"outcome":"blocked"'),
     }))
   })
 

--- a/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
+++ b/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
@@ -82,6 +82,86 @@ describe('baseline repair worker', () => {
       }),
     }))
   })
+
+  it('publishes a verified patch with safe metadata when Agent output is malformed', async () => {
+    const mapping = repositoryMapping()
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const recorded: Array<{ taskId: string, item: unknown }> = []
+    let commitMessage = ''
+    const worker = createBaselineRepairWorker({
+      activityLog: {
+        record: (taskId, item) => recorded.push({ taskId, item }),
+      },
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([
+        { _tag: 'SessionStarted', sessionId: 'session-1' },
+        { _tag: 'Message', text: '{' },
+        { _tag: 'TurnCompleted' },
+      ])),
+      github: {
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Found', body: '### Description\n\n### Linked Issues' })),
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' as const },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      store: {
+        getWorkerSession: () => null,
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: value => Promise.resolve(ok(value)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/baseline-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.baseSha })),
+        verify: () => Promise.resolve(ok({ digest: 'patch-digest', changedFiles: 2 })),
+        commit: (_task, _worktree, _patch, message) => {
+          commitMessage = message
+          return Promise.resolve(ok({
+            commitSha: 'repair-commit',
+            baseSha: pullRequest.baseSha,
+            artifactRef: 'artifact-ref',
+            digest: 'patch-digest',
+            changedFiles: 2,
+          }))
+        },
+      },
+    })
+
+    const result = await worker.run({
+      id: 'baseline-task',
+      kind: 'baseline_repair',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'baseline-agent', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+    }, new AbortController().signal)
+
+    expect(commitMessage).toBe('fix: repair default branch CI')
+    expect(recorded).toEqual([{
+      taskId: 'baseline-task',
+      item: expect.objectContaining({
+        _tag: 'Reasoning',
+        text: expect.stringMatching(/malformed Baseline repair JSON[\s\S]*\{/),
+      }),
+    }])
+    expect(result).toEqual(ok({
+      _tag: 'Publish',
+      publication: expect.objectContaining({
+        pullRequestTitle: 'fix: repair default branch CI',
+        pullRequestBody: expect.stringMatching(/### Description[\s\S]*### Linked Issues[\s\S]*Repairs failing default branch CI\./),
+      }),
+    }))
+  })
+
   it.each([
     ['the default branch went green', { green: true }, 'Default branch CI no longer fails'],
     ['the default branch moved past the failing commit', { moved: true }, 'The default branch moved to'],

--- a/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
+++ b/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
@@ -213,7 +213,7 @@ describe('baseline repair worker', () => {
 
     expect(result).toEqual(ok({
       _tag: 'ActionRequired',
-      reason: '',
+      reason: 'The Agent reported that it could not safely repair Baseline CI.',
       evidence: expect.stringContaining('"outcome":"blocked"'),
     }))
   })

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -103,7 +103,7 @@ Closes #12.`,
       },
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([
         { _tag: 'SessionStarted', sessionId: 'session-1' },
-        { _tag: 'Message', text: '{' },
+        { _tag: 'Message', text: '{ broken ghp_Abcdefghijklmnopqrstuvwx' },
         { _tag: 'TurnCompleted' },
       ])),
       github: {
@@ -147,9 +147,10 @@ Closes #12.`,
       taskId: 'issue-work-task',
       item: expect.objectContaining({
         _tag: 'Reasoning',
-        text: expect.stringMatching(/malformed issue work JSON[\s\S]*\{/),
+        text: expect.stringMatching(/malformed issue work JSON[\s\S]*ghp_\*\*\*/),
       }),
     }])
+    expect(JSON.stringify(recorded)).not.toContain('ghp_Abcdefghijklmnopqrstuvwx')
     expect(result).toEqual(ok({
       _tag: 'Publish',
       publication: expect.objectContaining({
@@ -166,7 +167,7 @@ Closes #12.`,
     const worker = createIssueWorkWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([
         { _tag: 'SessionStarted', sessionId: 'session-1' },
-        { _tag: 'Message', text: '{"outcome":"blocked","summary":"Cannot determine safe implementation"}' },
+        { _tag: 'Message', text: '{"outcome":"blocked"}' },
         { _tag: 'TurnCompleted' },
       ])),
       github: {
@@ -208,8 +209,8 @@ Closes #12.`,
     expect(committed).toBe(false)
     expect(result).toEqual(ok({
       _tag: 'ActionRequired',
-      reason: 'Cannot determine safe implementation',
-      evidence: '{"outcome":"blocked","summary":"Cannot determine safe implementation","checks":[]}',
+      reason: 'The Agent reported that it could not safely complete the issue work.',
+      evidence: '{"outcome":"blocked","summary":"The Agent reported that it could not safely complete the issue work.","checks":[]}',
     }))
   })
 


### PR DESCRIPTION
## Description

Baseline and Issue Work patches could be lost when an Agent returned malformed pull request text. The controller now supplies safe metadata, preserves blocked intent, and redacts raw fallback logs before Review and Repair take over.

## AI disclosure

This pull request was generated by an AI agent. The agent verified the changes with the repository test suite, lint, typecheck, and build.
