### PR TITLE
fix(agent): recover workflow state from GitHub

### DIFF
--- a/packages/harlan-github-agent/src/agent-provider.ts
+++ b/packages/harlan-github-agent/src/agent-provider.ts
@@ -7,6 +7,11 @@
 
 export type AgentProviderName = 'codex' | 'opencode'
 
+/** Keeps the failure owner intact after workers persist only its reason. */
+export function agentProviderFailureReason(provider: AgentProviderName, reason: string): string {
+  return `The ${provider} session failed: ${reason}`
+}
+
 export type AgentTokenUsage
   = | { _tag: 'Unavailable' }
     | {

--- a/packages/harlan-github-agent/src/baseline-repair-state.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-state.ts
@@ -1,0 +1,48 @@
+export const BASELINE_REPAIR_LABEL = 'harlan-agent-baseline-repair'
+export const BASELINE_REPAIR_MARKER = '<!-- harlan-agent-kit:baseline-repair -->'
+
+export const BASELINE_REPAIR_LABEL_SPEC = {
+  name: BASELINE_REPAIR_LABEL,
+  color: '8250df',
+  description: 'Marks a pull request that repairs default branch CI.',
+} as const
+
+export type PullRequestPurpose
+  = | { _tag: 'Change' }
+    | { _tag: 'BaselineRepair', baseShaPrefix: string }
+
+interface PullRequestPurposeInput {
+  actorLogin: string
+  authorLogin: string
+  body: string
+  headRef: string
+  headRepository: string
+  labels: string[]
+  repository: string
+}
+
+const baselineBranch = /(?:^|\/)baseline-ci-([a-f\d]{12,64})$/i
+
+/** Derives controller-owned work from GitHub state alone. */
+export function pullRequestPurpose(input: PullRequestPurposeInput): PullRequestPurpose {
+  const controllerOwned = input.authorLogin.toLowerCase() === input.actorLogin.toLowerCase()
+    && input.headRepository.toLowerCase() === input.repository.toLowerCase()
+  if (!controllerOwned)
+    return { _tag: 'Change' }
+  const branch = input.headRef.match(baselineBranch)
+  const marked = input.body.includes(BASELINE_REPAIR_MARKER)
+    || input.labels.some(label => label.toLowerCase() === BASELINE_REPAIR_LABEL)
+    || branch !== null
+  return marked && branch?.[1] !== undefined
+    ? { _tag: 'BaselineRepair', baseShaPrefix: branch[1].toLowerCase() }
+    : { _tag: 'Change' }
+}
+
+export function withBaselineRepairMarker(body: string): string {
+  const description = body
+    .split(/\r?\n/)
+    .filter(line => line.trim() !== BASELINE_REPAIR_MARKER)
+    .join('\n')
+    .trim()
+  return `${BASELINE_REPAIR_MARKER}\n${description}`
+}

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -7,6 +7,7 @@ import type { AgentProgress, ClaimedBaselineRepairTask, MutationWorkerOutcome, R
 import type { BaselineRepairWorktreeManager } from './worktree.ts'
 import { redactSecrets, truncateOutput } from './agent-activity.ts'
 import { runAgentTurn } from './agent-turn.ts'
+import { withBaselineRepairMarker } from './baseline-repair-state.ts'
 import { canRepairBaseline } from './repository-policy.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
@@ -192,14 +193,14 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
       // A Baseline repair exists for one red base commit. If that commit moved on,
       // or its CI went green, there is nothing left to repair.
       if (snapshot.value.pullRequest.baseSha !== task.pullRequest.baseSha)
-        return ok({ _tag: 'Obsolete', evidence: `The pull request now builds on ${snapshot.value.pullRequest.baseSha}, not the failing ${task.pullRequest.baseSha}.` })
+        return ok({ _tag: 'Superseded', reason: `The pull request now builds on ${snapshot.value.pullRequest.baseSha}, not the failing ${task.pullRequest.baseSha}.` })
       if (checks.length === 0)
-        return ok({ _tag: 'Obsolete', evidence: `Default branch CI no longer fails at ${task.pullRequest.baseSha}.` })
+        return ok({ _tag: 'Superseded', reason: `Default branch CI no longer fails at ${task.pullRequest.baseSha}.` })
       const prepared = await options.worktrees.prepare({ ...task, repositoryMapping: validated.value }, signal)
       if (prepared._tag === 'Err')
         return prepared
       if (prepared.value.headSha !== task.pullRequest.baseSha)
-        return ok({ _tag: 'Obsolete', evidence: `The default branch moved to ${prepared.value.headSha}. This repair targeted ${task.pullRequest.baseSha}.` })
+        return ok({ _tag: 'Superseded', reason: `The default branch moved to ${prepared.value.headSha}. This repair targeted ${task.pullRequest.baseSha}.` })
       const ready = progress({ percent: 35, label: 'Git worktree ready' })
       if (ready._tag === 'Err')
         return ready
@@ -252,7 +253,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
           taskKind: 'baseline_repair',
           pullRequestNumber: task.pullRequestNumber,
           pullRequestTitle: response.pullRequestTitle,
-          pullRequestBody: withDisclosure(response.pullRequestBody),
+          pullRequestBody: withBaselineRepairMarker(withDisclosure(response.pullRequestBody)),
           commitSha: committed.value.commitSha,
           baseSha: committed.value.baseSha,
           // A Baseline repair fixes the default branch, so it never stacks.

--- a/packages/harlan-github-agent/src/codex-provider.ts
+++ b/packages/harlan-github-agent/src/codex-provider.ts
@@ -1,6 +1,7 @@
 import type { CodexOptions, ThreadEvent, ThreadOptions } from '@openai/codex-sdk'
 import type { AgentEvent, AgentProvider, AgentTokenUsage, AgentTurnRequest } from './agent-provider.ts'
 import { Codex } from '@openai/codex-sdk'
+import { agentProviderFailureReason } from './agent-provider.ts'
 
 interface CodexThread {
   runStreamed: (prompt: string, options: { outputSchema: unknown, signal: AbortSignal }) => Promise<{ events: AsyncIterable<ThreadEvent> }>
@@ -50,9 +51,9 @@ export function codexAgentEvent(event: ThreadEvent): AgentEvent | undefined {
   if (event.type === 'turn.completed')
     return { _tag: 'TurnCompleted' }
   if (event.type === 'turn.failed')
-    return { _tag: 'Failed', reason: event.error.message }
+    return { _tag: 'Failed', reason: agentProviderFailureReason('codex', event.error.message) }
   if (event.type === 'error')
-    return { _tag: 'Failed', reason: event.message }
+    return { _tag: 'Failed', reason: agentProviderFailureReason('codex', event.message) }
   return undefined
 }
 

--- a/packages/harlan-github-agent/src/failure.ts
+++ b/packages/harlan-github-agent/src/failure.ts
@@ -200,6 +200,11 @@ const agentProviderPatterns: RegExp[] = [
   /\bcontext\b.+\blength\b/i,
 ]
 
+/** Provider boundaries add this owner before a reason enters the Journal. */
+const ownedAgentProviderPatterns: RegExp[] = [
+  /\b(?:codex|opencode) session failed:/i,
+]
+
 /**
  * The controller lost a race with itself. The next pass starts from a clean state.
  *
@@ -259,6 +264,10 @@ export function classifyFailure(signal: FailureSignal): FailureClass {
   if (permanentMessages.has(message.trim()) || matches(permanentPatterns, message))
     return { _tag: 'Permanent', kind: 'policy' }
 
+  // Provider errors carry their owner in the persisted reason. Match that
+  // before generic service and rate-limit text that any provider may return.
+  if (matches(ownedAgentProviderPatterns, message))
+    return { _tag: 'Transient', kind: 'agent_provider' }
   if (signal.status === 429 || matches(rateLimitPatterns, message))
     return { _tag: 'Transient', kind: 'rate_limit' }
   if (signal.status !== undefined && signal.status >= 500)

--- a/packages/harlan-github-agent/src/failure.ts
+++ b/packages/harlan-github-agent/src/failure.ts
@@ -317,7 +317,7 @@ export function mayRetryFailure(signal: FailureSignal): boolean {
   return failure._tag !== 'Permanent' || failure.kind === 'unknown'
 }
 
-/** How many times the controller requeues a Failed Task before it waits for a person. */
+/** Recovery limit for failures a person can affect. Provider outages keep capped backoff. */
 export const MAXIMUM_RECOVERY_ATTEMPTS = 5
 
 const baseRecoveryDelayMilliseconds = 60_000

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -4,7 +4,9 @@ import type { Result } from './result.ts'
 import type { PriorAutomatedReview } from './review-comment.ts'
 import type { GitHubPullRequestItem, GitHubRepositoryAccess, RepositoryMapping } from './types.ts'
 import { hasAutoMergeLabel } from './auto-merge.ts'
+import { pullRequestPurpose } from './baseline-repair-state.ts'
 import { createAuthenticatedClient } from './github-auth.ts'
+import { currentBaseSha } from './github-base.ts'
 import { AUTOMATED_ISSUE_TRIAGE_MARKER } from './issue-triage-comment.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedReviewHead, priorAutomatedReviewForHead } from './review-comment.ts'
@@ -199,6 +201,7 @@ export interface GitHubAgentSource {
 export interface GitHubAgentSourceOptions {
   /** The login the controller posts as, which depends on how the repository authenticates. */
   actorLogin: (repository: RepositoryMapping) => string
+  createClient?: (token: string) => Octokit
   tokens: GitHubTokenProvider
   userAgent?: string
 }
@@ -262,11 +265,17 @@ function errorStatus(error: unknown): number | undefined {
     : undefined
 }
 
-function pullRequestItem(repository: RepositoryMapping, pull: Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data']): GitHubPullRequestItem {
+function pullRequestItem(
+  repository: RepositoryMapping,
+  pull: Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data'],
+  liveBaseSha: string,
+  actorLogin: string,
+): GitHubPullRequestItem {
+  const labels = pull.labels.flatMap(label => label.name === undefined ? [] : [label.name])
   return {
     kind: 'pull_request',
     approvalLabels: [],
-    autoMerge: hasAutoMergeLabel(pull.labels.flatMap(label => label.name === undefined ? [] : [label.name])),
+    autoMerge: hasAutoMergeLabel(labels),
     repository: repository.github,
     number: pull.number,
     state: pull.state === 'closed' ? 'closed' : 'open',
@@ -277,13 +286,22 @@ function pullRequestItem(repository: RepositoryMapping, pull: Awaited<ReturnType
     createdAt: pull.created_at,
     updatedAt: pull.updated_at,
     draft: pull.draft ?? false,
-    baseSha: pull.base.sha,
+    baseSha: liveBaseSha,
     baseRef: pull.base.ref,
     headSha: pull.head.sha,
     headRepository: pull.head.repo?.full_name ?? '',
     headRef: pull.head.ref,
     maintainerCanModify: pull.maintainer_can_modify ?? false,
     mergeState: pull.mergeable === false ? 'conflicting' : pull.mergeable === true ? 'clean' : 'unknown',
+    purpose: pullRequestPurpose({
+      actorLogin,
+      authorLogin: pull.user?.login ?? 'ghost',
+      body: pull.body ?? '',
+      headRef: pull.head.ref,
+      headRepository: pull.head.repo?.full_name ?? '',
+      labels,
+      repository: repository.github,
+    }),
     priorAutomatedReview: { _tag: 'None' },
   }
 }
@@ -293,7 +311,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
     const token = await options.tokens.getToken(repository, access, signal)
     return token._tag === 'Err'
       ? err(token.error.message)
-      : ok(createAuthenticatedClient({
+      : ok(options.createClient?.(token.value.token) ?? createAuthenticatedClient({
           access,
           repository,
           signal,
@@ -511,9 +529,10 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
             return contexts.length === 0 ? { _tag: 'None' } : { _tag: 'Declared', contexts }
           })
           .catch((error: unknown): RequiredChecks => ({ _tag: 'Unavailable', reason: message(error) }))
+        const liveBaseSha = await currentBaseSha(octokit.value, owner, repo, pull.data.base.ref, signal)
         const [checks, baseChecks, requiredChecks] = await Promise.all([
           checksFor(pull.data.head.sha),
-          checksFor(pull.data.base.sha),
+          checksFor(liveBaseSha),
           requiredChecksFor(pull.data.base.ref),
         ])
         return ok({
@@ -539,7 +558,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
                   body: comment.body,
                   url: comment.html_url,
                 }]), pull.data.head.sha, options.actorLogin(repository)),
-          pullRequest: pullRequestItem(repository, pull.data),
+          pullRequest: pullRequestItem(repository, pull.data, liveBaseSha, options.actorLogin(repository)),
           requiredChecks,
           reviews: chronologicalPullRequestComments(reviews.flatMap(review => review.body === undefined || review.body === null
             ? []

--- a/packages/harlan-github-agent/src/github-base.ts
+++ b/packages/harlan-github-agent/src/github-base.ts
@@ -1,0 +1,18 @@
+import type { Octokit } from 'octokit'
+
+/** Reads the live commit behind a pull request base branch. */
+export async function currentBaseSha(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  branch: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const response = await octokit.rest.repos.getBranch({
+    owner,
+    repo,
+    branch,
+    ...(signal === undefined ? {} : { request: { signal } }),
+  })
+  return response.data.commit.sha
+}

--- a/packages/harlan-github-agent/src/github.ts
+++ b/packages/harlan-github-agent/src/github.ts
@@ -5,7 +5,9 @@ import type { Result } from './result.ts'
 import type { GitHubItem, GitHubPullRequestItem, RepositoryMapping } from './types.ts'
 import { approvalLabels } from './approval-labels.ts'
 import { hasAutoMergeLabel } from './auto-merge.ts'
+import { pullRequestPurpose } from './baseline-repair-state.ts'
 import { createAuthenticatedClient } from './github-auth.ts'
+import { currentBaseSha } from './github-base.ts'
 import { err, ok } from './result.ts'
 import { priorAutomatedReviewForHead } from './review-comment.ts'
 import { isReviewRerunCommand } from './review-rerun.ts'
@@ -36,6 +38,7 @@ export interface GitHubSourceOptions {
   issueCutoff: string
   /** The login the controller posts as, which depends on how the repository authenticates. */
   actorLogin: (repository: RepositoryMapping) => string
+  createClient?: (token: string) => Octokit
   userAgent?: string
 }
 
@@ -53,6 +56,7 @@ export interface GitHubPullRequestPublisher {
     expectedHeadSha: string
     title: string
     body: string
+    labels?: Array<{ name: string, color: string, description: string }>
   }, signal?: AbortSignal) => Promise<Result<PublishedPullRequest, GitHubReadError>>
 }
 
@@ -91,7 +95,12 @@ function labelNames(labels: Array<string | { name?: string }>): string[] {
   return labels.flatMap(label => typeof label === 'string' ? [label] : label.name === undefined ? [] : [label.name])
 }
 
-function pullRequestItem(repository: RepositoryMapping, pull: Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data']): GitHubPullRequestItem {
+function pullRequestItem(
+  repository: RepositoryMapping,
+  pull: Awaited<ReturnType<Octokit['rest']['pulls']['get']>>['data'],
+  liveBaseSha: string,
+  actorLogin: string,
+): GitHubPullRequestItem {
   const labels = labelNames(pull.labels)
   return {
     kind: 'pull_request',
@@ -107,7 +116,7 @@ function pullRequestItem(repository: RepositoryMapping, pull: Awaited<ReturnType
     createdAt: pull.created_at,
     updatedAt: pull.updated_at,
     draft: pull.draft ?? false,
-    baseSha: pull.base.sha,
+    baseSha: liveBaseSha,
     baseRef: pull.base.ref,
     headSha: pull.head.sha,
     headRepository: pull.head.repo?.full_name ?? '',
@@ -116,6 +125,15 @@ function pullRequestItem(repository: RepositoryMapping, pull: Awaited<ReturnType
     mergeState: pull.mergeable === false
       ? 'conflicting'
       : pull.mergeable === true ? 'clean' : 'unknown',
+    purpose: pullRequestPurpose({
+      actorLogin,
+      authorLogin: pull.user?.login ?? 'ghost',
+      body: pull.body ?? '',
+      headRef: pull.head.ref,
+      headRepository: pull.head.repo?.full_name ?? '',
+      labels,
+      repository: repository.github,
+    }),
     priorAutomatedReview: { _tag: 'None' },
   }
 }
@@ -147,7 +165,7 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
     const token = await options.tokens.getToken(repository, 'read', signal)
     if (token._tag === 'Err')
       return err(token.error)
-    return ok(createAuthenticatedClient({
+    return ok(options.createClient?.(token.value.token) ?? createAuthenticatedClient({
       access: 'read',
       repository,
       signal,
@@ -203,7 +221,10 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
       if (octokit._tag === 'Err')
         return octokit
       return octokit.value.rest.pulls.get({ owner, repo, pull_number: number, ...(signal === undefined ? {} : { request: { signal } }) })
-        .then(response => ok(pullRequestItem(repository, response.data)))
+        .then(async (response) => {
+          const baseSha = await currentBaseSha(octokit.value, owner, repo, response.data.base.ref, signal)
+          return ok(pullRequestItem(repository, response.data, baseSha, options.actorLogin(repository)))
+        })
         .catch((error: unknown): Result<GitHubPullRequestItem, GitHubReadError> => {
           const status = errorStatus(error)
           return err({
@@ -252,6 +273,15 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
         octokit.value.paginate(octokit.value.rest.issues.listForRepo, { owner, repo, state: 'open', per_page: 100, ...requestOptions }),
         octokit.value.paginate(octokit.value.rest.pulls.list, { owner, repo, state: 'open', per_page: 100, ...requestOptions }),
       ]).then(async ([issueRows, pullRows]) => {
+        const baseShas = new Map<string, Promise<string>>()
+        const baseShaFor = (branch: string): Promise<string> => {
+          const existing = baseShas.get(branch)
+          if (existing !== undefined)
+            return existing
+          const requested = currentBaseSha(octokit.value, owner, repo, branch, signal)
+          baseShas.set(branch, requested)
+          return requested
+        }
         const issues: GitHubItem[] = issueRows
           .filter(issue => issue.pull_request === undefined)
           .filter(issue => !isAutomatedGitHubActor({
@@ -281,8 +311,9 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
             octokit.value.rest.pulls.get({ owner, repo, pull_number: pull.number, ...requestOptions }).then(response => response.data),
             octokit.value.paginate(octokit.value.rest.issues.listComments, { owner, repo, issue_number: pull.number, per_page: 100, ...requestOptions }),
           ])
+          const baseSha = await baseShaFor(detail.base.ref)
           return {
-            ...pullRequestItem(repository, detail),
+            ...pullRequestItem(repository, detail, baseSha, options.actorLogin(repository)),
             priorAutomatedReview: priorAutomatedReviewForHead(comments.flatMap(comment =>
               comment.body === undefined || comment.body === null || comment.user?.login === undefined
                 ? []
@@ -329,6 +360,24 @@ export function createGitHubPullRequestPublisher(options: GitHubPullRequestPubli
           userAgent: options.userAgent ?? 'harlan-github-agent/0.0.0',
         })
       const request = signal === undefined ? {} : { request: { signal } }
+      const applyLabels = async (pullRequestNumber: number): Promise<void> => {
+        if (input.labels === undefined || input.labels.length === 0)
+          return
+        for (const label of input.labels) {
+          await octokit.rest.issues.createLabel({ owner, repo, ...label, ...request })
+            .catch((error: unknown) => {
+              if (errorStatus(error) !== 422)
+                throw error
+            })
+        }
+        await octokit.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: pullRequestNumber,
+          labels: input.labels.map(label => label.name),
+          ...request,
+        })
+      }
       return octokit.rest.pulls.list({
         owner,
         repo,
@@ -345,8 +394,10 @@ export function createGitHubPullRequestPublisher(options: GitHubPullRequestPubli
             message: `Pull request #${existing.number} is still draft.`,
           })
         }
-        if (existing !== undefined)
+        if (existing !== undefined) {
+          await applyLabels(existing.number)
           return ok({ number: existing.number, url: existing.html_url })
+        }
         return octokit.rest.pulls.create({
           owner,
           repo,
@@ -356,7 +407,10 @@ export function createGitHubPullRequestPublisher(options: GitHubPullRequestPubli
           body: input.body,
           draft: false,
           ...request,
-        }).then(created => ok({ number: created.data.number, url: created.data.html_url }))
+        }).then(async (created) => {
+          await applyLabels(created.data.number)
+          return ok({ number: created.data.number, url: created.data.html_url })
+        })
       }).catch((error: unknown): Result<PublishedPullRequest, GitHubReadError> => {
         const status = errorStatus(error)
         return err({

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -80,7 +80,7 @@ export interface ItemAgentOptions {
   /** Called when a progress update succeeds, so Recovery can close an earlier failure. */
   onProgressPublishSuccess?: (task: ClaimedAgentTask) => void
   runtime: AgentRuntimeSource
-  store: Pick<JournalStore, 'getWorkerSession' | 'isBaselineRepairPullRequest' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'updateAgentProgress'>
+  store: Pick<JournalStore, 'getWorkerSession' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'updateAgentProgress'>
   status: Pick<ReviewStatusController, 'publish'>
   triageStatus: IssueTriageCommentController
   workspaces: Pick<AgentWorkspaceManager, 'prepareIssue'>
@@ -88,7 +88,7 @@ export interface ItemAgentOptions {
 
 export interface ReviewWorkerOptions extends Omit<ItemAgentOptions, 'workspaces'> {
   preflightRepair: (repository: string, signal: AbortSignal) => Promise<Result<void, string>>
-  store: Pick<JournalStore, 'getRepairedHeadFindings' | 'getWorkerSession' | 'isBaselineRepairPullRequest' | 'queueReviewFixTaskForReview' | 'recordIncident' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'updateAgentProgress'>
+  store: Pick<JournalStore, 'getRepairedHeadFindings' | 'getWorkerSession' | 'queueReviewFixTaskForReview' | 'recordIncident' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'updateAgentProgress'>
   workspaces: Pick<AgentWorkspaceManager, 'prepareIssue' | 'prepareReview' | 'verifyReview'>
 }
 
@@ -622,6 +622,22 @@ function progressComment(headSha: string, progress: AgentProgress, at: string): 
 Next: ${progress.percent >= 90 ? 'Post the review comment.' : progress.percent >= 85 ? 'Check the head commit and CI.' : progress.percent >= 70 ? 'Verify findings or fixes.' : progress.percent >= 55 ? 'Finish checking the changed files and docs.' : progress.percent >= 35 ? 'Review the diff.' : 'Create a Git worktree.'}`
 }
 
+function baselineWaitingComment(headSha: string, baseSha: string, at: string): string {
+  const workflow = JSON.stringify({ _tag: 'WaitingForBaselineRepair', baseSha })
+  return `${AUTOMATED_REVIEW_MARKER}
+<!-- reviewed-sha: ${headSha} -->
+<!-- workflow-state: ${workflow} -->
+### 🤖 WAITING
+
+> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated status. Last updated: ${updatedAtLabel(at)}.
+
+\`${formatProgressBar(100)}\`
+
+Base branch CI fails at \`${baseSha}\`.
+
+Next: merge or repair the marked Baseline repair pull request.`
+}
+
 function terminalComment(headSha: string, gates: ReviewGates, findings: ReviewFinding[], confidence: number | undefined, reportedChecks: string[]): string {
   const result = reviewOutcome(gates)
   const heading = result === 'READY' && confidence !== undefined ? `${result} · ${confidence}/100` : result
@@ -788,8 +804,8 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         recordRunnerLostIncident(options, task.repository)
       if (snapshot.value.priorAutomatedReview._tag === 'Found' && task.rerun._tag === 'NotRequested')
         return ok({ evidence: `Existing automated review by @${snapshot.value.priorAutomatedReview.authorLogin}: ${snapshot.value.priorAutomatedReview.url}` })
-      const knownBaselineRepair = options.store.isBaselineRepairPullRequest(task.repository, task.pullRequest.headRef)
-      const repairsBaseline = knownBaselineRepair
+      const markedBaselineRepair = snapshot.value.pullRequest.purpose._tag === 'BaselineRepair'
+      const repairsBaseline = markedBaselineRepair
         || (basesDefaultBranch(snapshot.value.pullRequest, task.repositoryMapping) && headRepairsFailedBaseChecks(snapshot.value))
       const ciAtStart = ciGate(snapshot.value, repairsBaseline).state
       const repairAccess = await options.preflightRepair(task.repository, signal)
@@ -807,10 +823,19 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
           return err(baseline.reason)
         // A repository Harlan only watches cannot get a Baseline repair. The
         // review still runs, and its CI gate reports the red default branch.
-        if (baseline._tag !== 'NotAuthorized')
+        if (baseline._tag !== 'NotAuthorized') {
+          const waiting = await options.status.publish(
+            task,
+            'terminal',
+            baselineWaitingComment(task.pullRequest.headSha, snapshot.value.pullRequest.baseSha, options.now().toISOString()),
+            signal,
+          )
+          if (waiting._tag === 'Err')
+            return waiting
           return ok({ evidence: `Waiting for Baseline repair ${baseline.taskId}.` })
+        }
       }
-      else if (!knownBaselineRepair) {
+      else if (!markedBaselineRepair) {
         // This head needs no separate Baseline repair, so retire a dead one.
         options.store.retireBaselineRepairForReview({
           taskId: task.id,

--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -6,7 +6,7 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 import { createInterface } from 'node:readline'
-import { DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
+import { agentProviderFailureReason, DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
 
 /** Tools that write files, so activity shows a file change instead of a command. */
 const fileTools = new Set(['edit', 'write', 'patch', 'multiedit'])
@@ -106,7 +106,7 @@ export function opencodeAgentUsage(line: OpencodeLine): Extract<AgentTokenUsage,
 /** Maps one `opencode run --format json` line to the provider-neutral event. */
 export function opencodeAgentEvent(line: OpencodeLine): AgentEvent | undefined {
   if (line.type === 'error')
-    return { _tag: 'Failed', reason: errorMessage(line.error) }
+    return { _tag: 'Failed', reason: agentProviderFailureReason('opencode', errorMessage(line.error)) }
   if (line.type === 'reasoning')
     return { _tag: 'Reasoning', text: text(line.part?.text) }
   if (line.type === 'text')
@@ -284,7 +284,7 @@ function opencodeFailureReason(standardError: string, exit: { code: number | nul
   // eslint-disable-next-line no-control-regex
   const clean = standardError.replaceAll(/\u001B\[[\d;]*m/g, '').replace(/^Error:\s*/m, '').trim()
   if (clean.length > 0)
-    return clean
+    return agentProviderFailureReason('opencode', clean)
   // A signal means something outside the turn ended it, which names the cause.
   return exit.signal === null
     ? `The opencode session exited with code ${exit.code ?? 'unknown'}.`

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -161,7 +161,7 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
       }
       const findings = options.store.getReviewFixFindings(task.repository, task.pullRequestNumber, task.revisionId)
       if (findings.length === 0)
-        return ok({ _tag: 'Obsolete', evidence: 'The current Review has no open finding.' })
+        return ok({ _tag: 'Superseded', reason: 'The current Review has no open finding.' })
 
       const prepared = await options.worktrees.prepare({ ...task, repositoryMapping: validated.value, pullRequest: current }, signal)
       if (prepared._tag === 'Err')

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -12,6 +12,11 @@ export type StoppedReviewOutcome
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
 
+export type StoppedReviewDisposition
+  = | { _tag: 'Stopped' }
+    | { _tag: 'Merged' }
+    | { _tag: 'Closed' }
+
 export interface ReviewStopSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
@@ -19,7 +24,28 @@ export interface ReviewStopSweepOptions {
   store: Pick<JournalStore, 'listStoppedReviews' | 'recordStoppedReviewStatus'>
 }
 
-export function stoppedReviewComment(review: StoppedReview, at: string): string {
+export function stoppedReviewComment(
+  review: StoppedReview,
+  at: string,
+  disposition: StoppedReviewDisposition = { _tag: 'Stopped' },
+): string {
+  if (disposition._tag !== 'Stopped') {
+    const workflow = JSON.stringify({
+      _tag: disposition._tag === 'Merged' ? 'PullRequestMerged' : 'PullRequestClosed',
+      headSha: review.headSha,
+    })
+    const action = disposition._tag === 'Merged' ? 'merged' : 'closed'
+    return `${AUTOMATED_REVIEW_MARKER}
+<!-- reviewed-sha: ${review.headSha} -->
+<!-- workflow-state: ${workflow} -->
+### 🤖 ${disposition._tag.toUpperCase()}
+
+> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. It is not Harlan's personal review or approval. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Last updated: ${updatedAtLabel(at)}.
+
+\`${formatProgressBar(100)}\`
+
+GitHub ${action} this pull request. The unfinished automated review stopped.`
+  }
   if (review.taskKind === 'review_fix') {
     const findings = review.findings.map(finding => finding._tag === 'Fixed'
       ? `- **Fixed:** ${cleanLine(finding.summary)}`
@@ -71,11 +97,16 @@ export async function publishStoppedReviews(
     const current = await options.github.getPullRequestReviewSnapshot(mapping, review.pullRequestNumber, signal)
     if (current._tag === 'Err')
       return err(`${review.repository}#${review.pullRequestNumber}: ${current.error}`)
-    if (current.value.pullRequest.state !== 'open' || current.value.pullRequest.headSha !== review.headSha)
+    if (current.value.pullRequest.headSha !== review.headSha)
       return err(`${review.repository}#${review.pullRequestNumber}: the pull request changed before the final comment.`)
 
     const at = options.now().toISOString()
-    const body = stoppedReviewComment(review, at)
+    const disposition: StoppedReviewDisposition = current.value.pullRequest.state === 'open'
+      ? { _tag: 'Stopped' }
+      : current.value.pullRequest.mergedAt === null
+        ? { _tag: 'Closed' }
+        : { _tag: 'Merged' }
+    const body = stoppedReviewComment(review, at, disposition)
     const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, review.publishedBody, body, signal)
     if (edited._tag === 'Err')
       return err(`${review.repository}#${review.pullRequestNumber}: ${edited.error}`)

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -97,8 +97,8 @@ export async function publishStoppedReviews(
     const current = await options.github.getPullRequestReviewSnapshot(mapping, review.pullRequestNumber, signal)
     if (current._tag === 'Err')
       return err(`${review.repository}#${review.pullRequestNumber}: ${current.error}`)
-    if (current.value.pullRequest.headSha !== review.headSha)
-      return err(`${review.repository}#${review.pullRequestNumber}: the pull request changed before the final comment.`)
+    if (current.value.pullRequest.state === 'open' && current.value.pullRequest.headSha !== review.headSha)
+      return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
 
     const at = options.now().toISOString()
     const disposition: StoppedReviewDisposition = current.value.pullRequest.state === 'open'

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -7100,6 +7100,7 @@ export function openJournalStore(
     JOIN subjects ON subjects.id = stopped.subject_id
     JOIN repositories ON repositories.id = subjects.repository_id
     JOIN revisions ON revisions.id = stopped.revision_id
+    JOIN revisions AS current_revisions ON current_revisions.id = subjects.current_revision_id
     JOIN review_status_commands AS published ON published.id = COALESCE(
       (
         SELECT candidate.id FROM review_status_commands AS candidate
@@ -7121,10 +7122,11 @@ export function openJournalStore(
       )
     )
     WHERE stopped.state_tag IN ('Failed', 'ActionRequired', 'Superseded')
-      AND stopped.revision_id = subjects.current_revision_id
-      AND json_extract(revisions.payload, '$.state') = 'open'
       AND published.phase != 'terminal'
       AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
+      -- GitHub closure creates a new Revision. The stopped Review still owns
+      -- the canonical comment while GitHub reports the same exact head SHA.
+      AND json_extract(current_revisions.payload, '$.headSha') = json_extract(revisions.payload, '$.headSha')
       AND repositories.enabled = 1
       AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
       -- A live review posts its own comment, so leave the pull request to it.
@@ -7171,10 +7173,20 @@ export function openJournalStore(
         SELECT ${taskTable}.fence
         FROM ${taskTable}
         JOIN subjects ON subjects.id = ${taskTable}.subject_id
+        JOIN revisions AS task_revision ON task_revision.id = ${taskTable}.revision_id
+        JOIN revisions AS current_revision ON current_revision.id = subjects.current_revision_id
         WHERE ${taskTable}.id = ? AND ${taskTable}.kind = ?
           AND ${taskTable}.state_tag IN ('Failed', 'ActionRequired', 'Superseded')
-          AND ${taskTable}.revision_id = ? AND subjects.current_revision_id = ?
-      `).get(input.taskId, input.taskKind, input.revisionId, input.revisionId) as { fence: number } | undefined
+          AND ${taskTable}.revision_id = ?
+          AND json_extract(task_revision.payload, '$.headSha') = ?
+          AND json_extract(current_revision.payload, '$.headSha') = ?
+      `).get(
+        input.taskId,
+        input.taskKind,
+        input.revisionId,
+        input.expectedHeadSha,
+        input.expectedHeadSha,
+      ) as { fence: number } | undefined
       if (authorized === undefined) {
         database.exec('COMMIT')
         return false

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -267,6 +267,36 @@ function restoreRecoveryBudget(database: DatabaseSync, github: string, at: strin
   return restored
 }
 
+/**
+ * Gives exhausted provider failures another budget after one Agent succeeds.
+ *
+ * A completed Agent turn is the provider health signal. Only exhausted Tasks
+ * need help; Tasks still inside their budget already have a scheduled retry.
+ */
+function restoreAgentProviderRecoveryBudget(database: DatabaseSync, at: string): number {
+  let restored = 0
+  for (const table of ['tasks', 'worker_tasks'] as const) {
+    const rows = database.prepare(`
+      SELECT id, reason FROM ${table}
+      WHERE state_tag = 'Failed' AND recovery_attempts >= ? AND reason IS NOT NULL
+    `).all(MAXIMUM_RECOVERY_ATTEMPTS) as unknown as Array<{ id: string, reason: string }>
+    const reset = database.prepare(`
+      UPDATE ${table} SET recovery_attempts = 0, updated_at = ?
+      WHERE id = ? AND state_tag = 'Failed' AND recovery_attempts >= ?
+    `)
+    for (const row of rows) {
+      const failure = classifyFailure({ message: row.reason })
+      if (failure._tag !== 'Transient' || failure.kind !== 'agent_provider')
+        continue
+      if (reset.run(at, row.id, MAXIMUM_RECOVERY_ATTEMPTS).changes !== 1)
+        continue
+      restored += 1
+      resolveTaskIncidents(database, row.id, at)
+    }
+  }
+  return restored
+}
+
 interface RecoveryCandidateRow {
   id: string
   fence: number
@@ -5319,6 +5349,7 @@ export function openJournalStore(
       if (result.changes === 1) {
         recordWorkerTransition(database, { taskId: input.taskId, from: 'Running', to: 'Completed', reason: null, fence: input.fence, at: input.at })
         resolveTaskIncidents(database, input.taskId, input.at)
+        restoreAgentProviderRecoveryBudget(database, input.at)
         const row = database.prepare(`
           SELECT worker_tasks.subject_id, worker_tasks.revision_id, revisions.payload, repositories.policy_json
           FROM worker_tasks
@@ -6039,6 +6070,7 @@ export function openJournalStore(
       if (result.changes === 1) {
         recordTransition(database, { taskId: input.taskId, from: 'Running', to: 'Completed', reason: null, fence: input.fence, at: input.at })
         resolveTaskIncidents(database, input.taskId, input.at)
+        restoreAgentProviderRecoveryBudget(database, input.at)
       }
       database.exec('COMMIT')
       return result.changes === 1

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4506,7 +4506,10 @@ export function openJournalStore(
         JOIN subjects ON subjects.id = ${table}.subject_id
         WHERE (${table}.state_tag IN ('Completed', 'Superseded')
           OR ${table}.revision_id != subjects.current_revision_id
-          OR (${table}.state_tag = 'Failed' AND incidents.message != ${table}.reason))
+          OR (${table}.state_tag = 'Failed' AND incidents.message != ${table}.reason)
+          OR (${table}.state_tag = 'Failed'
+            AND incidents.kind = 'agent_provider'
+            AND json_extract(incidents.recovery, '$._tag') = 'Exhausted'))
       )
     `
     const resolved = (['tasks', 'worker_tasks'] as const)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -7121,7 +7121,10 @@ export function openJournalStore(
         LIMIT 1
       )
     )
-    WHERE stopped.state_tag IN ('Failed', 'ActionRequired', 'Superseded')
+    -- The GitHub comment is nonterminal while its Task is terminal. Task
+    -- outcome does not change that contradiction, including legacy Tasks that
+    -- completed while waiting for separate work.
+    WHERE stopped.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
       AND published.phase != 'terminal'
       AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
       -- GitHub closure creates a new Revision. The stopped Review still owns
@@ -7129,6 +7132,16 @@ export function openJournalStore(
       AND json_extract(current_revisions.payload, '$.headSha') = json_extract(revisions.payload, '$.headSha')
       AND repositories.enabled = 1
       AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
+      -- Repair owns the canonical comment after Review hands work to it.
+      AND NOT (
+        stopped.task_kind = 'adversarial_review'
+        AND EXISTS (
+          SELECT 1 FROM tasks AS repair
+          WHERE repair.subject_id = stopped.subject_id
+            AND repair.revision_id = stopped.revision_id
+            AND repair.kind = 'review_fix'
+        )
+      )
       -- A live review posts its own comment, so leave the pull request to it.
       AND NOT EXISTS (
         SELECT 1 FROM worker_tasks AS live
@@ -7176,7 +7189,7 @@ export function openJournalStore(
         JOIN revisions AS task_revision ON task_revision.id = ${taskTable}.revision_id
         JOIN revisions AS current_revision ON current_revision.id = subjects.current_revision_id
         WHERE ${taskTable}.id = ? AND ${taskTable}.kind = ?
-          AND ${taskTable}.state_tag IN ('Failed', 'ActionRequired', 'Superseded')
+          AND ${taskTable}.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
           AND ${taskTable}.revision_id = ?
           AND json_extract(task_revision.payload, '$.headSha') = ?
           AND json_extract(current_revision.payload, '$.headSha') = ?

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -188,7 +188,8 @@ function recordTaskIncident(database: DatabaseSync, taskId: string, reason: stri
   // instead of leaving several contradictory recovery instructions visible.
   resolveTaskIncidents(database, taskId, at)
   const failure = classifyFailure({ message: reason })
-  const exhausted = row.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS
+  const providerWillRetry = failure._tag === 'Transient' && failure.kind === 'agent_provider'
+  const exhausted = row.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS && !providerWillRetry
   upsertIncident(database, {
     scope: { _tag: 'Task', taskId, repository: row.repository, itemNumber: row.github_number },
     kind: failure.kind,
@@ -319,9 +320,12 @@ interface RecoveryCandidateRow {
 function isRecoverable(row: RecoveryCandidateRow, at: string): boolean {
   if (row.reason === null)
     return false
-  if (classifyFailure({ message: row.reason })._tag !== 'Transient')
+  const failure = classifyFailure({ message: row.reason })
+  if (failure._tag !== 'Transient')
     return false
-  if (row.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS)
+  // A provider outage cannot be fixed by a person. Keep checking it at capped
+  // backoff so every Task resumes after the selected provider recovers.
+  if (row.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS && failure.kind !== 'agent_provider')
     return false
   return Date.parse(at) >= Date.parse(nextRecoveryAt(row.updated_at, row.recovery_attempts))
 }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -477,8 +477,6 @@ export interface JournalStore {
   heartbeatWorkerTask: (input: { taskId: string, workerId: string, fence: number, at: string, leaseMilliseconds: number }) => boolean
   heartbeatPublication: (input: { commandId: string, workerId: string, fence: number, at: string, leaseMilliseconds: number }) => boolean
   hasPullRequestApproval: (repository: string, pullRequestNumber: number, revisionId: string, kind: PullRequestApprovalKind) => boolean
-  /** True when the controller opened this branch to repair the default branch. */
-  isBaselineRepairPullRequest: (repository: string, headRef: string) => boolean
   /**
    * The open pull requests this service opened in one repository.
    *
@@ -617,6 +615,7 @@ export interface JournalStore {
     at: string
     publication: PreparedPublication
   }) => StagePublicationResult
+  supersedeTask: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   supersedePublication: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   syncRepositories: (repositories: RepositoryMapping[], at: string) => void
 }
@@ -649,6 +648,8 @@ interface SubjectRow {
   head_ref: string | null
   merge_state: 'clean' | 'conflicting' | 'unknown' | null
   merged_at: string | null
+  purpose_tag?: 'Change' | 'BaselineRepair' | null
+  purpose_base_sha_prefix?: string | null
   revision_id: string
   observed_at: string
 }
@@ -2155,6 +2156,9 @@ function githubSubjectFromRow(row: SubjectRow): GitHubItem {
     headRepository: row.head_repository,
     headRef: row.head_ref,
     mergeState: row.merge_state,
+    purpose: row.purpose_tag === 'BaselineRepair' && row.purpose_base_sha_prefix !== undefined && row.purpose_base_sha_prefix !== null
+      ? { _tag: 'BaselineRepair', baseShaPrefix: row.purpose_base_sha_prefix }
+      : { _tag: 'Change' },
     priorAutomatedReview: { _tag: 'None' },
   }
 }
@@ -3015,6 +3019,43 @@ function planAdversarialReview(
     recordWorkerTransition(database, { taskId: existing.id, from: 'Failed', to: 'Queued', reason: 'Retrying a recoverable review failure.', fence: existing.fence, at: observedAt })
     return
   }
+  const completedBaseline = subject.kind === 'pull_request' && existing?.state_tag === 'Completed' && localAttempt.revision_attempt === 0
+    ? database.prepare(`
+        SELECT tasks.id, tasks.fence
+        FROM tasks
+        WHERE tasks.subject_id = ? AND tasks.revision_id = ?
+          AND tasks.kind = 'baseline_repair' AND tasks.state_tag = 'Completed'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM subjects AS repair_subjects
+            JOIN repositories AS repair_repositories ON repair_repositories.id = repair_subjects.repository_id
+            JOIN revisions AS repair_revisions ON repair_revisions.id = repair_subjects.current_revision_id
+            WHERE repair_repositories.github = ? AND repair_subjects.kind = 'pull_request'
+              AND json_extract(repair_revisions.payload, '$.state') = 'open'
+              AND json_extract(repair_revisions.payload, '$.purpose._tag') = 'BaselineRepair'
+              AND lower(substr(?, 1, length(json_extract(repair_revisions.payload, '$.purpose.baseShaPrefix'))))
+                = lower(json_extract(repair_revisions.payload, '$.purpose.baseShaPrefix'))
+          )
+        LIMIT 1
+      `).get(subjectId, revisionId, mapping.github, subject.baseSha) as { id: string, fence: number } | undefined
+    : undefined
+  if (completedBaseline !== undefined && existing !== undefined) {
+    const reason = 'GitHub reports no open Baseline repair for this base commit.'
+    database.prepare(`
+      UPDATE tasks SET state_tag = 'Superseded', reason = ?, evidence = NULL, updated_at = ?
+      WHERE id = ? AND state_tag = 'Completed'
+    `).run(reason, observedAt, completedBaseline.id)
+    recordTransition(database, { taskId: completedBaseline.id, from: 'Completed', to: 'Superseded', reason, fence: completedBaseline.fence, at: observedAt })
+    database.prepare(`
+      UPDATE worker_tasks
+      SET state_tag = 'Queued', reason = NULL, evidence = NULL, attempts = 0,
+        worker_id = NULL, lease_expires_at = NULL, progress_percent = 0,
+        progress_label = 'Starting', updated_at = ?
+      WHERE id = ? AND state_tag = 'Completed'
+    `).run(observedAt, existing.id)
+    recordWorkerTransition(database, { taskId: existing.id, from: 'Completed', to: 'Queued', reason: 'Recovering from current GitHub state.', fence: existing.fence, at: observedAt })
+    return
+  }
   if (existing !== undefined)
     return
 
@@ -3326,6 +3367,16 @@ const freshProviderSessionMigration = `
   PRAGMA user_version = 35;
 `
 
+/** Adds the GitHub-derived purpose to pull request Revisions. */
+const pullRequestPurposeMigration = `
+  UPDATE revisions
+  SET payload = json_set(payload, '$.purpose', json('{"_tag":"Change"}'))
+  WHERE json_extract(payload, '$.kind') = 'pull_request'
+    AND json_type(payload, '$.purpose') IS NULL;
+
+  PRAGMA user_version = 36;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -3351,7 +3402,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 35)
+  if (version === 36)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -3492,6 +3543,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 34) {
     applyMigration(database, freshProviderSessionMigration)
+    version = 35
+  }
+  if (version === 35) {
+    applyMigration(database, pullRequestPurposeMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -4298,6 +4353,8 @@ export function openJournalStore(
         json_extract(revisions.payload, '$.headRef') AS head_ref,
         json_extract(revisions.payload, '$.mergeState') AS merge_state,
         json_extract(revisions.payload, '$.mergedAt') AS merged_at,
+        json_extract(revisions.payload, '$.purpose._tag') AS purpose_tag,
+        json_extract(revisions.payload, '$.purpose.baseShaPrefix') AS purpose_base_sha_prefix,
         revisions.id AS revision_id,
         revisions.observed_at
       FROM subjects
@@ -4340,6 +4397,7 @@ export function openJournalStore(
             headRepository: current.headRepository,
             headRef: current.headRef,
             mergeState: 'unknown',
+            purpose: current.purpose,
             priorAutomatedReview: { _tag: 'None' },
           }
       recordObservation({
@@ -5011,6 +5069,39 @@ export function openJournalStore(
       const taskId = digest(`${row.github}:baseline:${input.baseSha}`)
       const existing = database.prepare('SELECT state_tag, fence FROM tasks WHERE id = ?').get(taskId) as
         { state_tag: TaskRow['state_tag'], fence: number } | undefined
+      const openRepair = database.prepare(`
+        SELECT subjects.github_number, json_extract(revisions.payload, '$.url') AS url
+        FROM subjects
+        JOIN repositories ON repositories.id = subjects.repository_id
+        JOIN revisions ON revisions.id = subjects.current_revision_id
+        WHERE repositories.github = ? AND subjects.kind = 'pull_request'
+          AND json_extract(revisions.payload, '$.state') = 'open'
+          AND json_extract(revisions.payload, '$.purpose._tag') = 'BaselineRepair'
+          AND lower(substr(?, 1, length(json_extract(revisions.payload, '$.purpose.baseShaPrefix'))))
+            = lower(json_extract(revisions.payload, '$.purpose.baseShaPrefix'))
+        LIMIT 1
+      `).get(row.github, input.baseSha) as { github_number: number, url: string } | undefined
+      if (openRepair !== undefined) {
+        const evidence = `GitHub reports Baseline repair pull request #${openRepair.github_number}: ${openRepair.url}`
+        if (existing === undefined) {
+          database.prepare(`
+            INSERT INTO tasks (id, subject_id, revision_id, kind, state_tag, evidence, updated_at)
+            VALUES (?, ?, ?, 'baseline_repair', 'Completed', ?, ?)
+          `).run(taskId, row.subject_id, row.revision_id, evidence, input.at)
+          recordTransition(database, { taskId, from: null, to: 'Completed', reason: 'Recovered from GitHub.', fence: 0, at: input.at })
+        }
+        else if (existing.state_tag === 'Queued' || existing.state_tag === 'ActionRequired' || existing.state_tag === 'Failed' || existing.state_tag === 'Superseded') {
+          database.prepare(`
+            UPDATE tasks
+            SET state_tag = 'Completed', reason = NULL, evidence = ?, worker_id = NULL,
+              command_id = NULL, lease_expires_at = NULL, updated_at = ?
+            WHERE id = ? AND state_tag = ?
+          `).run(evidence, input.at, taskId, existing.state_tag)
+          recordTransition(database, { taskId, from: existing.state_tag, to: 'Completed', reason: 'Recovered from GitHub.', fence: existing.fence, at: input.at })
+        }
+        database.exec('COMMIT')
+        return { _tag: 'Existing', taskId }
+      }
       if (existing !== undefined && existing.state_tag !== 'Failed' && existing.state_tag !== 'Superseded') {
         database.exec('COMMIT')
         return { _tag: 'Existing', taskId }
@@ -5947,6 +6038,30 @@ export function openJournalStore(
       `).run(input.evidence, input.at, input.taskId, input.workerId, input.fence, input.at)
       if (result.changes === 1) {
         recordTransition(database, { taskId: input.taskId, from: 'Running', to: 'Completed', reason: null, fence: input.fence, at: input.at })
+        resolveTaskIncidents(database, input.taskId, input.at)
+      }
+      database.exec('COMMIT')
+      return result.changes === 1
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  const supersedeTask: JournalStore['supersedeTask'] = (input) => {
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      const result = database.prepare(`
+        UPDATE tasks
+        SET state_tag = 'Superseded', reason = ?, evidence = NULL, worker_id = NULL,
+          command_id = NULL, lease_expires_at = NULL, updated_at = ?
+        WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
+          AND lease_expires_at > ?
+          AND revision_id = (SELECT current_revision_id FROM subjects WHERE subjects.id = tasks.subject_id)
+      `).run(input.reason, input.at, input.taskId, input.workerId, input.fence, input.at)
+      if (result.changes === 1) {
+        recordTransition(database, { taskId: input.taskId, from: 'Running', to: 'Superseded', reason: input.reason, fence: input.fence, at: input.at })
         resolveTaskIncidents(database, input.taskId, input.at)
       }
       database.exec('COMMIT')
@@ -7093,17 +7208,6 @@ export function openJournalStore(
     }
   }
 
-  const isBaselineRepairPullRequest: JournalStore['isBaselineRepairPullRequest'] = (repository, headRef) => database.prepare(`
-    SELECT 1
-    FROM publication_commands
-    JOIN tasks ON tasks.id = publication_commands.task_id
-    JOIN subjects ON subjects.id = tasks.subject_id
-    JOIN repositories ON repositories.id = subjects.repository_id
-    WHERE repositories.github = ? AND publication_commands.head_ref = ?
-      AND tasks.kind = 'baseline_repair' AND publication_commands.state_tag = 'Published'
-    LIMIT 1
-  `).get(repository, headRef) !== undefined
-
   const listOpenAgentPullRequests: JournalStore['listOpenAgentPullRequests'] = repository => (database.prepare(`
     SELECT
       subjects.github_number AS pull_request_number,
@@ -7208,7 +7312,6 @@ export function openJournalStore(
 
   return {
     approveIssueWork,
-    isBaselineRepairPullRequest,
     isIssueWorkApprovalReady,
     listOpenAgentPullRequests,
     listActiveTaskLeases,
@@ -7236,6 +7339,7 @@ export function openJournalStore(
     close: () => database.close(),
     closeMissingItems,
     completeTask,
+    supersedeTask,
     completeWorkerTask,
     completeIssueTriageComment,
     completePublication,

--- a/packages/harlan-github-agent/src/task-scheduler.ts
+++ b/packages/harlan-github-agent/src/task-scheduler.ts
@@ -26,7 +26,7 @@ export interface TaskSchedulerOptions<Task extends PublicationTask = ClaimedConf
   /** Called once the worker stops running a task, whatever the outcome. */
   onTaskSettled?: (taskId: string) => void
   permits: AgentPermitPool
-  store: Pick<JournalStore, 'claimNextConflictTask' | 'completeTask' | 'failTask' | 'heartbeatTask' | 'needsAttentionTask' | 'stagePublication'>
+  store: Pick<JournalStore, 'claimNextConflictTask' | 'failTask' | 'heartbeatTask' | 'needsAttentionTask' | 'stagePublication' | 'supersedeTask'>
   worker: PublicationWorker<Task>
   workerId: string
 }
@@ -76,13 +76,13 @@ export function createTaskScheduler<Task extends PublicationTask = ClaimedConfli
       if (executionController.signal.aborted)
         return
       if (result._tag === 'Ok') {
-        if (result.value._tag === 'Obsolete') {
-          options.store.completeTask({
+        if (result.value._tag === 'Superseded') {
+          options.store.supersedeTask({
             taskId: task.id,
             workerId: options.workerId,
             fence: task.state.fence,
             at: options.now().toISOString(),
-            evidence: result.value.evidence,
+            reason: result.value.reason,
           })
           return
         }

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -1,5 +1,6 @@
 import type { AgentProviderName, AgentTokenUsage } from './agent-provider.ts'
 import type { AutoMergePolicy } from './auto-merge.ts'
+import type { PullRequestPurpose } from './baseline-repair-state.ts'
 import type { PriorAutomatedReview } from './review-comment.ts'
 
 export type RepositoryOwnership = 'owned' | 'maintained' | 'external'
@@ -116,6 +117,8 @@ export interface GitHubPullRequestItem extends GitHubItemBase {
   headRef: string
   maintainerCanModify?: boolean
   mergeState: 'clean' | 'conflicting' | 'unknown'
+  /** Why this pull request exists, derived from marked GitHub state. */
+  purpose: PullRequestPurpose
   priorAutomatedReview: PriorAutomatedReview
 }
 
@@ -549,7 +552,7 @@ export type MutationWorkerOutcome
      * Retrying cannot help and nobody needs to act, so the Task completes
      * instead of failing. A failure here used to sit in the dashboard forever.
      */
-    | { _tag: 'Obsolete', evidence: string }
+    | { _tag: 'Superseded', reason: string }
 
 export type ClaimedPublicationCommand = PublicationCommand & {
   workerId: string

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -11,6 +11,7 @@ import { mkdir } from 'node:fs/promises'
 import { isAbsolute, join } from 'node:path'
 import process from 'node:process'
 import { StringDecoder } from 'node:string_decoder'
+import { BASELINE_REPAIR_LABEL_SPEC } from './baseline-repair-state.ts'
 import { canPushBranch, canRepairBaseline, canWorkIssues, canWritePullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
@@ -1295,6 +1296,7 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
         expectedHeadSha: command.commitSha,
         title: command.pullRequestTitle,
         body: command.pullRequestBody,
+        ...(command.taskKind === 'baseline_repair' ? { labels: [BASELINE_REPAIR_LABEL_SPEC] } : {}),
       }, signal)
       return pullRequest._tag === 'Err'
         ? err(pullRequest.error.message)

--- a/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
+++ b/packages/harlan-github-agent/test/baseline-repair-worker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
+import { BASELINE_REPAIR_MARKER } from '../src/baseline-repair-state.ts'
 import { createBaselineRepairWorker } from '../src/baseline-repair-worker.ts'
 import { ok } from '../src/result.ts'
 import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
@@ -69,8 +70,10 @@ describe('baseline repair worker', () => {
     }, new AbortController().signal)
 
     expect(commitMessage).toBe(response.commitMessage)
-    if (result._tag === 'Ok' && result.value._tag === 'Publish' && result.value.publication._tag === 'OpenPullRequest')
+    if (result._tag === 'Ok' && result.value._tag === 'Publish' && result.value.publication._tag === 'OpenPullRequest') {
       expect(result.value.publication.pullRequestBody.match(/🤖 AI disclosure:/g)).toHaveLength(1)
+      expect(result.value.publication.pullRequestBody).toContain(BASELINE_REPAIR_MARKER)
+    }
     expect(result).toEqual(ok({
       _tag: 'Publish',
       publication: expect.objectContaining({
@@ -335,6 +338,6 @@ describe('baseline repair worker', () => {
       pullRequest,
     }, new AbortController().signal)
 
-    expect(result).toEqual(ok({ _tag: 'Obsolete', evidence: expect.stringContaining(expected) }))
+    expect(result).toEqual(ok({ _tag: 'Superseded', reason: expect.stringContaining(expected) }))
   })
 })

--- a/packages/harlan-github-agent/test/codex-provider.test.ts
+++ b/packages/harlan-github-agent/test/codex-provider.test.ts
@@ -49,7 +49,7 @@ describe('codexAgentEvent', () => {
 
   it('maps a failed turn to a turn failure', () => {
     expect(codexAgentEvent({ type: 'turn.failed', error: { message: 'Usage limit reached.' } } as ThreadEvent))
-      .toEqual({ _tag: 'Failed', reason: 'Usage limit reached.' })
+      .toEqual({ _tag: 'Failed', reason: 'The codex session failed: Usage limit reached.' })
   })
 })
 

--- a/packages/harlan-github-agent/test/failure.test.ts
+++ b/packages/harlan-github-agent/test/failure.test.ts
@@ -13,6 +13,7 @@ describe('classifyFailure', () => {
     ['fetch failed', 'network'],
     ['The opencode session stopped sending output.', 'agent_provider'],
     ['The opencode session exited with code 1.', 'agent_provider'],
+    ['The opencode session failed: Unexpected server error. Check server logs for details.', 'agent_provider'],
     ['The agent finished without a result.', 'agent_provider'],
     ['The review Task lease changed before the repair started.', 'subject_changed'],
     ['The repair Task changed before the review claimed it.', 'subject_changed'],

--- a/packages/harlan-github-agent/test/fixtures.ts
+++ b/packages/harlan-github-agent/test/fixtures.ts
@@ -65,6 +65,7 @@ export function pullRequestItem(overrides: Partial<GitHubPullRequestItem> = {}):
     headRef: 'fix/broken-thing',
     maintainerCanModify: true,
     mergeState: 'conflicting',
+    purpose: { _tag: 'Change' },
     priorAutomatedReview: { _tag: 'None' },
     ...overrides,
   }

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -1,0 +1,100 @@
+import type { Octokit } from 'octokit'
+import { describe, expect, it } from 'vitest'
+import { createGitHubAgentSource } from '../src/github-agent-source.ts'
+import { createGitHubSource } from '../src/github.ts'
+import { ok } from '../src/result.ts'
+import { repositoryMapping } from './fixtures.ts'
+
+const historicBaseSha = 'a'.repeat(40)
+const liveBaseSha = 'b'.repeat(40)
+const headSha = 'c'.repeat(40)
+
+function pullRequest() {
+  return {
+    number: 24,
+    state: 'open',
+    merged_at: null,
+    title: 'Fix the broken thing',
+    body: 'Fixes the bug.',
+    user: { login: 'harlan-zw' },
+    html_url: 'https://github.com/harlan-zw/example/pull/24',
+    created_at: '2026-08-01T00:00:00.000Z',
+    updated_at: '2026-08-13T00:00:00.000Z',
+    draft: false,
+    labels: [],
+    base: { sha: historicBaseSha, ref: 'main' },
+    head: { sha: headSha, ref: 'fix/thing', repo: { full_name: 'harlan-zw/example' } },
+    maintainer_can_modify: true,
+    mergeable: true,
+  }
+}
+
+function tokens() {
+  return {
+    getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T02:00:00.000Z' })),
+    invalidate: () => undefined,
+  }
+}
+
+describe('live pull request base', () => {
+  it('observes the current base branch commit instead of GitHub pull history', async () => {
+    const client = {
+      rest: {
+        pulls: { get: () => Promise.resolve({ data: pullRequest() }) },
+        repos: { getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }) },
+      },
+    } as unknown as Octokit
+    const source = createGitHubSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      issueCutoff: '2026-07-01',
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequest(repositoryMapping(), 24)
+
+    expect(result).toEqual(ok(expect.objectContaining({ baseSha: liveBaseSha })))
+  })
+
+  it('reads base checks from the current base branch commit', async () => {
+    const checkedRefs: string[] = []
+    const client = {
+      paginate: (_method: unknown, input: { ref?: string }) => {
+        if (input.ref !== undefined)
+          checkedRefs.push(input.ref)
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')) },
+        checks: { listForRef: () => undefined },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: (input: { ref: string }) => {
+            checkedRefs.push(input.ref)
+            return Promise.resolve({ data: { statuses: [] } })
+          },
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      pullRequest: expect.objectContaining({ baseSha: liveBaseSha }),
+    })))
+    expect(checkedRefs).toContain(liveBaseSha)
+    expect(checkedRefs).not.toContain(historicBaseSha)
+  })
+})

--- a/packages/harlan-github-agent/test/github-pull-request.test.ts
+++ b/packages/harlan-github-agent/test/github-pull-request.test.ts
@@ -1,5 +1,6 @@
 import type { Octokit } from 'octokit'
 import { describe, expect, it } from 'vitest'
+import { BASELINE_REPAIR_LABEL_SPEC } from '../src/baseline-repair-state.ts'
 import { createGitHubPullRequestPublisher } from '../src/github.ts'
 import { ok } from '../src/result.ts'
 import { repositoryMapping } from './fixtures.ts'
@@ -73,5 +74,47 @@ describe('gitHub pull request publication', () => {
 
     expect(draft).toBe(false)
     expect(result).toEqual(ok({ number: 31, url: 'https://github.com/harlan-zw/example/pull/31' }))
+  })
+
+  it('marks a Baseline repair pull request on GitHub', async () => {
+    const createdLabels: string[] = []
+    const appliedLabels: string[] = []
+    const publisher = createGitHubPullRequestPublisher({
+      createClient: () => ({
+        rest: {
+          issues: {
+            addLabels: (input: { labels: string[] }) => {
+              appliedLabels.push(...input.labels)
+              return Promise.resolve({ data: [] })
+            },
+            createLabel: (input: { name: string }) => {
+              createdLabels.push(input.name)
+              return Promise.resolve({ data: {} })
+            },
+          },
+          pulls: {
+            create: () => Promise.resolve({ data: { html_url: 'https://github.com/harlan-zw/example/pull/31', number: 31 } }),
+            list: () => Promise.resolve({ data: [] }),
+          },
+        },
+      }) as unknown as Octokit,
+      tokens: {
+        getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T02:00:00.000Z' })),
+        invalidate: () => undefined,
+      },
+    })
+
+    await publisher.ensurePullRequest({
+      repository: repositoryMapping(),
+      baseRef: 'main',
+      headRef: 'fix/baseline-ci-abcdef012345',
+      expectedHeadSha: 'abc123',
+      title: 'fix: repair default branch CI',
+      body: 'Repairs CI.',
+      labels: [BASELINE_REPAIR_LABEL_SPEC],
+    })
+
+    expect(createdLabels).toEqual(['harlan-agent-baseline-repair'])
+    expect(appliedLabels).toEqual(['harlan-agent-baseline-repair'])
   })
 })

--- a/packages/harlan-github-agent/test/github.test.ts
+++ b/packages/harlan-github-agent/test/github.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { approvalLabels } from '../src/approval-labels.ts'
+import { BASELINE_REPAIR_MARKER, pullRequestPurpose } from '../src/baseline-repair-state.ts'
 import { isAutomatedGitHubActor, isIssueAtOrAfterCutoff } from '../src/github.ts'
 
 describe('gitHub subjects', () => {
@@ -32,5 +33,33 @@ describe('gitHub subjects', () => {
   it('recognizes only exact Approval labels', () => {
     expect(approvalLabels(['HARLAN-AGENT-REVIEW', 'bug'])).toEqual(['review'])
     expect(approvalLabels(['harlan-agent-review-later'])).toEqual([])
+  })
+
+  it.each([
+    ['marked body', BASELINE_REPAIR_MARKER, [], 'fix/baseline-ci-abcdef012345'],
+    ['durable label', '', ['harlan-agent-baseline-repair'], 'fix/baseline-ci-abcdef012345'],
+    ['legacy branch', '', [], 'fix/baseline-ci-abcdef012345'],
+  ])('recovers Baseline repair purpose from a %s', (_name, body, labels, headRef) => {
+    expect(pullRequestPurpose({
+      actorLogin: 'harlan-github-agent[bot]',
+      authorLogin: 'harlan-github-agent[bot]',
+      body,
+      headRef,
+      headRepository: 'harlan-zw/example',
+      labels,
+      repository: 'harlan-zw/example',
+    })).toEqual({ _tag: 'BaselineRepair', baseShaPrefix: 'abcdef012345' })
+  })
+
+  it('does not trust a Baseline repair marker from another author', () => {
+    expect(pullRequestPurpose({
+      actorLogin: 'harlan-github-agent[bot]',
+      authorLogin: 'contributor',
+      body: BASELINE_REPAIR_MARKER,
+      headRef: 'fix/baseline-ci-abcdef012345',
+      headRepository: 'harlan-zw/example',
+      labels: ['harlan-agent-baseline-repair'],
+      repository: 'harlan-zw/example',
+    })).toEqual({ _tag: 'Change' })
   })
 })

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -552,6 +552,45 @@ describe('recovery budget after a GitHub outage', () => {
 })
 
 describe('stale task incidents', () => {
+  it('refreshes a legacy exhausted provider Incident to Retrying', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'legacy-provider-incident-pr',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    const reason = 'The opencode session failed: Unexpected server error.'
+    let taskId = ''
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextAdversarialReviewTask(`provider-${attempt}`, `2026-08-18T00:00:0${attempt}.000Z`, 10_000)
+      if (task === null)
+        throw new Error(`Expected provider failure attempt ${attempt}.`)
+      taskId = task.id
+      store.failWorkerTask({
+        taskId,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-18T00:00:0${attempt}.000Z`,
+        reason,
+      })
+    }
+    store.recordIncident({
+      scope: { _tag: 'Task', taskId, repository: 'harlan-zw/example', itemNumber: 24 },
+      kind: 'agent_provider',
+      severity: 'error',
+      operation: 'adversarial_review',
+      message: reason,
+      recovery: { _tag: 'Exhausted' },
+      at: '2026-08-18T00:00:04.000Z',
+    })
+    expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
+
+    expect(store.resolveStaleTaskIncidents('2026-08-18T00:00:05.000Z')).toBe(1)
+    expect(store.listIncidents()[0]?.recovery).toEqual(expect.objectContaining({ _tag: 'Retrying' }))
+  })
+
   it('restores a missing incident for the current failed task', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -437,6 +437,35 @@ describe('recovery budget after a GitHub outage', () => {
     return store
   }
 
+  function storeWithProviderFailureAtRecoveryLimit() {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'provider-outage-pr',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    for (let round = 0; round <= 5; round += 1) {
+      const at = new Date(Date.parse('2026-08-18T00:00:00.000Z') + round * 2 * 60 * 60_000).toISOString()
+      if (round > 0)
+        expect(store.retryRecoverableWorkerFailures(at)).toBe(1)
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const task = store.claimNextAdversarialReviewTask(`provider-${round}-${attempt}`, at, 10_000)
+        if (task === null)
+          throw new Error(`Expected provider recovery ${round}, attempt ${attempt}.`)
+        store.failWorkerTask({
+          taskId: task.id,
+          workerId: task.state.workerId,
+          fence: task.state.fence,
+          at,
+          reason: 'The opencode session failed: Unexpected server error.',
+        })
+      }
+    }
+    return store
+  }
+
   it('frees a task the outage exhausted once the repository polls again', () => {
     const store = storeWithExhaustedReview('Resource not accessible by integration')
     expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
@@ -489,29 +518,36 @@ describe('recovery budget after a GitHub outage', () => {
     expect(store.retryRecoverableWorkerFailures('2026-08-18T12:02:00.000Z')).toBe(1)
   })
 
-  it('frees exhausted provider failures after another Agent completes', () => {
-    const store = storeWithExhaustedReview('The opencode session failed: Unexpected server error.')
-    expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
+  it('keeps retrying a provider failure at capped backoff', () => {
+    const store = storeWithProviderFailureAtRecoveryLimit()
+
+    expect(store.listIncidents()[0]?.recovery).toEqual(expect.objectContaining({ _tag: 'Retrying' }))
+    expect(store.retryRecoverableWorkerFailures('2026-08-18T12:00:00.000Z')).toBe(1)
+  })
+
+  it('frees backed-off provider failures after another Agent completes', () => {
+    const store = storeWithProviderFailureAtRecoveryLimit()
+    expect(store.listIncidents()[0]?.recovery).toEqual(expect.objectContaining({ _tag: 'Retrying' }))
 
     store.recordObservation({
       externalId: 'healthy-provider-pr',
-      observedAt: '2026-08-18T12:00:00.000Z',
+      observedAt: '2026-08-18T10:00:01.000Z',
       source: 'poll',
       subject: pullRequestItem({ number: 25, mergeState: 'clean' }),
     })
-    const healthy = store.claimNextAdversarialReviewTask('healthy-provider', '2026-08-18T12:00:01.000Z', 10_000)
+    const healthy = store.claimNextAdversarialReviewTask('healthy-provider', '2026-08-18T10:00:02.000Z', 10_000)
     if (healthy === null)
       throw new Error('Expected a Review Task for the healthy Agent provider.')
     expect(store.completeWorkerTask({
       taskId: healthy.id,
       workerId: healthy.state.workerId,
       fence: healthy.state.fence,
-      at: '2026-08-18T12:00:02.000Z',
+      at: '2026-08-18T10:00:03.000Z',
       evidence: 'The Agent provider completed a Review.',
     })).toBe(true)
 
     expect(store.listIncidents()).toEqual([])
-    expect(store.retryRecoverableWorkerFailures('2026-08-18T12:00:03.000Z')).toBe(1)
+    expect(store.retryRecoverableWorkerFailures('2026-08-18T10:00:04.000Z')).toBe(1)
   })
 })
 

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -488,6 +488,31 @@ describe('recovery budget after a GitHub outage', () => {
     expect(store.restoreOutageRecoveryBudget('2026-08-18T12:01:00.000Z')).toBe(1)
     expect(store.retryRecoverableWorkerFailures('2026-08-18T12:02:00.000Z')).toBe(1)
   })
+
+  it('frees exhausted provider failures after another Agent completes', () => {
+    const store = storeWithExhaustedReview('The opencode session failed: Unexpected server error.')
+    expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
+
+    store.recordObservation({
+      externalId: 'healthy-provider-pr',
+      observedAt: '2026-08-18T12:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ number: 25, mergeState: 'clean' }),
+    })
+    const healthy = store.claimNextAdversarialReviewTask('healthy-provider', '2026-08-18T12:00:01.000Z', 10_000)
+    if (healthy === null)
+      throw new Error('Expected a Review Task for the healthy Agent provider.')
+    expect(store.completeWorkerTask({
+      taskId: healthy.id,
+      workerId: healthy.state.workerId,
+      fence: healthy.state.fence,
+      at: '2026-08-18T12:00:02.000Z',
+      evidence: 'The Agent provider completed a Review.',
+    })).toBe(true)
+
+    expect(store.listIncidents()).toEqual([])
+    expect(store.retryRecoverableWorkerFailures('2026-08-18T12:00:03.000Z')).toBe(1)
+  })
 })
 
 describe('stale task incidents', () => {

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -80,7 +80,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A clean review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -168,7 +167,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A second review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('A second review must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -264,7 +262,6 @@ describe('subject Workers', () => {
         },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -368,7 +365,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A wrong premise must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -481,7 +477,6 @@ describe('subject Workers', () => {
           }]
         },
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -526,6 +521,7 @@ describe('subject Workers', () => {
   it('waits for Baseline repair without starting a review agent', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     let baselineQueued = false
+    let published = ''
     const capture: ProviderCapture = { requests: [] }
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([], capture)),
@@ -555,7 +551,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('Base CI failure must prevent Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => {
           baselineQueued = true
@@ -568,7 +563,11 @@ describe('subject Workers', () => {
         updateAgentProgress: () => true,
       },
       status: {
-        publish: () => Promise.reject(new Error('Review must not publish a status.')),
+        publish: (_task, phase, body) => {
+          expect(phase).toBe('terminal')
+          published = body
+          return Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
       },
       triageStatus: { publish: () => Promise.reject(new Error('Unexpected issue triage.')) },
       workspaces: {
@@ -593,6 +592,9 @@ describe('subject Workers', () => {
 
     expect(result).toEqual(ok({ evidence: 'Waiting for Baseline repair baseline-task.' }))
     expect(baselineQueued).toBe(true)
+    expect(published).toContain('### 🤖 WAITING')
+    expect(published).toContain('WaitingForBaselineRepair')
+    expect(published).toContain(pullRequest.baseSha)
   })
 
   it('reviews the pull request anyway when policy does not authorize Baseline repair', async () => {
@@ -634,7 +636,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => ({
           _tag: 'NotAuthorized',
@@ -720,7 +721,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => false,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('A stacked pull request must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -802,7 +802,6 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        isBaselineRepairPullRequest: () => true,
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         queueBaselineRepairForReview: () => { throw new Error('A Baseline repair must not queue another Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
@@ -872,7 +871,6 @@ describe('subject Workers', () => {
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       store: {
         getWorkerSession: () => 'poisoned-session',
-        isBaselineRepairPullRequest: () => false,
         saveWorkerSession: () => undefined,
         updateAgentProgress: () => true,
         recordReviewRun: () => { throw new Error('Unexpected review Attempt.') },

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -119,7 +119,7 @@ describe('opencodeAgentEvent', () => {
 
   it('reports a session error as a turn failure', () => {
     expect(opencodeAgentEvent({ type: 'error', error: { name: 'ProviderError', data: { message: 'Rate limited.' } } }))
-      .toEqual({ _tag: 'Failed', reason: 'Rate limited.' })
+      .toEqual({ _tag: 'Failed', reason: 'The opencode session failed: Rate limited.' })
   })
 
   it('completes the turn when the model stops', () => {
@@ -143,7 +143,8 @@ describe('createOpencodeProvider', () => {
       spawnOpencode: replay([], { exitCode: 1, standardError: 'Error: No such model' }),
     })
 
-    expect(await collect(provider.runTurn(request()))).toEqual([{ _tag: 'Failed', reason: 'No such model' }])
+    expect(await collect(provider.runTurn(request())))
+      .toEqual([{ _tag: 'Failed', reason: 'The opencode session failed: No such model' }])
   })
 
   it('starts a fresh session even when one was saved', async () => {

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -353,6 +353,7 @@ describe('git publication remote', () => {
           headRepository: command.repository,
           headRef: command.headRef,
           mergeState: 'conflicting',
+          purpose: { _tag: 'Change' },
           priorAutomatedReview: { _tag: 'None' },
         })),
         hasOpenPullRequestForBranch: () => Promise.resolve(ok(false)),

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -76,7 +76,6 @@ function reviewWith(input: { headChecks: GitHubCheck[], requiredChecks: Required
       queueReviewFixTaskForReview: () => { throw new Error('Unexpected Repair queue.') },
       getRepairedHeadFindings: () => [],
       getWorkerSession: () => null,
-      isBaselineRepairPullRequest: () => false,
       recordIncident: () => { throw new Error('Unexpected Incident.') },
       queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
       retireBaselineRepairForReview: () => 0,

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -116,7 +116,6 @@ function harness(input: {
       }),
       getRepairedHeadFindings: () => [],
       getWorkerSession: () => null,
-      isBaselineRepairPullRequest: () => false,
       recordIncident: () => { throw new Error('Unexpected Incident.') },
       queueBaselineRepairForReview: () => { throw new Error('Unexpected Baseline repair.') },
       retireBaselineRepairForReview: () => 0,

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -90,6 +90,32 @@ describe('publishStoppedReviews', () => {
     expect(recorded).toBe(1)
   })
 
+  it('closes a stale progress comment after GitHub merges the pull request', async () => {
+    let body = ''
+    const results = await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({
+          state: 'closed',
+          mergedAt: '2026-08-15T03:00:00.000Z',
+        })),
+        editReviewStatus: (_repository, _number, _commentId, _expectedBody, value) => {
+          body = value
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listStoppedReviews: () => [stopped],
+        recordStoppedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(body).toContain('### 🤖 MERGED')
+    expect(body).not.toContain('REVIEWING')
+  })
+
   it('writes nothing when a person deleted the comment, rather than posting it again', async () => {
     let recorded = 0
     const results = await publishStoppedReviews({

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -97,6 +97,7 @@ describe('publishStoppedReviews', () => {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({
           state: 'closed',
           mergedAt: '2026-08-15T03:00:00.000Z',
+          headSha: 'def456',
         })),
         editReviewStatus: (_repository, _number, _commentId, _expectedBody, value) => {
           body = value
@@ -157,6 +158,6 @@ describe('publishStoppedReviews', () => {
     }, new AbortController().signal)
 
     expect(writes).toBe(0)
-    expect(results).toEqual([{ _tag: 'Err', error: 'harlan-zw/example#24: the pull request changed before the final comment.' }])
+    expect(results).toEqual([ok({ _tag: 'Superseded', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
   })
 })

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -84,7 +84,6 @@ function reviewWith(input: { headChecks: GitHubCheck[], baseChecks?: GitHubCheck
       queueReviewFixTaskForReview: () => { throw new Error('Unexpected Repair queue.') },
       getRepairedHeadFindings: () => [],
       getWorkerSession: () => null,
-      isBaselineRepairPullRequest: () => false,
       recordIncident: (incident) => {
         incidents.push(incident)
         return { ...incident, id: 'incident-1', occurrences: 1, firstSeenAt: incident.at, lastSeenAt: incident.at } satisfies Incident

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -321,7 +321,7 @@ describe('provider session recovery migration', () => {
       if (recovery < 5)
         expect(store.retryRecoverableWorkerFailures(at(3_600_000))).toBe(1)
     }
-    expect(store.listIncidents()[0]?.recovery).toEqual({ _tag: 'Exhausted' })
+    expect(store.listIncidents()[0]?.recovery).toEqual(expect.objectContaining({ _tag: 'Retrying' }))
     store.close()
 
     const oldJournal = new DatabaseSync(path)

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -357,7 +357,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(35)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(36)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1393,6 +1393,13 @@ describe('journal store', () => {
       commentId: 42,
       url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
     })
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:03.000Z',
+      evidence: 'Waiting for Baseline repair baseline-task.',
+    })).toBe(true)
 
     store.recordObservation({
       externalId: 'review-merged',

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1354,71 +1354,6 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
-  it('recognises the pull request the controller opened to repair the default branch', () => {
-    const store = createStore()
-    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
-    store.recordObservation({
-      externalId: 'baseline-identity-pr',
-      observedAt: '2026-08-13T01:00:00.000Z',
-      source: 'poll',
-      subject: pullRequestItem({ mergeState: 'clean' }),
-    })
-    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
-    if (review === null)
-      throw new Error('Expected the review Task.')
-    const queued = store.queueBaselineRepairForReview({
-      taskId: review.id,
-      workerId: review.state.workerId,
-      fence: review.state.fence,
-      baseSha: review.pullRequest.baseSha,
-      at: '2026-08-13T01:02:00.000Z',
-    })
-    if (queued._tag === 'Rejected' || queued._tag === 'NotAuthorized')
-      throw new Error(queued.reason)
-    const repair = store.claimNextBaselineRepairTask('baseline-agent', '2026-08-13T01:03:00.000Z', 600_000)
-    if (repair === null)
-      throw new Error('Expected the Baseline repair Task.')
-    const staged = store.stagePublication({
-      taskId: repair.id,
-      workerId: repair.state.workerId,
-      fence: repair.state.fence,
-      at: '2026-08-13T01:04:00.000Z',
-      publication: {
-        _tag: 'OpenPullRequest',
-        taskKind: 'baseline_repair',
-        pullRequestNumber: repair.pullRequestNumber,
-        pullRequestTitle: 'fix(ci): repair the default branch',
-        pullRequestBody: 'Repairs default branch CI.',
-        commitSha: 'baseline-commit',
-        baseSha: repair.pullRequest.baseSha,
-        baseRef: 'main',
-        expectedHeadSha: repair.pullRequest.baseSha,
-        headRef: 'fix/baseline-ci-abcdef012345',
-        artifactRef: 'refs/harlan-github-agent/publications/baseline',
-        patchDigest: 'patch',
-        changedFiles: 1,
-      },
-    })
-    if (staged._tag !== 'Staged')
-      throw new Error('Expected a staged publication.')
-
-    expect(store.isBaselineRepairPullRequest('harlan-zw/example', 'fix/baseline-ci-abcdef012345')).toBe(false)
-
-    const claimed = store.claimNextPublication('publisher', '2026-08-13T01:05:00.000Z', 60_000)
-    if (claimed === null)
-      throw new Error('Expected the publication command.')
-    store.completePublication({
-      commandId: claimed.id,
-      workerId: claimed.workerId,
-      fence: claimed.fence,
-      at: '2026-08-13T01:05:30.000Z',
-      evidence: 'Opened pull request #99.',
-    })
-
-    expect(store.isBaselineRepairPullRequest('harlan-zw/example', 'fix/baseline-ci-abcdef012345')).toBe(true)
-    expect(store.isBaselineRepairPullRequest('harlan-zw/example', 'fix/other')).toBe(false)
-  })
-
   it('lists the open pull requests this service opened, so a new one can stack on them', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
@@ -1837,6 +1772,51 @@ describe('journal store', () => {
       taskKind: 'baseline_repair',
       pullRequestNumber: repair.pullRequestNumber,
     }))
+  })
+
+  it('recovers an open Baseline repair from GitHub without local Task history', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const baseSha = 'a'.repeat(40)
+    store.recordObservation({
+      externalId: 'cold-recovery-subject',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ baseSha, mergeState: 'clean' }),
+    })
+    store.recordObservation({
+      externalId: 'cold-recovery-baseline-pr',
+      observedAt: '2026-08-13T01:00:01.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 99,
+        author: 'harlan-github-agent[bot]',
+        headRef: `fix/baseline-ci-${baseSha.slice(0, 12)}`,
+        headSha: 'repair-head',
+        mergeState: 'clean',
+        purpose: { _tag: 'BaselineRepair', baseShaPrefix: baseSha.slice(0, 12) },
+        url: 'https://github.com/harlan-zw/example/pull/99',
+      }),
+    })
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 60_000)
+    if (review === null)
+      throw new Error('Expected the original Review Task.')
+
+    const recovered = store.queueBaselineRepairForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      baseSha,
+      at: '2026-08-13T01:01:01.000Z',
+    })
+
+    expect(recovered).toEqual({ _tag: 'Existing', taskId: expect.any(String) })
+    expect(store.claimNextBaselineRepairTask('baseline-agent', '2026-08-13T01:01:02.000Z', 60_000)).toBeNull()
+    expect(store.getDashboardSnapshot('2026-08-13T01:01:03.000Z').tasks)
+      .toContainEqual(expect.objectContaining({
+        id: recovered._tag === 'Existing' ? recovered.taskId : '',
+        state: { _tag: 'Completed', evidence: expect.stringContaining('pull/99') },
+      }))
   })
 
   it('shows separately claimed Review and Repair agents', () => {
@@ -2403,6 +2383,124 @@ describe('journal store', () => {
       revisionId: secondObservation.revisionId,
       pullRequest: expect.objectContaining({ baseSha: 'new-base' }),
     }))
+  })
+
+  it('releases a review after its completed Baseline repair becomes stale', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'stale-baseline-old-base',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean', baseSha: 'old-base' }),
+    })
+    const review = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:01:00.000Z', 60_000)
+    if (review === null)
+      throw new Error('Expected the first Review Task.')
+    const queued = store.queueBaselineRepairForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      baseSha: review.pullRequest.baseSha,
+      at: '2026-08-13T01:01:01.000Z',
+    })
+    if (queued._tag === 'Rejected' || queued._tag === 'NotAuthorized')
+      throw new Error(queued.reason)
+    const baseline = store.claimNextBaselineRepairTask('baseline-1', '2026-08-13T01:01:02.000Z', 60_000)
+    if (baseline === null)
+      throw new Error('Expected the Baseline repair Task.')
+    store.completeTask({
+      taskId: baseline.id,
+      workerId: baseline.state.workerId,
+      fence: baseline.state.fence,
+      at: '2026-08-13T01:01:03.000Z',
+      evidence: 'Opened Baseline repair pull request.',
+    })
+    store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:01:04.000Z',
+      evidence: 'Waiting for the Baseline repair.',
+    })
+
+    const moved = store.recordObservation({
+      externalId: 'stale-baseline-live-base',
+      observedAt: '2026-08-13T02:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean', baseSha: 'live-base' }),
+    })
+
+    if (moved._tag !== 'Inserted')
+      throw new Error('Expected GitHub state to create a fresh Revision.')
+    expect(store.claimNextAdversarialReviewTask('reviewer-2', '2026-08-13T02:01:00.000Z', 60_000))
+      .toEqual(expect.objectContaining({
+        revisionId: moved.revisionId,
+        pullRequest: expect.objectContaining({ baseSha: 'live-base' }),
+      }))
+    expect(store.getDashboardSnapshot('2026-08-13T02:01:00.000Z').queue)
+      .not
+      .toContainEqual(expect.objectContaining({
+        state: expect.objectContaining({
+          reason: 'Waiting for GitHub to report the Baseline repair pull request.',
+        }),
+      }))
+  })
+
+  it('requeues a completed review when GitHub has no open Baseline repair', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const subject = pullRequestItem({ mergeState: 'clean', baseSha: 'red-base' })
+    store.recordObservation({
+      externalId: 'missing-baseline-first-poll',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject,
+    })
+    const review = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:01:00.000Z', 60_000)
+    if (review === null)
+      throw new Error('Expected the first Review Task.')
+    const queued = store.queueBaselineRepairForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      baseSha: review.pullRequest.baseSha,
+      at: '2026-08-13T01:01:01.000Z',
+    })
+    if (queued._tag === 'Rejected' || queued._tag === 'NotAuthorized')
+      throw new Error(queued.reason)
+    const baseline = store.claimNextBaselineRepairTask('baseline-1', '2026-08-13T01:01:02.000Z', 60_000)
+    if (baseline === null)
+      throw new Error('Expected the Baseline repair Task.')
+    store.completeTask({
+      taskId: baseline.id,
+      workerId: baseline.state.workerId,
+      fence: baseline.state.fence,
+      at: '2026-08-13T01:01:03.000Z',
+      evidence: 'Publication finished locally.',
+    })
+    store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:01:04.000Z',
+      evidence: 'Waiting for the Baseline repair.',
+    })
+
+    store.recordObservation({
+      externalId: 'missing-baseline-second-poll',
+      observedAt: '2026-08-13T02:00:00.000Z',
+      source: 'poll',
+      subject,
+    })
+
+    expect(store.claimNextAdversarialReviewTask('reviewer-2', '2026-08-13T02:01:00.000Z', 60_000))
+      .toEqual(expect.objectContaining({ id: review.id }))
+    expect(store.getDashboardSnapshot('2026-08-13T02:01:00.000Z').tasks)
+      .toContainEqual(expect.objectContaining({
+        id: baseline.id,
+        state: { _tag: 'Superseded', reason: 'GitHub reports no open Baseline repair for this base commit.' },
+      }))
   })
 
   it('deduplicates one GitHub review rerun command', () => {

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1354,6 +1354,76 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
+  it('keeps a stopped Review eligible after GitHub closes its pull request Revision', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const observed = store.recordObservation({
+      externalId: 'review-before-merge',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request Revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'review',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 REVIEWING · Git worktree ready',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+
+    store.recordObservation({
+      externalId: 'review-merged',
+      observedAt: '2026-08-13T01:03:00.000Z',
+      source: 'poll',
+      subject: {
+        ...pullRequest,
+        state: 'closed',
+        mergedAt: '2026-08-13T01:03:00.000Z',
+        updatedAt: '2026-08-13T01:03:00.000Z',
+      },
+    })
+
+    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
+      taskId: review.id,
+      revisionId: observed.revisionId,
+      headSha: pullRequest.headSha,
+    })])
+    expect(store.recordStoppedReviewStatus({
+      taskId: review.id,
+      taskKind: 'adversarial_review',
+      revisionId: observed.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 MERGED',
+      at: '2026-08-13T01:04:00.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })).toBe(true)
+    expect(store.listStoppedReviews()).toEqual([])
+  })
+
   it('lists the open pull requests this service opened, so a new one can stack on them', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/task-scheduler.test.ts
+++ b/packages/harlan-github-agent/test/task-scheduler.test.ts
@@ -78,7 +78,7 @@ describe('task scheduler', () => {
     store.close()
   })
 
-  it('completes a Task whose work the world already did', async () => {
+  it('supersedes a Task whose work the world already did', async () => {
     const store = openJournalStore(':memory:')
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
     store.recordObservation({
@@ -94,14 +94,14 @@ describe('task scheduler', () => {
       onError: (error) => { throw error },
       permits: createAgentPermitPool(1),
       store,
-      worker: { run: () => Promise.resolve(ok({ _tag: 'Obsolete', evidence: 'The conflict resolved itself.' })) },
+      worker: { run: () => Promise.resolve(ok({ _tag: 'Superseded', reason: 'The conflict resolved itself.' })) },
       workerId: 'worker-1',
     })
 
     await scheduler.runNow()
 
     expect(store.getDashboardSnapshot('2026-08-13T02:00:00.000Z').tasks[0]?.state)
-      .toEqual({ _tag: 'Completed', evidence: 'The conflict resolved itself.' })
+      .toEqual({ _tag: 'Superseded', reason: 'The conflict resolved itself.' })
     await scheduler.stop()
     store.close()
   })


### PR DESCRIPTION
## Summary

- derive live base state and Baseline repair identity from GitHub
- mark repair pull requests with a durable label and body marker
- rebuild missing local coordination from open GitHub pull requests
- finalize waiting, closed, and merged review comments from GitHub state
- keep provider failures owned, bounded, and automatically retrying

## Verification

- pnpm test, 662 passed
- pnpm --filter harlan-github-agent lint
- pnpm typecheck
- pnpm build
- live recovery corrected gscdump.com pull requests 66 and 141

> AI disclosure: Codex implemented and verified this change.