### PR TITLE
feat(agent): add dedicated runner system pane

### DIFF
--- a/packages/harlan-github-agent/assets/github-runner-icon.svg
+++ b/packages/harlan-github-agent/assets/github-runner-icon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <radialGradient id="background" cx="42%" cy="36%" r="78%">
+      <stop offset="0" stop-color="#12352c"/>
+      <stop offset="1" stop-color="#031914"/>
+    </radialGradient>
+    <pattern id="halftone" width="16" height="16" patternUnits="userSpaceOnUse">
+      <circle cx="3" cy="3" r="2.2" fill="#ff7a1a"/>
+    </pattern>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#background)"/>
+  <circle cx="256" cy="250" r="210" fill="#061d17" stroke="#ff7a1a" stroke-width="18"/>
+  <path fill="#ffd6ad" d="M256 82.3c-72.9 0-132 59.1-132 132c0 58.3 37.8 107.8 90.3 125.2c6.6 1.2 9-2.8 9-6.3c0-3.1-.1-11.4-.2-22.4c-36.7 8-44.5-17.7-44.5-17.7c-6-15.2-14.7-19.3-14.7-19.3c-12-8.2.9-8 .9-8c13.3.9 20.2 13.6 20.2 13.6c11.8 20.2 30.9 14.4 38.4 11c1.2-8.5 4.6-14.4 8.4-17.7c-29.3-3.3-60.1-14.7-60.1-65.2c0-14.4 5.1-26.2 13.6-35.4c-1.5-3.3-5.9-16.8 1.2-34.9c0 0 11.1-3.5 36.3 13.5c10.6-2.9 21.8-4.4 33-4.5c11.2.1 22.4 1.5 33 4.5c25.1-17.1 36.1-13.5 36.1-13.5c7.1 18.2 2.6 31.6 1.3 34.9c8.4 9.2 13.5 21 13.5 35.4c0 50.7-30.9 61.9-60.2 65.1c4.6 4 8.9 12.1 8.9 24.4c0 17.7-.2 31.9-.2 36.1c0 3.5 2.3 7.6 9.1 6.3c52.6-17.4 90.4-66.9 90.4-125.2c0-72.9-59.1-132-132-132z"/>
+  <path d="M92 344a210 210 0 0 0 328 0v80H92z" fill="url(#halftone)" opacity=".48"/>
+  <circle cx="390" cy="390" r="79" fill="#ff7a1a" stroke="#031914" stroke-width="18"/>
+  <path d="m370 346l67 44l-67 44z" fill="#031914"/>
+</svg>

--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -26,8 +26,6 @@ DASHBOARD_ORIGIN = DASHBOARD_URL.rstrip('/')
 PASSWORD_FILE = Path.home() / '.config/harlan-github-agent/dashboard-password'
 APP_ICON = Path(__file__).resolve().parent.parent / 'assets/github-app-icon.png'
 WATCHER = Path(__file__).resolve().parent / 'harlan-github-agent-watch'
-RUNNER_LABEL = 'com.harlanzw.desktop-runner=true'
-RUNNER_HOSTS_ENV = 'HARLAN_GITHUB_RUNNER_HOSTS'
 WEEKLY_LIMIT_MINS = 7 * 24 * 60
 WEEKLY_SECONDS = 7 * 24 * 60 * 60
 CODEX_LIMIT_REFRESH_SECONDS = 60
@@ -111,136 +109,26 @@ def request_agent_eject(task_id):
         return json.load(response)
 
 
-def parse_labels(value):
-    return dict(label.split('=', 1) for label in value.split(',') if '=' in label)
-
-
-def parse_runner_hosts(value):
-    hosts = []
-    names = set()
-    for definition in value.split(','):
-        name, separator, docker_host = definition.strip().partition('=')
-        name = name.strip()
-        docker_host = docker_host.strip()
-        if not separator or not name or not docker_host:
-            raise ValueError('Each self-hosted runner location must use Name=Docker URL.')
-        if name in names:
-            raise ValueError(f'Self-hosted runner location {name} appears more than once.')
-        names.add(name)
-        hosts.append({'name': name, 'dockerHost': docker_host})
-    if not hosts:
-        raise ValueError('Configure at least one self-hosted runner location.')
-    return hosts
-
-
-def runner_activity(runner, logs):
-    if runner.get('State', '').lower() != 'running':
-        return {'_tag': 'Offline', 'detail': runner.get('Status', 'Container stopped')}
-    for line in reversed(logs.splitlines()):
-        if 'Listening for Jobs' in line or 'completed with result:' in line:
-            return {'_tag': 'Idle'}
-        if 'Running job:' in line:
-            return {'_tag': 'Running', 'job': line.split('Running job:', 1)[1].strip()}
-    return {'_tag': 'Starting'}
-
-
-def request_runners(host):
-    docker = ['docker', '--host', host['dockerHost']]
-    completed = subprocess.run(
-        [*docker, 'ps', '--all', '--filter', f'label={RUNNER_LABEL}', '--format', '{{json .}}'],
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=4,
-    )
-    runners = []
-    for line in completed.stdout.splitlines():
-        if not line:
-            continue
-        runner = json.loads(line)
-        logs = subprocess.run(
-            [*docker, 'logs', '--tail', '80', runner['ID']],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=3,
-        )
-        activity = runner_activity(runner, logs.stdout + logs.stderr) if logs.returncode == 0 else {
-            '_tag': 'Unknown',
-            'detail': logs.stderr.strip() or 'Runner logs unavailable',
-        }
-        runners.append({
-            **runner,
-            'Activity': activity,
-            'RunnerLabels': parse_labels(runner.get('Labels', '')),
-            'Host': host['name'],
-        })
-    return runners
-
-
-def request_runner_hosts(hosts):
-    results = []
-    for host in hosts:
-        try:
-            results.append({
-                '_tag': 'Available',
-                'name': host['name'],
-                'runners': request_runners(host),
-            })
-        except Exception as caught:
-            results.append({
-                '_tag': 'Unavailable',
-                'name': host['name'],
-                'message': str(caught),
-            })
-    return results
-
-
-def read_system_sources(fetch_dashboard, fetch_runner_hosts):
-    """Read the two systems independently, so one failure cannot mask the other."""
+def read_system_sources(fetch_dashboard):
     try:
         harlan_github_agent = {'_tag': 'Available', 'dashboard': fetch_dashboard()}
     except Exception as caught:
         harlan_github_agent = {'_tag': 'Unavailable', 'message': str(caught)}
 
-    try:
-        github_actions = {'_tag': 'Available', 'hosts': fetch_runner_hosts()}
-    except Exception as caught:
-        github_actions = {'_tag': 'Unavailable', 'message': str(caught)}
-
     return {
         'harlanGithubAgent': harlan_github_agent,
-        'githubActions': github_actions,
     }
 
 
 def loading_system_sources():
     return {
         'harlanGithubAgent': {'_tag': 'Loading'},
-        'githubActions': {'_tag': 'Loading'},
     }
 
 
 def source_dashboard(sources):
     source = sources['harlanGithubAgent']
     return source['dashboard'] if source['_tag'] == 'Available' else None
-
-
-def source_runners(sources):
-    source = sources['githubActions']
-    if source['_tag'] != 'Available':
-        return []
-    return [
-        runner
-        for host in source['hosts']
-        if host['_tag'] == 'Available'
-        for runner in host['runners']
-    ]
-
-
-def source_runner_hosts(sources):
-    source = sources['githubActions']
-    return source['hosts'] if source['_tag'] == 'Available' else []
 
 
 def active_provider(dashboard):
@@ -580,27 +468,6 @@ def confirm_agent_eject(agent, eject_agent):
         eject_agent(agent['id'])
 
 
