### PR TITLE
fix(agent): recover status incidents and watch provider logs

### DIFF
--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -395,6 +395,7 @@ def open_agent_watch(agent):
         '-e',
         sys.executable,
         str(WATCHER),
+        agent['provider'],
         session['id'],
     ], start_new_session=True)
 

--- a/packages/harlan-github-agent/bin/harlan-github-agent-watch
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-watch
@@ -252,10 +252,9 @@ def watch_opencode(session_id):
     console.print(Text(f'Watching opencode session {session_id}', style='bold white'))
     console.print(Text(f"{session['info']['directory']}\n", style='dim'))
     parts = opencode_parts(session)
-    seen = {}
+    seen = {part['id']: json.dumps(part, sort_keys=True) for part in parts}
     for part in parts[-80:]:
         render_opencode_part(part, console)
-        seen[part['id']] = json.dumps(part, sort_keys=True)
     if opencode_session_complete(session):
         input('\nAutomation finished. Press Enter to close.')
         return

--- a/packages/harlan-github-agent/bin/harlan-github-agent-watch
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-watch
@@ -2,6 +2,7 @@
 
 import json
 import re
+import sqlite3
 import sys
 import time
 from collections import deque
@@ -12,7 +13,9 @@ from rich.syntax import Syntax
 from rich.text import Text
 
 SESSION_ID = re.compile(r'^[a-f\d]{8}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{4}-[a-f\d]{12}$', re.IGNORECASE)
+OPENCODE_SESSION_ID = re.compile(r'^ses_[A-Za-z\d]+$')
 SESSION_ROOT = Path.home() / '.codex/sessions'
+OPENCODE_DATABASE = Path.home() / '.local/share/opencode/opencode.db'
 
 
 def clean(value, limit=2400):
@@ -135,10 +138,140 @@ def render_event(event, console):
 
 
 def find_session_log(session_id, root=SESSION_ROOT):
-    if SESSION_ID.fullmatch(session_id) is None:
-        raise ValueError('Invalid Codex session ID.')
+    validate_session_id('codex', session_id)
     matches = list(root.glob(f'**/*{session_id}.jsonl'))
     return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
