### PR TITLE
feat(agent): group self-hosted runners by host

### DIFF
--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -742,7 +742,7 @@ def github_actions_status_label(runners, error):
 
 def runner_host_status_label(host):
     if host['_tag'] == 'Unavailable':
-        return f"🔴 {host['name']} · unavailable"
+        return f"🔴 {host['name']} · unavailable · {host['message'][:100]}"
     status = github_actions_status_label(host['runners'], None)
     marker, detail = status.split(' ', 1)
     return f"{marker} {host['name']} · {detail}"
@@ -793,6 +793,12 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
     runner_hosts = source_runner_hosts(sources)
     dashboard_error = dashboard_source.get('message') if dashboard_source['_tag'] == 'Unavailable' else None
     runner_error = runner_source.get('message') if runner_source['_tag'] == 'Unavailable' else None
+    if (
+        runner_source['_tag'] == 'Available'
+        and runner_source['hosts']
+        and all(host['_tag'] == 'Unavailable' for host in runner_source['hosts'])
+    ):
+        runner_error = 'All runner hosts unavailable'
     agents = [] if dashboard is None else [agent for agent in dashboard.get('agents', []) if agent.get('_tag') == 'ActiveAgent']
     queue = [] if dashboard is None else dashboard.get('queue', [])
     menu.append(section_item('Harlan GitHub Agent'))
@@ -862,20 +868,19 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
     menu.append(menu_item(github_actions_status_label(runners, runner_error), enabled=False))
     if runner_error is not None:
         menu.append(menu_item(runner_error[:100], enabled=False))
-    else:
-        for host in runner_hosts:
-            if host['_tag'] == 'Unavailable' or not host['runners']:
-                menu.append(menu_item(runner_host_status_label(host), enabled=False))
-                continue
-            runner_items = []
-            for runner in sorted(host['runners'], key=lambda item: runner_label(item)):
-                repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
-                runner_items.append(menu_item(
-                    runner_label(runner),
-                    None if repository is None else f'https://github.com/{repository}/actions',
-                    enabled=repository is not None,
-                ))
-            menu.append(submenu_item(runner_host_status_label(host), runner_items))
+    for host in runner_hosts:
+        if host['_tag'] == 'Unavailable' or not host['runners']:
+            menu.append(menu_item(runner_host_status_label(host), enabled=False))
+            continue
+        runner_items = []
+        for runner in sorted(host['runners'], key=lambda item: runner_label(item)):
+            repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
+            runner_items.append(menu_item(
+                runner_label(runner),
+                None if repository is None else f'https://github.com/{repository}/actions',
+                enabled=repository is not None,
+            ))
+        menu.append(submenu_item(runner_host_status_label(host), runner_items))
 
     menu.append(separator())
     refresh_item = menu_item('Refresh')

--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -27,6 +27,7 @@ PASSWORD_FILE = Path.home() / '.config/harlan-github-agent/dashboard-password'
 APP_ICON = Path(__file__).resolve().parent.parent / 'assets/github-app-icon.png'
 WATCHER = Path(__file__).resolve().parent / 'harlan-github-agent-watch'
 RUNNER_LABEL = 'com.harlanzw.desktop-runner=true'
+RUNNER_HOSTS_ENV = 'HARLAN_GITHUB_RUNNER_HOSTS'
 WEEKLY_LIMIT_MINS = 7 * 24 * 60
 WEEKLY_SECONDS = 7 * 24 * 60 * 60
 CODEX_LIMIT_REFRESH_SECONDS = 60
@@ -114,6 +115,24 @@ def parse_labels(value):
     return dict(label.split('=', 1) for label in value.split(',') if '=' in label)
 
 
+def parse_runner_hosts(value):
+    hosts = []
+    names = set()
+    for definition in value.split(','):
+        name, separator, docker_host = definition.strip().partition('=')
+        name = name.strip()
+        docker_host = docker_host.strip()
+        if not separator or not name or not docker_host:
+            raise ValueError('Each self-hosted runner location must use Name=Docker URL.')
+        if name in names:
+            raise ValueError(f'Self-hosted runner location {name} appears more than once.')
+        names.add(name)
+        hosts.append({'name': name, 'dockerHost': docker_host})
+    if not hosts:
+        raise ValueError('Configure at least one self-hosted runner location.')
+    return hosts
+
+
 def runner_activity(runner, logs):
     if runner.get('State', '').lower() != 'running':
         return {'_tag': 'Offline', 'detail': runner.get('Status', 'Container stopped')}
