### PR TITLE
fix(agent): stop one new pull request rewriting every queued comment

### DIFF
--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -22,15 +22,20 @@ function ordinal(position: number): string {
 /**
  * The canonical comment while its Task waits in the Queue.
  *
- * No timestamp and no estimate. The comment carries one changing fact, the
- * Queue position, so an unchanged position renders an identical body and the
- * sweep writes nothing. A timestamp here would edit every comment every pass.
+ * No timestamp, no estimate, and no Queue length. The comment carries one
+ * changing fact, this Task's own position, so a Task nobody overtook renders
+ * an identical body and the sweep writes nothing.
+ *
+ * The length used to appear as "3rd of 7". Every Task joining the Queue moved
+ * that number, so one new pull request rewrote the comment on every other
+ * waiting pull request, once per poll. A position moves only when the Task
+ * ahead leaves, which is the fact worth an edit.
  */
 export function queuePositionComment(status: QueuedReviewStatus): string {
   const work = workLabel[status.taskKind]
   const heading = status.queue._tag === 'Paused'
     ? 'PAUSED'
-    : `QUEUED · ${ordinal(status.queue.position)} of ${status.queue.total}`
+    : `QUEUED · ${ordinal(status.queue.position)}`
   const ahead = status.queue._tag === 'Paused' ? 0 : status.queue.position - 1
   const next = status.queue._tag === 'Paused'
     ? `${work} starts when this repository resumes.`

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -36,7 +36,7 @@ describe('queuePositionComment', () => {
   it('states the exact position and how many Tasks come first', () => {
     const body = queuePositionComment(queuedRepair())
 
-    expect(body).toContain('### 🤖 QUEUED · 3rd of 7')
+    expect(body).toContain('### 🤖 QUEUED · 3rd')
     expect(body).toContain('Next: Repair starts after the 2 Tasks ahead of it finish.')
     expect(body).toContain('░░░░░ 0%')
   })
@@ -55,6 +55,13 @@ describe('queuePositionComment', () => {
     expect(queuePositionComment(queuedRepair())).toBe(queuePositionComment(queuedRepair()))
   })
 
+  it('ignores the Queue length, so a Task joining behind rewrites nothing', () => {
+    const before = queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 3, total: 7 } }))
+    const after = queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 3, total: 40 } }))
+
+    expect(after).toBe(before)
+  })
+
   it('names the pause, because a position on a paused repository never moves', () => {
     const body = queuePositionComment(queuedRepair({ queue: { _tag: 'Paused' } }))
 
@@ -63,8 +70,8 @@ describe('queuePositionComment', () => {
   })
 
   it('writes an ordinal a person reads, not a number with a wrong suffix', () => {
-    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 11, total: 20 } }))).toContain('11th of 20')
-    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 22, total: 30 } }))).toContain('22nd of 30')
+    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 11, total: 20 } }))).toContain('QUEUED · 11th')
+    expect(queuePositionComment(queuedRepair({ queue: { _tag: 'Waiting', position: 22, total: 30 } }))).toContain('QUEUED · 22nd')
   })
 })
 
@@ -94,7 +101,7 @@ describe('publishQueuePositions', () => {
 
     expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24, queue: { _tag: 'Waiting', position: 3, total: 7 } })])
     expect(edited?.commentId).toBe(42)
-    expect(edited?.body).toContain('### 🤖 QUEUED · 3rd of 7')
+    expect(edited?.body).toContain('### 🤖 QUEUED · 3rd')
     expect(recorded?.taskId).toBe('repair-task')
     expect(recorded?.body).toBe(edited?.body)
   })


### PR DESCRIPTION
### 🔗 Linked issue

Follows #45.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Watching the service after #45 shipped, every queued pull request had its comment edited on every poll pass:

```
13:52:13  #609: the comment now reads Queue position 2 of 5.
13:53:37  #609: the comment now reads Queue position 2 of 6.
13:55:10  #609: the comment now reads Queue position 2 of 7.
```

609 had not moved. The Queue grew behind it, and the comment carried the Queue length, so one new pull request rewrote the comment on every other waiting one. #45 widened the population the sweep covers, which is what made it show.

The comment states its own position now, `🤖 QUEUED · 2nd`. That moves only when the Task ahead of it leaves. The "Next: Review starts after the 1 Task ahead of it finishes" line already said the same thing in words, so nothing a reader used is gone. The Queue length still goes to the log, where churn is free.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).