-def runner_label(runner):
-    labels = runner['RunnerLabels']
-    repository = labels.get('com.harlanzw.desktop-runner.repository', 'Unknown repository')
-    name = runner.get('Names') or labels.get('com.harlanzw.desktop-runner.pool', 'runner')
-    activity = runner['Activity']
-    marker = {
-        'Idle': '⚪',
-        'Offline': '🔴',
-        'Running': '🟢',
-        'Starting': '🟡',
-        'Unknown': '🟠',
-    }.get(activity['_tag'], '🟠')
-    if activity['_tag'] == 'Running':
-        return f"{marker} Running · {activity['job']} · {repository} · {name}"
-    if activity['_tag'] == 'Offline':
-        return f"{marker} Offline · {repository} · {name} · {activity['detail']}"
-    if activity['_tag'] == 'Unknown':
-        return f"{marker} Status unavailable · {repository} · {name}"
-    return f"{marker} {activity['_tag']} · {repository} · {name}"
-
-
 def queue_state(entry):
     labels = {
         'Active': '🟢 Running',
@@ -705,49 +572,6 @@ def harlan_github_agent_status_label(dashboard, agents, error):
     return f'⚪ Idle · {queue_label}'
 
 
-def github_actions_status_label(runners, error):
-    if error is not None:
-        return '🔴 Status unavailable'
-    if not runners:
-        return '⚪ No self-hosted runners found'
-
-    counts = {}
-    for runner in runners:
-        state = runner.get('Activity', {}).get('_tag', 'Unknown')
-        counts[state] = counts.get(state, 0) + 1
-
-    if counts.get('Offline', 0) > 0:
-        marker = '🔴'
-    elif counts.get('Unknown', 0) > 0:
-        marker = '🟠'
-    elif counts.get('Starting', 0) > 0:
-        marker = '🟡'
-    elif counts.get('Running', 0) > 0:
-        marker = '🟢'
-    else:
-        marker = '⚪'
-
-    states = []
-    for state, label in (
-        ('Running', 'running'),
-        ('Idle', 'idle'),
-        ('Starting', 'starting'),
-        ('Offline', 'offline'),
-        ('Unknown', 'unknown'),
-    ):
-        if counts.get(state, 0) > 0:
-            states.append(f"{counts[state]} {label}")
-    return ' · '.join((f'{marker} {counted(len(runners), "self-hosted runner")}', *states))
-
-
-def runner_host_status_label(host):
-    if host['_tag'] == 'Unavailable':
-        return f"🔴 {host['name']} · unavailable · {host['message'][:100]}"
-    status = github_actions_status_label(host['runners'], None)
-    marker, detail = status.split(' ', 1)
-    return f"{marker} {host['name']} · {detail}"
-
-
 def incident_scope_label(incident):
     scope = incident.get('scope', {})
     if scope.get('_tag') == 'Repository':
@@ -787,18 +611,8 @@ def usage_label(dashboard, usage):
 def build_menu(indicator, sources, usage, action_error, refresh, set_agent_control, eject_agent, select_agent):
     menu = Gtk.Menu()
     dashboard_source = sources['harlanGithubAgent']
-    runner_source = sources['githubActions']
     dashboard = source_dashboard(sources)
-    runners = source_runners(sources)
-    runner_hosts = source_runner_hosts(sources)
     dashboard_error = dashboard_source.get('message') if dashboard_source['_tag'] == 'Unavailable' else None
-    runner_error = runner_source.get('message') if runner_source['_tag'] == 'Unavailable' else None
-    if (
-        runner_source['_tag'] == 'Available'
-        and runner_source['hosts']
-        and all(host['_tag'] == 'Unavailable' for host in runner_source['hosts'])
-    ):
-        runner_error = 'All runner hosts unavailable'
     agents = [] if dashboard is None else [agent for agent in dashboard.get('agents', []) if agent.get('_tag') == 'ActiveAgent']
     queue = [] if dashboard is None else dashboard.get('queue', [])
     menu.append(section_item('Harlan GitHub Agent'))
@@ -864,25 +678,6 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
         menu.append(control_item)
 
     menu.append(separator())
-    menu.append(section_item('GitHub Actions'))
-    menu.append(menu_item(github_actions_status_label(runners, runner_error), enabled=False))
-    if runner_error is not None:
-        menu.append(menu_item(runner_error[:100], enabled=False))
-    for host in runner_hosts:
-        if host['_tag'] == 'Unavailable' or not host['runners']:
-            menu.append(menu_item(runner_host_status_label(host), enabled=False))
-            continue
-        runner_items = []
-        for runner in sorted(host['runners'], key=lambda item: runner_label(item)):
-            repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
-            runner_items.append(menu_item(
-                runner_label(runner),
-                None if repository is None else f'https://github.com/{repository}/actions',
-                enabled=repository is not None,
-            ))
-        menu.append(submenu_item(runner_host_status_label(host), runner_items))
-
-    menu.append(separator())
     refresh_item = menu_item('Refresh')
     refresh_item.connect('activate', lambda *_args: refresh())
     menu.append(refresh_item)
@@ -894,10 +689,6 @@ def build_menu(indicator, sources, usage, action_error, refresh, set_agent_contr
 
 
 def main():
-    runner_hosts = parse_runner_hosts(os.environ.get(
-        RUNNER_HOSTS_ENV,
-        'Desktop=unix:///var/run/docker.sock',
-    ))
     runtime = Path(os.environ.get('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}'))
     lock = (runtime / 'harlan-github-agent-indicator.lock').open('w')
     try:
@@ -945,7 +736,7 @@ def main():
                     request_agent_eject(action['taskId'])
             except Exception as caught:
                 control_error = f"{action['label']} failed: {caught}"
-        sources = read_system_sources(request_dashboard, lambda: request_runner_hosts(runner_hosts))
+        sources = read_system_sources(request_dashboard)
         dashboard = source_dashboard(sources)
         provider = active_provider(dashboard)
         stale = time.monotonic() - usage_cache['updatedAt'] >= CODEX_LIMIT_REFRESH_SECONDS

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -21,7 +21,7 @@ RUNNER_LABEL = 'com.harlanzw.desktop-runner=true'
 RUNNER_HOSTS_ENV = 'HARLAN_GITHUB_RUNNER_HOSTS'
 RUNNER_REPOSITORIES_ENV = 'HARLAN_GITHUB_RUNNER_REPOSITORIES'
 JOBS_REFRESH_SECONDS = 30
-RUNNER_ICON = 'system-run-symbolic'
+RUNNER_ICON = Path(__file__).resolve().parent.parent / 'assets/github-runner-icon.svg'
 
 
 def parse_labels(value):
@@ -518,7 +518,7 @@ def main():
 
     indicator = AyatanaAppIndicator3.Indicator.new(
         'harlan-github-runners',
-        RUNNER_ICON,
+        str(RUNNER_ICON),
         AyatanaAppIndicator3.IndicatorCategory.SYSTEM_SERVICES,
     )
     indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
@@ -531,6 +531,7 @@ def main():
         refreshing['active'] = False
         label, title = indicator_summary(source)
         indicator.set_label(label, '🟢 99')
+        indicator.set_icon_full(str(RUNNER_ICON), 'GitHub Actions')
         indicator.set_title(title)
         build_menu(indicator, source, jobs_source, action_error, manual_refresh, change_host_capacity)
         if pending_action['value'] is not None:

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -193,6 +193,7 @@ def read_runner_source(fetch_runner_hosts):
 
 
 WORKFLOW_RUNS_PAGE_SIZE = 50
+WORKFLOW_JOBS_PAGE_SIZE = 100
 
 
 def github_api(path):
@@ -224,6 +225,19 @@ def collect_workflow_jobs(repository, runs, fetch_jobs):
     return jobs
 
 
+def request_run_jobs(repository, run_id):
+    jobs = []
+    page = 1
+    while True:
+        fetched = github_api(
+            f'repos/{repository}/actions/runs/{run_id}/jobs?page={page}&per_page={WORKFLOW_JOBS_PAGE_SIZE}',
+        ).get('jobs', [])
+        jobs.extend(fetched)
+        if len(fetched) < WORKFLOW_JOBS_PAGE_SIZE:
+            return jobs
+        page += 1
+
+
 def request_workflow_jobs(repositories, on_error=None):
     jobs = []
     for repository in repositories:
@@ -237,9 +251,7 @@ def request_workflow_jobs(repositories, on_error=None):
                     jobs.extend(collect_workflow_jobs(
                         repository,
                         runs,
-                        lambda run_id, current=repository: github_api(
-                            f'repos/{current}/actions/runs/{run_id}/jobs',
-                        ).get('jobs', []),
+                        lambda run_id, current=repository: request_run_jobs(current, run_id),
                     ))
                     if len(runs) < WORKFLOW_RUNS_PAGE_SIZE:
                         break

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -21,6 +21,7 @@ RUNNER_LABEL = 'com.harlanzw.desktop-runner=true'
 RUNNER_HOSTS_ENV = 'HARLAN_GITHUB_RUNNER_HOSTS'
 RUNNER_REPOSITORIES_ENV = 'HARLAN_GITHUB_RUNNER_REPOSITORIES'
 JOBS_REFRESH_SECONDS = 30
+RUNNER_ICON = 'system-run-symbolic'
 
 
 def parse_labels(value):
@@ -505,7 +506,7 @@ def main():
 
     indicator = AyatanaAppIndicator3.Indicator.new(
         'harlan-github-runners',
-        'media-playback-start-symbolic',
+        RUNNER_ICON,
         AyatanaAppIndicator3.IndicatorCategory.SYSTEM_SERVICES,
     )
     indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -1,0 +1,322 @@
+#!/usr/bin/python3
+
+import fcntl
+import json
+import os
+import subprocess
+import threading
+import webbrowser
+from pathlib import Path
+
+import gi
+
+gi.require_version('AyatanaAppIndicator3', '0.1')
+gi.require_version('Gtk', '3.0')
+from gi.repository import AyatanaAppIndicator3, GLib, Gtk
+
+RUNNER_LABEL = 'com.harlanzw.desktop-runner=true'
+RUNNER_HOSTS_ENV = 'HARLAN_GITHUB_RUNNER_HOSTS'
+
+
+def parse_labels(value):
+    return dict(label.split('=', 1) for label in value.split(',') if '=' in label)
+
+
+def parse_runner_hosts(value):
+    hosts = []
+    names = set()
+    for definition in value.split(','):
+        name, separator, docker_host = definition.strip().partition('=')
+        name = name.strip()
+        docker_host = docker_host.strip()
+        if not separator or not name or not docker_host:
+            raise ValueError('Each self-hosted runner location must use Name=Docker URL.')
+        if name in names:
+            raise ValueError(f'Self-hosted runner location {name} appears more than once.')
+        names.add(name)
+        hosts.append({'name': name, 'dockerHost': docker_host})
+    if not hosts:
+        raise ValueError('Configure at least one self-hosted runner location.')
+    return hosts
+
+
+def runner_activity(runner, logs):
+    if runner.get('State', '').lower() != 'running':
+        return {'_tag': 'Offline', 'detail': runner.get('Status', 'Container stopped')}
+    for line in reversed(logs.splitlines()):
+        if 'Listening for Jobs' in line or 'completed with result:' in line:
+            return {'_tag': 'Idle'}
+        if 'Running job:' in line:
+            return {'_tag': 'Running', 'job': line.split('Running job:', 1)[1].strip()}
+    return {'_tag': 'Starting'}
+
+
+def request_runners(host):
+    docker = ['docker', '--host', host['dockerHost']]
+    completed = subprocess.run(
+        [*docker, 'ps', '--all', '--filter', f'label={RUNNER_LABEL}', '--format', '{{json .}}'],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=4,
+    )
+    runners = []
+    for line in completed.stdout.splitlines():
+        if not line:
+            continue
+        runner = json.loads(line)
+        logs = subprocess.run(
+            [*docker, 'logs', '--tail', '80', runner['ID']],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        activity = runner_activity(runner, logs.stdout + logs.stderr) if logs.returncode == 0 else {
+            '_tag': 'Unknown',
+            'detail': logs.stderr.strip() or 'Runner logs unavailable',
+        }
+        runners.append({
+            **runner,
+            'Activity': activity,
+            'RunnerLabels': parse_labels(runner.get('Labels', '')),
+            'Host': host['name'],
+        })
+    return runners
+
+
+def request_runner_hosts(hosts):
+    results = []
+    for host in hosts:
+        try:
+            results.append({
+                '_tag': 'Available',
+                'name': host['name'],
+                'runners': request_runners(host),
+            })
+        except Exception as caught:
+            results.append({
+                '_tag': 'Unavailable',
+                'name': host['name'],
+                'message': str(caught),
+            })
+    return results
+
+
+def read_runner_source(fetch_runner_hosts):
+    try:
+        return {'_tag': 'Available', 'hosts': fetch_runner_hosts()}
+    except Exception as caught:
+        return {'_tag': 'Unavailable', 'message': str(caught)}
+
+
+def source_runners(source):
+    if source['_tag'] != 'Available':
+        return []
+    return [
+        runner
+        for host in source['hosts']
+        if host['_tag'] == 'Available'
+        for runner in host['runners']
+    ]
+
+
+def counted(count, singular, plural=None):
+    return f'{count} {singular if count == 1 else plural or f"{singular}s"}'
+
+
+def runner_label(runner):
+    labels = runner['RunnerLabels']
+    repository = labels.get('com.harlanzw.desktop-runner.repository', 'Unknown repository')
+    name = runner.get('Names') or labels.get('com.harlanzw.desktop-runner.pool', 'runner')
+    activity = runner['Activity']
+    marker = {
+        'Idle': '⚪',
+        'Offline': '🔴',
+        'Running': '🟢',
+        'Starting': '🟡',
+        'Unknown': '🟠',
+    }.get(activity['_tag'], '🟠')
+    if activity['_tag'] == 'Running':
+        return f"{marker} Running · {activity['job']} · {repository} · {name}"
+    if activity['_tag'] == 'Offline':
+        return f"{marker} Offline · {repository} · {name} · {activity['detail']}"
+    if activity['_tag'] == 'Unknown':
+        return f'{marker} Status unavailable · {repository} · {name}'
+    return f"{marker} {activity['_tag']} · {repository} · {name}"
+
+
+def github_actions_status_label(runners, error):
+    if error is not None:
+        return '🔴 Status unavailable'
+    if not runners:
+        return '⚪ No self-hosted runners found'
+
+    counts = {}
+    for runner in runners:
+        state = runner.get('Activity', {}).get('_tag', 'Unknown')
+        counts[state] = counts.get(state, 0) + 1
+
+    if counts.get('Offline', 0) > 0:
+        marker = '🔴'
+    elif counts.get('Unknown', 0) > 0:
+        marker = '🟠'
+    elif counts.get('Starting', 0) > 0:
+        marker = '🟡'
+    elif counts.get('Running', 0) > 0:
+        marker = '🟢'
+    else:
+        marker = '⚪'
+
+    states = []
+    for state, label in (
+        ('Running', 'running'),
+        ('Idle', 'idle'),
+        ('Starting', 'starting'),
+        ('Offline', 'offline'),
+        ('Unknown', 'unknown'),
+    ):
+        if counts.get(state, 0) > 0:
+            states.append(f'{counts[state]} {label}')
+    return ' · '.join((f'{marker} {counted(len(runners), "self-hosted runner")}', *states))
+
+
+def runner_host_status_label(host):
+    if host['_tag'] == 'Unavailable':
+        return f"🔴 {host['name']} · unavailable · {host['message'][:100]}"
+    status = github_actions_status_label(host['runners'], None)
+    marker, detail = status.split(' ', 1)
+    return f"{marker} {host['name']} · {detail}"
+
+
+def menu_item(label, url=None, enabled=True):
+    item = Gtk.MenuItem(label=label)
+    item.set_sensitive(enabled)
+    if url is not None:
+        item.connect('activate', lambda *_args: webbrowser.open(url))
+    return item
+
+
+def submenu_item(label, items):
+    item = Gtk.MenuItem(label=label)
+    submenu = Gtk.Menu()
+    for child in items:
+        submenu.append(child)
+    item.set_submenu(submenu)
+    return item
+
+
+def section_item(label):
+    item = Gtk.MenuItem(label=label)
+    item.set_sensitive(False)
+    return item
+
+
+def separator():
+    return Gtk.SeparatorMenuItem()
+
+
+def runner_error(source):
+    if source['_tag'] == 'Unavailable':
+        return source['message']
+    if source['_tag'] == 'Loading':
+        return None
+    if source['hosts'] and all(host['_tag'] == 'Unavailable' for host in source['hosts']):
+        return 'All runner hosts unavailable'
+    return None
+
+
+def build_menu(indicator, source, refresh):
+    menu = Gtk.Menu()
+    error = runner_error(source)
+    runners = source_runners(source)
+    hosts = source['hosts'] if source['_tag'] == 'Available' else []
+    status = '🟡 Loading…' if source['_tag'] == 'Loading' else github_actions_status_label(runners, error)
+
+    menu.append(section_item('GitHub Actions'))
+    menu.append(menu_item(status, enabled=False))
+    if error is not None:
+        menu.append(menu_item(error[:100], enabled=False))
+    for host in hosts:
+        if host['_tag'] == 'Unavailable' or not host['runners']:
+            menu.append(menu_item(runner_host_status_label(host), enabled=False))
+            continue
+        items = []
+        for runner in sorted(host['runners'], key=runner_label):
+            repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
+            items.append(menu_item(
+                runner_label(runner),
+                None if repository is None else f'https://github.com/{repository}/actions',
+                enabled=repository is not None,
+            ))
+        menu.append(submenu_item(runner_host_status_label(host), items))
+
+    menu.append(separator())
+    refresh_item = menu_item('Refresh')
+    refresh_item.connect('activate', lambda *_args: refresh())
+    menu.append(refresh_item)
+    quit_item = menu_item('Quit')
+    quit_item.connect('activate', lambda *_args: Gtk.main_quit())
+    menu.append(quit_item)
+    menu.show_all()
+    indicator.set_menu(menu)
+
+
+def indicator_summary(source):
+    if source['_tag'] == 'Loading':
+        return ('🟡', 'Loading GitHub Actions')
+    runners = source_runners(source)
+    status = github_actions_status_label(runners, runner_error(source))
+    marker, detail = status.split(' ', 1)
+    running = sum(runner.get('Activity', {}).get('_tag') == 'Running' for runner in runners)
+    return (f'{marker} {running}' if running else marker, f'GitHub Actions · {detail}')
+
+
+def main():
+    runner_hosts = parse_runner_hosts(os.environ.get(
+        RUNNER_HOSTS_ENV,
+        'Desktop=unix:///var/run/docker.sock',
+    ))
+    runtime = Path(os.environ.get('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}'))
+    lock = (runtime / 'harlan-github-runner-indicator.lock').open('w')
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return
+
+    indicator = AyatanaAppIndicator3.Indicator.new(
+        'harlan-github-runners',
+        'media-playback-start-symbolic',
+        AyatanaAppIndicator3.IndicatorCategory.SYSTEM_SERVICES,
+    )
+    indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
+    indicator.set_title('GitHub Actions')
+    refreshing = {'active': False}
+
+    def apply_state(source):
+        refreshing['active'] = False
+        label, title = indicator_summary(source)
+        indicator.set_label(label, '🟢 99')
+        indicator.set_title(title)
+        build_menu(indicator, source, refresh)
+        return False
+
+    def load_state():
+        source = read_runner_source(lambda: request_runner_hosts(runner_hosts))
+        GLib.idle_add(apply_state, source)
+
+    def refresh(*_args):
+        if refreshing['active']:
+            return True
+        refreshing['active'] = True
+        threading.Thread(target=load_state, daemon=True).start()
+        return True
+
+    build_menu(indicator, {'_tag': 'Loading'}, refresh)
+    refresh()
+    GLib.timeout_add_seconds(5, refresh)
+    Gtk.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -227,21 +227,22 @@ def request_workflow_jobs(repositories, on_error=None):
     jobs = []
     for repository in repositories:
         try:
-            page = 1
-            while True:
-                runs = github_api(
-                    f'repos/{repository}/actions/runs?page={page}&per_page={WORKFLOW_RUNS_PAGE_SIZE}',
-                ).get('workflow_runs', [])
-                jobs.extend(collect_workflow_jobs(
-                    repository,
-                    runs,
-                    lambda run_id, current=repository: github_api(
-                        f'repos/{current}/actions/runs/{run_id}/jobs',
-                    ).get('jobs', []),
-                ))
-                if len(runs) < WORKFLOW_RUNS_PAGE_SIZE:
-                    break
-                page += 1
+            for status in ('queued', 'in_progress'):
+                page = 1
+                while True:
+                    runs = github_api(
+                        f'repos/{repository}/actions/runs?status={status}&page={page}&per_page={WORKFLOW_RUNS_PAGE_SIZE}',
+                    ).get('workflow_runs', [])
+                    jobs.extend(collect_workflow_jobs(
+                        repository,
+                        runs,
+                        lambda run_id, current=repository: github_api(
+                            f'repos/{current}/actions/runs/{run_id}/jobs',
+                        ).get('jobs', []),
+                    ))
+                    if len(runs) < WORKFLOW_RUNS_PAGE_SIZE:
+                        break
+                    page += 1
         except Exception as caught:
             if on_error is not None:
                 on_error(f'{repository} · Jobs unavailable · {caught}')

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -191,9 +191,12 @@ def read_runner_source(fetch_runner_hosts):
         return {'_tag': 'Unavailable', 'message': str(caught)}
 
 
+WORKFLOW_RUNS_PAGE_SIZE = 50
+
+
 def github_api(path):
     completed = subprocess.run(
-        ['gh', 'api', path, '--method', 'GET', '-f', 'per_page=50'],
+        ['gh', 'api', path, '--method', 'GET'],
         check=True,
         capture_output=True,
         text=True,
@@ -220,25 +223,29 @@ def collect_workflow_jobs(repository, runs, fetch_jobs):
     return jobs
 
 
-def request_workflow_jobs(repositories):
+def request_workflow_jobs(repositories, on_error=None):
     jobs = []
     for repository in repositories:
-        runs = github_api(f'repos/{repository}/actions/runs').get('workflow_runs', [])
-        jobs.extend(collect_workflow_jobs(
-            repository,
-            runs,
-            lambda run_id, current=repository: github_api(
-                f'repos/{current}/actions/runs/{run_id}/jobs',
-            ).get('jobs', []),
-        ))
+        try:
+            page = 1
+            while True:
+                runs = github_api(
+                    f'repos/{repository}/actions/runs?page={page}&per_page={WORKFLOW_RUNS_PAGE_SIZE}',
+                ).get('workflow_runs', [])
+                jobs.extend(collect_workflow_jobs(
+                    repository,
+                    runs,
+                    lambda run_id, current=repository: github_api(
+                        f'repos/{current}/actions/runs/{run_id}/jobs',
+                    ).get('jobs', []),
+                ))
+                if len(runs) < WORKFLOW_RUNS_PAGE_SIZE:
+                    break
+                page += 1
+        except Exception as caught:
+            if on_error is not None:
+                on_error(f'{repository} · Jobs unavailable · {caught}')
     return jobs
-
-
-def read_jobs_source(fetch_jobs):
-    try:
-        return {'_tag': 'Available', 'jobs': fetch_jobs()}
-    except Exception as caught:
-        return {'_tag': 'Unavailable', 'message': str(caught)}
 
 
 def source_runners(source):
@@ -426,6 +433,8 @@ def build_menu(indicator, source, jobs_source, action_error, refresh, set_accept
         running_jobs = [job for job in jobs_source['jobs'] if job['_tag'] == 'Running']
         menu.append(job_menu('Queued jobs', queued_jobs))
         menu.append(job_menu('Running jobs', running_jobs))
+        for message in jobs_source.get('errors', []):
+            menu.append(menu_item(message[:100], enabled=False))
 
     for host in hosts:
         control = host.get('control')
@@ -532,7 +541,13 @@ def main():
                 repositories.append(repository)
         stale = time.monotonic() - jobs_cache['updatedAt'] >= JOBS_REFRESH_SECONDS
         if stale:
-            jobs_cache['source'] = read_jobs_source(lambda: request_workflow_jobs(repositories))
+            errors = []
+            jobs = request_workflow_jobs(repositories, errors.append)
+            jobs_cache['source'] = (
+                {'_tag': 'Unavailable', 'message': '\n'.join(errors)}
+                if errors and not jobs
+                else {'_tag': 'Available', 'jobs': jobs, 'errors': errors}
+            )
             jobs_cache['updatedAt'] = time.monotonic()
         GLib.idle_add(apply_state, source, jobs_cache['source'], action_error)
 

--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -3,10 +3,13 @@
 import fcntl
 import json
 import os
+import re
 import subprocess
 import threading
+import time
 import webbrowser
 from pathlib import Path
+from urllib.parse import urlparse
 
 import gi
 
@@ -16,6 +19,8 @@ from gi.repository import AyatanaAppIndicator3, GLib, Gtk
 
 RUNNER_LABEL = 'com.harlanzw.desktop-runner=true'
 RUNNER_HOSTS_ENV = 'HARLAN_GITHUB_RUNNER_HOSTS'
+RUNNER_REPOSITORIES_ENV = 'HARLAN_GITHUB_RUNNER_REPOSITORIES'
+JOBS_REFRESH_SECONDS = 30
 
 
 def parse_labels(value):
@@ -28,16 +33,77 @@ def parse_runner_hosts(value):
     for definition in value.split(','):
         name, separator, docker_host = definition.strip().partition('=')
         name = name.strip()
+        docker_host, control_separator, control_value = docker_host.strip().partition('|')
         docker_host = docker_host.strip()
         if not separator or not name or not docker_host:
             raise ValueError('Each self-hosted runner location must use Name=Docker URL.')
         if name in names:
             raise ValueError(f'Self-hosted runner location {name} appears more than once.')
         names.add(name)
-        hosts.append({'name': name, 'dockerHost': docker_host})
+        host = {'name': name, 'dockerHost': docker_host}
+        if control_separator:
+            scope, scope_separator, unit = control_value.strip().partition(':')
+            if scope not in ('system', 'user') or not scope_separator or not re.fullmatch(r'[A-Za-z0-9@_.-]+\.service', unit):
+                raise ValueError(f'Self-hosted runner control for {name} must use system:UNIT.service or user:UNIT.service.')
+            host['control'] = {'scope': scope, 'unit': unit}
+        hosts.append(host)
     if not hosts:
         raise ValueError('Configure at least one self-hosted runner location.')
     return hosts
+
+
+def parse_repositories(value):
+    repositories = []
+    for repository in value.split(','):
+        repository = repository.strip()
+        if not repository:
+            continue
+        if not re.fullmatch(r'[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+', repository):
+            raise ValueError(f'GitHub repository {repository} must use OWNER/REPOSITORY.')
+        if repository not in repositories:
+            repositories.append(repository)
+    return repositories
+
+
+def host_systemctl_command(host, action):
+    control = host.get('service') or host.get('control')
+    if control is not None and control.get('configuration') is not None:
+        control = control['configuration']
+    if control is None:
+        raise ValueError(f"{host['name']} has no self-hosted runner service control.")
+
+    docker_url = urlparse(host['dockerHost'])
+    prefix = []
+    if docker_url.scheme == 'ssh':
+        if docker_url.hostname is None:
+            raise ValueError(f"{host['name']} has an invalid SSH Docker URL.")
+        target = f'{docker_url.username}@{docker_url.hostname}' if docker_url.username else docker_url.hostname
+        prefix = ['ssh']
+        if docker_url.port is not None:
+            prefix.extend(['-p', str(docker_url.port)])
+        prefix.append(target)
+    elif docker_url.scheme != 'unix':
+        raise ValueError(f"{host['name']} service control requires an SSH or Unix Docker URL.")
+
+    systemctl = ['sudo', '-n', 'systemctl'] if control['scope'] == 'system' else ['systemctl', '--user']
+    return [*prefix, *systemctl, action, control['unit']]
+
+
+def request_host_control(host, run=subprocess.run):
+    command = host_systemctl_command(host, 'is-active')
+    completed = run(command, check=False, capture_output=True, text=True, timeout=4)
+    status = completed.stdout.strip()
+    if status not in ('active', 'activating', 'deactivating', 'inactive', 'failed'):
+        message = completed.stderr.strip() or status or 'Service status unavailable'
+        return {'configuration': host['control'], 'status': 'unavailable', 'message': message}
+    return {'configuration': host['control'], 'status': status}
+
+
+def set_host_accepting_jobs(host, accepting, run=subprocess.run):
+    action = 'start' if accepting else 'stop'
+    command = host_systemctl_command(host, action)
+    command.insert(-1, '--no-block')
+    run(command, check=True, capture_output=True, text=True, timeout=4)
 
 
 def runner_activity(runner, logs):
@@ -88,24 +154,89 @@ def request_runners(host):
 def request_runner_hosts(hosts):
     results = []
     for host in hosts:
+        control = None
+        if host.get('control') is not None:
+            try:
+                control = request_host_control(host)
+            except Exception as caught:
+                control = {
+                    'configuration': host['control'],
+                    'status': 'unavailable',
+                    'message': str(caught),
+                }
         try:
-            results.append({
+            result = {
                 '_tag': 'Available',
                 'name': host['name'],
                 'runners': request_runners(host),
-            })
+            }
         except Exception as caught:
-            results.append({
+            result = {
                 '_tag': 'Unavailable',
                 'name': host['name'],
                 'message': str(caught),
-            })
+            }
+        if control is not None:
+            result['dockerHost'] = host['dockerHost']
+            result['service'] = host['control']
+            result['control'] = control
+        results.append(result)
     return results
 
 
 def read_runner_source(fetch_runner_hosts):
     try:
         return {'_tag': 'Available', 'hosts': fetch_runner_hosts()}
+    except Exception as caught:
+        return {'_tag': 'Unavailable', 'message': str(caught)}
+
+
+def github_api(path):
+    completed = subprocess.run(
+        ['gh', 'api', path, '--method', 'GET', '-f', 'per_page=50'],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=8,
+    )
+    return json.loads(completed.stdout)
+
+
+def collect_workflow_jobs(repository, runs, fetch_jobs):
+    jobs = []
+    for run in runs:
+        if run.get('status') not in ('queued', 'in_progress'):
+            continue
+        for job in fetch_jobs(run['id']):
+            if job.get('status') not in ('queued', 'in_progress') or 'self-hosted' not in job.get('labels', []):
+                continue
+            jobs.append({
+                '_tag': 'Queued' if job['status'] == 'queued' else 'Running',
+                'repository': repository,
+                'workflow': run.get('name', 'Workflow'),
+                'name': job.get('name', 'Job'),
+                'url': job.get('html_url') or run.get('html_url'),
+            })
+    return jobs
+
+
+def request_workflow_jobs(repositories):
+    jobs = []
+    for repository in repositories:
+        runs = github_api(f'repos/{repository}/actions/runs').get('workflow_runs', [])
+        jobs.extend(collect_workflow_jobs(
+            repository,
+            runs,
+            lambda run_id, current=repository: github_api(
+                f'repos/{current}/actions/runs/{run_id}/jobs',
+            ).get('jobs', []),
+        ))
+    return jobs
+
+
+def read_jobs_source(fetch_jobs):
+    try:
+        return {'_tag': 'Available', 'jobs': fetch_jobs()}
     except Exception as caught:
         return {'_tag': 'Unavailable', 'message': str(caught)}
 
@@ -226,7 +357,52 @@ def runner_error(source):
     return None
 
 
-def build_menu(indicator, source, refresh):
+def workflow_job_label(job):
+    marker = '🟡' if job['_tag'] == 'Queued' else '🟢'
+    return f"{marker} {job['repository']} · {job['workflow']} · {job['name']}"
+
+
+def job_menu(label, jobs):
+    if not jobs:
+        return menu_item(f'{label} · 0', enabled=False)
+    return submenu_item(
+        f'{label} · {len(jobs)}',
+        [menu_item(workflow_job_label(job), job['url']) for job in jobs],
+    )
+
+
+def host_control_status_label(control):
+    status = control['status']
+    if status == 'active':
+        return '🟢 Accepting new jobs'
+    if status == 'activating':
+        return '🟡 Starting'
+    if status == 'deactivating':
+        return '🟡 Finishing current jobs'
+    if status == 'inactive':
+        return '⚪ Not accepting new jobs'
+    if status == 'failed':
+        return '🔴 Service failed'
+    return f"🔴 Service unavailable · {control.get('message', 'Status unavailable')[:80]}"
+
+
+def confirm_stop_accepting_jobs(host, set_accepting):
+    dialog = Gtk.MessageDialog(
+        transient_for=None,
+        flags=0,
+        message_type=Gtk.MessageType.WARNING,
+        buttons=Gtk.ButtonsType.CANCEL,
+        text=f"Stop accepting new jobs on {host['name']}?",
+    )
+    dialog.format_secondary_text('Current jobs finish. Queued jobs wait for another self-hosted runner.')
+    dialog.add_button('Stop accepting', Gtk.ResponseType.OK)
+    response = dialog.run()
+    dialog.destroy()
+    if response == Gtk.ResponseType.OK:
+        set_accepting(host, False)
+
+
+def build_menu(indicator, source, jobs_source, action_error, refresh, set_accepting):
     menu = Gtk.Menu()
     error = runner_error(source)
     runners = source_runners(source)
@@ -237,18 +413,50 @@ def build_menu(indicator, source, refresh):
     menu.append(menu_item(status, enabled=False))
     if error is not None:
         menu.append(menu_item(error[:100], enabled=False))
+    if action_error is not None:
+        menu.append(menu_item(action_error[:100], enabled=False))
+
+    if jobs_source['_tag'] == 'Loading':
+        menu.append(menu_item('Queued jobs · Loading…', enabled=False))
+    elif jobs_source['_tag'] == 'Unavailable':
+        menu.append(menu_item('Queued jobs · unavailable', enabled=False))
+        menu.append(menu_item(jobs_source['message'][:100], enabled=False))
+    else:
+        queued_jobs = [job for job in jobs_source['jobs'] if job['_tag'] == 'Queued']
+        running_jobs = [job for job in jobs_source['jobs'] if job['_tag'] == 'Running']
+        menu.append(job_menu('Queued jobs', queued_jobs))
+        menu.append(job_menu('Running jobs', running_jobs))
+
     for host in hosts:
-        if host['_tag'] == 'Unavailable' or not host['runners']:
+        control = host.get('control')
+        if control is None and (host['_tag'] == 'Unavailable' or not host['runners']):
             menu.append(menu_item(runner_host_status_label(host), enabled=False))
             continue
         items = []
-        for runner in sorted(host['runners'], key=runner_label):
-            repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
-            items.append(menu_item(
-                runner_label(runner),
-                None if repository is None else f'https://github.com/{repository}/actions',
-                enabled=repository is not None,
-            ))
+        if host['_tag'] == 'Available':
+            for runner in sorted(host['runners'], key=runner_label):
+                repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
+                items.append(menu_item(
+                    runner_label(runner),
+                    None if repository is None else f'https://github.com/{repository}/actions',
+                    enabled=repository is not None,
+                ))
+        if not items:
+            items.append(menu_item(runner_host_status_label(host), enabled=False))
+        if control is not None:
+            items.append(separator())
+            items.append(menu_item(host_control_status_label(control), enabled=False))
+            if control['status'] == 'active':
+                control_item = menu_item('Stop accepting new jobs…')
+                control_item.connect(
+                    'activate',
+                    lambda *_args, current=host: confirm_stop_accepting_jobs(current, set_accepting),
+                )
+                items.append(control_item)
+            elif control['status'] in ('inactive', 'failed', 'deactivating'):
+                control_item = menu_item('Accept new jobs')
+                control_item.connect('activate', lambda *_args, current=host: set_accepting(current, True))
+                items.append(control_item)
         menu.append(submenu_item(runner_host_status_label(host), items))
 
     menu.append(separator())
@@ -277,6 +485,7 @@ def main():
         RUNNER_HOSTS_ENV,
         'Desktop=unix:///var/run/docker.sock',
     ))
+    configured_repositories = parse_repositories(os.environ.get(RUNNER_REPOSITORIES_ENV, ''))
     runtime = Path(os.environ.get('XDG_RUNTIME_DIR', f'/run/user/{os.getuid()}'))
     lock = (runtime / 'harlan-github-runner-indicator.lock').open('w')
     try:
@@ -292,18 +501,40 @@ def main():
     indicator.set_status(AyatanaAppIndicator3.IndicatorStatus.ACTIVE)
     indicator.set_title('GitHub Actions')
     refreshing = {'active': False}
+    pending_action = {'value': None}
+    jobs_cache = {'source': {'_tag': 'Loading'}, 'updatedAt': 0.0}
 
-    def apply_state(source):
+    def apply_state(source, jobs_source, action_error):
         refreshing['active'] = False
         label, title = indicator_summary(source)
         indicator.set_label(label, '🟢 99')
         indicator.set_title(title)
-        build_menu(indicator, source, refresh)
+        build_menu(indicator, source, jobs_source, action_error, manual_refresh, change_host_capacity)
+        if pending_action['value'] is not None:
+            refresh()
         return False
 
     def load_state():
+        action_error = None
+        action = pending_action['value']
+        pending_action['value'] = None
+        if action is not None:
+            try:
+                set_host_accepting_jobs(action['host'], action['accepting'])
+            except Exception as caught:
+                action_error = f"{action['host']['name']} · Action required · {caught}"
+
         source = read_runner_source(lambda: request_runner_hosts(runner_hosts))
-        GLib.idle_add(apply_state, source)
+        repositories = list(configured_repositories)
+        for runner in source_runners(source):
+            repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
+            if repository is not None and repository not in repositories:
+                repositories.append(repository)
+        stale = time.monotonic() - jobs_cache['updatedAt'] >= JOBS_REFRESH_SECONDS
+        if stale:
+            jobs_cache['source'] = read_jobs_source(lambda: request_workflow_jobs(repositories))
+            jobs_cache['updatedAt'] = time.monotonic()
+        GLib.idle_add(apply_state, source, jobs_cache['source'], action_error)
 
     def refresh(*_args):
         if refreshing['active']:
@@ -312,9 +543,28 @@ def main():
         threading.Thread(target=load_state, daemon=True).start()
         return True
 
-    build_menu(indicator, {'_tag': 'Loading'}, refresh)
+    def manual_refresh(*_args):
+        jobs_cache['updatedAt'] = 0.0
+        return refresh()
+
+    def change_host_capacity(host, accepting):
+        pending_action['value'] = {
+            'host': host,
+            'accepting': accepting,
+        }
+        jobs_cache['updatedAt'] = 0.0
+        return refresh()
+
+    build_menu(
+        indicator,
+        {'_tag': 'Loading'},
+        {'_tag': 'Loading'},
+        None,
+        manual_refresh,
+        change_host_capacity,
+    )
     refresh()
-    GLib.timeout_add_seconds(5, refresh)
+    GLib.timeout_add_seconds(15, refresh)
     Gtk.main()
 
 

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -280,6 +280,43 @@ class RunnerActivityTest(unittest.TestCase):
             'url': 'https://github.com/job/99',
         }])
 
