### PR TITLE
fix(agent): keep the canonical comment honest after its Task ends

### DIFF
--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -1,6 +1,6 @@
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
-import type { JournalStore, QueuedReviewStatus } from './store.ts'
+import type { JournalStore, QueuedReviewStatus, ReviewQueueState } from './store.ts'
 import type { RepositoryMapping } from './types.ts'
 import { formatProgressBar } from './agent-progress.ts'
 import { err, ok } from './result.ts'
@@ -28,15 +28,20 @@ function ordinal(position: number): string {
  */
 export function queuePositionComment(status: QueuedReviewStatus): string {
   const work = workLabel[status.taskKind]
-  const ahead = status.position - 1
-  const next = ahead === 0
-    ? `${work} starts as soon as an agent is free.`
-    : ahead === 1
-      ? `${work} starts after the 1 Task ahead of it finishes.`
-      : `${work} starts after the ${ahead} Tasks ahead of it finish.`
+  const heading = status.queue._tag === 'Paused'
+    ? 'PAUSED'
+    : `QUEUED · ${ordinal(status.queue.position)} of ${status.queue.total}`
+  const ahead = status.queue._tag === 'Paused' ? 0 : status.queue.position - 1
+  const next = status.queue._tag === 'Paused'
+    ? `${work} starts when this repository resumes.`
+    : ahead === 0
+      ? `${work} starts as soon as an agent is free.`
+      : ahead === 1
+        ? `${work} starts after the 1 Task ahead of it finishes.`
+        : `${work} starts after the ${ahead} Tasks ahead of it finish.`
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${status.headSha} -->
-### 🤖 QUEUED · ${ordinal(status.position)} of ${status.total}
+### 🤖 ${heading}
 
 > [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). This comment updates as the Queue moves.
 
@@ -53,7 +58,7 @@ export interface QueuePositionSweepOptions {
 }
 
 export type QueuePositionOutcome
-  = | { _tag: 'Published', repository: string, pullRequestNumber: number, position: number, total: number }
+  = | { _tag: 'Published', repository: string, pullRequestNumber: number, queue: ReviewQueueState }
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
 
@@ -68,6 +73,10 @@ export type QueuePositionOutcome
  * Only a comment this service already published is rewritten. The edit cannot
  * open a comment, so a quiet pull request stays quiet and a comment a person
  * deleted stays deleted.
+ *
+ * A paused repository queues Tasks that no agent claims. Its comment used to
+ * keep whatever the last Task left on it, so a pause read as work in progress.
+ * The comment names the pause instead, and returns to a position on resume.
  *
  * An agent can claim the Task between the Queue read and the comment write,
  * because both GitHub round trips sit in between. No local check closes that
@@ -118,8 +127,7 @@ export async function publishQueuePositions(
           _tag: 'Published',
           repository: status.repository,
           pullRequestNumber: status.pullRequestNumber,
-          position: status.position,
-          total: status.total,
+          queue: status.queue,
         })
       // The claim was lost while the edit was in flight, so the claimed agent
       // now owns the comment. Nothing was saved and nothing needs to be.

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -582,7 +582,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
               ? `${result.value.repository}#${result.value.pullRequestNumber}: the automated comment was deleted, so nothing was written.`
               : result.value._tag === 'Superseded'
                 ? `${result.value.repository}#${result.value.pullRequestNumber}: an agent claimed the Task, so the Queue position comment was left to it.`
-                : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.position} of ${result.value.total}.`)
+                : result.value.queue._tag === 'Paused'
+                  ? `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads that the repository is paused.`
+                  : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.queue.position} of ${result.value.queue.total}.`)
           }
           else {
             options.logger.error(`Queue position comment: ${result.error}`)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -7064,28 +7064,27 @@ export function openJournalStore(
         ORDER BY candidate.updated_at DESC, candidate.id DESC
         LIMIT 1
       ),
-      -- A Repair queued straight after a Review has published nothing of its
-      -- own. It inherits the canonical comment of the Review for the same
-      -- revision, which is the comment left reading "Repair queued".
+      -- A Task that has published nothing of its own inherits the canonical
+      -- comment the pull request already carries. One comment serves the whole
+      -- pull request and outlives every Revision, so this finds both the
+      -- Review comment a Repair queues behind and the Repair comment a Review
+      -- queues behind once the Repair push becomes the next head.
       (
         SELECT candidate.id FROM review_status_commands AS candidate
-        JOIN worker_tasks AS sibling ON sibling.id = candidate.task_id
-        WHERE candidate.task_kind = 'adversarial_review' AND candidate.state_tag = 'Published'
-          AND sibling.subject_id = claimable.subject_id
-          AND candidate.revision_id = claimable.revision_id
+        JOIN revisions AS candidate_revision ON candidate_revision.id = candidate.revision_id
+        WHERE candidate.state_tag = 'Published'
+          AND candidate_revision.subject_id = claimable.subject_id
         ORDER BY candidate.updated_at DESC, candidate.id DESC
         LIMIT 1
       )
     )
     WHERE json_extract(revisions.payload, '$.state') = 'open'
       AND COALESCE(published.github_comment_id, prompt.github_comment_id) IS NOT NULL
