### PR TITLE
fix(agent): stabilize runner backpressure

### DIFF
--- a/packages/harlan-github-agent/bin/harlan-github-runner-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-runner-indicator
@@ -8,6 +8,7 @@ import subprocess
 import threading
 import time
 import webbrowser
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -118,43 +119,53 @@ def runner_activity(runner, logs):
     return {'_tag': 'Starting'}
 
 
-def request_runners(host):
+def request_runners(host, run=None):
+    run = run or subprocess.run
     docker = ['docker', '--host', host['dockerHost']]
-    completed = subprocess.run(
+    completed = run(
         [*docker, 'ps', '--all', '--filter', f'label={RUNNER_LABEL}', '--format', '{{json .}}'],
         check=True,
         capture_output=True,
         text=True,
         timeout=4,
     )
-    runners = []
+    listed_runners = []
     for line in completed.stdout.splitlines():
         if not line:
             continue
-        runner = json.loads(line)
-        logs = subprocess.run(
+        listed_runners.append(json.loads(line))
+
+    def read_runner(runner):
+        if runner.get('State', '').lower() != 'running':
+            activity = runner_activity(runner, '')
+        else:
+            logs = run(
             [*docker, 'logs', '--tail', '80', runner['ID']],
             check=False,
             capture_output=True,
             text=True,
             timeout=3,
         )
-        activity = runner_activity(runner, logs.stdout + logs.stderr) if logs.returncode == 0 else {
-            '_tag': 'Unknown',
-            'detail': logs.stderr.strip() or 'Runner logs unavailable',
-        }
-        runners.append({
+            if logs.returncode != 0 and 'no such container' in logs.stderr.lower():
+                return None
+            activity = runner_activity(runner, logs.stdout + logs.stderr) if logs.returncode == 0 else {
+                '_tag': 'Unknown',
+                'detail': logs.stderr.strip() or 'Runner logs unavailable',
+            }
+        return {
             **runner,
             'Activity': activity,
             'RunnerLabels': parse_labels(runner.get('Labels', '')),
             'Host': host['name'],
-        })
-    return runners
+        }
+
+    if not listed_runners:
+        return []
+    with ThreadPoolExecutor(max_workers=min(8, len(listed_runners))) as executor:
+        return [runner for runner in executor.map(read_runner, listed_runners) if runner is not None]
 
 
-def request_runner_hosts(hosts):
-    results = []
-    for host in hosts:
+def request_runner_host(host):
         control = None
         if host.get('control') is not None:
             try:
@@ -181,8 +192,14 @@ def request_runner_hosts(hosts):
             result['dockerHost'] = host['dockerHost']
             result['service'] = host['control']
             result['control'] = control
-        results.append(result)
-    return results
+        return result
+
+
+def request_runner_hosts(hosts):
+    if not hosts:
+        return []
+    with ThreadPoolExecutor(max_workers=len(hosts)) as executor:
+        return list(executor.map(request_runner_host, hosts))
 
 
 def read_runner_source(fetch_runner_hosts):
@@ -190,6 +207,46 @@ def read_runner_source(fetch_runner_hosts):
         return {'_tag': 'Available', 'hosts': fetch_runner_hosts()}
     except Exception as caught:
         return {'_tag': 'Unavailable', 'message': str(caught)}
+
+
+def merge_runner_source(previous, current, now=None):
+    now = time.monotonic() if now is None else now
+    if current['_tag'] == 'Unavailable':
+        if previous is None or previous['_tag'] != 'Available':
+            return current
+        return {
+            '_tag': 'Available',
+            'hosts': [{
+                **host,
+                'stale': {
+                    'message': current['message'],
+                    'observedAt': host.get('observedAt', now),
+                },
+            } for host in previous['hosts']],
+        }
+
+    previous_hosts = {
+        host['name']: host
+        for host in previous.get('hosts', [])
+    } if previous is not None and previous['_tag'] == 'Available' else {}
+    hosts = []
+    for host in current['hosts']:
+        if host['_tag'] == 'Available':
+            hosts.append({**host, 'observedAt': now})
+            continue
+        last_known = previous_hosts.get(host['name'])
+        if last_known is None or last_known['_tag'] != 'Available':
+            hosts.append(host)
+            continue
+        hosts.append({
+            **last_known,
+            **{key: value for key, value in host.items() if key in ('dockerHost', 'service', 'control')},
+            'stale': {
+                'message': host['message'],
+                'observedAt': last_known.get('observedAt', now),
+            },
+        })
+    return {'_tag': 'Available', 'hosts': hosts}
 
 
 WORKFLOW_RUNS_PAGE_SIZE = 50
@@ -239,9 +296,9 @@ def request_run_jobs(repository, run_id):
 
 
 def request_workflow_jobs(repositories, on_error=None):
-    jobs = []
-    for repository in repositories:
+    def request_repository(repository):
         try:
+            jobs = []
             for status in ('queued', 'in_progress'):
                 page = 1
                 while True:
@@ -256,9 +313,19 @@ def request_workflow_jobs(repositories, on_error=None):
                     if len(runs) < WORKFLOW_RUNS_PAGE_SIZE:
                         break
                     page += 1
+            return jobs, None
         except Exception as caught:
-            if on_error is not None:
-                on_error(f'{repository} · Jobs unavailable · {caught}')
+            return [], f'{repository} · Jobs unavailable · {caught}'
+
+    if not repositories:
+        return []
+    with ThreadPoolExecutor(max_workers=min(8, len(repositories))) as executor:
+        results = list(executor.map(request_repository, repositories))
+    jobs = []
+    for repository_jobs, error in results:
+        jobs.extend(repository_jobs)
+        if error is not None and on_error is not None:
+            on_error(error)
     return jobs
 
 
@@ -333,11 +400,15 @@ def github_actions_status_label(runners, error):
     return ' · '.join((f'{marker} {counted(len(runners), "self-hosted runner")}', *states))
 
 
-def runner_host_status_label(host):
+def runner_host_status_label(host, now=None):
     if host['_tag'] == 'Unavailable':
         return f"🔴 {host['name']} · unavailable · {host['message'][:100]}"
     status = github_actions_status_label(host['runners'], None)
     marker, detail = status.split(' ', 1)
+    if host.get('stale') is not None:
+        now = time.monotonic() if now is None else now
+        age = max(0, int(now - host['stale']['observedAt']))
+        return f"🟠 {host['name']} · last known status {age}s old · {detail}"
     return f"{marker} {host['name']} · {detail}"
 
 
@@ -526,15 +597,17 @@ def main():
     refreshing = {'active': False}
     pending_action = {'value': None}
     jobs_cache = {'source': {'_tag': 'Loading'}, 'updatedAt': 0.0}
+    runner_cache = {'source': None}
 
-    def apply_state(source, jobs_source, action_error):
-        refreshing['active'] = False
+    def apply_state(source, jobs_source, action_error, complete=True):
+        if complete:
+            refreshing['active'] = False
         label, title = indicator_summary(source)
         indicator.set_label(label, '🟢 99')
         indicator.set_icon_full(str(RUNNER_ICON), 'GitHub Actions')
         indicator.set_title(title)
         build_menu(indicator, source, jobs_source, action_error, manual_refresh, change_host_capacity)
-        if pending_action['value'] is not None:
+        if complete and pending_action['value'] is not None:
             refresh()
         return False
 
@@ -548,7 +621,9 @@ def main():
             except Exception as caught:
                 action_error = f"{action['host']['name']} · Action required · {caught}"
 
-        source = read_runner_source(lambda: request_runner_hosts(runner_hosts))
+        current_source = read_runner_source(lambda: request_runner_hosts(runner_hosts))
+        source = merge_runner_source(runner_cache['source'], current_source)
+        runner_cache['source'] = source
         repositories = list(configured_repositories)
         for runner in source_runners(source):
             repository = runner['RunnerLabels'].get('com.harlanzw.desktop-runner.repository')
@@ -556,6 +631,7 @@ def main():
                 repositories.append(repository)
         stale = time.monotonic() - jobs_cache['updatedAt'] >= JOBS_REFRESH_SECONDS
         if stale:
+            GLib.idle_add(apply_state, source, jobs_cache['source'], action_error, False)
             errors = []
             jobs = request_workflow_jobs(repositories, errors.append)
             jobs_cache['source'] = (
@@ -564,7 +640,7 @@ def main():
                 else {'_tag': 'Available', 'jobs': jobs, 'errors': errors}
             )
             jobs_cache['updatedAt'] = time.monotonic()
-        GLib.idle_add(apply_state, source, jobs_cache['source'], action_error)
+        GLib.idle_add(apply_state, source, jobs_cache['source'], action_error, True)
 
     def refresh(*_args):
         if refreshing['active']:

--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -21,7 +21,7 @@ auto_merge:
   enabled: false
   minimum_confidence: 100
   method: squash
-# No new issue work starts above this many open pull requests.
+# No new issue work starts when open pull requests reach this limit.
 max_open_pull_requests: 8
 poll_interval_seconds: 60
 issue_cutoff: 2026-07-14
@@ -34,3 +34,4 @@ external_repositories: []
 repositories: []
 # Owned repositories enable issue work and conflict resolution by default.
 # Maintained repositories need an explicit policy and GitHub App installation.
+# Set repositories[].max_open_pull_requests to hold new Issue work for one busy repository.

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -179,6 +179,15 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
   const writablePullRequestAuthors = stringArray(value, 'writable_pr_authors', path, issues)
   const writablePullRequestHeadPrefixes = stringArray(value, 'writable_pr_head_prefixes', path, issues)
   const issueWork = requiredBoolean(value, 'issue_work', path, issues)
+  const openPullRequestsValue = value.max_open_pull_requests
+  const maxOpenPullRequests = openPullRequestsValue === undefined
+    ? null
+    : typeof openPullRequestsValue === 'number'
+      && Number.isInteger(openPullRequestsValue)
+      && openPullRequestsValue >= 1
+      && openPullRequestsValue <= 100
+      ? openPullRequestsValue
+      : undefined
   const pullRequestReview = requiredBoolean(value, 'pr_review', path, issues)
   const pullRequestConformance = requiredBoolean(value, 'pr_conformance', path, issues)
   const conflictResolution = requiredBoolean(value, 'conflict_resolution', path, issues)
@@ -202,6 +211,8 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
     issues.push({ path: `${path}.conflict_resolution`, message: 'Conflict resolution requires an owned repository.' })
   if (conflictResolution === true && pullRequestReview !== true)
     issues.push({ path: `${path}.conflict_resolution`, message: 'Conflict resolution requires pull request review.' })
+  if (maxOpenPullRequests === undefined)
+    issues.push({ path: `${path}.max_open_pull_requests`, message: 'Expected an integer from 1 to 100.' })
 
   if (
     github === undefined
@@ -212,6 +223,7 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
     || writablePullRequestAuthors === undefined
     || writablePullRequestHeadPrefixes === undefined
     || issueWork === undefined
+    || maxOpenPullRequests === undefined
     || pullRequestReview === undefined
     || pullRequestConformance === undefined
     || conflictResolution === undefined
@@ -230,6 +242,7 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
     writablePullRequestAuthors,
     writablePullRequestHeadPrefixes,
     issueWork,
+    maxOpenPullRequests,
     pullRequestReview,
     pullRequestConformance,
     conflictResolution,

--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -96,7 +96,7 @@ export async function publishQueuePositions(
   const mappings = new Map(options.repositories.map(mapping => [mapping.github.toLowerCase(), mapping]))
   const changed = options.store.listQueuedReviewStatuses()
     .filter(status => queuePositionComment(status) !== status.publishedBody)
-  return Promise.all(changed.map(async (status): Promise<Result<QueuePositionOutcome, string>> => {
+  const publish = async (status: QueuedReviewStatus): Promise<Result<QueuePositionOutcome, string>> => {
     const mapping = mappings.get(status.repository.toLowerCase())
     if (mapping === undefined)
       return err(`${status.repository}: the repository is no longer configured.`)
@@ -137,5 +137,10 @@ export async function publishQueuePositions(
       // The claim was lost while the edit was in flight, so the claimed agent
       // now owns the comment. Nothing was saved and nothing needs to be.
       : ok({ _tag: 'Superseded', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
-  }))
+  }
+
+  const results: Array<Result<QueuePositionOutcome, string>> = []
+  for (const status of changed)
+    results.push(await publish(status))
+  return results
 }

--- a/packages/harlan-github-agent/src/repository-discovery.ts
+++ b/packages/harlan-github-agent/src/repository-discovery.ts
@@ -108,6 +108,7 @@ function defaultMapping(repository: InstalledRepository, checkout: string): Repo
     writablePullRequestAuthors: ['harlan-zw', AGENT_ACTOR_LOGIN],
     writablePullRequestHeadPrefixes: ['fix/', 'feat/', 'chore/', 'docs/', 'refactor/', 'perf/', 'test/'],
     issueWork: ownership === 'owned',
+    maxOpenPullRequests: null,
     pullRequestReview: true,
     pullRequestConformance: true,
     conflictResolution: ownership === 'owned',

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -87,7 +87,7 @@ export async function publishStoppedReviews(
 ): Promise<Array<Result<StoppedReviewOutcome, string>>> {
   const mappings = new Map(options.repositories.map(mapping => [mapping.github.toLowerCase(), mapping]))
   const reviews = options.store.listStoppedReviews()
-  return Promise.all(reviews.map(async (review): Promise<Result<StoppedReviewOutcome, string>> => {
+  const publish = async (review: StoppedReview): Promise<Result<StoppedReviewOutcome, string>> => {
     const mapping = mappings.get(review.repository.toLowerCase())
     if (mapping === undefined)
       return err(`${review.repository}: the repository is no longer configured.`)
@@ -132,5 +132,10 @@ export async function publishStoppedReviews(
     return recorded
       ? ok({ _tag: 'Published', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
       : err(`${review.repository}#${review.pullRequestNumber}: the final review comment could not be saved.`)
-  }))
+  }
+
+  const results: Array<Result<StoppedReviewOutcome, string>> = []
+  for (const review of reviews)
+    results.push(await publish(review))
+  return results
 }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -2341,6 +2341,8 @@ function dashboardQueue(
   reviewAgents: Array<Extract<DashboardAgent, { _tag: 'ReviewAgent' }>>,
   mappings: Map<string, RepositoryMapping>,
   rejectedIssueWorkResults: Map<string, number>,
+  openPullRequestsByRepository: Map<string, number>,
+  currentSelectionMode: SelectionMode,
 ): QueueEntry[] {
   const currentTasks = new Map<string, AgentTask>()
   tasks.forEach((task) => {
@@ -2377,7 +2379,22 @@ function dashboardQueue(
         switch (work.state._tag) {
           case 'Running':
           case 'Publishing': return [{ ...base, kind: 'issue', state: { _tag: 'Active', work: 'issue_work' } }]
-          case 'Queued': return [{ ...base, kind: 'issue', state: { _tag: 'Queued', work: 'issue_work' } }]
+          case 'Queued': {
+            const limit = mapping.maxOpenPullRequests
+            const openPullRequests = openPullRequestsByRepository.get(subject.repository) ?? 0
+            if (currentSelectionMode === 'auto' && limit !== null && openPullRequests >= limit) {
+              const pullRequest = limit === 1 ? 'pull request' : 'pull requests'
+              return [{
+                ...base,
+                kind: 'issue',
+                state: {
+                  _tag: 'Pending',
+                  reason: `${subject.repository} reached its limit of ${limit} open ${pullRequest}. Merge or close one to start Issue work.`,
+                },
+              }]
+            }
+            return [{ ...base, kind: 'issue', state: { _tag: 'Queued', work: 'issue_work' } }]
+          }
           case 'ActionRequired': {
             const rejectedResults = rejectedIssueWorkResults.get(work.id)
             const reason = rejectedResults === undefined
@@ -3837,7 +3854,7 @@ export function openJournalStore(
   path: string,
   mutationsEnabled = false,
   profile: AgentProfile = CODEX_AGENT_PROFILE,
-  /** Issue work stops above this many open pull requests. Matches the configuration default. */
+  /** Issue work stops when open pull requests reach this limit. Matches the configuration default. */
   maxOpenPullRequests = 8,
 ): JournalStore {
   const database = openDatabase(path)
@@ -4947,9 +4964,35 @@ export function openJournalStore(
                 AND pull_request_approvals.kind = 'fixes'
             )
           )
+          AND (
+            tasks.kind != 'issue_work'
+            OR (SELECT selection_mode FROM agent_control WHERE singleton = 1) = 'manual'
+            OR (
+              (
+                SELECT COUNT(*)
+                FROM subjects AS open_subjects
+                JOIN repositories AS open_repositories ON open_repositories.id = open_subjects.repository_id
+                JOIN revisions AS open_revisions ON open_revisions.id = open_subjects.current_revision_id
+                WHERE open_subjects.kind = 'pull_request'
+                  AND open_repositories.enabled = 1
+                  AND json_extract(open_revisions.payload, '$.state') = 'open'
+              ) < ?
+              AND (
+                json_extract(repositories.policy_json, '$.maxOpenPullRequests') IS NULL
+                OR (
+                  SELECT COUNT(*)
+                  FROM subjects AS repository_subjects
+                  JOIN revisions AS repository_revisions ON repository_revisions.id = repository_subjects.current_revision_id
+                  WHERE repository_subjects.repository_id = subjects.repository_id
+                    AND repository_subjects.kind = 'pull_request'
+                    AND json_extract(repository_revisions.payload, '$.state') = 'open'
+                ) < json_extract(repositories.policy_json, '$.maxOpenPullRequests')
+              )
+            )
+          )
         ORDER BY tasks.updated_at, tasks.id
         LIMIT 1
-      `).get(kind, exactTaskId ?? null, exactTaskId ?? null) as ClaimRow | undefined
+      `).get(kind, exactTaskId ?? null, exactTaskId ?? null, maxOpenPullRequests) as ClaimRow | undefined
       if (row === undefined) {
         database.exec('COMMIT')
         return null
@@ -6939,6 +6982,12 @@ export function openJournalStore(
       ...reviewAgents,
     ]
     const mappings = new Map(subjectRows.map(row => [row.repository, JSON.parse(row.policy_json) as RepositoryMapping]))
+    const openPullRequestsByRepository = new Map<string, number>()
+    items.forEach((item) => {
+      if (item.kind === 'pull_request' && item.state === 'open')
+        openPullRequestsByRepository.set(item.repository, (openPullRequestsByRepository.get(item.repository) ?? 0) + 1)
+    })
+    const currentSelectionMode = selectionMode(database)
 
     const storedAgentControl = getAgentControl()
     const agentControl = storedAgentControl._tag === 'Running'
@@ -6950,14 +6999,22 @@ export function openJournalStore(
       status,
       mutationsEnabled,
       agentControl,
-      selectionMode: selectionMode(database),
+      selectionMode: currentSelectionMode,
       openPullRequests: countOpenPullRequests(),
       maxOpenPullRequests,
       agentProfile: resolveAgentProfile(activeSelection(), profile.maximumActiveAgents),
       agentSelection: getAgentSelection(),
       agents,
       incidents: listIncidents(),
-      queue: dashboardQueue(items.filter(item => !item.dismissed), tasks, reviewAgents, mappings, rejectedIssueWorkResults),
+      queue: dashboardQueue(
+        items.filter(item => !item.dismissed),
+        tasks,
+        reviewAgents,
+        mappings,
+        rejectedIssueWorkResults,
+        openPullRequestsByRepository,
+        currentSelectionMode,
+      ),
       repositories,
       items,
       tasks,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -30,6 +30,8 @@ export interface RepositoryMapping {
   writablePullRequestAuthors: string[]
   writablePullRequestHeadPrefixes: string[]
   issueWork: boolean
+  /** New issue work stops when this repository reaches the limit. */
+  maxOpenPullRequests: number | null
   pullRequestReview: boolean
   pullRequestConformance: boolean
   conflictResolution: boolean
@@ -61,7 +63,7 @@ export interface AgentConfig {
   trustedCheckoutRoots: string[]
   mutationsEnabled: boolean
   autoMerge: AutoMergePolicy
-  /** New issue work stops above this many open pull requests waiting on Harlan. */
+  /** New issue work stops when open pull requests reach this limit. */
   maxOpenPullRequests: number
   pollIntervalSeconds: number
   issueCutoff: string
@@ -812,7 +814,7 @@ export interface DashboardSnapshot {
   selectionMode: SelectionMode
   /** Open pull requests across every enabled repository. */
   openPullRequests: number
-  /** Issue work stops above this many open pull requests. */
+  /** Issue work stops when open pull requests reach this limit. */
   maxOpenPullRequests: number
   agentProfile: AgentProfile
   agentSelection: AgentSelection

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -70,6 +70,25 @@ describe('configuration boundary', () => {
     const parsed = parseConfigText(configText)
     expect(parsed._tag === 'Ok' && parsed.value.autoMerge).toEqual({ _tag: 'Disabled' })
     expect(parsed._tag === 'Ok' && parsed.value.maxOpenPullRequests).toBe(8)
+    expect(parsed._tag === 'Ok' && parsed.value.repositories[0]?.maxOpenPullRequests).toBeNull()
+  })
+
+  it('parses a repository pull request limit', () => {
+    const parsed = parseConfigText(configText.replace(
+      'issue_work: true',
+      'issue_work: true\n    max_open_pull_requests: 4',
+    ))
+
+    expect(parsed._tag === 'Ok' && parsed.value.repositories[0]?.maxOpenPullRequests).toBe(4)
+
+    const invalid = parseConfigText(configText.replace(
+      'issue_work: true',
+      'issue_work: true\n    max_open_pull_requests: 0',
+    ))
+    expect(invalid._tag === 'Err' && invalid.error).toContainEqual({
+      path: '$.repositories[0].max_open_pull_requests',
+      message: 'Expected an integer from 1 to 100.',
+    })
   })
 
   it('parses an enabled auto merge policy with its defaults', () => {

--- a/packages/harlan-github-agent/test/fixtures.ts
+++ b/packages/harlan-github-agent/test/fixtures.ts
@@ -19,6 +19,7 @@ export function repositoryMapping(overrides: Partial<RepositoryMapping> = {}): R
     writablePullRequestAuthors: ['harlan-zw'],
     writablePullRequestHeadPrefixes: ['fix/', 'feat/', 'chore/'],
     issueWork: true,
+    maxOpenPullRequests: null,
     pullRequestReview: true,
     pullRequestConformance: true,
     conflictResolution: true,

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -121,6 +121,49 @@ class RunnerActivityTest(unittest.TestCase):
             },
         ])
 
+    def test_ignores_a_runner_that_disappears_between_list_and_logs(self):
+        def run(command, **_options):
+            if 'ps' in command:
+                return subprocess.CompletedProcess(command, 0, stdout=(
+                    '{"ID":"gone","State":"running","Status":"Up 2 seconds",'
+                    '"Labels":"com.harlanzw.desktop-runner.repository=harlan-zw/example"}\n'
+                ), stderr='')
+            return subprocess.CompletedProcess(
+                command,
+                1,
+                stdout='',
+                stderr='Error response from daemon: No such container: gone',
+            )
+
+        host = runner_indicator.parse_runner_hosts('Hogwild=ssh://hogwild')[0]
+
+        self.assertEqual(runner_indicator.request_runners(host, run), [])
+
+    def test_keeps_last_known_runner_state_during_a_short_host_failure(self):
+        previous = {'_tag': 'Available', 'hosts': [{
+            '_tag': 'Available',
+            'name': 'Hogwild',
+            'observedAt': 100.0,
+            'runners': [{'Activity': {'_tag': 'Idle'}}],
+        }]}
+        current = {'_tag': 'Available', 'hosts': [{
+            '_tag': 'Unavailable',
+            'name': 'Hogwild',
+            'message': 'SSH connection reset',
+        }]}
+
+        merged = runner_indicator.merge_runner_source(previous, current, 118.9)
+
+        self.assertEqual(merged['hosts'][0]['runners'], [{'Activity': {'_tag': 'Idle'}}])
+        self.assertEqual(merged['hosts'][0]['stale'], {
+            'message': 'SSH connection reset',
+            'observedAt': 100.0,
+        })
+        self.assertEqual(
+            runner_indicator.runner_host_status_label(merged['hosts'][0], 118.9),
+            '🟠 Hogwild · last known status 18s old · 1 self-hosted runner · 1 idle',
+        )
+
     def test_reports_idle_runner(self):
         self.assertEqual(runner_indicator.runner_activity(
             {'State': 'running', 'Status': 'Up 10 minutes'},

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -76,6 +76,37 @@ describe('queuePositionComment', () => {
 })
 
 describe('publishQueuePositions', () => {
+  it('reads Queue positions one at a time to protect the GitHub request quota', async () => {
+    let active = 0
+    let maximumActive = 0
+    const statuses = Array.from({ length: 8 }, (_, index) => queuedRepair({
+      taskId: `repair-task-${index}`,
+      pullRequestNumber: 24 + index,
+    }))
+
+    await publishQueuePositions({
+      github: {
+        getPullRequestReviewSnapshot: async () => {
+          active += 1
+          maximumActive = Math.max(maximumActive, active)
+          await new Promise(resolve => setTimeout(resolve, 5))
+          active -= 1
+          return snapshot()
+        },
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listQueuedReviewStatuses: () => statuses,
+        isQueuedReviewStatus: () => true,
+        recordQueuedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(maximumActive).toBe(1)
+  })
+
   it('rewrites the canonical comment and records the position it published', async () => {
     let edited: { commentId: number, body: string } | undefined
     let recorded: { taskId: string, body: string } | undefined

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -63,6 +63,37 @@ describe('stoppedReviewComment', () => {
 })
 
 describe('publishStoppedReviews', () => {
+  it('reads stopped reviews one at a time to protect the GitHub request quota', async () => {
+    let active = 0
+    let maximumActive = 0
+    const reviews = Array.from({ length: 8 }, (_, index): StoppedReview => ({
+      ...stopped,
+      taskId: `review-task-${index}`,
+      pullRequestNumber: 24 + index,
+    }))
+
+    await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: async () => {
+          active += 1
+          maximumActive = Math.max(maximumActive, active)
+          await new Promise(resolve => setTimeout(resolve, 5))
+          active -= 1
+          return snapshot()
+        },
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listStoppedReviews: () => reviews,
+        recordStoppedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(maximumActive).toBe(1)
+  })
+
   it('rewrites the canonical comment and records it once', async () => {
     let edited: { commentId: number, body: string } | undefined
     let recorded = 0

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -987,6 +987,54 @@ describe('journal store', () => {
     })).toEqual({ _tag: 'Rejected', reason: { _tag: 'ApprovalNotRequired' } })
   })
 
+  it('holds issue work when its repository reaches the pull request limit', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping({ maxOpenPullRequests: 1 })], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'limited-issue',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: issueItem({ author: 'harlan-zw' }),
+    })
+    const triage = store.claimNextIssueTriageTask('issue-worker', '2026-08-13T01:01:00.000Z', 600_000)
+    if (triage === null)
+      throw new Error('Expected issue triage.')
+    store.completeWorkerTask({
+      taskId: triage.id,
+      workerId: triage.state.workerId,
+      fence: triage.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      evidence: JSON.stringify({ validity: 'valid' }),
+    })
+
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.recordObservation({
+      externalId: 'open-pull-request',
+      observedAt: '2026-08-13T01:02:01.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+
+    expect(store.claimNextIssueWorkTask('issue-worker', '2026-08-13T01:02:02.000Z', 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot('2026-08-13T01:02:03.000Z').queue).toContainEqual(expect.objectContaining({
+      number: 12,
+      state: {
+        _tag: 'Pending',
+        reason: 'harlan-zw/example reached its limit of 1 open pull request. Merge or close one to start Issue work.',
+      },
+    }))
+
+    store.recordObservation({
+      externalId: 'closed-pull-request',
+      observedAt: '2026-08-13T01:02:04.000Z',
+      source: 'poll',
+      subject: { ...pullRequest, state: 'closed', updatedAt: '2026-08-13T01:02:04.000Z' },
+    })
+    expect(store.claimNextIssueWorkTask('issue-worker', '2026-08-13T01:02:05.000Z', 600_000)).toEqual(
+      expect.objectContaining({ kind: 'issue_work', issueNumber: 12 }),
+    )
+  })
+
   it('allows approved issue work in an explicitly configured maintained repository', () => {
     const store = createStore()
     const mapping = repositoryMapping({


### PR DESCRIPTION
## Summary

- add repository-specific open pull request limits for Issue work
- enforce limits atomically when Tasks claim
- keep last known self-hosted runner status during short host failures
- parallelize runner, host, and workflow status reads

## Verification

- pnpm --filter harlan-github-agent typecheck
- pnpm --filter harlan-github-agent lint
- pnpm --filter harlan-github-agent test
- python3 test/indicator_test.py