### PR TITLE
chore(agent): give every automated comment one voice

### DIFF
--- a/packages/harlan-github-agent/src/approval-controller.ts
+++ b/packages/harlan-github-agent/src/approval-controller.ts
@@ -4,7 +4,7 @@ import type { JournalStore } from './store.ts'
 import type { GitHubItem, GitHubPullRequestItem, RepositoryMapping } from './types.ts'
 import { APPROVAL_LABELS } from './approval-labels.ts'
 import { err, ok } from './result.ts'
-import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
+import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 
 export interface ApprovalController {
   reconcile: (repository: RepositoryMapping, subject: GitHubItem, revisionId: string, signal: AbortSignal) => Promise<Result<void, string>>
@@ -21,7 +21,7 @@ function approvalPrompt(label: string, headSha: string): string {
 <!-- reviewed-sha: ${headSha} -->
 ### 🤖 REVIEW PAUSED
 
-> Harlan GitHub Agent posted this automated comment. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source).
+${automatedDisclosure({ kind: 'status' })}
 
 This pull request is from an outside contributor. Add the \`${label}\` label to approve automated review and verified repairs for head commit \`${headSha.slice(0, 12)}\`.`
 }

--- a/packages/harlan-github-agent/src/issue-triage-comment.ts
+++ b/packages/harlan-github-agent/src/issue-triage-comment.ts
@@ -1,3 +1,5 @@
+import { automatedDisclosure } from './review-comment.ts'
+
 export const AUTOMATED_ISSUE_TRIAGE_MARKER = '<!-- harlan-agent-kit:issue-triage -->'
 
 export interface IssueTriageCommentInput {
@@ -20,9 +22,9 @@ function validityLabel(validity: IssueTriageCommentInput['validity']): string {
 
 export function issueTriageComment(input: IssueTriageCommentInput): string {
   return `${AUTOMATED_ISSUE_TRIAGE_MARKER}
-### 🤖 Issue triage
+### 🤖 ISSUE TRIAGE
 
-> Harlan Agent Kit posted this automated triage. It is not Harlan's personal assessment or commitment.
+${automatedDisclosure({ kind: 'triage', disclaimer: `It is not Harlan's personal assessment or commitment.` })}
 
 - **Validity:** ${validityLabel(input.validity)}
 - **Difficulty:** ${input.difficulty}/5

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -24,7 +24,7 @@ import { currentGitHubChecks } from './github-agent-source.ts'
 import { issueTriageComment } from './issue-triage-comment.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
-import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
+import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 import { cleanLine, updatedAtLabel } from './text.ts'
 
 interface GateResponse {
@@ -615,7 +615,7 @@ function progressComment(headSha: string, progress: AgentProgress, at: string): 
 <!-- reviewed-sha: ${headSha} -->
 ### 🤖 REVIEWING · ${progress.label}
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Last updated: ${updatedAtLabel(at)}.
+${automatedDisclosure({ kind: 'review', updatedAt: updatedAtLabel(at) })}
 
 \`${formatProgressBar(progress.percent)}\`
 
@@ -629,11 +629,11 @@ function baselineWaitingComment(headSha: string, baseSha: string, at: string): s
 <!-- workflow-state: ${workflow} -->
 ### 🤖 WAITING
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated status. Last updated: ${updatedAtLabel(at)}.
+${automatedDisclosure({ kind: 'status', updatedAt: updatedAtLabel(at) })}
 
 \`${formatProgressBar(100)}\`
 
-Base branch CI fails at \`${baseSha}\`.
+Base branch CI fails at \`${baseSha.slice(0, 12)}\`.
 
 Next: merge or repair the marked Baseline repair pull request.`
 }
@@ -644,7 +644,14 @@ function terminalComment(headSha: string, gates: ReviewGates, findings: ReviewFi
   const reason = result === 'PENDING'
     ? Object.values(gates).find(gate => gate._tag === 'Pending')
     : undefined
-  const disclosure = `> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. It is not Harlan's personal review or approval. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Human merge decision still required.${reason?._tag === 'Pending' ? ` Waiting: ${cleanLine(reason.reason)}` : ''}`
+  const disclosure = automatedDisclosure({
+    kind: 'review',
+    disclaimer: `It is not Harlan's personal review or approval.`,
+    notes: [
+      'A person still decides the merge.',
+      ...(reason?._tag === 'Pending' ? [`Waiting: ${cleanLine(reason.reason)}`] : []),
+    ],
+  })
   const findingLines = findings.map(finding => finding._tag === 'Fixed'
     ? `- **Fixed:** ${cleanLine(finding.summary)}`
     : finding.resolution === 'Dismissal'

--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -4,7 +4,7 @@ import type { JournalStore, QueuedReviewStatus } from './store.ts'
 import type { RepositoryMapping } from './types.ts'
 import { formatProgressBar } from './agent-progress.ts'
 import { err, ok } from './result.ts'
-import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
+import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 
 const workLabel: Record<QueuedReviewStatus['taskKind'], string> = {
   adversarial_review: 'Review',
@@ -38,7 +38,7 @@ export function queuePositionComment(status: QueuedReviewStatus): string {
 <!-- reviewed-sha: ${status.headSha} -->
 ### 🤖 QUEUED · ${ordinal(status.position)} of ${status.total}
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). This comment updates as the Queue moves.
+${automatedDisclosure({ kind: 'review', notes: ['This comment updates as the Queue moves.'] })}
 
 \`${formatProgressBar(0)}\`
 

--- a/packages/harlan-github-agent/src/review-comment.ts
+++ b/packages/harlan-github-agent/src/review-comment.ts
@@ -2,6 +2,37 @@ export const AUTOMATED_REVIEW_MARKER = '<!-- harlan-agent-kit:pr-triage -->'
 /** The login the GitHub App posts as. */
 export const AGENT_ACTOR_LOGIN = 'harlan-github-agent[bot]'
 
+const AGENT_LINK = '[Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit)'
+const POLICY_LINK = '[AI open source policy](https://harlanzw.com/blog/ai-in-open-source)'
+
+export interface AutomatedDisclosure {
+  /** What this comment is, as one noun. The reader sees it in the first sentence. */
+  kind: 'review' | 'repair update' | 'status' | 'triage'
+  /** Says the comment is not Harlan speaking, where a reader could take it that way. */
+  disclaimer?: string
+  /** Sentences after the policy link, before the timestamp. */
+  notes?: string[]
+  /** Absent on a comment that carries no timestamp, so an unchanged body writes nothing. */
+  updatedAt?: string
+}
+
+/**
+ * The disclosure line every automated comment carries.
+ *
+ * Eight templates wrote eight versions of this sentence, under two different
+ * names for the same bot, and one of them linked no policy at all. A reader
+ * cannot tell one bot from two. One function means one name and one wording.
+ */
+export function automatedDisclosure(input: AutomatedDisclosure): string {
+  return `> ${[
+    `${AGENT_LINK} posted this automated ${input.kind}.`,
+    ...(input.disclaimer === undefined ? [] : [input.disclaimer]),
+    `${POLICY_LINK}.`,
+    ...(input.notes ?? []),
+    ...(input.updatedAt === undefined ? [] : [`Last updated: ${input.updatedAt}.`]),
+  ].join(' ')}`
+}
+
 export type PriorAutomatedReview
   = | { _tag: 'None' }
     | {

--- a/packages/harlan-github-agent/src/review-status-controller.ts
+++ b/packages/harlan-github-agent/src/review-status-controller.ts
@@ -4,7 +4,7 @@ import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedAdversarialReviewTask, ClaimedReviewFixTask, ReviewStatusTaskPhase } from './types.ts'
 import { formatProgressBar } from './agent-progress.ts'
 import { err, ok } from './result.ts'
-import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
+import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 import { updatedAtLabel } from './text.ts'
 
 export interface ReviewStatusController {
@@ -21,20 +21,23 @@ export interface ReviewStatusControllerOptions {
 }
 
 function repairProgressComment(headSha: string, progress: AgentProgress, at: string): string {
+  // Declarative, and about the Repair rather than the reader. These lines read
+  // as instructions to whoever opened the pull request when they are imperative,
+  // and every other automated comment states what the work does next.
   const next = progress.percent >= 90
-    ? 'Push the repair commit, then review the new head.'
+    ? 'Repair pushes its commit, then a new Review reads the new head.'
     : progress.percent >= 70
-      ? 'Verify the repair.'
+      ? 'Repair verifies its fix.'
       : progress.percent >= 55
-        ? 'Finish the repair.'
+        ? 'Repair finishes its fix.'
         : progress.percent >= 35
-          ? 'Repair the review findings.'
-          : 'Create a Git worktree.'
+          ? 'Repair fixes the Review findings.'
+          : 'Repair creates its Git worktree.'
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${headSha} -->
 ### 🤖 REPAIR · ${progress.label}
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated repair update. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Last updated: ${updatedAtLabel(at)}.
+${automatedDisclosure({ kind: 'repair update', updatedAt: updatedAtLabel(at) })}
 
 \`${formatProgressBar(progress.percent)}\`
 

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -4,7 +4,7 @@ import type { JournalStore, StoppedReview } from './store.ts'
 import type { RepositoryMapping } from './types.ts'
 import { formatProgressBar } from './agent-progress.ts'
 import { err, ok } from './result.ts'
-import { AUTOMATED_REVIEW_MARKER } from './review-comment.ts'
+import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 import { cleanLine, updatedAtLabel } from './text.ts'
 
 export type StoppedReviewOutcome
@@ -40,7 +40,7 @@ export function stoppedReviewComment(
 <!-- workflow-state: ${workflow} -->
 ### 🤖 ${disposition._tag.toUpperCase()}
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. It is not Harlan's personal review or approval. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Last updated: ${updatedAtLabel(at)}.
+${automatedDisclosure({ kind: 'review', disclaimer: `It is not Harlan's personal review or approval.`, updatedAt: updatedAtLabel(at) })}
 
 \`${formatProgressBar(100)}\`
 
@@ -54,7 +54,7 @@ GitHub ${action} this pull request. The unfinished automated review stopped.`
 <!-- reviewed-sha: ${review.headSha} -->
 ### 🤖 BLOCKED
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. It is not Harlan's personal review or approval. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Human merge decision still required. Last updated: ${updatedAtLabel(at)}.
+${automatedDisclosure({ kind: 'review', disclaimer: `It is not Harlan's personal review or approval.`, notes: ['A person still decides the merge.'], updatedAt: updatedAtLabel(at) })}
 
 \`${formatProgressBar(100)}\`
 
@@ -66,13 +66,13 @@ ${findings.join('\n')}`
 <!-- reviewed-sha: ${review.headSha} -->
 ### 🤖 STOPPED
 
-> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated review. It is not Harlan's personal review or approval. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source). Human merge decision still required. Last updated: ${updatedAtLabel(at)}.
+${automatedDisclosure({ kind: 'review', disclaimer: `It is not Harlan's personal review or approval.`, notes: ['A person still decides the merge.'], updatedAt: updatedAtLabel(at) })}
 
 \`${formatProgressBar(100)}\`
 
-The automated review stopped before it finished. Reason: ${cleanLine(review.reason)}
+The automated review stopped. Reason: ${cleanLine(review.reason)}
 
-Push a new commit or ask for a review rerun to start a new review.`
+Push a new commit to start a new review. To review this commit again, comment \`/harlan-agent rerun\`.`
 }
 
 /**

--- a/packages/harlan-github-agent/test/approval-controller.test.ts
+++ b/packages/harlan-github-agent/test/approval-controller.test.ts
@@ -59,7 +59,7 @@ describe('approval controller', () => {
     })
 
     expect(await controller.reconcile(repositoryMapping(), pullRequestItem({ author: 'contributor' }), 'a'.repeat(64), new AbortController().signal)).toEqual(ok(undefined))
-    expect(body).toContain('Harlan GitHub Agent posted this automated comment.')
+    expect(body).toContain('[Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated status.')
     expect(body).toContain('<!-- reviewed-sha: abc123 -->')
     expect(body).toContain('`harlan-agent-review` label')
     expect(body).toContain('head commit `abc123`')

--- a/packages/harlan-github-agent/test/automated-disclosure.test.ts
+++ b/packages/harlan-github-agent/test/automated-disclosure.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { automatedDisclosure } from '../src/review-comment.ts'
+
+describe('automatedDisclosure', () => {
+  it('names the bot once and links the policy, whatever the comment is', () => {
+    const kinds = ['review', 'repair update', 'status', 'triage'] as const
+
+    kinds.forEach((kind) => {
+      const line = automatedDisclosure({ kind })
+
+      expect(line).toContain('[Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated')
+      expect(line).toContain('[AI open source policy](https://harlanzw.com/blog/ai-in-open-source).')
+      expect(line).toContain(`automated ${kind}.`)
+    })
+  })
+
+  it('reads as one quoted line, so a comment never breaks its own blockquote', () => {
+    const line = automatedDisclosure({
+      kind: 'review',
+      disclaimer: 'It is not Harlan\'s personal review or approval.',
+      notes: ['A person still decides the merge.'],
+      updatedAt: '2026-08-27 03:02 UTC',
+    })
+
+    expect(line.split('\n')).toHaveLength(1)
+    expect(line.startsWith('> ')).toBe(true)
+  })
+
+  it('puts the disclaimer before the policy and the timestamp last', () => {
+    const line = automatedDisclosure({
+      kind: 'review',
+      disclaimer: 'Disclaimed.',
+      notes: ['Noted.'],
+      updatedAt: '2026-08-27 03:02 UTC',
+    })
+
+    expect(line.indexOf('Disclaimed.')).toBeLessThan(line.indexOf('AI open source policy'))
+    expect(line.indexOf('Noted.')).toBeLessThan(line.indexOf('Last updated'))
+    expect(line.endsWith('Last updated: 2026-08-27 03:02 UTC.')).toBe(true)
+  })
+
+  it('leaves out the timestamp, so a comment that repeats itself writes nothing', () => {
+    expect(automatedDisclosure({ kind: 'review' })).not.toContain('Last updated')
+  })
+})

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -916,9 +916,9 @@ describe('subject Workers', () => {
     })
     expect(capture.requests).toEqual([expect.objectContaining({ model: 'gpt-5.6-terra', reasoningEffort: 'medium', sessionId: null })])
     expect(triageBody).toBe(`<!-- harlan-agent-kit:issue-triage -->
-### 🤖 Issue triage
+### 🤖 ISSUE TRIAGE
 
-> Harlan Agent Kit posted this automated triage. It is not Harlan's personal assessment or commitment.
+> [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) posted this automated triage. It is not Harlan's personal assessment or commitment. [AI open source policy](https://harlanzw.com/blog/ai-in-open-source).
 
 - **Validity:** Valid
 - **Difficulty:** 2/5


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Reading the eight comment templates side by side, the bot does not sound like one thing. It signs itself "Harlan GitHub Agent" on the approval prompt and "Harlan Agent Kit" everywhere else. It calls itself an automated review, an automated status, an automated comment and an automated triage. The issue triage comment links no AI policy at all, and its heading is sentence case against READY, BLOCKED, QUEUED, WAITING and STOPPED everywhere else. A contributor cannot tell whether one bot or two is on their pull request.

One `automatedDisclosure` function writes that line now, so the four variants cannot drift apart again.

The rest is wording:

- "The automated review stopped before it finished" said stopped twice. Now: "The automated review stopped."
- "Push a new commit or ask for a review rerun to start a new review" used review three times and never named the command. Now it names `/harlan-agent rerun`.
- "Human merge decision still required" had no actor. Now: "A person still decides the merge."
- Repair progress read "Verify the repair", which a contributor takes as an instruction to them. Now: "Repair verifies its fix", matching how the Queue comment already talks about itself.
- The Baseline waiting comment printed a 40 character base SHA where every other comment prints 12.

Left alone: the dashboard and CLI text, which nobody outside this machine reads.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).