@@ -125,9 +144,10 @@ def runner_activity(runner, logs):
     return {'_tag': 'Starting'}
 
 
-def request_runners():
+def request_runners(host):
+    docker = ['docker', '--host', host['dockerHost']]
     completed = subprocess.run(
-        ['docker', 'ps', '--all', '--filter', f'label={RUNNER_LABEL}', '--format', '{{json .}}'],
+        [*docker, 'ps', '--all', '--filter', f'label={RUNNER_LABEL}', '--format', '{{json .}}'],
         check=True,
         capture_output=True,
         text=True,
@@ -139,7 +159,7 @@ def request_runners():
             continue
         runner = json.loads(line)
         logs = subprocess.run(
-            ['docker', 'logs', '--tail', '80', runner['ID']],
+            [*docker, 'logs', '--tail', '80', runner['ID']],
             check=False,
             capture_output=True,
             text=True,
@@ -153,11 +173,30 @@ def request_runners():
             **runner,
             'Activity': activity,
             'RunnerLabels': parse_labels(runner.get('Labels', '')),
+            'Host': host['name'],
         })
     return runners
 
 
-def read_system_sources(fetch_dashboard, fetch_runners):
+def request_runner_hosts(hosts):
+    results = []
+    for host in hosts:
+        try:
+            results.append({
+                '_tag': 'Available',
+                'name': host['name'],
+                'runners': request_runners(host),
+            })
+        except Exception as caught:
+            results.append({
+                '_tag': 'Unavailable',
+                'name': host['name'],
+                'message': str(caught),
+            })
+    return results
+
+
+def read_system_sources(fetch_dashboard, fetch_runner_hosts):
     """Read the two systems independently, so one failure cannot mask the other."""
     try:
         harlan_github_agent = {'_tag': 'Available', 'dashboard': fetch_dashboard()}
@@ -165,7 +204,7 @@ def read_system_sources(fetch_dashboard, fetch_runners):
         harlan_github_agent = {'_tag': 'Unavailable', 'message': str(caught)}
 
     try:
-        github_actions = {'_tag': 'Available', 'runners': fetch_runners()}
+        github_actions = {'_tag': 'Available', 'hosts': fetch_runner_hosts()}
     except Exception as caught:
         github_actions = {'_tag': 'Unavailable', 'message': str(caught)}
 
@@ -189,7 +228,19 @@ def source_dashboard(sources):
 
 def source_runners(sources):
     source = sources['githubActions']
-    return source['runners'] if source['_tag'] == 'Available' else []
+    if source['_tag'] != 'Available':
+        return []
+    return [
+        runner
+        for host in source['hosts']
+        if host['_tag'] == 'Available'
+        for runner in host['runners']
+    ]
+
+
+def source_runner_hosts(sources):
+    source = sources['githubActions']
+    return source['hosts'] if source['_tag'] == 'Available' else []
 
 
 def active_provider(dashboard):
@@ -689,6 +740,14 @@ def github_actions_status_label(runners, error):
     return ' · '.join((f'{marker} {counted(len(runners), "self-hosted runner")}', *states))
 
 
+def runner_host_status_label(host):
+    if host['_tag'] == 'Unavailable':
+        return f"🔴 {host['name']} · unavailable"
+    status = github_actions_status_label(host['runners'], None)
+    marker, detail = status.split(' ', 1)
+    return f"{marker} {host['name']} · {detail}"
+
+
 def incident_scope_label(incident):
     scope = incident.get('scope', {})
     if scope.get('_tag') == 'Repository':
@@ -731,6 +790,7 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
     runner_source = sources['githubActions']
     dashboard = source_dashboard(sources)
     runners = source_runners(sources)
+    runner_hosts = source_runner_hosts(sources)
     dashboard_error = dashboard_source.get('message') if dashboard_source['_tag'] == 'Unavailable' else None
     runner_error = runner_source.get('message') if runner_source['_tag'] == 'Unavailable' else None
     agents = [] if dashboard is None else [agent for agent in dashboard.get('agents', []) if agent.get('_tag') == 'ActiveAgent']