+
+
+def validate_session_id(provider, session_id):
+    pattern = SESSION_ID if provider == 'codex' else OPENCODE_SESSION_ID if provider == 'opencode' else None
+    if pattern is None:
+        raise ValueError('Unsupported Agent provider.')
+    if pattern.fullmatch(session_id) is None:
+        label = 'Codex' if provider == 'codex' else 'opencode'
+        raise ValueError(f'Invalid {label} session ID.')
+    return session_id
+
+
+def load_opencode_session(session_id, database=OPENCODE_DATABASE):
+    validate_session_id('opencode', session_id)
+    connection = sqlite3.connect(f'file:{database}?mode=ro', uri=True)
+    connection.row_factory = sqlite3.Row
+    try:
+        session = connection.execute(
+            'SELECT title, directory FROM session WHERE id = ?',
+            (session_id,),
+        ).fetchone()
+        if session is None:
+            raise ValueError('The opencode session is unavailable.')
+        rows = connection.execute(
+            '''
+            SELECT message.id AS message_id, message.data AS message_data,
+              part.id AS part_id, part.time_created, part.time_updated, part.data AS part_data
+            FROM message
+            JOIN part ON part.message_id = message.id
+            WHERE message.session_id = ?
+            ORDER BY message.time_created, part.time_created, part.id
+            ''',
+            (session_id,),
+        ).fetchall()
+    finally:
+        connection.close()
+
+    messages = []
+    current = None
+    for row in rows:
+        if current is None or current['id'] != row['message_id']:
+            current = {
+                'id': row['message_id'],
+                'info': json.loads(row['message_data']),
+                'parts': [],
+            }
+            messages.append(current)
+        current['parts'].append({
+            'id': row['part_id'],
+            'timeCreated': row['time_created'],
+            'timeUpdated': row['time_updated'],
+            **json.loads(row['part_data']),
+        })
+    return {
+        'info': {'title': session['title'], 'directory': session['directory']},
+        'messages': messages,
+    }
+
+
+def format_opencode_part(part):
+    part_type = part.get('type')
+    if part_type in ('reasoning', 'text'):
+        text = clean(part.get('text', ''))
+        return f'Agent\n{text}' if text else None
+    if part_type == 'tool':
+        state = part.get('state', {})
+        tool_input = state.get('input', {})
+        command = tool_input.get('command') or state.get('title') or part.get('tool', 'tool')
+        status = state.get('status', 'running')
+        metadata = state.get('metadata', {})
+        exit_code = metadata.get('exit')
+        status_label = f'exit {exit_code}' if isinstance(exit_code, int) else status
+        output = clean(state.get('output') or metadata.get('output') or '')
+        return f'$ {clean(command)}\n[{status_label}]' if not output else f'$ {clean(command)}\n[{status_label}]\n{output}'
+    if part_type == 'step-finish' and part.get('reason') == 'stop':
+        return 'Task complete'
+    return None
+
+
+def opencode_parts(session):
+    return [
+        part
+        for message in session.get('messages', [])
+        if message.get('info', {}).get('role') == 'assistant'
+        for part in message.get('parts', [])
+        if format_opencode_part(part) is not None
+    ]
+
+
+def opencode_session_complete(session):
+    assistant_messages = [
+        message for message in session.get('messages', [])
+        if message.get('info', {}).get('role') == 'assistant'
+    ]
+    return bool(assistant_messages) and assistant_messages[-1].get('info', {}).get('finish') == 'stop'
+
+
+def render_opencode_part(part, console):
+    formatted = format_opencode_part(part)
+    if formatted is None:
+        return False
+    console.print(Text.from_ansi(formatted))
+    return True
+
+
+def watch_opencode(session_id):
+    session = load_opencode_session(session_id)
+    console = Console(force_terminal=True, color_system='truecolor', highlight=False)
+    console.print(Text(f'Watching opencode session {session_id}', style='bold white'))
+    console.print(Text(f"{session['info']['directory']}\n", style='dim'))
+    parts = opencode_parts(session)
+    seen = {}
+    for part in parts[-80:]:
+        render_opencode_part(part, console)
+        seen[part['id']] = json.dumps(part, sort_keys=True)
+    if opencode_session_complete(session):
+        input('\nAutomation finished. Press Enter to close.')
+        return
+
+    while True:
+        time.sleep(0.5)
+        session = load_opencode_session(session_id)
+        for part in opencode_parts(session):
+            version = json.dumps(part, sort_keys=True)
+            if seen.get(part['id']) == version:
+                continue
+            render_opencode_part(part, console)
+            seen[part['id']] = version
+        if opencode_session_complete(session):
+            input('\nAutomation finished. Press Enter to close.')
+            return
 
 
 def wait_for_session_log(session_id, timeout_seconds=15):
@@ -184,16 +317,28 @@ def watch(path, session_id):
 
 
 def main():
-    if len(sys.argv) != 2:
-        raise SystemExit('Usage: harlan-github-agent-watch SESSION_ID')
+    if len(sys.argv) != 3:
+        raise SystemExit('Usage: harlan-github-agent-watch PROVIDER SESSION_ID')
+    provider, session_id = sys.argv[1:]
     try:
-        path = wait_for_session_log(sys.argv[1])
+        validate_session_id(provider, session_id)
     except ValueError as error:
         raise SystemExit(str(error)) from error
+    if provider == 'opencode':
+        try:
+            watch_opencode(session_id)
+        except BrokenPipeError:
+            return
+        except ValueError as error:
+            raise SystemExit(str(error)) from error
+        except (json.JSONDecodeError, sqlite3.Error) as error:
+            raise SystemExit('The opencode session log is unavailable.') from error
+        return
+    path = wait_for_session_log(session_id)
     if path is None:
         raise SystemExit('The Codex session log is unavailable.')
     try:
-        watch(path, sys.argv[1])
+        watch(path, session_id)
     except BrokenPipeError:
         return
 

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -77,6 +77,8 @@ export interface ItemAgentOptions {
   now: () => Date
   /** Called when a cosmetic status update fails, which never stops the turn. */
   onProgressPublishFailure?: (task: ClaimedAgentTask, reason: string) => void
+  /** Called when a progress update succeeds, so Recovery can close an earlier failure. */
+  onProgressPublishSuccess?: (task: ClaimedAgentTask) => void
   runtime: AgentRuntimeSource
   store: Pick<JournalStore, 'getWorkerSession' | 'isBaselineRepairPullRequest' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'updateAgentProgress'>
   status: Pick<ReviewStatusController, 'publish'>
@@ -671,6 +673,8 @@ async function reportReviewProgress(
   const posted = await options.status.publish(task, phase, progressComment(task.pullRequest.headSha, progress, options.now().toISOString()), signal)
   if (posted._tag === 'Err')
     options.onProgressPublishFailure?.(task, posted.error)
+  else
+    options.onProgressPublishSuccess?.(task)
   return ok(undefined)
 }
 

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -271,6 +271,13 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           at: now().toISOString(),
         })
       },