-      AND (
-        published.id IS NULL
-        OR (
-          published.phase != 'terminal'
-          AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
-        )
-      )
+      -- A terminal comment is a complete statement, so the Queue leaves it for
+      -- the Review that replaces it. A nonterminal comment claims work is
+      -- under way, which is false the moment its Task ends, whichever head it
+      -- named. That comment is the one the Queue position corrects.
+      AND (published.id IS NULL OR published.phase != 'terminal')
       -- A final status for this exact head is a complete statement. Writing a
       -- Queue position over it would delete the review a person still needs.
       AND NOT EXISTS (

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -383,11 +383,29 @@ interface QueuedReviewStatusRow {
   github_number: number
   revision_id: string
   head_sha: string
-  position: number
-  total: number
+  paused: number
+  position: number | null
+  total: number | null
   github_comment_id: number
   published_body: string
 }
+
+/**
+ * Why a queued Task has not started yet.
+ *
+ * A paused repository still queues Tasks and still owns the canonical comment,
+ * but no agent can claim one until the pause lifts. A Queue position there is a
+ * number that never moves, so the comment names the pause instead.
+ */
+export type ReviewQueueState
+  = | {
+    _tag: 'Waiting'
+    /** 1 for the Task the next free agent claims. */
+    position: number
+    /** Claimable queued Tasks of the same kind, this one included. */
+    total: number
+  }
+  | { _tag: 'Paused' }
 
 export interface QueuedReviewStatus {
   taskId: string
@@ -396,10 +414,7 @@ export interface QueuedReviewStatus {
   pullRequestNumber: number
   revisionId: string
   headSha: string
-  /** 1 for the Task the next free agent claims. */
-  position: number
-  /** Claimable queued Tasks of the same kind, this one included. */
-  total: number
+  queue: ReviewQueueState
   commentId: number
   /** What the canonical comment holds now, so an unchanged position writes nothing. */
   publishedBody: string
@@ -6992,20 +7007,23 @@ export function openJournalStore(
   }
 
   const listQueuedReviewStatuses: JournalStore['listQueuedReviewStatuses'] = () => (database.prepare(`
-    WITH claimable AS (
+    -- Every queued Task that owns a canonical comment, paused repositories
+    -- included. A paused repository queues work and writes no code, so its
+    -- comment still has to say why nothing is happening.
+    WITH candidates AS (
       SELECT
         worker_tasks.id AS task_id,
         'adversarial_review' AS task_kind,
         worker_tasks.subject_id,
         worker_tasks.revision_id,
-        worker_tasks.updated_at
+        worker_tasks.updated_at,
+        repositories.paused
       FROM worker_tasks
       JOIN subjects ON subjects.id = worker_tasks.subject_id
       JOIN repositories ON repositories.id = subjects.repository_id
       WHERE worker_tasks.kind = 'adversarial_review' AND worker_tasks.state_tag = 'Queued'
         AND worker_tasks.revision_id = subjects.current_revision_id
         AND repositories.enabled = 1
-        AND repositories.paused = 0
         AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
       UNION ALL
       SELECT
@@ -7013,14 +7031,14 @@ export function openJournalStore(
         'review_fix' AS task_kind,
         tasks.subject_id,
         tasks.revision_id,
-        tasks.updated_at
+        tasks.updated_at,
+        repositories.paused
       FROM tasks
       JOIN subjects ON subjects.id = tasks.subject_id
       JOIN repositories ON repositories.id = subjects.repository_id
       WHERE tasks.kind = 'review_fix' AND tasks.state_tag = 'Queued'
         AND tasks.revision_id = subjects.current_revision_id
         AND repositories.enabled = 1
-        AND repositories.paused = 0
         AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
         AND EXISTS (
           SELECT 1 FROM pull_request_approvals
@@ -7028,38 +7046,44 @@ export function openJournalStore(
             AND pull_request_approvals.revision_id = tasks.revision_id
             AND pull_request_approvals.kind = 'fixes'
         )
-    )
+    ),
+    -- The Queue an agent actually draws from. A paused Task waits outside it,
+    -- so it takes no position and moves nobody else along.
+    claimable AS (SELECT * FROM candidates WHERE paused = 0)
     SELECT
-      claimable.task_id,
-      claimable.task_kind,
+      candidates.task_id,
+      candidates.task_kind,
       repositories.github AS repository,
       subjects.github_number,
-      claimable.revision_id,
+      candidates.revision_id,
       json_extract(revisions.payload, '$.headSha') AS head_sha,
+      candidates.paused,
       (
         SELECT COUNT(*) + 1 FROM claimable AS ahead
-        WHERE ahead.task_kind = claimable.task_kind
+        WHERE candidates.paused = 0
+          AND ahead.task_kind = candidates.task_kind
           AND (
-            ahead.updated_at < claimable.updated_at
-            OR (ahead.updated_at = claimable.updated_at AND ahead.task_id < claimable.task_id)
+            ahead.updated_at < candidates.updated_at
+            OR (ahead.updated_at = candidates.updated_at AND ahead.task_id < candidates.task_id)
           )
       ) AS position,
       (
-        SELECT COUNT(*) FROM claimable AS peer WHERE peer.task_kind = claimable.task_kind
+        SELECT COUNT(*) FROM claimable AS peer
+        WHERE candidates.paused = 0 AND peer.task_kind = candidates.task_kind
       ) AS total,
       COALESCE(published.github_comment_id, prompt.github_comment_id) AS github_comment_id,
       COALESCE(published.body, prompt.body) AS published_body
-    FROM claimable
-    JOIN subjects ON subjects.id = claimable.subject_id
+    FROM candidates
+    JOIN subjects ON subjects.id = candidates.subject_id
     JOIN repositories ON repositories.id = subjects.repository_id
-    JOIN revisions ON revisions.id = claimable.revision_id
+    JOIN revisions ON revisions.id = candidates.revision_id
     -- The Approval prompt is the canonical comment until a Task publishes one.
     LEFT JOIN approval_prompt_comments AS prompt
-      ON prompt.subject_id = claimable.subject_id AND prompt.revision_id = claimable.revision_id
+      ON prompt.subject_id = candidates.subject_id AND prompt.revision_id = candidates.revision_id
     LEFT JOIN review_status_commands AS published ON published.id = COALESCE(
       (
         SELECT candidate.id FROM review_status_commands AS candidate
-        WHERE candidate.task_kind = claimable.task_kind AND candidate.task_id = claimable.task_id
+        WHERE candidate.task_kind = candidates.task_kind AND candidate.task_id = candidates.task_id
           AND candidate.state_tag = 'Published'
         ORDER BY candidate.updated_at DESC, candidate.id DESC
         LIMIT 1
@@ -7073,7 +7097,7 @@ export function openJournalStore(
         SELECT candidate.id FROM review_status_commands AS candidate
         JOIN revisions AS candidate_revision ON candidate_revision.id = candidate.revision_id
         WHERE candidate.state_tag = 'Published'
-          AND candidate_revision.subject_id = claimable.subject_id
+          AND candidate_revision.subject_id = candidates.subject_id
         ORDER BY candidate.updated_at DESC, candidate.id DESC
         LIMIT 1
       )
@@ -7090,7 +7114,7 @@ export function openJournalStore(
       AND NOT EXISTS (
         SELECT 1 FROM review_status_commands AS final
         WHERE final.phase = 'terminal' AND final.state_tag = 'Published'
-          AND final.revision_id = claimable.revision_id
+          AND final.revision_id = candidates.revision_id
           AND final.expected_head_sha = json_extract(revisions.payload, '$.headSha')
       )
   `).all() as unknown as QueuedReviewStatusRow[]).map(row => ({
@@ -7100,8 +7124,9 @@ export function openJournalStore(
     pullRequestNumber: row.github_number,
     revisionId: row.revision_id,
     headSha: row.head_sha,
-    position: row.position,
-    total: row.total,
+    queue: row.paused === 1 || row.position === null || row.total === null
+      ? { _tag: 'Paused' as const }
+      : { _tag: 'Waiting' as const, position: row.position, total: row.total },
     commentId: row.github_comment_id,
     publishedBody: row.published_body,
   }))

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -12,8 +12,7 @@ function queuedRepair(overrides: Partial<QueuedReviewStatus> = {}): QueuedReview
     pullRequestNumber: 24,
     revisionId: 'revision-1',
     headSha: 'abc123',
-    position: 3,
-    total: 7,
+    queue: { _tag: 'Waiting', position: 3, total: 7 },
     commentId: 42,
     publishedBody: '### 🤖 REVIEWING · Repair queued',
     ...overrides,
@@ -43,12 +42,12 @@ describe('queuePositionComment', () => {
   })
 
   it('says an agent is the only thing left to wait for at the head of the Queue', () => {
-    expect(queuePositionComment(queuedRepair({ position: 1, total: 4 })))
+    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 1, total: 4 } })))
       .toContain('Next: Repair starts as soon as an agent is free.')
   })
 
   it('names the work the Queue is holding', () => {
-    expect(queuePositionComment(queuedRepair({ taskKind: 'adversarial_review', position: 2, total: 2 })))
+    expect(queuePositionComment(queuedRepair({ taskKind: 'adversarial_review', queue: { _tag: 'Waiting', position: 2, total: 2 } })))
       .toContain('Next: Review starts after the 1 Task ahead of it finishes.')
   })
 
