### PR TITLE
fix(agent): close out the comment on a merged pull request whose head moved

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -7241,9 +7241,13 @@ export function openJournalStore(
     WHERE stopped.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
       AND published.phase != 'terminal'
       AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
-      -- GitHub closure creates a new Revision. The stopped Review still owns
-      -- the canonical comment while GitHub reports the same exact head SHA.
-      AND json_extract(current_revisions.payload, '$.headSha') = json_extract(revisions.payload, '$.headSha')
+      -- A closed pull request takes no more work, so its last Task still owns
+      -- the canonical comment however far the head moved first. An open one
+      -- hands the comment to the Task queued for its current head instead.
+      AND (
+        json_extract(current_revisions.payload, '$.headSha') = json_extract(revisions.payload, '$.headSha')
+        OR json_extract(current_revisions.payload, '$.state') = 'closed'
+      )
       AND repositories.enabled = 1
       AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
       -- Repair owns the canonical comment after Review hands work to it.
@@ -7306,7 +7310,10 @@ export function openJournalStore(
           AND ${taskTable}.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
           AND ${taskTable}.revision_id = ?
           AND json_extract(task_revision.payload, '$.headSha') = ?
-          AND json_extract(current_revision.payload, '$.headSha') = ?
+          AND (
+            json_extract(current_revision.payload, '$.headSha') = ?
+            OR json_extract(current_revision.payload, '$.state') = 'closed'
+          )
       `).get(
         input.taskId,
         input.taskKind,

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1431,6 +1431,93 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
+  it('keeps a stopped Review eligible when the merge carried a head its Review never saw', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const observed = store.recordObservation({
+      externalId: 'repaired-before-merge',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request Revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'review',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 REVIEWING · Git worktree ready',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:03.000Z',
+      evidence: 'Repair queued.',
+    })).toBe(true)
+
+    // A commit landed on the branch, then GitHub merged it. Two Revisions
+    // separate the merge from the head this Review answered for.
+    store.recordObservation({
+      externalId: 'repaired-head',
+      observedAt: '2026-08-13T01:03:00.000Z',
+      source: 'poll',
+      subject: { ...pullRequest, headSha: 'repaired24', updatedAt: '2026-08-13T01:03:00.000Z' },
+    })
+    store.recordObservation({
+      externalId: 'repaired-merged',
+      observedAt: '2026-08-13T01:04:00.000Z',
+      source: 'poll',
+      subject: {
+        ...pullRequest,
+        headSha: 'repaired24',
+        state: 'closed',
+        mergedAt: '2026-08-13T01:04:00.000Z',
+        updatedAt: '2026-08-13T01:04:00.000Z',
+      },
+    })
+
+    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
+      taskId: review.id,
+      revisionId: observed.revisionId,
+      headSha: pullRequest.headSha,
+      commentId: 42,
+    })])
+    expect(store.recordStoppedReviewStatus({
+      taskId: review.id,
+      taskKind: 'adversarial_review',
+      revisionId: observed.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 MERGED',
+      at: '2026-08-13T01:05:00.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })).toBe(true)
+    expect(store.listStoppedReviews()).toEqual([])
+  })
+
   it('lists the open pull requests this service opened, so a new one can stack on them', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### 🔗 Linked issue

Follows #45.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

nuxtseo.com#615 is merged and still reads "🤖 REPAIR · Repair ready to publish · Next: Push the repair commit". That is the same pull request #45 was written for, so the hole is worth naming precisely.

The stopped-review sweep only claimed a comment while GitHub still reported the head its Task ran on. The gate was written for closure, which creates a Revision at the same head. 615 took the repair commit first and then merged, so it moved twice and fell outside. #45 hands a nonterminal comment to the next queued Task, and a merged pull request queues nothing, so nothing owned it.

A closed pull request takes no more work, so its last Task keeps the comment however far the head moved first. An open one still hands it to the Task queued for the current head. `publishStoppedReviews` already refused an open pull request with a moved head, so only the query was stricter than the sweep it feeds.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).