+      onProgressPublishSuccess: (task: ClaimedAgentTask) => {
+        store.resolveIncidents(
+          { _tag: 'Task', taskId: task.id, repository: task.repository, itemNumber: null },
+          now().toISOString(),
+          'review_status_comment',
+        )
+      },
       preflightRepair: (repository: string, signal: AbortSignal) => preflightGitHubWriteAccess(tokens, repository, ['contents_write'], signal),
       store,
       runtime,

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -2,6 +2,7 @@ import importlib.machinery
 import importlib.util
 import io
 import os
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -548,9 +549,10 @@ class IndicatorDisplayTest(unittest.TestCase):
     def test_opens_a_read_only_watch_terminal_for_the_exact_session(self):
         agent = {
             'id': 'task-123',
+            'provider': 'opencode',
             'repository': 'harlan-zw/example',
             'itemNumber': 24,
-            'session': {'_tag': 'Connected', 'id': '019fff56-466c-7980-9a63-962018752af2'},
+            'session': {'_tag': 'Connected', 'id': 'ses_fc1f02fd3ffeCm7SwBkWsH6YGb'},
         }
 
         with patch.object(indicator.subprocess, 'Popen') as spawn:
@@ -562,7 +564,8 @@ class IndicatorDisplayTest(unittest.TestCase):
             '-e',
             sys.executable,
             str(indicator.WATCHER),
-            '019fff56-466c-7980-9a63-962018752af2',
+            'opencode',
+            'ses_fc1f02fd3ffeCm7SwBkWsH6YGb',
         ], start_new_session=True)
 
 
@@ -824,6 +827,65 @@ class WatchLogTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'Invalid Codex session ID'):
             watch.find_session_log('../session', Path('/tmp'))
+
+    def test_formats_an_opencode_command_and_validates_its_session(self):
+        session_id = 'ses_fc1f02fd3ffeCm7SwBkWsH6YGb'
+        self.assertEqual(watch.validate_session_id('opencode', session_id), session_id)
+        with self.assertRaisesRegex(ValueError, 'Invalid opencode session ID'):
+            watch.validate_session_id('opencode', '../session')
+
+        self.assertEqual(watch.format_opencode_part({
+            'type': 'tool',
+            'tool': 'bash',
+            'state': {
+                'status': 'completed',
+                'input': {'command': 'pnpm test'},
+                'output': 'passed',
+                'metadata': {'exit': 0},
+            },
+        }), '$ pnpm test\n[exit 0]\npassed')
+
+    def test_loads_an_opencode_session_from_its_read_only_store(self):
+        session_id = 'ses_fc1f02fd3ffeCm7SwBkWsH6YGb'
+        with tempfile.TemporaryDirectory() as directory:
+            database = Path(directory) / 'opencode.db'
+            connection = sqlite3.connect(database)
+            connection.executescript('''
+                CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT);
+                CREATE TABLE message (
+                    id TEXT PRIMARY KEY,
+                    session_id TEXT,
+                    time_created INTEGER,
+                    data TEXT
+                );
+                CREATE TABLE part (
+                    id TEXT PRIMARY KEY,
+                    message_id TEXT,
+                    time_created INTEGER,
+                    time_updated INTEGER,
+                    data TEXT
+                );
+            ''')
+            connection.execute(
+                'INSERT INTO session VALUES (?, ?, ?)',
+                (session_id, 'Review #24', '/tmp/example'),
+            )
+            connection.execute(
+                'INSERT INTO message VALUES (?, ?, ?, ?)',
+                ('msg_1', session_id, 1, '{"role":"assistant","finish":"stop"}'),
+            )
+            connection.execute(
+                'INSERT INTO part VALUES (?, ?, ?, ?, ?)',
+                ('part_1', 'msg_1', 2, 3, '{"type":"text","text":"Done."}'),
+            )
+            connection.commit()
+            connection.close()
+
+            session = watch.load_opencode_session(session_id, database)
+
+        self.assertEqual(session['info'], {'title': 'Review #24', 'directory': '/tmp/example'})
+        self.assertEqual(watch.format_opencode_part(watch.opencode_parts(session)[0]), 'Agent\nDone.')
+        self.assertTrue(watch.opencode_session_complete(session))
 
     def test_renders_commands_with_terminal_syntax_highlighting(self):
         output = io.StringIO()

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -908,6 +908,32 @@ class WatchLogTest(unittest.TestCase):
         self.assertIn('pnpm test', output.getvalue())
         self.assertIn('\x1b[', output.getvalue())
 
