### PR TITLE
feat(agent): stamp the Review verdict on the pull request

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -2,7 +2,7 @@ import type { Octokit } from 'octokit'
 import type { GitHubTokenProvider } from './github-auth.ts'
 import type { Result } from './result.ts'
 import type { PriorAutomatedReview } from './review-comment.ts'
-import type { GitHubPullRequestItem, GitHubRepositoryAccess, RepositoryMapping } from './types.ts'
+import type { GitHubPullRequestItem, GitHubRepositoryAccess, RepositoryMapping, ReviewOutcomeName } from './types.ts'
 import { hasAutoMergeLabel } from './auto-merge.ts'
 import { pullRequestPurpose } from './baseline-repair-state.ts'
 import { createAuthenticatedClient } from './github-auth.ts'
@@ -10,6 +10,7 @@ import { currentBaseSha } from './github-base.ts'
 import { AUTOMATED_ISSUE_TRIAGE_MARKER } from './issue-triage-comment.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedReviewHead, priorAutomatedReviewForHead } from './review-comment.ts'
+import { planReviewOutcomeLabels, REVIEW_OUTCOME_LABELS } from './review-outcome-label.ts'
 
 /**
  * What the job steps say about a check run GitHub reports as failed.
@@ -171,6 +172,16 @@ export type EditedReviewStatus
 export interface GitHubAgentSource {
   consumeApprovalLabel: (repository: RepositoryMapping, subjectKind: 'issue' | 'pull_request', itemNumber: number, label: string, signal: AbortSignal) => Promise<Result<void, string>>
   ensureApprovalLabel: (repository: RepositoryMapping, label: string, signal: AbortSignal) => Promise<Result<void, string>>
+  /**
+   * Stamps the pull request with the verdict its Review reached.
+   *
+   * The canonical comment states the verdict, but a person choosing what to
+   * review next reads the pull request list. Only labels show there.
+   *
+   * The write is skipped when the pull request already carries the label, so a
+   * rerun that reaches the same verdict costs one read.
+   */
+  stampReviewOutcome: (repository: RepositoryMapping, pullRequestNumber: number, outcome: ReviewOutcomeName, signal: AbortSignal) => Promise<Result<void, string>>
   getIssueTriageSnapshot: (repository: RepositoryMapping, issueNumber: number, signal: AbortSignal) => Promise<Result<IssueTriageSnapshot, string>>
   getPullRequestTemplate: (repository: RepositoryMapping, signal: AbortSignal) => Promise<Result<PullRequestTemplate, string>>
   getPullRequestReviewSnapshot: (repository: RepositoryMapping, pullRequestNumber: number, signal: AbortSignal) => Promise<Result<PullRequestReviewSnapshot, string>>
@@ -355,6 +366,59 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
       if (current.value.some(value => value.toLowerCase() === label.toLowerCase()))
         return removed._tag === 'Err' ? removed : err(`GitHub did not remove the ${label} label.`)
       return ok(undefined)