@@ -56,9 +55,16 @@ describe('queuePositionComment', () => {
     expect(queuePositionComment(queuedRepair())).toBe(queuePositionComment(queuedRepair()))
   })
 
+  it('names the pause, because a position on a paused repository never moves', () => {
+    const body = queuePositionComment(queuedRepair({ queue: { _tag: 'Paused' } }))
+
+    expect(body).toContain('### 🤖 PAUSED')
+    expect(body).toContain('Next: Repair starts when this repository resumes.')
+  })
+
   it('writes an ordinal a person reads, not a number with a wrong suffix', () => {
-    expect(queuePositionComment(queuedRepair({ position: 11, total: 20 }))).toContain('11th of 20')
-    expect(queuePositionComment(queuedRepair({ position: 22, total: 30 }))).toContain('22nd of 30')
+    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 11, total: 20 } }))).toContain('11th of 20')
+    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 22, total: 30 } }))).toContain('22nd of 30')
   })
 })
 
@@ -86,7 +92,7 @@ describe('publishQueuePositions', () => {
       },
     }, new AbortController().signal)
 
-    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24, position: 3, total: 7 })])
+    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24, queue: { _tag: 'Waiting', position: 3, total: 7 } })])
     expect(edited?.commentId).toBe(42)
     expect(edited?.body).toContain('### 🤖 QUEUED · 3rd of 7')
     expect(recorded?.taskId).toBe('repair-task')