+    def test_first_opencode_poll_tick_skips_history_before_the_initial_window(self):
+        session_id = 'ses_fc1f02fd3ffeCm7SwBkWsH6YGb'
+        parts = [
+            {'id': f'part_{index}', 'type': 'text', 'text': f'message {index:03d}'}
+            for index in range(100)
+        ]
+
+        def message(finish):
+            return {'id': 'msg_1', 'info': {'role': 'assistant', 'finish': finish}, 'parts': parts}
+
+        sessions = iter([
+            {'info': {'title': 'Review #24', 'directory': '/tmp/example'}, 'messages': [message(None)]},
+            {'info': {'title': 'Review #24', 'directory': '/tmp/example'}, 'messages': [message('stop')]},
+        ])
+        output = io.StringIO()
+        console = watch.Console(file=output, force_terminal=False, width=200)
+
+        with patch.object(watch, 'load_opencode_session', side_effect=lambda _id: next(sessions)), \
+                patch.object(watch.time, 'sleep'), \
+                patch.object(watch, 'Console', return_value=console), \
+                patch.object(watch, 'input', lambda *_args: None):
+            watch.watch_opencode(session_id)
+
+        self.assertEqual(output.getvalue().count('message 005'), 0)
+        self.assertEqual(output.getvalue().count('message 099'), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -57,6 +57,7 @@ interface Harness {
   attempts: RecordReviewRunInput[]
   comments: string[]
   progressFailures: string[]
+  progressSuccesses: number
   provider: ProviderCapture
   queued: number
   options: ReviewWorkerOptions
@@ -75,6 +76,7 @@ function harness(input: {
   const attempts: RecordReviewRunInput[] = []
   const comments: string[] = []
   const progressFailures: string[] = []
+  let progressSuccesses = 0
   const provider: ProviderCapture = { requests: [] }
   const repairs = { queued: 0 }
   const snapshots = input.snapshots ?? [reviewSnapshot(input.pullRequest)]
@@ -103,6 +105,9 @@ function harness(input: {
     },
     now: () => new Date('2026-08-13T01:00:00.000Z'),
     onProgressPublishFailure: (_task, reason) => progressFailures.push(reason),
+    onProgressPublishSuccess: () => {
+      progressSuccesses += 1
+    },
     preflightRepair: input.preflightRepair ?? (() => Promise.resolve(ok(undefined))),
     store: {
       queueReviewFixTaskForReview: input.queueRepair ?? (() => {
@@ -144,6 +149,9 @@ function harness(input: {
     attempts,
     comments,
     progressFailures,
+    get progressSuccesses() {
+      return progressSuccesses
+    },
     provider,
     get queued() {
       return repairs.queued
@@ -342,6 +350,32 @@ describe('review resilience', () => {
     // The terminal comment still failed, which the Task reports, but the review
     // itself was completed and stored rather than thrown away at 10 percent.
     expect(result).toEqual({ _tag: 'Err', error: 'Resource not accessible by integration' })
+  })
+
+  it('reports a successful status retry after an earlier progress failure', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    let publications = 0
+    const test = harness({
+      pullRequest,
+      response: {
+        metadata: passingGate,
+        review: passingGate,
+        verification: passingGate,
+        findings: [],
+        confidence: 91,
+      },
+      publish: () => {
+        publications += 1
+        return Promise.resolve(publications === 1
+          ? err('This operation was aborted')
+          : ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+      },
+    })
+
+    await createReviewWorker(test.options).run(reviewTask(pullRequest), new AbortController().signal)
+
+    expect(test.progressFailures).toEqual(['This operation was aborted'])
+    expect(test.progressSuccesses).toBeGreaterThan(0)
   })
 
   it('rejects a Review Agent that changed the worktree', async () => {


### PR DESCRIPTION
## Summary

- Route Watch logs to the active Agent provider.
- Read opencode session logs from its local store without resuming the Agent.
- Resolve retrying status Incidents after a later status update succeeds.

## Verification

- 647 tests passed
- 48 indicator and watcher tests passed
- Live opencode session loaded with 57 visible log parts
- Typecheck passed
- Lint passed
- Build passed

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) prepared this pull request. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source).