+    },
+
+    async stampReviewOutcome(repository, pullRequestNumber, outcome, signal) {
+      const octokit = await client(repository.github, 'item_write', signal)
+      if (octokit._tag === 'Err')
+        return octokit
+      const { owner, repo } = repositoryParts(repository.github)
+      const request = { owner, repo, issue_number: pullRequestNumber, request: { signal } }
+      const current = await octokit.value.rest.issues.get(request)
+        .then(response => ok(response.data.labels.flatMap(value => typeof value === 'string' ? [value] : value.name === undefined ? [] : [value.name])))
+        .catch((error: unknown): Result<string[], string> => err(message(error)))
+      if (current._tag === 'Err')
+        return current
+      const plan = planReviewOutcomeLabels(outcome, current.value)
+      if (plan.add === null && plan.remove.length === 0)
+        return ok(undefined)
+      if (plan.add !== null) {
+        const created = await octokit.value.rest.issues.createLabel({
+          owner,
+          repo,
+          name: plan.add.name,
+          color: plan.add.color,
+          description: plan.add.description,
+          request: { signal },
+        })
+          .then((): Result<void, string> => ok(undefined))
+          .catch((error: unknown): Result<void, string> => errorStatus(error) === 422 ? ok(undefined) : err(message(error)))
+        if (created._tag === 'Err')
+          return created
+        const added = await octokit.value.rest.issues.addLabels({ ...request, labels: [plan.add.name] })
+          .then((): Result<void, string> => ok(undefined))
+          .catch((error: unknown): Result<void, string> => err(message(error)))
+        if (added._tag === 'Err')
+          return added
+      }
+      // A label another writer already removed answers this call. Only a label
+      // GitHub still reports after the write is a failure.
+      const removals = await Promise.all(plan.remove.map(label =>
+        octokit.value.rest.issues.removeLabel({ ...request, name: label })
+          .then((): Result<void, string> => ok(undefined))
+          .catch((error: unknown): Result<void, string> => errorStatus(error) === 404 ? ok(undefined) : err(message(error)))))
+      const failed = removals.find(removal => removal._tag === 'Err')
+      if (failed !== undefined)
+        return failed
+      const confirmed = await octokit.value.rest.issues.get(request)
+        .then(response => ok(response.data.labels.flatMap(value => typeof value === 'string' ? [value] : value.name === undefined ? [] : [value.name])))
+        .catch((error: unknown): Result<string[], string> => err(message(error)))
+      if (confirmed._tag === 'Err')
+        return confirmed
+      const settled = planReviewOutcomeLabels(outcome, confirmed.value)
+      return settled.add === null && settled.remove.length === 0
+        ? ok(undefined)
+        : err(`GitHub did not stamp the ${REVIEW_OUTCOME_LABELS[outcome].name} label.`)
     },
 
     async ensureApprovalLabel(repository, label, signal) {

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -15,6 +15,7 @@ import type {
   ReviewFinding,
   ReviewGates,
   ReviewGateState,
+  ReviewOutcomeName,
 } from './types.ts'
 import type { AgentWorkspaceManager } from './worktree.ts'
 import { createHash, randomUUID } from 'node:crypto'
@@ -603,7 +604,7 @@ function reviewGates(snapshot: PullRequestReviewSnapshot, response: ReviewRespon
  * a pull request the agent had answered it did not review, which reads to
  * everyone as "the agent found defects here".
  */
-export function reviewOutcome(gates: ReviewGates): 'READY' | 'PENDING' | 'BLOCKED' {
+export function reviewOutcome(gates: ReviewGates): ReviewOutcomeName {
   const states = Object.values(gates).map(gate => gate._tag)
   if (gates.review._tag === 'Pending')
     return 'PENDING'
@@ -790,6 +791,25 @@ function recordRunnerLostIncident(options: ReviewWorkerOptions, repository: stri
   })
 }
 
+/**
+ * Puts the Review verdict on the pull request itself.
+ *
+ * A person choosing what to review next reads the pull request list, where
+ * only labels show. The canonical comment already carries the verdict, so a
+ * failed stamp costs nothing the reader cannot recover and never fails the
+ * Review. It is reported the way every other cosmetic status write is.
+ */
+async function stampReviewOutcome(
+  options: ReviewWorkerOptions,
+  task: ClaimedAdversarialReviewTask,
+  outcome: ReviewOutcomeName,
+  signal: AbortSignal,
+): Promise<void> {
+  const stamped = await options.github.stampReviewOutcome(task.repositoryMapping, task.pullRequestNumber, outcome, signal)
+  if (stamped._tag === 'Err' && !signal.aborted)
+    options.onProgressPublishFailure?.(task, stamped.error)
+}
+
 export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
   return {
     async run(task, signal) {
@@ -832,6 +852,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
           )
           if (waiting._tag === 'Err')
             return waiting
+          await stampReviewOutcome(options, task, 'PENDING', signal)
           return ok({ evidence: `Waiting for Baseline repair ${baseline.taskId}.` })
         }
       }
@@ -960,7 +981,12 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         })
         if (queued._tag === 'Queued') {
           const reported = await reportReviewProgress(options, task, 'review', { percent: 95, label: 'Repair queued' }, signal)
-          return reported._tag === 'Err' ? reported : ok({ evidence: reviewRunId })
+          if (reported._tag === 'Err')
+            return reported
+          // Repair owns the canonical comment from here, so this is the last
+          // point the Review can state its verdict on the pull request.
+          await stampReviewOutcome(options, task, outcome, signal)
+          return ok({ evidence: reviewRunId })
         }
         findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0
           ? { ...finding, nextAction: queued.reason }