--- a/packages/harlan-github-agent/test/queue-position.test.ts
+++ b/packages/harlan-github-agent/test/queue-position.test.ts
@@ -130,8 +130,8 @@ describe('listQueuedReviewStatuses', () => {
     const second = queuedRepair(store, 25, '2026-08-13T02:00:00.000Z')
 
     expect(store.listQueuedReviewStatuses()).toEqual([
-      expect.objectContaining({ pullRequestNumber: 24, position: 1, total: 2, commentId: first.commentId, publishedBody: first.body }),
-      expect.objectContaining({ pullRequestNumber: 25, position: 2, total: 2, commentId: second.commentId, publishedBody: second.body }),
+      expect.objectContaining({ pullRequestNumber: 24, queue: { _tag: 'Waiting', position: 1, total: 2 }, commentId: first.commentId, publishedBody: first.body }),
+      expect.objectContaining({ pullRequestNumber: 25, queue: { _tag: 'Waiting', position: 2, total: 2 }, commentId: second.commentId, publishedBody: second.body }),
     ])
   })
 
@@ -143,7 +143,7 @@ describe('listQueuedReviewStatuses', () => {
     const claimed = store.claimNextReviewFixTask('repair-agent', '2026-08-13T03:00:00.000Z', 60_000)
     expect(claimed?.pullRequestNumber).toBe(24)
     expect(store.listQueuedReviewStatuses()).toEqual([
-      expect.objectContaining({ pullRequestNumber: 25, position: 1, total: 1 }),
+      expect.objectContaining({ pullRequestNumber: 25, queue: { _tag: 'Waiting', position: 1, total: 1 } }),
     ])
   })
 
