### PR TITLE
fix(agent): harden Worktrunk startup and shutdown

### DIFF
--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -687,7 +687,7 @@ async function reportReviewProgress(
   if (saved._tag === 'Err')
     return saved
   const posted = await options.status.publish(task, phase, progressComment(task.pullRequest.headSha, progress, options.now().toISOString()), signal)
-  if (posted._tag === 'Err')
+  if (posted._tag === 'Err' && !signal.aborted)
     options.onProgressPublishFailure?.(task, posted.error)
   else
     options.onProgressPublishSuccess?.(task)

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -138,7 +138,7 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
         if (!saved)
           return err('This Agent is no longer assigned to the current pull request.')
         const published = await options.status.publishRepair(task, value, signal)
-        if (published._tag === 'Err')
+        if (published._tag === 'Err' && !signal.aborted)
           options.onProgressPublishFailure?.(task, published.error)
         return ok(undefined)
       }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -3,6 +3,7 @@ import type { Server } from 'srvx'
 import type { GitIdentity } from './git-identity.ts'
 import type { GitHubUserAccess } from './github-user-access.ts'
 import type { Result } from './result.ts'
+import type { JournalStore } from './store.ts'
 import type { ClaimedAgentTask, RepositoryMapping, ValidatedAgentConfig } from './types.ts'
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
@@ -60,6 +61,38 @@ export interface StartAgentServiceOptions {
   gitIdentity: GitIdentity
   logger: Pick<ConsolaInstance, 'error' | 'info'>
   now?: () => Date
+}
+
+function recordServiceIncident(
+  store: Pick<JournalStore, 'recordIncident'>,
+  at: string,
+  operation: string,
+  message: string,
+): void {
+  const failure = classifyFailure({ message })
+  store.recordIncident({
+    scope: { _tag: 'Service' },
+    kind: failure.kind,
+    severity: failure._tag === 'Transient' ? 'warning' : 'error',
+    operation,
+    message,
+    recovery: failure._tag === 'Transient'
+      ? { _tag: 'Retrying', attempt: 0, nextAttemptAt: at }
+      : { _tag: 'ActionRequired' },
+    at,
+  })
+}
+
+/** Replaces one controller pass's Service Incidents with its current failures. */
+export function replaceServiceIncidents(
+  store: Pick<JournalStore, 'recordIncident' | 'resolveIncidents'>,
+  at: string,
+  operation: string,
+  messages: readonly string[],
+): void {
+  const currentMessages = [...new Set(messages)]
+  currentMessages.forEach(message => recordServiceIncident(store, at, operation, message))
+  store.resolveIncidents({ _tag: 'Service' }, at, operation, currentMessages)
 }
 
 /**
@@ -310,7 +343,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
             return
           }
           options.logger.error(`${event.repository}#${event.pullRequestNumber}: GitHub refused auto-merge: ${event.reason}`)
-          recordServiceIncident('auto_merge', event.reason)
+          recordServiceIncident(store, now().toISOString(), 'auto_merge', event.reason)
         },
         store,
       }),
@@ -464,26 +497,6 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     store.close()
     throw error
   })
-  function recordServiceIncident(operation: string, message: string): void {
-    const failure = classifyFailure({ message })
-    store.recordIncident({
-      scope: { _tag: 'Service' },
-      kind: failure.kind,
-      severity: failure._tag === 'Transient' ? 'warning' : 'error',
-      operation,
-      message,
-      recovery: failure._tag === 'Transient'
-        ? { _tag: 'Retrying', attempt: 0, nextAttemptAt: now().toISOString() }
-        : { _tag: 'ActionRequired' },
-      at: now().toISOString(),
-    })
-  }
-
-  function replaceServiceIncidents(operation: string, messages: string[]): void {
-    messages.forEach(message => recordServiceIncident(operation, message))
-    store.resolveIncidents({ _tag: 'Service' }, now().toISOString(), operation, messages)
-  }
-
   const poller = createPoller({
     intervalMilliseconds: config.pollIntervalSeconds * 1_000,
     timeoutMilliseconds: Math.max(5 * 60_000, config.pollIntervalSeconds * 4_000),
@@ -531,12 +544,12 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           options.logger.info(`${result.value.repository}: queued a requested review rerun.`)
         }
       })
-      replaceServiceIncidents('review_rerun', reruns.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+      replaceServiceIncidents(store, now().toISOString(), 'review_rerun', reruns.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       const statusSync = await pullRequestStatuses.sync(store.getDashboardSnapshot(now().toISOString()), signal)
       statusSync.errors.forEach((error) => {
         options.logger.error(`Pull request status: ${error}`)
       })
-      replaceServiceIncidents('pull_request_status', statusSync.errors)
+      replaceServiceIncidents(store, now().toISOString(), 'pull_request_status', statusSync.errors)
       if (mutationSchedulers !== undefined) {
         const stopped = await publishStoppedReviews({
           github: workerGithub,
@@ -556,7 +569,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
             options.logger.error(`Stopped review comment: ${result.error}`)
           }
         })
-        replaceServiceIncidents('stopped_review_comment', stopped.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+        replaceServiceIncidents(store, now().toISOString(), 'stopped_review_comment', stopped.flatMap(result => result._tag === 'Err' ? [result.error] : []))
         const positions = await publishQueuePositions({
           github: workerGithub,
           now,
@@ -575,7 +588,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
             options.logger.error(`Queue position comment: ${result.error}`)
           }
         })
-        replaceServiceIncidents('queue_position_comment', positions.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+        replaceServiceIncidents(store, now().toISOString(), 'queue_position_comment', positions.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       }
       // Only a pass where nothing succeeded describes an outage. Throwing for a
       // partial failure backed the poller off to its 15 minute ceiling and held
@@ -610,6 +623,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     intervalMilliseconds: 5 * 60_000,
     poll: async (signal) => {
       const checkouts = [...new Set(config.repositories.map(repository => repository.checkout))]
+      const failures: string[] = []
       for (const checkout of checkouts) {
         const swept = await sweepAgentWorktrees({
           checkout,
@@ -617,15 +631,18 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         }, signal)
         if (swept._tag === 'Err') {
           options.logger.error(`Agent worktree sweep in ${checkout}: ${swept.error}`)
-          recordServiceIncident('agent_worktree_sweep', swept.error)
+          failures.push(swept.error)
           continue
         }
         if (swept.value.removed.length > 0)
           options.logger.info(`${checkout}: removed ${swept.value.removed.length} agent worktrees that no task uses.`)
         swept.value.failures.forEach((failure) => {
-          options.logger.error(`Could not remove agent worktree ${failure.branch}: ${failure.reason}`)
+          const message = `Could not remove agent worktree ${failure.branch}: ${failure.reason}`
+          options.logger.error(message)
+          failures.push(message)
         })
       }
+      replaceServiceIncidents(store, now().toISOString(), 'agent_worktree_sweep', failures)
     },
     onError: error => options.logger.error(error),
   })

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -124,6 +124,10 @@ interface WtWorktree {
   path: string
 }
 
+type WtList
+  = | { _tag: 'Schema1', entries: unknown[] }
+    | { _tag: 'Schema2', entries: unknown[] }
+
 function gitEnvironment(githubToken?: string): NodeJS.ProcessEnv {
   const allowed = [
     'GIT_CONFIG_GLOBAL',
@@ -289,14 +293,27 @@ export function parseWtWorktrees(stdout: string): Result<WtWorktree[], string> {
   catch {
     return err('wt list returned invalid JSON.')
   }
-  if (!Array.isArray(value))
+  const list: WtList | null = Array.isArray(value)
+    ? { _tag: 'Schema1', entries: value }
+    : typeof value === 'object'
+      && value !== null
+      && 'schema' in value
+      && value.schema === 2
+      && 'items' in value
+      && Array.isArray(value.items)
+      ? { _tag: 'Schema2', entries: value.items }
+      : null
+  if (list === null)
     return err('wt list returned an invalid worktree list.')
   const worktrees: WtWorktree[] = []
-  for (const entry of value) {
+  for (const entry of list.entries) {
     if (typeof entry !== 'object' || entry === null)
       continue
     const branch: unknown = 'branch' in entry ? entry.branch : undefined
-    const path: unknown = 'path' in entry ? entry.path : undefined
+    const worktree = 'worktree' in entry ? entry.worktree : undefined
+    const path: unknown = list._tag === 'Schema1'
+      ? 'path' in entry ? entry.path : undefined
+      : typeof worktree === 'object' && worktree !== null && 'path' in worktree ? worktree.path : undefined
     if (typeof branch !== 'string' || branch.length === 0)
       continue
     if (typeof path !== 'string' || !isAbsolute(path))
@@ -307,7 +324,7 @@ export function parseWtWorktrees(stdout: string): Result<WtWorktree[], string> {
 }
 
 async function listWtWorktrees(checkout: string, signal: AbortSignal): Promise<Result<WtWorktree[], string>> {
-  const listed = await runWt(checkout, ['list', '--format=json'], signal)
+  const listed = await runWt(checkout, ['--config-set', 'list.json-schema=2', 'list', '--format=json'], signal)
   if (listed.exitCode !== 0)
     return err(`Could not list wt worktrees: ${listed.stderr}`)
   return parseWtWorktrees(listed.stdout)

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { contextBudgetExhaustedReason } from '../src/failure.ts'
+import { replaceServiceIncidents } from '../src/service.ts'
 import { openJournalStore } from '../src/store.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
@@ -9,6 +10,16 @@ function createStore() {
 }
 
 describe('incident log', () => {
+  it('clears a worktree sweep incident after the next clean sweep', () => {
+    const store = createStore()
+
+    replaceServiceIncidents(store, '2026-08-18T00:01:00.000Z', 'agent_worktree_sweep', ['wt list failed'])
+    expect(store.listIncidents()).toHaveLength(1)
+
+    replaceServiceIncidents(store, '2026-08-18T00:02:00.000Z', 'agent_worktree_sweep', [])
+    expect(store.listIncidents()).toEqual([])
+  })
+
   it('folds a repeated failure into one incident instead of one row per poll', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -377,6 +377,29 @@ describe('review resilience', () => {
     expect(test.progressSuccesses).toBeGreaterThan(0)
   })
 
+  it('does not report a progress failure caused by an intentional stop', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const controller = new AbortController()
+    const test = harness({
+      pullRequest,
+      response: {
+        metadata: passingGate,
+        review: passingGate,
+        verification: passingGate,
+        findings: [],
+        confidence: 91,
+      },
+      publish: () => {
+        controller.abort()
+        return Promise.resolve(err('This operation was aborted'))
+      },
+    })
+
+    await createReviewWorker(test.options).run(reviewTask(pullRequest), controller.signal)
+
+    expect(test.progressFailures).toEqual([])
+  })
+
   it('rejects a Review Agent that changed the worktree', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const test = harness({

--- a/packages/harlan-github-agent/test/worktree-sweep.test.ts
+++ b/packages/harlan-github-agent/test/worktree-sweep.test.ts
@@ -45,8 +45,14 @@ function createCheckout(): { checkout: string, baseSha: string } {
 }
 
 function branches(checkout: string): string[] {
-  const listed: unknown = JSON.parse(wt(checkout, 'list', '--format=json'))
-  return (listed as Array<{ branch: string | null }>).flatMap(entry => entry.branch === null ? [] : [entry.branch]).sort()
+  const listed: unknown = JSON.parse(wt(checkout, '--config-set', 'list.json-schema=2', 'list', '--format=json'))
+  if (typeof listed !== 'object' || listed === null || !('items' in listed) || !Array.isArray(listed.items))
+    throw new Error('Expected Worktrunk list schema 2.')
+  return listed.items.flatMap((entry: unknown) => {
+    if (typeof entry !== 'object' || entry === null || !('branch' in entry) || typeof entry.branch !== 'string')
+      return []
+    return [entry.branch]
+  }).sort()
 }
 
 describe('agent worktree branch', () => {

--- a/packages/harlan-github-agent/test/wt-list.test.ts
+++ b/packages/harlan-github-agent/test/wt-list.test.ts
@@ -6,6 +6,32 @@ function entry(branch: string | null, path: string): unknown {
 }
 
 describe('parseWtWorktrees', () => {
+  it('reads Worktrunk schema 2 worktree entries', () => {
+    const parsed = parseWtWorktrees(JSON.stringify({
+      schema: 2,
+      repo: { default_branch: 'main' },
+      collected: { ci: false, summary: false },
+      items: [
+        {
+          branch: 'main',
+          worktree: { path: '/home/harlan/pkg/repo', detached: false },
+        },
+        {
+          branch: 'harlan-agent/review-1',
+          worktree: { path: '/home/harlan/pkg/repo.review-1', detached: false },
+        },
+      ],
+    }))
+
+    expect(parsed).toEqual({
+      _tag: 'Ok',
+      value: [
+        { branch: 'main', path: '/home/harlan/pkg/repo' },
+        { branch: 'harlan-agent/review-1', path: '/home/harlan/pkg/repo.review-1' },
+      ],
+    })
+  })
+
   it('keeps every branch worktree when a detached worktree sits between them', () => {
     const parsed = parseWtWorktrees(JSON.stringify([
       entry('main', '/home/harlan/pkg/repo'),
@@ -37,7 +63,7 @@ describe('parseWtWorktrees', () => {
     })
   })
 
-  it('rejects output that is not a list of worktrees', () => {
+  it('rejects output that is not a supported worktree collection', () => {
     expect(parseWtWorktrees('{"worktrees":[]}')._tag).toBe('Err')
     expect(parseWtWorktrees('not json')._tag).toBe('Err')
   })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Worktrunk 0.74 moved JSON lists to schema 2, which HGA treated as invalid. Intentional shutdowns also recorded their cancelled progress updates as network Incidents. HGA now reads the current Worktrunk contract, clears sweep Incidents after recovery, and keeps shutdown cancellation out of the Incident log.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.