@@ -987,6 +1013,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         return err('The automated review comment could not be saved.')
       if (published._tag === 'Err')
         return published
+      await stampReviewOutcome(options, task, reviewOutcome(gates), signal)
       return ok({ evidence: reviewRunId })
     },
   }

--- a/packages/harlan-github-agent/src/review-outcome-label.ts
+++ b/packages/harlan-github-agent/src/review-outcome-label.ts
@@ -1,0 +1,59 @@
+import type { ReviewOutcomeName } from './types.ts'
+
+export interface ReviewOutcomeLabelDefinition {
+  name: string
+  color: string
+  description: string
+}
+
+/**
+ * The pull request label a finished Review stamps.
+ *
+ * The canonical comment already states the verdict, but a person deciding what
+ * to review next reads a list of pull requests, not a list of comments. The
+ * label carries the same word the comment heading uses, so the two never
+ * disagree.
+ */
+export const REVIEW_OUTCOME_LABELS = {
+  READY: {
+    name: 'harlan-agent-ready',
+    color: '0e8a16',
+    description: 'The automated Review passed every gate on this head commit.',
+  },
+  PENDING: {
+    name: 'harlan-agent-pending',
+    color: 'fbca04',
+    description: 'The automated Review is waiting on a gate for this head commit.',
+  },
+  BLOCKED: {
+    name: 'harlan-agent-blocked',
+    color: 'd73a4a',
+    description: 'The automated Review found a material defect in this head commit.',
+  },
+} as const satisfies Record<ReviewOutcomeName, ReviewOutcomeLabelDefinition>
+
+/**
+ * The label writes one Review outcome needs.
+ *
+ * `add` is null when the pull request already carries the right label, so an
+ * unchanged verdict writes nothing to GitHub. `remove` never names a label
+ * outside this set: a person's own labels are theirs.
+ */
+export interface ReviewOutcomeLabelPlan {
+  add: ReviewOutcomeLabelDefinition | null
+  remove: string[]
+}
+
+const ownedLabels = new Set(Object.values(REVIEW_OUTCOME_LABELS).map(label => label.name.toLowerCase()))
+
+export function planReviewOutcomeLabels(outcome: ReviewOutcomeName, current: string[]): ReviewOutcomeLabelPlan {
+  const wanted = REVIEW_OUTCOME_LABELS[outcome]
+  const present = current.map(label => label.toLowerCase())
+  return {
+    add: present.includes(wanted.name.toLowerCase()) ? null : wanted,
+    // One head commit reached one verdict. A second outcome label on the same
+    // pull request states a second one, so every other outcome label goes.
+    remove: current.filter(label =>
+      ownedLabels.has(label.toLowerCase()) && label.toLowerCase() !== wanted.name.toLowerCase()),
+  }
+}

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -234,6 +234,9 @@ export type ReviewOutcome
     | { _tag: 'Pending' }
     | { _tag: 'Blocked' }
 