@@ -188,21 +188,34 @@ describe('listQueuedReviewStatuses', () => {
       expect.objectContaining({
         taskKind: 'adversarial_review',
         pullRequestNumber: 30,
-        position: 1,
-        total: 1,
+        queue: { _tag: 'Waiting', position: 1, total: 1 },
         commentId: 900,
         publishedBody: '### 🤖 REVIEW PAUSED',
       }),
     ])
   })
 
-  it('says nothing about a Task no agent can claim', () => {
+  it('reports the pause for a Task no agent can claim, so the comment stops claiming progress', () => {
     const store = createStore()
     queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
     store.setRepositoryPaused('harlan-zw/example', true)
 
-    expect(store.listQueuedReviewStatuses()).toEqual([])
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({ pullRequestNumber: 24, queue: { _tag: 'Paused' } }),
+    ])
     expect(store.claimNextReviewFixTask('repair-agent', '2026-08-13T03:00:00.000Z', 60_000)).toBeNull()
+  })
+
+  it('reports every Task of a paused repository as paused, never as a Queue position', () => {
+    const store = createStore()
+    queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    queuedRepair(store, 25, '2026-08-13T02:00:00.000Z')
+    store.setRepositoryPaused('harlan-zw/example', true)
+
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({ pullRequestNumber: 24, queue: { _tag: 'Paused' } }),
+      expect.objectContaining({ pullRequestNumber: 25, queue: { _tag: 'Paused' } }),
+    ])
   })
 })
 
@@ -328,8 +341,7 @@ describe('listQueuedReviewStatuses across revisions', () => {
         taskKind: 'adversarial_review',
         pullRequestNumber: 24,
         headSha: 'repaired24',
-        position: 1,
-        total: 1,
+        queue: { _tag: 'Waiting', position: 1, total: 1 },
         commentId: review.commentId,
         publishedBody: progress,
       }),

--- a/packages/harlan-github-agent/test/queue-position.test.ts
+++ b/packages/harlan-github-agent/test/queue-position.test.ts
@@ -263,3 +263,213 @@ describe('isQueuedReviewStatus', () => {
     expect(store.isQueuedReviewStatus({ taskId: 'missing-task', taskKind: 'review_fix' })).toBe(false)
   })
 })
