### PR TITLE
fix(agent): recover hidden permission incidents

### DIFF
--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -195,6 +195,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
       if (ready._tag === 'Err')
         return ready
       const turn = await runAgentTurn(options, {
+        freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
         progress: { currentPercent: 35, report: progress, work: 'baseline' },
         prompt: prompt(task, checks, template.value),

--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -125,6 +125,7 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
         return worktreeReady
 
       const turn = await runAgentTurn(options, {
+        freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
         progress: { currentPercent: 35, report: reportProgress, work: 'conflict' },
         prompt: workerPrompt(currentTask),

--- a/packages/harlan-github-agent/src/github-auth.ts
+++ b/packages/harlan-github-agent/src/github-auth.ts
@@ -72,7 +72,9 @@ function permissions(access: GitHubRepositoryAccess): Record<string, PermissionL
     return { checks: 'read', metadata: 'read', statuses: 'read' }
   if (access === 'item_write')
     return { contents: 'read', issues: 'write', metadata: 'read', pull_requests: 'write' }
-  return { contents: 'write', metadata: 'read', workflows: 'write' }
+  if (access === 'workflows_write')
+    return { contents: 'write', metadata: 'read', workflows: 'write' }
+  return { contents: 'write', metadata: 'read' }
 }
 
 /**

--- a/packages/harlan-github-agent/src/github-write-gate.ts
+++ b/packages/harlan-github-agent/src/github-write-gate.ts
@@ -16,12 +16,12 @@ export function repositoryQuarantineReason(github: string): string {
   return `The controller has never been trusted to write to ${github}. Enable writes for it first.`
 }
 
-const writeAccess = new Set<GitHubRepositoryAccess>(['contents_write', 'item_write'])
+const writeAccess = new Set<GitHubRepositoryAccess>(['contents_write', 'item_write', 'workflows_write'])
 
 /**
  * Refuses every write credential to a repository nobody enabled.
  *
- * Every GitHub mutation needs one of the two write access levels. Keeping the
+ * Every GitHub mutation needs a write access level. Keeping the
  * gate at that shared boundary covers comments, labels, branches, pull requests,
  * and future writers without each caller remembering a separate policy check.
  */

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -298,6 +298,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       if (sessionId === null)
         return err('The issue changed before work started.')
       const turn = await runAgentTurn(options, {
+        freshSession: task.state.fence > 1,
         number: task.issueNumber,
         progress: { currentPercent: 35, report: reportProgress, work: 'fix' },
         prompt: workerPrompt(task, snapshot.value.body, snapshot.value.comments, template.value),

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -810,6 +810,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       const preflight = repairPreflight(task, snapshot.value, repairsBaseline, repairAccess)
       const repairedHeadFindings = options.store.getRepairedHeadFindings(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
       const turn = await runParsedAgentTurn({ ...options, parse: parseReviewResponse, runtime: () => reviewRuntime }, {
+        freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
         prompt: reviewPrompt(task, snapshot.value, workspace.value.path, preflight, repairedHeadFindings),
         progress: {
@@ -955,6 +956,7 @@ export function createIssueTriageWorker(options: ItemAgentOptions): IssueTriageW
         return started
       const scopeDigest = issueSnapshotDigest({ ...snapshot.value, baseSha: workspace.value.baseSha })
       const turn = await runParsedAgentTurn({ ...options, parse: parseIssueTriageResponse }, {
+        freshSession: task.state.fence > 1,
         number: task.issueNumber,
         prompt: issuePrompt(task, snapshot.value, workspace.value.path),
         progress: {

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -208,7 +208,7 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
             evidence,
           })
         }
-        if (rerun._tag === 'Duplicate') {
+        if (rerun._tag === 'Duplicate' || rerun.reason._tag === 'DisputeCapReached') {
           return ok({
             _tag: 'ActionRequired',
             reason: `Repair and the fresh Review still disagree: ${turn.value.value.summary}`,

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -24,10 +24,16 @@ interface BlockedResponse {
   checks: string[]
 }
 
-type AgentResponse = RepairedResponse | BlockedResponse
+interface DisputedResponse {
+  outcome: 'disputed'
+  summary: string
+  checks: string[]
+}
+
+type AgentResponse = RepairedResponse | BlockedResponse | DisputedResponse
 
 interface AgentResponsePayload {
-  outcome?: 'repaired' | 'blocked'
+  outcome?: 'repaired' | 'blocked' | 'disputed'
   summary?: string
   checks?: unknown[]
   commitMessage?: string
@@ -40,7 +46,7 @@ export interface ReviewFixWorkerOptions {
   onProgressPublishFailure?: (task: ClaimedReviewFixTask, reason: string) => void
   runtime: AgentRuntimeSource
   status: Pick<ReviewStatusController, 'publishRepair'>
-  store: Pick<JournalStore, 'getReviewFixFindings' | 'getWorkerSession' | 'saveWorkerSession' | 'updateAgentProgress'>
+  store: Pick<JournalStore, 'getReviewFixFindings' | 'getWorkerSession' | 'requestReviewRerun' | 'saveWorkerSession' | 'updateAgentProgress'>
   validateMapping: (mapping: RepositoryMapping) => Promise<Result<RepositoryMapping, string>>
   worktrees: ReviewFixWorktreeManager
 }
@@ -54,7 +60,7 @@ const outputSchema = {
   additionalProperties: false,
   required: ['outcome', 'summary', 'checks', 'commitMessage'],
   properties: {
-    outcome: { type: 'string', enum: ['repaired', 'blocked'] },
+    outcome: { type: 'string', enum: ['repaired', 'blocked', 'disputed'] },
     summary: { type: 'string' },
     checks: { type: 'array', items: { type: 'string' } },
     commitMessage: { type: 'string' },
@@ -66,7 +72,7 @@ function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
     .then(value => JSON.parse(value) as AgentResponsePayload)
     .then((value): Result<AgentResponse, string> => {
       if (
-        (value.outcome !== 'repaired' && value.outcome !== 'blocked')
+        (value.outcome !== 'repaired' && value.outcome !== 'blocked' && value.outcome !== 'disputed')
         || typeof value.summary !== 'string'
         || cleanLine(value.summary).length === 0
         || !Array.isArray(value.checks)
@@ -76,9 +82,9 @@ function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
       ) {
         return err('The Agent returned an invalid Repair result.')
       }
-      return value.outcome === 'blocked'
-        ? ok({ outcome: 'blocked', summary: cleanLine(value.summary), checks: value.checks })
-        : ok({ outcome: 'repaired', summary: cleanLine(value.summary), checks: value.checks, commitMessage: cleanLine(value.commitMessage) })
+      return value.outcome === 'repaired'
+        ? ok({ outcome: 'repaired', summary: cleanLine(value.summary), checks: value.checks, commitMessage: cleanLine(value.commitMessage) })
+        : ok({ outcome: value.outcome, summary: cleanLine(value.summary), checks: value.checks })
     })
     .catch(() => err('The Agent returned malformed Repair JSON.'))
 }
@@ -92,10 +98,11 @@ Apply the unit-tests skill before every bug or validation fix.
 Treat the findings below as the complete Repair scope.
 For each finding, write the named failing regression test first. Confirm it fails for the stated reason.
 Fix every finding. Run focused checks that cover every changed behavior.
-Do not expand scope. Return blocked when the requested scope is unsafe or cannot be verified.
+Do not expand scope. Return disputed only when a regression test or exact source behavior proves the finding false at this head commit.
+Return blocked when the requested scope is unsafe or cannot be verified.
 Do not stage, commit, push, approve, merge, or post comments. The controller owns those operations.
 Choose a concise commit message that describes the actual fix.
-Return an empty commitMessage with outcome blocked.
+Return an empty commitMessage with outcome blocked or disputed.
 Return every schema field.
 Return only the required JSON.
 
@@ -170,6 +177,37 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
           _tag: 'ActionRequired',
           reason: turn.value.value.summary,
           evidence: JSON.stringify({ findings, checks: turn.value.value.checks }),
+        })
+      }
+      if (turn.value.value.outcome === 'disputed') {
+        const evidence = JSON.stringify({ findings, checks: turn.value.value.checks })
+        const rerun = options.store.requestReviewRerun({
+          repository: task.repository,
+          pullRequestNumber: task.pullRequestNumber,
+          revisionId: task.revisionId,
+          requestId: `repair-dispute:${task.id}`,
+          source: 'repair_dispute',
+          requestedBy: 'review_fix',
+          at: options.now().toISOString(),
+        })
+        if (rerun._tag === 'Queued' || rerun._tag === 'AlreadyQueued') {
+          return ok({
+            _tag: 'ActionRequired',
+            reason: `Repair disputed the finding. One fresh Review was queued: ${turn.value.value.summary}`,
+            evidence,
+          })
+        }
+        if (rerun._tag === 'Duplicate') {
+          return ok({
+            _tag: 'ActionRequired',
+            reason: `Repair and the fresh Review still disagree: ${turn.value.value.summary}`,
+            evidence,
+          })
+        }
+        return ok({
+          _tag: 'ActionRequired',
+          reason: `The disputed finding could not receive a fresh Review: ${rerun.reason._tag}.`,
+          evidence,
         })
       }
 

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -6,6 +6,7 @@ import type { ReviewStatusController } from './review-status-controller.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedReviewFixTask, MutationWorkerOutcome, RepositoryMapping, ReviewFinding } from './types.ts'
 import type { ReviewFixWorktreeManager } from './worktree.ts'
+import { createHash } from 'node:crypto'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
@@ -112,6 +113,16 @@ Exact Review findings:
 ${JSON.stringify(findings)}`
 }
 
+function disputeRequestId(taskId: string, findings: ReviewFinding[]): string {
+  const fingerprints = findings
+    .map(finding => finding._tag === 'Open'
+      ? (finding.details?.fingerprint ?? cleanLine(finding.summary).toLocaleLowerCase('en-US'))
+      : '')
+    .sort()
+  const digest = createHash('sha256').update(fingerprints.join('\n')).digest('hex')
+  return `repair-dispute:${taskId}:${digest}`
+}
+
 export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFixWorker {
   return {
     async run(task, signal) {
@@ -185,7 +196,7 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
           repository: task.repository,
           pullRequestNumber: task.pullRequestNumber,
           revisionId: task.revisionId,
-          requestId: `repair-dispute:${task.id}`,
+          requestId: disputeRequestId(task.id, findings),
           source: 'repair_dispute',
           requestedBy: 'review_fix',
           at: options.now().toISOString(),

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3888,6 +3888,24 @@ export function openJournalStore(
         database.exec('COMMIT')
         return { _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }
       }
+      // A Repair dispute mints its request id from reviewer-coined finding
+      // identities, so wording drift evades the exact-digest duplicate check.
+      // Cap disputes at one fresh Review per subject and revision.
+      if (input.source === 'repair_dispute') {
+        const priorDispute = database.prepare(`
+          SELECT 1
+          FROM review_rerun_requests
+          JOIN worker_tasks ON worker_tasks.id = review_rerun_requests.task_id
+          WHERE review_rerun_requests.source = 'repair_dispute'
+            AND worker_tasks.subject_id = ?
+            AND worker_tasks.revision_id = ?
+          LIMIT 1
+        `).get(row.subject_id, input.revisionId) !== undefined
+        if (priorDispute) {
+          database.exec('COMMIT')
+          return { _tag: 'Rejected', reason: { _tag: 'DisputeCapReached' } }
+        }
+      }
 
       const pullRequest = JSON.parse(row.payload) as GitHubPullRequestItem
       const mapping = JSON.parse(row.policy_json) as RepositoryMapping

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -1197,7 +1197,7 @@ const reviewRerunMigration = `
   CREATE TABLE review_rerun_requests (
     id TEXT PRIMARY KEY,
     task_id TEXT NOT NULL REFERENCES worker_tasks(id),
-    source TEXT NOT NULL CHECK (source IN ('dashboard', 'github_comment')),
+    source TEXT NOT NULL CHECK (source IN ('dashboard', 'github_comment', 'repair_dispute')),
     requested_by TEXT NOT NULL,
     requested_at TEXT NOT NULL
   );
@@ -3276,6 +3276,22 @@ const narrowPublicationPermissionMigration = `
   PRAGMA user_version = 33;
 `
 
+const repairDisputeRerunMigration = `
+  ALTER TABLE review_rerun_requests RENAME TO review_rerun_requests_v33;
+  CREATE TABLE review_rerun_requests (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL REFERENCES worker_tasks(id),
+    source TEXT NOT NULL CHECK (source IN ('dashboard', 'github_comment', 'repair_dispute')),
+    requested_by TEXT NOT NULL,
+    requested_at TEXT NOT NULL
+  );
+  INSERT INTO review_rerun_requests (id, task_id, source, requested_by, requested_at)
+    SELECT id, task_id, source, requested_by, requested_at FROM review_rerun_requests_v33;
+  DROP TABLE review_rerun_requests_v33;
+  CREATE INDEX review_rerun_requests_task ON review_rerun_requests(task_id, requested_at);
+  PRAGMA user_version = 34;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -3301,7 +3317,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 33)
+  if (version === 34)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -3434,6 +3450,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 32) {
     applyMigration(database, narrowPublicationPermissionMigration)
+    version = 33
+  }
+  if (version === 33) {
+    applyMigration(database, repairDisputeRerunMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -4477,6 +4497,17 @@ export function openJournalStore(
         contentDigest,
         usage,
       )
+      const repairableFinding = input.findings.some(finding => finding._tag === 'Open' && finding.resolution !== 'Dismissal')
+      if (!repairableFinding) {
+        supersedeTasks(
+          database,
+          revision.subject_id,
+          input.completedAt,
+          'A fresh Review found no repairable finding.',
+          undefined,
+          'review_fix',
+        )
+      }
       database.exec('COMMIT')
       return { _tag: 'Inserted', reviewRunId: input.id }
     }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3292,6 +3292,40 @@ const repairDisputeRerunMigration = `
   PRAGMA user_version = 34;
 `
 
+/**
+ * Gives Tasks exhausted by one poisoned provider session a fresh recovery.
+ *
+ * Retries now start a fresh Agent session after the first claim. These old
+ * Tasks exhausted their recovery budget before that boundary existed.
+ */
+const freshProviderSessionMigration = `
+  UPDATE incidents
+  SET resolved_at = last_seen_at
+  WHERE resolved_at IS NULL
+    AND scope_tag = 'Task'
+    AND task_id IN (
+      SELECT id FROM worker_tasks
+      WHERE state_tag = 'Failed'
+        AND reason = 'The opencode session stopped sending output.'
+      UNION ALL
+      SELECT id FROM tasks
+      WHERE state_tag = 'Failed'
+        AND reason = 'The opencode session stopped sending output.'
+    );
+
+  UPDATE worker_tasks
+  SET recovery_attempts = 0
+  WHERE state_tag = 'Failed'
+    AND reason = 'The opencode session stopped sending output.';
+
+  UPDATE tasks
+  SET recovery_attempts = 0
+  WHERE state_tag = 'Failed'
+    AND reason = 'The opencode session stopped sending output.';
+
+  PRAGMA user_version = 35;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -3317,7 +3351,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 34)
+  if (version === 35)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -3454,6 +3488,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 33) {
     applyMigration(database, repairDisputeRerunMigration)
+    version = 34
+  }
+  if (version === 34) {
+    applyMigration(database, freshProviderSessionMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3249,6 +3249,33 @@ const queuedReviewStatusMigration = `
   PRAGMA user_version = 32;
 `
 
+/**
+ * Gives mutation Tasks one fresh recovery after removing the unconditional
+ * Workflow permission from ordinary branch writes.
+ *
+ * The old token request exhausted these Tasks before an Agent could inspect
+ * their patch. A real missing permission can still spend this one new bounded
+ * recovery and return to Action required.
+ */
+const narrowPublicationPermissionMigration = `
+  UPDATE incidents
+  SET resolved_at = last_seen_at
+  WHERE resolved_at IS NULL
+    AND scope_tag = 'Task'
+    AND task_id IN (
+      SELECT id FROM tasks
+      WHERE state_tag = 'Failed'
+        AND reason LIKE '%permissions requested are not granted to this installation%'
+    );
+
+  UPDATE tasks
+  SET recovery_attempts = 0
+  WHERE state_tag = 'Failed'
+    AND reason LIKE '%permissions requested are not granted to this installation%';
+
+  PRAGMA user_version = 33;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -3274,7 +3301,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 32)
+  if (version === 33)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -3403,6 +3430,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 31) {
     applyForeignKeyMigration(database, queuedReviewStatusMigration)
+    version = 32
+  }
+  if (version === 32) {
+    applyMigration(database, narrowPublicationPermissionMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -3433,51 +3464,45 @@ function openDatabase(path: string): DatabaseSync {
 }
 
 function taskRows(database: DatabaseSync): TaskRow[] {
-  const conflictRows = database.prepare(`
+  const rows = (table: 'tasks' | 'worker_tasks', current: boolean): TaskRow[] => database.prepare(`
     SELECT
-      tasks.id,
-      tasks.kind,
+      ${table}.id,
+      ${table}.kind,
       repositories.github AS repository,
       subjects.github_number,
-      tasks.revision_id,
-      tasks.state_tag,
-      tasks.reason,
-      tasks.worker_id,
-      tasks.evidence,
-      tasks.command_id,
-      tasks.fence,
-      tasks.lease_expires_at,
-      tasks.updated_at
-    FROM tasks
-    JOIN subjects ON subjects.id = tasks.subject_id
+      ${table}.revision_id,
+      ${table}.state_tag,
+      ${table}.reason,
+      ${table}.worker_id,
+      ${table}.evidence,
+      ${table === 'tasks' ? 'tasks.command_id' : 'NULL'} AS command_id,
+      ${table}.fence,
+      ${table}.lease_expires_at,
+      ${table}.updated_at
+    FROM ${table}
+    JOIN subjects ON subjects.id = ${table}.subject_id
     JOIN repositories ON repositories.id = subjects.repository_id
-    ORDER BY tasks.updated_at DESC
-    LIMIT 100
+    ${current
+      ? `JOIN revisions ON revisions.id = subjects.current_revision_id
+         WHERE ${table}.revision_id = subjects.current_revision_id
+           AND repositories.enabled = 1
+           AND json_extract(revisions.payload, '$.state') = 'open'`
+      : ''}
+    ORDER BY ${table}.updated_at DESC
+    ${current ? '' : 'LIMIT 100'}
   `).all() as unknown as TaskRow[]
-  const workerRows = database.prepare(`
-    SELECT
-      worker_tasks.id,
-      worker_tasks.kind,
-      repositories.github AS repository,
-      subjects.github_number,
-      worker_tasks.revision_id,
-      worker_tasks.state_tag,
-      worker_tasks.reason,
-      worker_tasks.worker_id,
-      worker_tasks.evidence,
-      NULL AS command_id,
-      worker_tasks.fence,
-      worker_tasks.lease_expires_at,
-      worker_tasks.updated_at
-    FROM worker_tasks
-    JOIN subjects ON subjects.id = worker_tasks.subject_id
-    JOIN repositories ON repositories.id = subjects.repository_id
-    ORDER BY worker_tasks.updated_at DESC
-    LIMIT 100
-  `).all() as unknown as TaskRow[]
-  return [...conflictRows, ...workerRows]
-    .sort((left, right) => right.updated_at.localeCompare(left.updated_at))
-    .slice(0, 100)
+  const current = [...rows('tasks', true), ...rows('worker_tasks', true)]
+  const currentIds = new Set(current.map(row => row.id))
+  const historyLimit = Math.max(0, 100 - current.length)
+  const history = [...rows('tasks', false), ...rows('worker_tasks', false)]
+    .filter(row => !currentIds.has(row.id))
+    .sort((left, right) => right.updated_at.localeCompare(left.updated_at) || left.id.localeCompare(right.id))
+    .slice(0, historyLimit)
+  const tableOrder = (row: TaskRow): number => row.kind === 'adversarial_review' || row.kind === 'issue_triage' ? 1 : 0
+  return [...current, ...history]
+    .sort((left, right) => right.updated_at.localeCompare(left.updated_at)
+      || tableOrder(left) - tableOrder(right)
+      || left.id.localeCompare(right.id))
 }
 
 function activeAgentRows(database: DatabaseSync, provider: AgentProviderName): ActiveAgentRow[] {

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -471,7 +471,7 @@ export interface ClaimedIssueTriageCommentCommand extends IssueTriageCommentComm
  * token that covers one kind and not the other fails half of those calls. One
  * level means no caller can pick the wrong one.
  */
-export type GitHubRepositoryAccess = 'read' | 'checks_read' | 'contents_write' | 'item_write'
+export type GitHubRepositoryAccess = 'read' | 'checks_read' | 'contents_write' | 'item_write' | 'workflows_write'
 
 export interface GitHubRepositoryToken {
   token: string

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -156,6 +156,7 @@ export type ReviewRerunRejection
     | { _tag: 'RevisionMismatch' }
     | { _tag: 'AuthorNotAllowed' }
     | { _tag: 'ReviewNotReady' }
+    | { _tag: 'DisputeCapReached' }
 
 export type ReviewRerunResult
   = | { _tag: 'Queued', taskId: string }

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -149,7 +149,7 @@ export type IssueWorkApprovalResult
     | { _tag: 'Duplicate', taskId: string }
     | { _tag: 'Rejected', reason: { _tag: 'ItemNotFound' | 'RevisionMismatch' | 'ApprovalNotRequired' | 'TriageRequired' | 'NotAuthorized' } }
 
-export type ReviewRerunSource = 'dashboard' | 'github_comment'
+export type ReviewRerunSource = 'dashboard' | 'github_comment' | 'repair_dispute'
 
 export type ReviewRerunRejection
   = | { _tag: 'ItemNotFound' }

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -1202,6 +1202,11 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
       const credential = await token(command, signal)
       if (credential._tag === 'Err')
         return credential
+      // A Repair commit is based on the unchanged pull request head. A moving
+      // base cannot invalidate its patch, and fresh Review checks the new head
+      // against the latest base after publication.
+      if (command._tag === 'UpdatePullRequest' && command.taskKind === 'review_fix')
+        return ok(undefined)
       // A stacked pull request merges into another pull request's head branch, so
       // the branch this pins is the recorded base, never the default branch.
       const base = await runGit(repositoryGitDirectory(options.root, command.repository), [

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -1126,7 +1126,19 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
   const remoteUrl = options.remoteUrl ?? publicationRemoteUrl
 
   async function token(command: ClaimedPublicationCommand, signal: AbortSignal): Promise<Result<string, string>> {
-    const result = await options.tokens.getToken(command.repository, 'contents_write', signal)
+    const changed = await runGit(repositoryGitDirectory(options.root, command.repository), [
+      'diff',
+      '--name-only',
+      '-z',
+      command.expectedHeadSha,
+      command.commitSha,
+    ], signal)
+    if (changed.exitCode !== 0)
+      return err(`Could not read the prepared publication paths: ${changed.stderr}`)
+    const access = changed.stdout.split('\0').some(path => path.startsWith('.github/workflows/'))
+      ? 'workflows_write'
+      : 'contents_write'
+    const result = await options.tokens.getToken(command.repository, access, signal)
     return result._tag === 'Ok' ? ok(result.value.token) : err(result.error.message)
   }
 

--- a/packages/harlan-github-agent/test/github-auth.test.ts
+++ b/packages/harlan-github-agent/test/github-auth.test.ts
@@ -7,8 +7,9 @@ describe('gitHub App authentication', () => {
   it.each([
     ['read', { contents: 'read', issues: 'read', metadata: 'read', pull_requests: 'read' }],
     ['checks_read', { checks: 'read', metadata: 'read', statuses: 'read' }],
-    ['contents_write', { contents: 'write', metadata: 'read', workflows: 'write' }],
+    ['contents_write', { contents: 'write', metadata: 'read' }],
     ['item_write', { contents: 'read', issues: 'write', metadata: 'read', pull_requests: 'write' }],
+    ['workflows_write', { contents: 'write', metadata: 'read', workflows: 'write' }],
   ] as const)('mints one repository-scoped %s token', async (access, permissions) => {
     const requests: unknown[] = []
     const provider = createRepositoryTokenProvider({

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -844,7 +844,7 @@ describe('subject Workers', () => {
     expect(published).toContain('READY · 88/100')
   })
 
-  it('publishes a valid issue triage result on the issue', async () => {
+  it('publishes a valid issue triage result from a fresh retry session', async () => {
     const issue = issueItem()
     const capture: ProviderCapture = { requests: [] }
     let triageBody = ''
@@ -871,7 +871,7 @@ describe('subject Workers', () => {
       },
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       store: {
-        getWorkerSession: () => null,
+        getWorkerSession: () => 'poisoned-session',
         isBaselineRepairPullRequest: () => false,
         saveWorkerSession: () => undefined,
         updateAgentProgress: () => true,
@@ -896,7 +896,7 @@ describe('subject Workers', () => {
       repository: 'harlan-zw/example',
       issueNumber: 12,
       revisionId: 'revision-1',
-      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 2, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: repositoryMapping(),
       issue,
@@ -916,7 +916,7 @@ describe('subject Workers', () => {
         }),
       },
     })
-    expect(capture.requests).toEqual([expect.objectContaining({ model: 'gpt-5.6-terra', reasoningEffort: 'medium' })])
+    expect(capture.requests).toEqual([expect.objectContaining({ model: 'gpt-5.6-terra', reasoningEffort: 'medium', sessionId: null })])
     expect(triageBody).toBe(`<!-- harlan-agent-kit:issue-triage -->
 ### 🤖 Issue triage
 

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -222,13 +222,18 @@ describe('git publication remote', () => {
     expect(git(bare, 'rev-parse', 'refs/heads/fix/baseline-ci')).toBe(repairSha)
   })
 
-  it('authorizes an approved repair while the pull request remains clean', async () => {
-    const { bare, command, root } = fixture()
+  it('authorizes an approved repair after its clean pull request base moves', async () => {
+    const { bare, checkout, command, root } = fixture()
     const repair = {
       ...command,
       repositoryMapping: { ...command.repositoryMapping, ownership: 'maintained' as const },
       taskKind: 'review_fix' as const,
     }
+    git(checkout, 'checkout', 'main')
+    writeFileSync(join(checkout, 'later.txt'), 'later base change\n')
+    git(checkout, 'add', 'later.txt')
+    git(checkout, 'commit', '-m', 'later base change')
+    git(checkout, 'push', 'origin', 'main')
     const remote = createGitPublicationRemote({
       github: {
         getPullRequest: () => Promise.resolve(ok(pullRequestItem({

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -32,7 +32,7 @@ function contentDigest(checkout: string, from: string, to: string): string {
   return createHash('sha256').update(git(checkout, 'diff', '--raw', '--no-abbrev', '--no-renames', from, to)).digest('hex')
 }
 
-function fixture(): { bare: string, checkout: string, command: Extract<ClaimedPublicationCommand, { _tag: 'UpdatePullRequest' }>, expectedHeadSha: string, root: string } {
+function fixture(changedPath = 'base.txt'): { bare: string, checkout: string, command: Extract<ClaimedPublicationCommand, { _tag: 'UpdatePullRequest' }>, expectedHeadSha: string, root: string } {
   const root = mkdtempSync(join(tmpdir(), 'harlan-publication-'))
   temporaryDirectories.push(root)
   const bare = join(root, 'remote.git')
@@ -48,8 +48,9 @@ function fixture(): { bare: string, checkout: string, command: Extract<ClaimedPu
   git(checkout, 'push', 'origin', 'fix/conflict')
   const expectedHeadSha = git(checkout, 'rev-parse', 'HEAD')
   git(checkout, 'checkout', '-b', 'main')
-  writeFileSync(join(checkout, 'base.txt'), 'base change\n')
-  git(checkout, 'add', 'base.txt')
+  mkdirSync(join(checkout, changedPath, '..'), { recursive: true })
+  writeFileSync(join(checkout, changedPath), 'base change\n')
+  git(checkout, 'add', changedPath)
   git(checkout, 'commit', '-m', 'base change')
   const baseSha = git(checkout, 'rev-parse', 'HEAD')
   git(checkout, 'push', 'origin', 'main')
@@ -92,6 +93,33 @@ function fixture(): { bare: string, checkout: string, command: Extract<ClaimedPu
 }
 
 describe('git publication remote', () => {
+  it.each([
+    ['a source patch', 'base.txt', 'contents_write'],
+    ['a workflow patch', '.github/workflows/ci.yml', 'workflows_write'],
+  ])('requests the narrow token for %s', async (_scenario, changedPath, expectedAccess) => {
+    const { bare, command, root } = fixture(changedPath)
+    const requested: string[] = []
+    const remote = createGitPublicationRemote({
+      github: {
+        getPullRequest: () => Promise.reject(new Error('Not needed.')),
+        hasOpenPullRequestForBranch: () => Promise.resolve(ok(false)),
+        isBranchProtected: () => Promise.reject(new Error('Not needed.')),
+      },
+      remoteUrl: () => bare,
+      root,
+      tokens: {
+        getToken: (_repository, access) => {
+          requested.push(access)
+          return Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' }))
+        },
+        invalidate: () => undefined,
+      },
+    })
+
+    expect(await remote.push(command, new AbortController().signal)).toEqual(ok(undefined))
+    expect(requested).toEqual([expectedAccess])
+  })
+
   it('pins the stack base branch, not the default branch', async () => {
     const { bare, command, expectedHeadSha, root } = fixture()
     const stacked: Extract<ClaimedPublicationCommand, { _tag: 'OpenPullRequest' }> = {

--- a/packages/harlan-github-agent/test/review-fix-worker.test.ts
+++ b/packages/harlan-github-agent/test/review-fix-worker.test.ts
@@ -250,6 +250,75 @@ describe('review fix Worker', () => {
     expect(repeatedDispute[0]).toBe(firstDispute[0])
   })
 
+  it('routes a capped second disagreement to action without another Review', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const mapping = repositoryMapping({ ownership: 'maintained' })
+    const task: ClaimedReviewFixTask = {
+      id: 'repair-task-dispute-capped',
+      kind: 'review_fix',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'repair-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+    }
+    const findings: ReviewFinding[] = [{
+      _tag: 'Open',
+      summary: 'The history query has no limit.',
+      nextAction: 'Limit the history query.',
+      details: {
+        fingerprint: 'b'.repeat(64),
+        location: { path: 'src/store.ts', line: 42 },
+        proof: 'The false branch omits LIMIT 100.',
+        regressionTest: null,
+      },
+    }]
+
+    const result = await createReviewFixWorker({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        outcome: 'disputed',
+        summary: 'The false branch already adds LIMIT 100.',
+        checks: [],
+        commitMessage: '',
+      }))),
+      status: { publishRepair: () => Promise.resolve(ok(undefined)) },
+      store: {
+        getReviewFixFindings: () => findings,
+        getWorkerSession: () => null,
+        requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'DisputeCapReached' } }),
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: () => Promise.resolve(ok(mapping)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/repair-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+        verify: () => { throw new Error('A disputed finding must not produce a patch.') },
+        commit: () => { throw new Error('A disputed finding must not produce a commit.') },
+      },
+    }).run(task, new AbortController().signal)
+
+    expect(result).toEqual(ok({
+      _tag: 'ActionRequired',
+      reason: 'Repair and the fresh Review still disagree: The false branch already adds LIMIT 100.',
+      evidence: JSON.stringify({ findings, checks: [] }),
+    }))
+  })
+
   it('rejects a blocked result with an empty summary', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const mapping = repositoryMapping({ ownership: 'maintained' })

--- a/packages/harlan-github-agent/test/review-fix-worker.test.ts
+++ b/packages/harlan-github-agent/test/review-fix-worker.test.ts
@@ -59,6 +59,7 @@ describe('review fix Worker', () => {
       store: {
         getReviewFixFindings: () => findings,
         getWorkerSession: () => 'review-session-must-not-resume',
+        requestReviewRerun: () => { throw new Error('A successful Repair must not queue another Review.') },
         saveWorkerSession: () => undefined,
         updateAgentProgress: () => true,
       },
@@ -89,6 +90,88 @@ describe('review fix Worker', () => {
       model: 'gpt-5.6-terra',
       prompt: expect.stringContaining('Split one UTF-8 sequence across two chunks'),
     })])
+  })
+
+  it('queues one fresh Review when Repair disproves a finding', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const mapping = repositoryMapping({ ownership: 'maintained' })
+    const task: ClaimedReviewFixTask = {
+      id: 'repair-task-disputed',
+      kind: 'review_fix',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'repair-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+    }
+    const findings: ReviewFinding[] = [{
+      _tag: 'Open',
+      summary: 'The history query has no limit.',
+      nextAction: 'Limit the history query.',
+      details: {
+        fingerprint: 'f'.repeat(64),
+        location: { path: 'src/store.ts', line: 42 },
+        proof: 'The false branch omits LIMIT 100.',
+        regressionTest: 'Seed old history and assert only 100 rows are read.',
+      },
+    }]
+    const reruns: unknown[] = []
+
+    const result = await createReviewFixWorker({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        outcome: 'disputed',
+        summary: 'The false branch already adds LIMIT 100.',
+        checks: ['pnpm vitest run test/dashboard-history-limit.test.ts'],
+        commitMessage: '',
+      }))),
+      status: { publishRepair: () => Promise.resolve(ok(undefined)) },
+      store: {
+        getReviewFixFindings: () => findings,
+        getWorkerSession: () => null,
+        requestReviewRerun: (input) => {
+          reruns.push(input)
+          return { _tag: 'Queued', taskId: 'review-task' }
+        },
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: () => Promise.resolve(ok(mapping)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/repair-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+        verify: () => { throw new Error('A disputed finding must not produce a patch.') },
+        commit: () => { throw new Error('A disputed finding must not produce a commit.') },
+      },
+    }).run(task, new AbortController().signal)
+
+    expect(result).toEqual(ok({
+      _tag: 'ActionRequired',
+      reason: 'Repair disputed the finding. One fresh Review was queued: The false branch already adds LIMIT 100.',
+      evidence: JSON.stringify({ findings, checks: ['pnpm vitest run test/dashboard-history-limit.test.ts'] }),
+    }))
+    expect(reruns).toEqual([{
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: task.revisionId,
+      requestId: `repair-dispute:${task.id}`,
+      source: 'repair_dispute',
+      requestedBy: 'review_fix',
+      at: '2026-08-13T01:00:00.000Z',
+    }])
   })
 
   it('rejects a blocked result with an empty summary', async () => {
@@ -142,6 +225,7 @@ describe('review fix Worker', () => {
       store: {
         getReviewFixFindings: () => findings,
         getWorkerSession: () => null,
+        requestReviewRerun: () => { throw new Error('An invalid result must not queue another Review.') },
         saveWorkerSession: () => undefined,
         updateAgentProgress: () => true,
       },

--- a/packages/harlan-github-agent/test/review-fix-worker.test.ts
+++ b/packages/harlan-github-agent/test/review-fix-worker.test.ts
@@ -167,11 +167,87 @@ describe('review fix Worker', () => {
       repository: mapping.github,
       pullRequestNumber: pullRequest.number,
       revisionId: task.revisionId,
-      requestId: `repair-dispute:${task.id}`,
+      requestId: expect.stringMatching(/^repair-dispute:repair-task-disputed:[0-9a-f]{64}$/),
       source: 'repair_dispute',
       requestedBy: 'review_fix',
       at: '2026-08-13T01:00:00.000Z',
     }])
+  })
+
+  it('gives each distinct dispute set its own rerun request', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const mapping = repositoryMapping({ ownership: 'maintained' })
+    const task: ClaimedReviewFixTask = {
+      id: 'repair-task-disputed',
+      kind: 'review_fix',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'repair-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+    }
+    const openFinding = (fingerprint: string): ReviewFinding => ({
+      _tag: 'Open',
+      summary: `Finding ${fingerprint.slice(0, 4)}.`,
+      nextAction: 'Fix it.',
+      details: {
+        fingerprint,
+        location: { path: 'src/store.ts', line: 42 },
+        proof: 'The false branch omits LIMIT 100.',
+        regressionTest: null,
+      },
+    })
+    const snapshot = () => Promise.resolve(ok({
+      baseChecks: { _tag: 'Available' as const, checks: [] },
+      body: '',
+      checks: { _tag: 'Available' as const, checks: [] },
+      comments: [],
+      priorAutomatedReview: { _tag: 'None' } as const,
+      pullRequest,
+      requiredChecks: { _tag: 'None' } as const,
+      reviews: [],
+    }))
+    const run = async (findings: ReviewFinding[]) => {
+      const reruns: string[] = []
+      await createReviewFixWorker({
+        github: { getPullRequestReviewSnapshot: snapshot },
+        now: () => new Date('2026-08-13T01:00:00.000Z'),
+        runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+          outcome: 'disputed',
+          summary: 'The false branch already adds LIMIT 100.',
+          checks: [],
+          commitMessage: '',
+        }))),
+        status: { publishRepair: () => Promise.resolve(ok(undefined)) },
+        store: {
+          getReviewFixFindings: () => findings,
+          getWorkerSession: () => null,
+          requestReviewRerun: (input) => {
+            reruns.push(input.requestId)
+            return { _tag: 'Queued', taskId: 'review-task' }
+          },
+          saveWorkerSession: () => undefined,
+          updateAgentProgress: () => true,
+        },
+        validateMapping: () => Promise.resolve(ok(mapping)),
+        worktrees: {
+          prepare: () => Promise.resolve(ok({ path: '/tmp/repair-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+          verify: () => { throw new Error('A disputed finding must not produce a patch.') },
+          commit: () => { throw new Error('A disputed finding must not produce a commit.') },
+        },
+      }).run(task, new AbortController().signal)
+      return reruns
+    }
+
+    const firstDispute = await run([openFinding('a'.repeat(64))])
+    const repeatedDispute = await run([openFinding('a'.repeat(64))])
+    const secondDispute = await run([openFinding('b'.repeat(64))])
+
+    expect(firstDispute[0]).toMatch(/^repair-dispute:repair-task-disputed:[0-9a-f]{64}$/)
+    expect(secondDispute[0]).not.toBe(firstDispute[0])
+    expect(repeatedDispute[0]).toBe(firstDispute[0])
   })
 
   it('rejects a blocked result with an empty summary', async () => {

--- a/packages/harlan-github-agent/test/review-repair-claim.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-claim.test.ts
@@ -125,6 +125,70 @@ describe('review Repair queue', () => {
     })._tag).toBe('Staged')
   })
 
+  it('retires a disputed Repair after a fresh Review finds no defect', () => {
+    const store = createStore()
+    const { review, revisionId } = runningReview(store, 'fix/disputed-finding')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
+    const queued = store.queueReviewFixTaskForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:04.000Z',
+    })
+    if (queued._tag !== 'Queued')
+      throw new Error(queued.reason)
+    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:05.000Z', 60_000)
+    if (repair === null)
+      throw new Error('Expected the Repair Task.')
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:05.500Z',
+      evidence: 'Queued Repair.',
+    })).toBe(true)
+    expect(store.needsAttentionTask({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:00:06.000Z',
+      reason: 'Repair disputed the finding.',
+      evidence: 'The query already has LIMIT 100.',
+    })).toBe(true)
+    expect(store.requestReviewRerun({
+      repository: review.repository,
+      pullRequestNumber: review.pullRequestNumber,
+      revisionId,
+      requestId: `repair-dispute:${repair.id}`,
+      source: 'repair_dispute',
+      requestedBy: 'review_fix',
+      at: '2026-08-13T01:00:06.500Z',
+    })._tag).toBe('Queued')
+    expect(store.claimNextAdversarialReviewTask('fresh-review-agent', '2026-08-13T01:00:06.750Z', 60_000)).not.toBeNull()
+
+    expect(store.recordReviewRun({
+      id: 'fresh-clean-review',
+      repository: review.repository,
+      pullRequestNumber: review.pullRequestNumber,
+      revisionId,
+      headSha: review.pullRequest.headSha,
+      provider: 'codex',
+      sessionId: 'fresh-review-session',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:00:07.000Z',
+      completedAt: '2026-08-13T01:00:08.000Z',
+      gates: passedReviewGates(),
+      findings: [],
+    })._tag).toBe('Inserted')
+
+    expect(store.getDashboardSnapshot('2026-08-13T01:00:09.000Z').tasks.find(task => task.id === repair.id)?.state).toEqual({
+      _tag: 'Superseded',
+      reason: 'A fresh Review found no repairable finding.',
+    })
+  })
+
   it('ends a review whose repair the controller may never publish', () => {
     const store = createStore()
     const { review, revisionId } = runningReview(store, 'wip/unwritable-branch')

--- a/packages/harlan-github-agent/test/review-repair-claim.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-claim.test.ts
@@ -50,11 +50,12 @@ function recordOpenFinding(
   headSha: string,
   resolution: 'Repair' | 'Dismissal' = 'Repair',
   identity = 'unsafe-parser-input',
+  runId?: string,
 ): void {
   const gates = passedReviewGates()
   gates.review = { _tag: 'Failed', reason: 'A material finding remains.', evidence: [] }
   store.recordReviewRun({
-    id: `review-run-${revisionId}`,
+    id: runId ?? `review-run-${revisionId}`,
     repository: 'harlan-zw/example',
     pullRequestNumber: 24,
     revisionId,
@@ -187,6 +188,91 @@ describe('review Repair queue', () => {
       _tag: 'Superseded',
       reason: 'A fresh Review found no repairable finding.',
     })
+  })
+
+  it('caps Repair disputes at one fresh Review per revision', () => {
+    const store = createStore()
+    const { review, revisionId } = runningReview(store, 'fix/dispute-loop')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
+    const queued = store.queueReviewFixTaskForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:04.000Z',
+    })
+    if (queued._tag !== 'Queued')
+      throw new Error(queued.reason)
+    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:05.000Z', 60_000)
+    if (repair === null)
+      throw new Error('Expected the Repair Task.')
+    expect(store.needsAttentionTask({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:00:06.000Z',
+      reason: 'Repair disputed the finding.',
+      evidence: 'The query already limits rows.',
+    })).toBe(true)
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:06.100Z',
+      evidence: 'Queued Repair.',
+    })).toBe(true)
+    expect(store.requestReviewRerun({
+      repository: review.repository,
+      pullRequestNumber: review.pullRequestNumber,
+      revisionId,
+      requestId: `repair-dispute:${repair.id}:first`,
+      source: 'repair_dispute',
+      requestedBy: 'review_fix',
+      at: '2026-08-13T01:00:06.500Z',
+    })._tag).toBe('Queued')
+
+    // The fresh Review rewords the same defect, so its Repair mints a new
+    // dispute digest. The second disagreement must not queue another Review.
+    const freshReview = store.claimNextAdversarialReviewTask('fresh-review-agent', '2026-08-13T01:00:07.000Z', 60_000)
+    if (freshReview === null)
+      throw new Error('Expected the fresh Review Task.')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha, 'Repair', 'history-query-unbounded', 'fresh-dispute-review')
+    const freshQueued = store.queueReviewFixTaskForReview({
+      taskId: freshReview.id,
+      workerId: freshReview.state.workerId,
+      fence: freshReview.state.fence,
+      at: '2026-08-13T01:00:07.500Z',
+    })
+    if (freshQueued._tag !== 'Queued')
+      throw new Error(freshQueued.reason)
+    const secondRepair = store.claimNextReviewFixTask('repair-agent-2', '2026-08-13T01:00:08.000Z', 60_000)
+    if (secondRepair === null)
+      throw new Error('Expected the second Repair Task.')
+    expect(store.needsAttentionTask({
+      taskId: secondRepair.id,
+      workerId: secondRepair.state.workerId,
+      fence: secondRepair.state.fence,
+      at: '2026-08-13T01:00:09.000Z',
+      reason: 'Repair disputed the finding again.',
+      evidence: 'The wording drifted, so the dispute is new.',
+    })).toBe(true)
+    expect(store.completeWorkerTask({
+      taskId: freshReview.id,
+      workerId: freshReview.state.workerId,
+      fence: freshReview.state.fence,
+      at: '2026-08-13T01:00:09.100Z',
+      evidence: 'Queued Repair.',
+    })).toBe(true)
+
+    expect(store.requestReviewRerun({
+      repository: review.repository,
+      pullRequestNumber: review.pullRequestNumber,
+      revisionId,
+      requestId: `repair-dispute:${secondRepair.id}:second`,
+      source: 'repair_dispute',
+      requestedBy: 'review_fix',
+      at: '2026-08-13T01:00:09.500Z',
+    })).toEqual({ _tag: 'Rejected', reason: { _tag: 'DisputeCapReached' } })
+    expect(store.claimNextAdversarialReviewTask('another-review-agent', '2026-08-13T01:00:10.000Z', 60_000)).toBeNull()
   })
 
   it('ends a review whose repair the controller may never publish', () => {

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -236,6 +236,58 @@ describe('review usage migration', () => {
   })
 })
 
+describe('installation permission recovery migration', () => {
+  it('gives Tasks blocked by the old Workflow permission request one bounded recovery', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'old-workflow-permission',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem(),
+    })
+    const reason = 'The level of access for permissions requested are not granted to this installation.'
+    let elapsedMilliseconds = 0
+    const at = (advance = 1_000) => {
+      elapsedMilliseconds += advance
+      return new Date(Date.parse('2026-08-18T00:00:00.000Z') + elapsedMilliseconds).toISOString()
+    }
+    for (let recovery = 0; recovery <= 5; recovery += 1) {
+      for (const attempt of [1, 2, 3]) {
+        const task = store.claimNextConflictTask(`worker-${recovery}-${attempt}`, at(), 60_000)
+        if (task === null)
+          throw new Error(`Expected attempt ${attempt} of recovery ${recovery}.`)
+        store.failTask({
+          taskId: task.id,
+          workerId: task.state.workerId,
+          fence: task.state.fence,
+          at: at(),
+          reason,
+        })
+      }
+      if (recovery < 5)
+        expect(store.retryRecoverableWorkerFailures(at(3_600_000))).toBe(1)
+    }
+    expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
+    store.close()
+
+    const oldJournal = new DatabaseSync(path)
+    oldJournal.exec('PRAGMA user_version = 32')
+    oldJournal.close()
+
+    const migrated = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    try {
+      expect(migrated.listIncidents()).toEqual([])
+      expect(migrated.retryRecoverableWorkerFailures(at())).toBe(1)
+      expect(migrated.claimNextConflictTask('recovered-worker', at(), 60_000)).not.toBeNull()
+    }
+    finally {
+      migrated.close()
+    }
+  })
+})
+
 describe('gitHub vocabulary migration', () => {
   it('carries a version 22 journal across without losing a row', () => {
     const path = join(directory, 'state.sqlite')
@@ -253,7 +305,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(32)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(33)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -5,7 +5,7 @@ import { DatabaseSync } from 'node:sqlite'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { openJournalStore } from '../src/store.ts'
-import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+import { issueItem, pullRequestItem, repositoryMapping } from './fixtures.ts'
 
 let directory: string
 
@@ -288,6 +288,58 @@ describe('installation permission recovery migration', () => {
   })
 })
 
+describe('provider session recovery migration', () => {
+  it('gives exhausted provider stalls one fresh Agent recovery', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'stalled-issue',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: issueItem(),
+    })
+    const reason = 'The opencode session stopped sending output.'
+    let elapsedMilliseconds = 0
+    const at = (advance = 1_000) => {
+      elapsedMilliseconds += advance
+      return new Date(Date.parse('2026-08-18T00:00:00.000Z') + elapsedMilliseconds).toISOString()
+    }
+    for (let recovery = 0; recovery <= 5; recovery += 1) {
+      for (const attempt of [1, 2, 3]) {
+        const task = store.claimNextIssueTriageTask(`worker-${recovery}-${attempt}`, at(), 60_000)
+        if (task === null)
+          throw new Error(`Expected attempt ${attempt} of recovery ${recovery}.`)
+        store.failWorkerTask({
+          taskId: task.id,
+          workerId: task.state.workerId,
+          fence: task.state.fence,
+          at: at(),
+          reason,
+        })
+      }
+      if (recovery < 5)
+        expect(store.retryRecoverableWorkerFailures(at(3_600_000))).toBe(1)
+    }
+    expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
+    store.close()
+
+    const oldJournal = new DatabaseSync(path)
+    oldJournal.exec('PRAGMA user_version = 34')
+    oldJournal.close()
+
+    const migrated = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    try {
+      expect(migrated.listIncidents()).toEqual([])
+      expect(migrated.retryRecoverableWorkerFailures(at())).toBe(1)
+      expect(migrated.claimNextIssueTriageTask('fresh-worker', at(), 60_000)?.state.fence).toBeGreaterThan(1)
+    }
+    finally {
+      migrated.close()
+    }
+  })
+})
+
 describe('gitHub vocabulary migration', () => {
   it('carries a version 22 journal across without losing a row', () => {
     const path = join(directory, 'state.sqlite')
@@ -305,7 +357,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(34)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(35)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -305,7 +305,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(33)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(34)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -210,6 +210,59 @@ describe('journal store', () => {
     ])
   })
 
+  it('keeps an older current failed Task in the Queue after newer history passes the snapshot limit', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'failed-current-task',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem(),
+    })
+    let failedTaskId = ''
+    for (const attempt of [1, 2, 3]) {
+      const at = `2026-08-13T01:00:0${attempt}.000Z`
+      const task = store.claimNextConflictTask(`failed-worker-${attempt}`, at, 60_000)
+      if (task === null)
+        throw new Error(`Expected failed Task attempt ${attempt}.`)
+      failedTaskId = task.id
+      store.failTask({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at,
+        reason: 'The mutation failed for an unknown reason.',
+      })
+    }
+
+    for (let index = 0; index < 101; index += 1) {
+      const observedAt = new Date(Date.parse('2026-08-13T02:00:00.000Z') + index * 1_000).toISOString()
+      store.recordObservation({
+        externalId: `newer-history-${index}`,
+        observedAt,
+        source: 'poll',
+        subject: pullRequestItem({
+          number: 25,
+          url: 'https://github.com/harlan-zw/example/pull/25',
+          headRef: 'fix/newer-history',
+          headSha: `newer-head-${index}`,
+          mergeState: 'clean',
+          updatedAt: observedAt,
+        }),
+      })
+    }
+
+    const snapshot = store.getDashboardSnapshot('2026-08-13T03:00:00.000Z')
+    expect(snapshot.tasks).toContainEqual(expect.objectContaining({
+      id: failedTaskId,
+      state: { _tag: 'Failed', reason: 'The mutation failed for an unknown reason.' },
+    }))
+    expect(snapshot.queue).toContainEqual(expect.objectContaining({
+      number: 24,
+      state: { _tag: 'ActionRequired', reason: 'The mutation failed for an unknown reason.' },
+    }))
+  })
+
   it('names the policy that leaves maintained merge conflicts for Harlan', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping({ ownership: 'maintained', conflictResolution: false })], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Ordinary Repair patches asked GitHub for Workflow permission before the Agent started. That blocked skilld pull requests #123 and #76. The 100 Task snapshot limit then hid older failures from Queue.

Branch pushes now ask for Workflow permission only when the patch changes `.github/workflows/`. Queue keeps every current Task. A moving base branch no longer discards a Repair based on the unchanged pull request head.

If Repair disproves a Review finding, one fresh Review now arbitrates it. A clean result clears the stopped Repair, while one repeated disagreement still waits for a person.

Recovered Tasks now start a fresh provider session. Existing Tasks exhausted by a stalled session receive one fresh recovery.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.