+/** How a Review outcome is spelled where a person reads it, in the canonical comment heading and on the pull request label. */
+export type ReviewOutcomeName = Uppercase<ReviewOutcome['_tag']>
+
 export type ReviewPublicationResult
   = | { _tag: 'Published', githubCommentId: number, url: string }
     | { _tag: 'Failed', reason: string }

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -39,6 +39,7 @@ describe('subject Workers', () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const capture: ProviderCapture = { requests: [] }
     const comments: string[] = []
+    const stamped: string[] = []
     let attempt: RecordReviewRunInput | undefined
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
@@ -53,6 +54,10 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: (_repository, _number, outcome) => {
+          stamped.push(outcome)
+          return Promise.resolve(ok(undefined))
+        },
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -126,6 +131,7 @@ describe('subject Workers', () => {
     expect(comments[3]).toContain('REVIEWING · Preparing the review comment')
     expect(comments[5]).toContain('READY · 96/100')
     expect(comments[5]).toContain('▓▓▓▓▓ 100%')
+    expect(stamped).toEqual(['READY'])
     expect(attempt).toEqual(expect.objectContaining({ model: 'gpt-5.6-sol', confidence: 96 }))
     expect(capture.requests).toEqual([expect.objectContaining({ model: 'gpt-5.6-sol', reasoningEffort: 'high' })])
   })
@@ -140,6 +146,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -237,6 +244,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -343,6 +351,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -437,6 +446,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -529,6 +539,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -614,6 +625,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -698,6 +710,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -779,6 +792,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
@@ -861,6 +875,7 @@ describe('subject Workers', () => {
         consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
         editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
         ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        stampReviewOutcome: () => Promise.resolve(ok(undefined)),
         getIssueTriageSnapshot: () => Promise.resolve(ok({ body: 'Reproduction', comments: [], state: 'open', title: issue.title, updatedAt: issue.updatedAt })),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -63,6 +63,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], requiredChecks: Required
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      stampReviewOutcome: () => Promise.resolve(ok(undefined)),
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       listPullRequestFiles: () => Promise.reject(new Error('Unexpected file listing.')),
       getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),

--- a/packages/harlan-github-agent/test/review-outcome-label.test.ts
+++ b/packages/harlan-github-agent/test/review-outcome-label.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { planReviewOutcomeLabels, REVIEW_OUTCOME_LABELS } from '../src/review-outcome-label.ts'
+
+describe('planReviewOutcomeLabels', () => {
+  it('adds the label for the verdict the Review reached', () => {
+    expect(planReviewOutcomeLabels('READY', [])).toEqual({
+      add: REVIEW_OUTCOME_LABELS.READY,
+      remove: [],
+    })
+  })
+
+  it('clears the verdict a head commit no longer holds', () => {
+    expect(planReviewOutcomeLabels('BLOCKED', ['harlan-agent-ready'])).toEqual({
+      add: REVIEW_OUTCOME_LABELS.BLOCKED,
+      remove: ['harlan-agent-ready'],
+    })
+  })
+
+  it('writes nothing when the pull request already states this verdict', () => {
+    expect(planReviewOutcomeLabels('PENDING', ['harlan-agent-pending'])).toEqual({ add: null, remove: [] })
+  })
+
+  it('leaves every label the service does not own', () => {
+    const plan = planReviewOutcomeLabels('READY', ['bug', 'harlan-agent-auto-merge', 'harlan-agent-review'])
+
+    expect(plan.remove).toEqual([])
+    expect(plan.add).toEqual(REVIEW_OUTCOME_LABELS.READY)
+  })
+
+  it('removes a second verdict GitHub reports in any casing', () => {
+    expect(planReviewOutcomeLabels('READY', ['Harlan-Agent-Blocked', 'harlan-agent-ready']).remove)
+      .toEqual(['Harlan-Agent-Blocked'])
+  })
+
+  it('gives each verdict its own label, so two verdicts never read alike', () => {
+    const names = Object.values(REVIEW_OUTCOME_LABELS).map(label => label.name)
+
+    expect(new Set(names).size).toBe(names.length)
+  })
+})

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -92,6 +92,7 @@ function harness(input: {
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      stampReviewOutcome: () => Promise.resolve(ok(undefined)),
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
       listPullRequestFiles: () => Promise.resolve(ok([])),

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -71,6 +71,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], baseChecks?: GitHubCheck
       consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      stampReviewOutcome: () => Promise.resolve(ok(undefined)),
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       listPullRequestFiles: () => Promise.reject(new Error('Unexpected file listing.')),
       getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

Deciding what to review next means opening pull requests one at a time to find the ones the agent already passed. The verdict exists, it just lives inside the canonical comment where the list cannot show it.

A finished Review now stamps one label: `harlan-agent-ready`, `harlan-agent-pending` or `harlan-agent-blocked`, using the same word its comment heading uses. It clears the other two, so one head commit never shows two verdicts. A Review that hands findings to Repair stamps before it lets go of the comment, so a pull request under repair reads blocked rather than unlabelled. Labels a person added are never touched.

The label describes the head the Review last answered for. Push a new commit and it keeps the old verdict until the next Review finishes, the same way the comment does. Worth clearing on a new head if that bites; I left it out rather than adding a GitHub write to the poller for it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).