+
+describe('listQueuedReviewStatuses across revisions', () => {
+  it('takes over the Repair comment left on the head the Repair itself pushed', () => {
+    const store = createStore()
+    const review = queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')
+    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:10:00.000Z', 600_000)
+    if (repair === null)
+      throw new Error('Expected the Repair Task.')
+
+    const progress = '### 🤖 REPAIR · Repair ready to publish'
+    const staged = store.stageReviewStatus({
+      taskKind: 'review_fix',
+      phase: 'repair',
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:15:00.000Z',
+      revisionId: repair.revisionId,
+      expectedHeadSha: repair.pullRequest.headSha,
+      body: progress,
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:15:00.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the Repair status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:15:00.000Z',
+      commentId: review.commentId,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-124',
+    })
+    expect(store.completeTask({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:16:00.000Z',
+      evidence: 'Published repaired24.',
+    })).toBe(true)
+
+    // The Repair push is the next head, so the comment it left behind belongs
+    // to a Revision the pull request has moved past.
+    const repaired = store.recordObservation({
+      externalId: 'queue-position-24-repaired',
+      observedAt: '2026-08-13T01:31:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 24,
+        headRef: 'fix/thing-24',
+        headSha: 'repaired24',
+        mergeState: 'clean',
+        updatedAt: '2026-08-13T01:31:00.000Z',
+        url: 'https://github.com/harlan-zw/example/pull/24',
+      }),
+    })
+    if (repaired._tag !== 'Inserted')
+      throw new Error('Expected the repaired head to be a new revision.')
+
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({
+        taskKind: 'adversarial_review',
+        pullRequestNumber: 24,
+        headSha: 'repaired24',
+        position: 1,
+        total: 1,
+        commentId: review.commentId,
+        publishedBody: progress,
+      }),
+    ])
+  })
+  it('takes over a Review comment the pull request left behind when a person pushed', () => {
+    const store = createStore()
+    const observed = store.recordObservation({
+      externalId: 'queue-position-40',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 40,
+        headRef: 'fix/thing-40',
+        headSha: 'head40',
+        mergeState: 'clean',
+        url: 'https://github.com/harlan-zw/example/pull/40',
+      }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:00:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the review Task.')
+
+    const progress = '### 🤖 REVIEWING · Reading the diff'
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'review',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:05:00.000Z',
+      revisionId: observed.revisionId,
+      expectedHeadSha: 'head40',
+      body: progress,
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:05:00.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:05:00.000Z',
+      commentId: 140,
+      url: 'https://github.com/harlan-zw/example/pull/40#issuecomment-140',
+    })
+
+    // The person pushes while the Review runs. The Review dies with its comment
+    // still reading as though it were under way.
+    const pushed = store.recordObservation({
+      externalId: 'queue-position-40-pushed',
+      observedAt: '2026-08-13T01:06:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 40,
+        headRef: 'fix/thing-40',
+        headSha: 'head40b',
+        mergeState: 'clean',
+        updatedAt: '2026-08-13T01:06:00.000Z',
+        url: 'https://github.com/harlan-zw/example/pull/40',
+      }),
+    })
+    if (pushed._tag !== 'Inserted')
+      throw new Error('Expected the pushed head to be a new revision.')
+
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({
+        pullRequestNumber: 40,
+        headSha: 'head40b',
+        commentId: 140,
+        publishedBody: progress,
+      }),
+    ])
+  })
+
+  it('leaves a finished Review comment alone, because it still answers the person', () => {
+    const store = createStore()
+    const observed = store.recordObservation({
+      externalId: 'queue-position-41',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 41,
+        headRef: 'fix/thing-41',
+        headSha: 'head41',
+        mergeState: 'clean',
+        url: 'https://github.com/harlan-zw/example/pull/41',
+      }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:00:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the review Task.')
+
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:05:00.000Z',
+      revisionId: observed.revisionId,
+      expectedHeadSha: 'head41',
+      body: '### 🤖 BLOCKED · One material finding',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:05:00.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:05:00.000Z',
+      commentId: 141,
+      url: 'https://github.com/harlan-zw/example/pull/41#issuecomment-141',
+    })
+
+    const pushed = store.recordObservation({
+      externalId: 'queue-position-41-pushed',
+      observedAt: '2026-08-13T01:06:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 41,
+        headRef: 'fix/thing-41',
+        headSha: 'head41b',
+        mergeState: 'clean',
+        updatedAt: '2026-08-13T01:06:00.000Z',
+        url: 'https://github.com/harlan-zw/example/pull/41',
+      }),
+    })
+    if (pushed._tag !== 'Inserted')
+      throw new Error('Expected the pushed head to be a new revision.')
+
+    expect(store.listQueuedReviewStatuses()).toEqual([])
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

nuxtseo.com#615 sat for hours showing `▓▓▓▓▓ 95%` and "Next: Push the repair commit" long after the repair commit was pushed and CI had gone green.

One canonical comment serves a whole pull request, but the Queue position sweep only ever adopted a comment published for the current Revision. A Repair pushes its own fix, and that push becomes the next Revision, so the progress comment it left behind belonged to a Revision the pull request had already moved past and no sweep would touch it. The same hole swallowed an in-flight Review comment whenever a person pushed over it. A queued Task now inherits whichever canonical comment the pull request carries, from any Revision, provided that comment is nonterminal. A finished Review comment is left alone, because it still answers the person reading it.

Second commit closes the other half. A paused repository queues Tasks that no agent can claim, and the sweep skipped it entirely, so a pause read as work in progress for as long as it lasted. The comment names the pause now, and goes back to a Queue position on resume.

Between them a nonterminal comment always has an owner: the running Task writes it, a claimable Task's position replaces it, a paused Task's comment says so, and the stopped-review sweep closes out the rest.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).