@@ -802,16 +862,20 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
     menu.append(menu_item(github_actions_status_label(runners, runner_error), enabled=False))
     if runner_error is not None:
         menu.append(menu_item(runner_error[:100], enabled=False))
-    elif runners:
-        runner_items = []
-        for runner in sorted(runners, key=lambda item: runner_label(item)):
-            repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
-            runner_items.append(menu_item(
-                runner_label(runner),
-                None if repository is None else f'https://github.com/{repository}/actions',
-                enabled=repository is not None,
-            ))
-        menu.append(submenu_item(f'Self-hosted runners · {len(runners)}', runner_items))
+    else:
+        for host in runner_hosts:
+            if host['_tag'] == 'Unavailable' or not host['runners']:
+                menu.append(menu_item(runner_host_status_label(host), enabled=False))
+                continue
+            runner_items = []
+            for runner in sorted(host['runners'], key=lambda item: runner_label(item)):
+                repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
+                runner_items.append(menu_item(
+                    runner_label(runner),
+                    None if repository is None else f'https://github.com/{repository}/actions',
+                    enabled=repository is not None,
+                ))
+            menu.append(submenu_item(runner_host_status_label(host), runner_items))
 
     menu.append(separator())
     refresh_item = menu_item('Refresh')
@@ -825,6 +889,10 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
 
 
 def main():
+    runner_hosts = parse_runner_hosts(os.environ.get(
+        RUNNER_HOSTS_ENV,
+        'Desktop=unix:///var/run/docker.sock',
+    ))
     runtime = Path(os.environ.get('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}'))
     lock = (runtime / 'harlan-github-agent-indicator.lock').open('w')
     try:
@@ -872,7 +940,7 @@ def main():
                     request_agent_eject(action['taskId'])
             except Exception as caught:
                 control_error = f"{action['label']} failed: {caught}"
-        sources = read_system_sources(request_dashboard, request_runners)
+        sources = read_system_sources(request_dashboard, lambda: request_runner_hosts(runner_hosts))
         dashboard = source_dashboard(sources)
         provider = active_provider(dashboard)
         stale = time.monotonic() - usage_cache['updatedAt'] >= CODEX_LIMIT_REFRESH_SECONDS

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -2,6 +2,7 @@ import importlib.machinery
 import importlib.util
 import io
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -34,6 +35,58 @@ watch = load_watch()
 
 
 class RunnerActivityTest(unittest.TestCase):
