### PR TITLE
fix(agent): recover stale and duplicate reviews

### DIFF
--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -97,6 +97,10 @@ function controllerBaselineMetadata(template: PullRequestTemplate): RepairedResp
   }
 }
 
+function isMissingTemplatePlaceholder(value: string): boolean {
+  return value.trim() === JSON.stringify({ _tag: 'Missing' })
+}
+
 function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
   return Promise.resolve(text)
     .then(value => JSON.parse(value) as AgentResponsePayload)
@@ -123,6 +127,7 @@ function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
         || cleanLine(value.commitMessage).length === 0
         || cleanLine(value.pullRequestTitle).length === 0
         || value.pullRequestBody.trim().length === 0
+        || isMissingTemplatePlaceholder(value.pullRequestBody)
       ) {
         return err('The agent returned an invalid Baseline repair result.')
       }
@@ -139,6 +144,9 @@ function parseResponse(text: string): Promise<Result<AgentResponse, string>> {
 }
 
 function prompt(task: ClaimedBaselineRepairTask, checks: string[], template: PullRequestTemplate): string {
+  const templateInstruction = template._tag === 'Found'
+    ? `Use this pull request template when useful: ${JSON.stringify(template.body)}`
+    : 'No pull request template exists. Write a short description of the actual fix.'
   return `Repair the failing default branch CI for ${task.repository} at commit ${task.pullRequest.baseSha}.
 
 Own the work end to end. Diagnose the actual failure, implement the complete fix, and verify it.
@@ -146,7 +154,8 @@ Work as a normal local agent session. Use the user's global agent context and in
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before returning a result.
 Read repository AGENTS.md and contributor instructions. Apply the unit-tests skill for bug fixes.
 Use GitHub read commands to inspect the failed runs and logs. The failing checks are ${JSON.stringify(checks)}.
-Apply the PR skill to draft the pull request title and body. Use this template when useful: ${JSON.stringify(template)}.
+Apply the PR skill to draft the pull request title and body.
+${templateInstruction}
 Choose a commit message that describes your actual fix. Avoid generic automated-review wording.
 Do not stage, commit, push, or publish. The controller handles those safety boundaries.
 Return blocked only when you cannot safely complete the fix. Return only the required JSON.`

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -20,6 +20,7 @@ import type { AgentWorkspaceManager } from './worktree.ts'
 import { createHash, randomUUID } from 'node:crypto'
 import { formatProgressBar } from './agent-progress.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
+import { currentGitHubChecks } from './github-agent-source.ts'
 import { issueTriageComment } from './issue-triage-comment.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
@@ -553,6 +554,25 @@ function baseChecksFailed(snapshot: PullRequestReviewSnapshot): boolean {
   return snapshot.baseChecks._tag === 'Available' && snapshot.baseChecks.checks.some(checkFailed)
 }
 
+function sameCheckContext(left: GitHubCheck, right: GitHubCheck): boolean {
+  if (left.name !== right.name || left.source._tag !== right.source._tag)
+    return false
+  return left.source._tag === 'CommitStatus'
+    || (right.source._tag === 'CheckRun' && left.source.appId === right.source.appId)
+}
+
+/** True when this head turns every failed base check green. */
+function headRepairsFailedBaseChecks(snapshot: PullRequestReviewSnapshot): boolean {
+  if (snapshot.baseChecks._tag !== 'Available' || snapshot.checks._tag !== 'Available')
+    return false
+  const failedBaseChecks = currentGitHubChecks(snapshot.baseChecks.checks).filter(checkFailed)
+  const headChecks = currentGitHubChecks(snapshot.checks.checks)
+  return failedBaseChecks.length > 0 && failedBaseChecks.every(baseCheck => headChecks.some(headCheck =>
+    sameCheckContext(baseCheck, headCheck)
+    && headCheck.status === 'completed'
+    && headCheck.conclusion === 'success'))
+}
+
 function reviewGates(snapshot: PullRequestReviewSnapshot, response: ReviewResponse, repairsBaseline: boolean): { gates: ReviewGates, reportedChecks: string[] } {
   const findings = response.findings
   const ci = ciGate(snapshot, repairsBaseline)
@@ -764,7 +784,10 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         recordRunnerLostIncident(options, task.repository)
       if (snapshot.value.priorAutomatedReview._tag === 'Found' && task.rerun._tag === 'NotRequested')
         return ok({ evidence: `Existing automated review by @${snapshot.value.priorAutomatedReview.authorLogin}: ${snapshot.value.priorAutomatedReview.url}` })
-      const repairsBaseline = options.store.isBaselineRepairPullRequest(task.repository, task.pullRequest.headRef)
+      const knownBaselineRepair = options.store.isBaselineRepairPullRequest(task.repository, task.pullRequest.headRef)
+      const repairsBaseline = knownBaselineRepair
+        || (basesDefaultBranch(snapshot.value.pullRequest, task.repositoryMapping) && headRepairsFailedBaseChecks(snapshot.value))
+      const ciAtStart = ciGate(snapshot.value, repairsBaseline).state
       const repairAccess = await options.preflightRepair(task.repository, signal)
       if (!repairsBaseline && baseChecksFailed(snapshot.value) && basesDefaultBranch(snapshot.value.pullRequest, task.repositoryMapping)) {
         const baseline = repairAccess._tag === 'Ok'
@@ -783,8 +806,8 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         if (baseline._tag !== 'NotAuthorized')
           return ok({ evidence: `Waiting for Baseline repair ${baseline.taskId}.` })
       }
-      else if (!repairsBaseline) {
-        // The base is healthy, so any Baseline repair that died for it is done.
+      else if (!knownBaselineRepair) {
+        // This head needs no separate Baseline repair, so retire a dead one.
         options.store.retireBaselineRepairForReview({
           taskId: task.id,
           workerId: task.state.workerId,
@@ -844,6 +867,10 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       const checked = await reportReviewProgress(options, task, 'review', { percent: 90, label: 'Head commit and CI checked' }, signal)
       if (checked._tag === 'Err')
         return checked
+      const ciAtCompletion = ciGate(frozen.value, repairsBaseline).state
+      const agentWaited = response.metadata.state === 'waiting' || response.verification.state === 'waiting'
+      if (ciAtStart._tag !== 'Passed' && ciAtCompletion._tag === 'Passed' && agentWaited)
+        return err('Required CI settled during the review. Retry with the current check results.')
       // The agent answers waiting on its own review gate when it did not review
       // the diff, which an unreliable model does after its first answer fails
       // the schema. Publishing that reports a verdict nobody produced, so the

--- a/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
+++ b/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
@@ -163,6 +163,72 @@ describe('baseline repair worker', () => {
     }))
   })
 
+  it('does not publish an internal missing-template value as the pull request body', async () => {
+    const mapping = repositoryMapping()
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const worker = createBaselineRepairWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        outcome: 'repaired',
+        summary: 'Fixed the failing harness type check.',
+        checks: ['pnpm test'],
+        commitMessage: 'fix(harness): accept bare sandbox sessions',
+        pullRequestTitle: 'fix(harness): accept bare sandbox sessions',
+        pullRequestBody: JSON.stringify({ _tag: 'Missing' }),
+      }))),
+      github: {
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'failure' }] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' as const },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      store: {
+        getWorkerSession: () => null,
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: value => Promise.resolve(ok(value)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/baseline-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.baseSha })),
+        verify: () => Promise.resolve(ok({ digest: 'patch-digest', changedFiles: 1 })),
+        commit: () => Promise.resolve(ok({
+          commitSha: 'repair-commit',
+          baseSha: pullRequest.baseSha,
+          artifactRef: 'artifact-ref',
+          digest: 'patch-digest',
+          changedFiles: 1,
+        })),
+      },
+    })
+
+    const result = await worker.run({
+      id: 'baseline-task',
+      kind: 'baseline_repair',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'baseline-agent', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+    }, new AbortController().signal)
+
+    expect(result).toEqual(ok({
+      _tag: 'Publish',
+      publication: expect.objectContaining({
+        pullRequestBody: expect.stringContaining('Repairs failing default branch CI.'),
+      }),
+    }))
+    expect(JSON.stringify(result)).not.toContain('"_tag":"Missing"')
+  })
+
   it('surfaces ActionRequired when a blocked result carries malformed metadata', async () => {
     const mapping = repositoryMapping()
     const pullRequest = pullRequestItem({ mergeState: 'clean' })

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -618,7 +618,7 @@ describe('subject Workers', () => {
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
           baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
           body: 'Fixes the parser.',
-          checks: { _tag: 'Available', checks: [{ id: 2, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'success' }] },
+          checks: { _tag: 'Available', checks: [{ id: 2, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'build', status: 'completed', conclusion: 'failure' }] },
           comments: [],
           priorAutomatedReview: { _tag: 'None' },
           pullRequest,

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -153,6 +153,33 @@ function harness(input: {
 }
 
 describe('review resilience', () => {
+  it('retries when required CI settles after the Agent answered waiting', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const initial = reviewSnapshot(pullRequest)
+    const frozen = reviewSnapshot(pullRequest)
+    initial.requiredChecks = { _tag: 'Declared', contexts: ['test'] }
+    initial.checks = { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'in_progress', conclusion: null }] }
+    frozen.requiredChecks = { _tag: 'Declared', contexts: ['test'] }
+    const test = harness({
+      pullRequest,
+      snapshots: [initial, frozen],
+      response: {
+        metadata: { state: 'waiting', reason: 'Required CI has not concluded.', evidence: 'CI is pending.' },
+        review: passingGate,
+        verification: { state: 'waiting', reason: 'Required CI is pending.', evidence: 'CI is pending.' },
+        findings: [],
+        confidence: null,
+      },
+    })
+
+    const result = await createReviewWorker(test.options).run(reviewTask(pullRequest), new AbortController().signal)
+
+    expect(result).toEqual(err('Required CI settled during the review. Retry with the current check results.'))
+    expect(test.attempts).toHaveLength(0)
+    expect(test.comments.at(-1)).toContain('REVIEWING')
+    expect(test.comments.at(-1)).not.toContain('PENDING')
+  })
+
   it('keeps the newest discussion inside one bounded Review context', () => {
     const oldComment = `old-comment-${'a'.repeat(8_000)}`
     const newComment = `new-comment-${'b'.repeat(8_000)}`

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -131,6 +131,21 @@ function terminal(comments: string[]): string {
   return comments[comments.length - 1] ?? ''
 }
 
+describe('baseline repair classification', () => {
+  it('reviews a pull request whose head already fixes the failed base check', async () => {
+    const probe = reviewWith({
+      baseChecks: [check(1, 'ci / test', 'failure')],
+      headChecks: [check(2, 'ci / test', 'success')],
+    })
+
+    await probe.run()
+
+    expect(probe.baselineRepairs).toBe(0)
+    expect(probe.runs).toHaveLength(1)
+    expect(terminal(probe.comments)).toContain('READY')
+  })
+})
+
 describe('a failing job with no failed step', () => {
   it('reads a killed container as a lost runner', () => {
     expect(classifyFailedJob([


### PR DESCRIPTION
## Summary

- Retry Review when CI settles after the Agent reports a waiting gate.
- Review a pull request that already fixes every failed base check.
- Keep internal missing-template values out of pull request descriptions.

## Verification

- 646 tests passed
- Typecheck passed
- Lint passed
- Build passed

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) prepared this pull request. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source).