+    def test_follows_pagination_for_jobs_within_one_run(self):
+        requests = []
+
+        def job(index):
+            return {
+                'name': f'test {index}',
+                'status': 'in_progress',
+                'labels': ['self-hosted'],
+                'html_url': f'https://github.com/job/{index}',
+            }
+
+        def fake_github_api(path):
+            requests.append(path)
+            if path == 'repos/harlan-zw/example/actions/runs?status=queued&page=1&per_page=50':
+                return {'workflow_runs': [
+                    {'id': 7, 'name': 'Code', 'status': 'in_progress', 'html_url': 'https://github.com/run/7'},
+                ]}
+            if path == 'repos/harlan-zw/example/actions/runs?status=in_progress&page=1&per_page=50':
+                return {'workflow_runs': []}
+            if path == 'repos/harlan-zw/example/actions/runs/7/jobs?page=1&per_page=100':
+                return {'jobs': [job(index) for index in range(100)]}
+            if path == 'repos/harlan-zw/example/actions/runs/7/jobs?page=2&per_page=100':
+                return {'jobs': [job(index) for index in range(100, 135)]}
+            raise AssertionError(f'unexpected GitHub API request {path}')
+
+        with patch.object(runner_indicator, 'github_api', side_effect=fake_github_api):
+            jobs = runner_indicator.request_workflow_jobs(['harlan-zw/example'])
+
+        self.assertEqual(len(jobs), 135)
+        self.assertEqual(
+            [path for path in requests if '/jobs' in path],
+            [
+                'repos/harlan-zw/example/actions/runs/7/jobs?page=1&per_page=100',
+                'repos/harlan-zw/example/actions/runs/7/jobs?page=2&per_page=100',
+            ],
+        )
+
     def test_stops_a_remote_runner_service_without_waiting_for_jobs(self):
         commands = []
         host = runner_indicator.parse_runner_hosts(

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -22,6 +22,18 @@ def load_indicator():
 indicator = load_indicator()
 
 
+def load_runner_indicator():
+    path = Path(__file__).parents[1] / 'bin/harlan-github-runner-indicator'
+    loader = importlib.machinery.SourceFileLoader('harlan_github_runner_indicator', str(path))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+runner_indicator = load_runner_indicator()
+
+
 def load_watch():
     path = Path(__file__).parents[1] / 'bin/harlan-github-agent-watch'
     loader = importlib.machinery.SourceFileLoader('harlan_github_agent_watch', str(path))
@@ -48,7 +60,7 @@ def menu_labels(menu):
 
 class RunnerActivityTest(unittest.TestCase):
     def test_parses_named_runner_hosts_for_future_balancing(self):
-        self.assertEqual(indicator.parse_runner_hosts(
+        self.assertEqual(runner_indicator.parse_runner_hosts(
             'Hogwild=ssh://hogwild,Desktop=unix:///var/run/docker.sock',
         ), [
             {'name': 'Hogwild', 'dockerHost': 'ssh://hogwild'},
@@ -72,11 +84,11 @@ class RunnerActivityTest(unittest.TestCase):
                 stderr='',
             )
 
-        hosts = indicator.parse_runner_hosts(
+        hosts = runner_indicator.parse_runner_hosts(
             'Hogwild=ssh://hogwild,Desktop=unix:///var/run/docker.sock',
         )
-        with patch.object(indicator.subprocess, 'run', side_effect=run):
-            result = indicator.request_runner_hosts(hosts)
+        with patch.object(runner_indicator.subprocess, 'run', side_effect=run):
+            result = runner_indicator.request_runner_hosts(hosts)
 
         self.assertEqual(result, [
             {
@@ -100,19 +112,19 @@ class RunnerActivityTest(unittest.TestCase):
         ])
 
     def test_reports_idle_runner(self):
-        self.assertEqual(indicator.runner_activity(
+        self.assertEqual(runner_indicator.runner_activity(
             {'State': 'running', 'Status': 'Up 10 minutes'},
             "2026-08-13T15:43:11Z: Listening for Jobs\n",
         ), {'_tag': 'Idle'})
 
     def test_reports_current_job(self):
-        self.assertEqual(indicator.runner_activity(
+        self.assertEqual(runner_indicator.runner_activity(
             {'State': 'running', 'Status': 'Up 10 minutes'},
             "Listening for Jobs\n2026-08-13T15:50:00Z: Running job: deploy production\n",
         ), {'_tag': 'Running', 'job': 'deploy production'})
 
     def test_reports_offline_runner(self):
-        self.assertEqual(indicator.runner_activity(
+        self.assertEqual(runner_indicator.runner_activity(
             {'State': 'exited', 'Status': 'Exited (1) 2 minutes ago'},
             '',
         ), {'_tag': 'Offline', 'detail': 'Exited (1) 2 minutes ago'})
@@ -124,7 +136,7 @@ class RunnerActivityTest(unittest.TestCase):
         ]
 
         self.assertEqual(
-            indicator.github_actions_status_label(runners, None),
+            runner_indicator.github_actions_status_label(runners, None),
             '🟢 2 self-hosted runners · 1 running · 1 idle',
         )
 
@@ -139,13 +151,13 @@ class RunnerActivityTest(unittest.TestCase):
         }
 
         self.assertEqual(
-            indicator.runner_host_status_label(host),
+            runner_indicator.runner_host_status_label(host),
             '🟢 Hogwild · 2 self-hosted runners · 1 running · 1 idle',
         )
 
     def test_appends_the_failure_message_to_an_unavailable_runner_host(self):
         self.assertEqual(
-            indicator.runner_host_status_label({
+            runner_indicator.runner_host_status_label({
                 '_tag': 'Unavailable',
                 'name': 'Hogwild',
                 'message': 'ssh://hogwild refused',
@@ -153,20 +165,13 @@ class RunnerActivityTest(unittest.TestCase):
             '🔴 Hogwild · unavailable · ssh://hogwild refused',
         )
 
-    def test_reports_runner_discovery_without_changing_agent_state(self):
+    def test_reports_runner_discovery_failure(self):
         def unavailable():
             raise RuntimeError('Docker is unavailable')
 
-        sources = indicator.read_system_sources(
-            lambda: {'status': 'ready'},
-            unavailable,
-        )
+        source = runner_indicator.read_runner_source(unavailable)
 
-        self.assertEqual(sources['harlanGithubAgent'], {
-            '_tag': 'Available',
-            'dashboard': {'status': 'ready'},
-        })
-        self.assertEqual(sources['githubActions'], {
+        self.assertEqual(source, {
             '_tag': 'Unavailable',
             'message': 'Docker is unavailable',
         })
@@ -205,7 +210,7 @@ class IndicatorDisplayTest(unittest.TestCase):
         }
 
         self.assertEqual(
-            indicator.runner_label(runner),
+            runner_indicator.runner_label(runner),
             '🟢 Running · deploy production · harlan-zw/example · runner-1',
         )
 
@@ -307,10 +312,24 @@ class IndicatorDisplayTest(unittest.TestCase):
         )
 
     def test_treats_an_all_unavailable_host_list_as_an_error_state(self):
-        sources = indicator.read_system_sources(
-            lambda: {'status': 'ready'},
+        source = runner_indicator.read_runner_source(
             lambda: [{'_tag': 'Unavailable', 'name': 'Hogwild', 'message': 'ssh://hogwild refused'}],
         )
+        stub = StubIndicator()
+
+        runner_indicator.build_menu(
+            stub,
+            source,
+            lambda: None,
+        )
+        labels = menu_labels(stub.menus[0])
+
+        self.assertIn('🔴 Status unavailable', labels)
+        self.assertNotIn('⚪ No self-hosted runners found', labels)
+        self.assertIn('🔴 Hogwild · unavailable · ssh://hogwild refused', labels)
+
+    def test_agent_menu_does_not_include_github_actions(self):
+        sources = indicator.read_system_sources(lambda: {'status': 'ready'})
         stub = StubIndicator()
 
         indicator.build_menu(
@@ -323,11 +342,8 @@ class IndicatorDisplayTest(unittest.TestCase):
             lambda *_args: None,
             lambda *_args: None,
         )
-        labels = menu_labels(stub.menus[0])
 
-        self.assertIn('🔴 Status unavailable', labels)
-        self.assertNotIn('⚪ No self-hosted runners found', labels)
-        self.assertIn('🔴 Hogwild · unavailable · ssh://hogwild refused', labels)
+        self.assertNotIn('GitHub Actions', menu_labels(stub.menus[0]))
 
     def test_opens_a_read_only_watch_terminal_for_the_exact_session(self):
         agent = {

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -231,9 +231,11 @@ class RunnerActivityTest(unittest.TestCase):
                     'labels': ['self-hosted'],
                     'html_url': 'https://github.com/job/9',
                 }]}
-            return {'workflow_runs': [
-                {'id': 7, 'name': 'Code', 'status': 'in_progress', 'html_url': 'https://github.com/run/7'},
-            ]}
+            if 'status=queued' in path:
+                return {'workflow_runs': [
+                    {'id': 7, 'name': 'Code', 'status': 'in_progress', 'html_url': 'https://github.com/run/7'},
+                ]}
+            return {'workflow_runs': []}
 
         with patch.object(runner_indicator, 'github_api', side_effect=fake_github_api):
             jobs = runner_indicator.request_workflow_jobs(['good/repo', 'broken/repo'], errors.append)
@@ -249,12 +251,12 @@ class RunnerActivityTest(unittest.TestCase):
 
     def test_follows_pagination_for_queued_jobs_beyond_the_first_page(self):
         def fake_github_api(path):
-            if path == 'repos/harlan-zw/example/actions/runs?page=1&per_page=50' or path == 'repos/harlan-zw/example/actions/runs':
+            if path == 'repos/harlan-zw/example/actions/runs?status=queued&page=1&per_page=50':
                 return {'workflow_runs': [
                     {'id': index, 'name': 'Recent', 'status': 'in_progress', 'html_url': f'https://github.com/run/{index}'}
                     for index in range(50)
                 ]}
-            if path == 'repos/harlan-zw/example/actions/runs?page=2&per_page=50':
+            if path == 'repos/harlan-zw/example/actions/runs?status=queued&page=2&per_page=50':
                 return {'workflow_runs': [
                     {'id': 99, 'name': 'Old', 'status': 'queued', 'html_url': 'https://github.com/run/99'},
                 ]}

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -218,6 +218,66 @@ class RunnerActivityTest(unittest.TestCase):
             'url': 'https://github.com/job/1',
         }])
 
+    def test_keeps_jobs_when_one_repository_fails(self):
+        errors = []
+
+        def fake_github_api(path):
+            if path.startswith('repos/broken/repo'):
+                raise RuntimeError('renamed repository')
+            if '/jobs' in path:
+                return {'jobs': [{
+                    'name': 'test',
+                    'status': 'queued',
+                    'labels': ['self-hosted'],
+                    'html_url': 'https://github.com/job/9',
+                }]}
+            return {'workflow_runs': [
+                {'id': 7, 'name': 'Code', 'status': 'in_progress', 'html_url': 'https://github.com/run/7'},
+            ]}
+
+        with patch.object(runner_indicator, 'github_api', side_effect=fake_github_api):
+            jobs = runner_indicator.request_workflow_jobs(['good/repo', 'broken/repo'], errors.append)
+
+        self.assertEqual(jobs, [{
+            '_tag': 'Queued',
+            'repository': 'good/repo',
+            'workflow': 'Code',
+            'name': 'test',
+            'url': 'https://github.com/job/9',
+        }])
+        self.assertEqual(errors, ['broken/repo · Jobs unavailable · renamed repository'])
+
+    def test_follows_pagination_for_queued_jobs_beyond_the_first_page(self):
+        def fake_github_api(path):
+            if path == 'repos/harlan-zw/example/actions/runs?page=1&per_page=50' or path == 'repos/harlan-zw/example/actions/runs':
+                return {'workflow_runs': [
+                    {'id': index, 'name': 'Recent', 'status': 'in_progress', 'html_url': f'https://github.com/run/{index}'}
+                    for index in range(50)
+                ]}
+            if path == 'repos/harlan-zw/example/actions/runs?page=2&per_page=50':
+                return {'workflow_runs': [
+                    {'id': 99, 'name': 'Old', 'status': 'queued', 'html_url': 'https://github.com/run/99'},
+                ]}
+            if '/runs/99/jobs' in path:
+                return {'jobs': [{
+                    'name': 'test',
+                    'status': 'queued',
+                    'labels': ['self-hosted'],
+                    'html_url': 'https://github.com/job/99',
+                }]}
+            return {'jobs': []}
+
+        with patch.object(runner_indicator, 'github_api', side_effect=fake_github_api):
+            jobs = runner_indicator.request_workflow_jobs(['harlan-zw/example'])
+
+        self.assertEqual(jobs, [{
+            '_tag': 'Queued',
+            'repository': 'harlan-zw/example',
+            'workflow': 'Old',
+            'name': 'test',
+            'url': 'https://github.com/job/99',
+        }])
+
     def test_stops_a_remote_runner_service_without_waiting_for_jobs(self):
         commands = []
         host = runner_indicator.parse_runner_hosts(

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -61,10 +61,19 @@ def menu_labels(menu):
 class RunnerActivityTest(unittest.TestCase):
     def test_parses_named_runner_hosts_for_future_balancing(self):
         self.assertEqual(runner_indicator.parse_runner_hosts(
-            'Hogwild=ssh://hogwild,Desktop=unix:///var/run/docker.sock',
+            'Hogwild=ssh://hogwild|system:hogwild-github-runner.service,'
+            'Desktop=unix:///var/run/docker.sock|user:harlan-desktop-github-runner.service',
         ), [
-            {'name': 'Hogwild', 'dockerHost': 'ssh://hogwild'},
-            {'name': 'Desktop', 'dockerHost': 'unix:///var/run/docker.sock'},
+            {
+                'name': 'Hogwild',
+                'dockerHost': 'ssh://hogwild',
+                'control': {'scope': 'system', 'unit': 'hogwild-github-runner.service'},
+            },
+            {
+                'name': 'Desktop',
+                'dockerHost': 'unix:///var/run/docker.sock',
+                'control': {'scope': 'user', 'unit': 'harlan-desktop-github-runner.service'},
+            },
         ])
 
     def test_keeps_runner_hosts_independent_when_one_is_unavailable(self):
@@ -175,6 +184,62 @@ class RunnerActivityTest(unittest.TestCase):
             '_tag': 'Unavailable',
             'message': 'Docker is unavailable',
         })
+
+    def test_lists_only_active_self_hosted_jobs(self):
+        runs = [
+            {'id': 12, 'name': 'Code', 'status': 'in_progress', 'html_url': 'https://github.com/run/12'},
+            {'id': 13, 'name': 'Docs', 'status': 'completed', 'html_url': 'https://github.com/run/13'},
+        ]
+
+        result = runner_indicator.collect_workflow_jobs(
+            'harlan-zw/example',
+            runs,
+            lambda _run_id: [
+                {
+                    'name': 'test',
+                    'status': 'queued',
+                    'labels': ['self-hosted', 'harlan-desktop-ci'],
+                    'html_url': 'https://github.com/job/1',
+                },
+                {
+                    'name': 'cloud',
+                    'status': 'in_progress',
+                    'labels': ['ubuntu-latest'],
+                    'html_url': 'https://github.com/job/2',
+                },
+            ],
+        )
+
+        self.assertEqual(result, [{
+            '_tag': 'Queued',
+            'repository': 'harlan-zw/example',
+            'workflow': 'Code',
+            'name': 'test',
+            'url': 'https://github.com/job/1',
+        }])
+
+    def test_stops_a_remote_runner_service_without_waiting_for_jobs(self):
+        commands = []
+        host = runner_indicator.parse_runner_hosts(
+            'Hogwild=ssh://hogwild|system:hogwild-github-runner.service',
+        )[0]
+
+        runner_indicator.set_host_accepting_jobs(
+            host,
+            False,
+            lambda command, **_options: commands.append(command),
+        )
+
+        self.assertEqual(commands, [[
+            'ssh',
+            'hogwild',
+            'sudo',
+            '-n',
+            'systemctl',
+            'stop',
+            '--no-block',
+            'hogwild-github-runner.service',
+        ]])
 
 
 class IndicatorDisplayTest(unittest.TestCase):
@@ -320,13 +385,49 @@ class IndicatorDisplayTest(unittest.TestCase):
         runner_indicator.build_menu(
             stub,
             source,
+            {'_tag': 'Available', 'jobs': []},
+            None,
             lambda: None,
+            lambda *_args: None,
         )
         labels = menu_labels(stub.menus[0])
 
         self.assertIn('🔴 Status unavailable', labels)
         self.assertNotIn('⚪ No self-hosted runners found', labels)
         self.assertIn('🔴 Hogwild · unavailable · ssh://hogwild refused', labels)
+
+    def test_shows_queued_jobs_and_runner_server_control(self):
+        source = {'_tag': 'Available', 'hosts': [{
+            '_tag': 'Available',
+            'name': 'Hogwild',
+            'runners': [],
+            'control': {
+                'configuration': {'scope': 'system', 'unit': 'hogwild-github-runner.service'},
+                'status': 'active',
+            },
+        }]}
+        jobs = {'_tag': 'Available', 'jobs': [{
+            '_tag': 'Queued',
+            'repository': 'harlan-zw/example',
+            'workflow': 'Code',
+            'name': 'test',
+            'url': 'https://github.com/job/1',
+        }]}
+        stub = StubIndicator()
+
+        runner_indicator.build_menu(
+            stub,
+            source,
+            jobs,
+            None,
+            lambda: None,
+            lambda *_args: None,
+        )
+
+        menu = stub.menus[0]
+        self.assertIn('Queued jobs · 1', menu_labels(menu))
+        host = next(item for item in menu.get_children() if item.get_label().startswith('⚪ Hogwild'))
+        self.assertIn('Stop accepting new jobs…', menu_labels(host.get_submenu()))
 
     def test_agent_menu_does_not_include_github_actions(self):
         sources = indicator.read_system_sources(lambda: {'status': 'ready'})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The Harlan GitHub Agent and GitHub Actions runners are independent, but they currently share one system pane. Runners now have a dedicated pane with queued and running jobs plus per-server controls. Stopping one server lets current jobs finish before GitHub sends queued jobs to another matching self-hosted runner.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).