+    def test_parses_named_runner_hosts_for_future_balancing(self):
+        self.assertEqual(indicator.parse_runner_hosts(
+            'Hogwild=ssh://hogwild,Desktop=unix:///var/run/docker.sock',
+        ), [
+            {'name': 'Hogwild', 'dockerHost': 'ssh://hogwild'},
+            {'name': 'Desktop', 'dockerHost': 'unix:///var/run/docker.sock'},
+        ])
+
+    def test_keeps_runner_hosts_independent_when_one_is_unavailable(self):
+        def run(command, **_options):
+            docker_host = command[command.index('--host') + 1]
+            if docker_host == 'unix:///var/run/docker.sock':
+                raise RuntimeError('Desktop Docker is unavailable')
+            if 'ps' in command:
+                return subprocess.CompletedProcess(command, 0, stdout=(
+                    '{"ID":"runner-1","State":"running","Status":"Up 10 minutes",'
+                    '"Labels":"com.harlanzw.desktop-runner.repository=harlan-zw/example"}\n'
+                ), stderr='')
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='2026-08-26T09:47:07Z: Listening for Jobs\n',
+                stderr='',
+            )
+
+        hosts = indicator.parse_runner_hosts(
+            'Hogwild=ssh://hogwild,Desktop=unix:///var/run/docker.sock',
+        )
+        with patch.object(indicator.subprocess, 'run', side_effect=run):
+            result = indicator.request_runner_hosts(hosts)
+
+        self.assertEqual(result, [
+            {
+                '_tag': 'Available',
+                'name': 'Hogwild',
+                'runners': [{
+                    'ID': 'runner-1',
+                    'State': 'running',
+                    'Status': 'Up 10 minutes',
+                    'Labels': 'com.harlanzw.desktop-runner.repository=harlan-zw/example',
+                    'Activity': {'_tag': 'Idle'},
+                    'RunnerLabels': {'com.harlanzw.desktop-runner.repository': 'harlan-zw/example'},
+                    'Host': 'Hogwild',
+                }],
+            },
+            {
+                '_tag': 'Unavailable',
+                'name': 'Desktop',
+                'message': 'Desktop Docker is unavailable',
+            },
+        ])
+
     def test_reports_idle_runner(self):
         self.assertEqual(indicator.runner_activity(
             {'State': 'running', 'Status': 'Up 10 minutes'},
@@ -61,6 +114,21 @@ class RunnerActivityTest(unittest.TestCase):
         self.assertEqual(
             indicator.github_actions_status_label(runners, None),
             '🟢 2 self-hosted runners · 1 running · 1 idle',
+        )
+
+    def test_summarises_each_host_separately(self):
+        host = {
+            '_tag': 'Available',
+            'name': 'Hogwild',
+            'runners': [
+                {'Activity': {'_tag': 'Running'}},
+                {'Activity': {'_tag': 'Idle'}},
+            ],
+        }
+
+        self.assertEqual(
+            indicator.runner_host_status_label(host),
+            '🟢 Hogwild · 2 self-hosted runners · 1 running · 1 idle',
         )
 
     def test_reports_runner_discovery_without_changing_agent_state(self):

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -34,6 +34,18 @@ def load_watch():
 watch = load_watch()
 
 
+class StubIndicator:
+    def __init__(self):
+        self.menus = []
+
+    def set_menu(self, menu):
+        self.menus.append(menu)
+
+
+def menu_labels(menu):
+    return [child.get_label() for child in menu.get_children()]
+
+
 class RunnerActivityTest(unittest.TestCase):
     def test_parses_named_runner_hosts_for_future_balancing(self):
         self.assertEqual(indicator.parse_runner_hosts(
@@ -129,6 +141,16 @@ class RunnerActivityTest(unittest.TestCase):
         self.assertEqual(
             indicator.runner_host_status_label(host),
             '🟢 Hogwild · 2 self-hosted runners · 1 running · 1 idle',
+        )
+
+    def test_appends_the_failure_message_to_an_unavailable_runner_host(self):
+        self.assertEqual(
+            indicator.runner_host_status_label({
+                '_tag': 'Unavailable',
+                'name': 'Hogwild',
+                'message': 'ssh://hogwild refused',
+            }),
+            '🔴 Hogwild · unavailable · ssh://hogwild refused',
         )
 
     def test_reports_runner_discovery_without_changing_agent_state(self):
@@ -283,6 +305,29 @@ class IndicatorDisplayTest(unittest.TestCase):
             indicator.harlan_github_agent_status_label(dashboard, [], None),
             '🔴 Action required · Queue empty',
         )
+
+    def test_treats_an_all_unavailable_host_list_as_an_error_state(self):
+        sources = indicator.read_system_sources(
+            lambda: {'status': 'ready'},
+            lambda: [{'_tag': 'Unavailable', 'name': 'Hogwild', 'message': 'ssh://hogwild refused'}],
+        )
+        stub = StubIndicator()
+
+        indicator.build_menu(
+            stub,
+            sources,
+            None,
+            None,
+            lambda: None,
+            lambda *_args: None,
+            lambda *_args: None,
+            lambda *_args: None,
+        )
+        labels = menu_labels(stub.menus[0])
+
+        self.assertIn('🔴 Status unavailable', labels)
+        self.assertNotIn('⚪ No self-hosted runners found', labels)
+        self.assertIn('🔴 Hogwild · unavailable · ssh://hogwild refused', labels)
 
     def test_opens_a_read_only_watch_terminal_for_the_exact_session(self):
         agent = {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Self-hosted runners moved to Hogwild, but the System pane could only query one anonymous Docker endpoint. A future desktop overflow pool would be impossible to distinguish.

The pane now accepts named Docker endpoints, keeps one failed endpoint from hiding the others, and groups self-hosted runners under Hogwild or Desktop.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).