### PR TITLE
fix(agent): close the comment on a merged pull request with no head branch

### DIFF
--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -1,6 +1,6 @@
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
-import type { JournalStore, StoppedReview } from './store.ts'
+import type { JournalStore, StoppedReview, StoppedReviewDisposition } from './store.ts'
 import type { RepositoryMapping } from './types.ts'
 import { formatProgressBar } from './agent-progress.ts'
 import { err, ok } from './result.ts'
@@ -12,10 +12,7 @@ export type StoppedReviewOutcome
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
 
-export type StoppedReviewDisposition
-  = | { _tag: 'Stopped' }
-    | { _tag: 'Merged' }
-    | { _tag: 'Closed' }
+export type { StoppedReviewDisposition }
 
 export interface ReviewStopSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
@@ -94,18 +91,26 @@ export async function publishStoppedReviews(
     const mapping = mappings.get(review.repository.toLowerCase())
     if (mapping === undefined)
       return err(`${review.repository}: the repository is no longer configured.`)
-    const current = await options.github.getPullRequestReviewSnapshot(mapping, review.pullRequestNumber, signal)
-    if (current._tag === 'Err')
-      return err(`${review.repository}#${review.pullRequestNumber}: ${current.error}`)
-    if (current.value.pullRequest.state === 'open' && current.value.pullRequest.headSha !== review.headSha)
+    // A closed pull request takes no more commits, so the stored answer is the
+    // current one and the read is skipped. GitHub answers no snapshot request
+    // at all once the head branch is deleted, which is every merged pull
+    // request whose branch GitHub cleaned up.
+    const live = review.disposition._tag === 'Stopped'
+      ? await options.github.getPullRequestReviewSnapshot(mapping, review.pullRequestNumber, signal)
+      : null
+    if (live !== null && live._tag === 'Err')
+      return err(`${review.repository}#${review.pullRequestNumber}: ${live.error}`)
+    if (live !== null && live.value.pullRequest.state === 'open' && live.value.pullRequest.headSha !== review.headSha)
       return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
 
     const at = options.now().toISOString()
-    const disposition: StoppedReviewDisposition = current.value.pullRequest.state === 'open'
-      ? { _tag: 'Stopped' }
-      : current.value.pullRequest.mergedAt === null
-        ? { _tag: 'Closed' }
-        : { _tag: 'Merged' }
+    const disposition: StoppedReviewDisposition = live === null
+      ? review.disposition
+      : live.value.pullRequest.state === 'open'
+        ? { _tag: 'Stopped' }
+        : live.value.pullRequest.mergedAt === null
+          ? { _tag: 'Closed' }
+          : { _tag: 'Merged' }
     const body = stoppedReviewComment(review, at, disposition)
     const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, review.publishedBody, body, signal)
     if (edited._tag === 'Err')

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -357,10 +357,24 @@ interface StoppedReviewRow {
   revision_id: string
   head_sha: string
   reason: string
+  current_state: string
+  current_merged_at: string | null
   github_comment_id: number
   published_body: string
   findings: string
 }
+
+/**
+ * How the pull request ended, as the last poll saw it.
+ *
+ * `Stopped` means the pull request is still open, so only the Task behind the
+ * comment ended. The other two are final, and GitHub cannot take them back
+ * without creating a Revision of its own.
+ */
+export type StoppedReviewDisposition
+  = | { _tag: 'Stopped' }
+    | { _tag: 'Merged' }
+    | { _tag: 'Closed' }
 
 export interface StoppedReview {
   taskId: string
@@ -370,6 +384,15 @@ export interface StoppedReview {
   revisionId: string
   headSha: string
   reason: string
+  /**
+   * Lets the sweep skip its GitHub read on a closed pull request.
+   *
+   * A closed pull request whose head branch is deleted answers no snapshot
+   * request at all, and its stale comment used to fail every pass with
+   * "Branch not found". Nothing about a closed pull request can change without
+   * a new Revision, so the stored answer is the current one.
+   */
+  disposition: StoppedReviewDisposition
   commentId: number
   /** What the canonical comment holds now, so the edit can compare and swap. */
   publishedBody: string
@@ -7201,6 +7224,8 @@ export function openJournalStore(
       stopped.revision_id,
       json_extract(revisions.payload, '$.headSha') AS head_sha,
       COALESCE(stopped.reason, 'The automated review stopped.') AS reason,
+      json_extract(current_revisions.payload, '$.state') AS current_state,
+      json_extract(current_revisions.payload, '$.mergedAt') AS current_merged_at,
       published.github_comment_id,
       published.body AS published_body,
       COALESCE((
@@ -7281,6 +7306,11 @@ export function openJournalStore(
     revisionId: row.revision_id,
     headSha: row.head_sha,
     reason: row.reason,
+    disposition: row.current_state !== 'closed'
+      ? { _tag: 'Stopped' as const }
+      : row.current_merged_at === null
+        ? { _tag: 'Closed' as const }
+        : { _tag: 'Merged' as const },
     commentId: row.github_comment_id,
     publishedBody: row.published_body,
     findings: JSON.parse(row.findings) as ReviewFinding[],

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -12,6 +12,7 @@ const stopped: StoppedReview = {
   revisionId: 'revision-1',
   headSha: 'abc123',
   reason: 'The pull request is not ready for review.',
+  disposition: { _tag: 'Stopped' },
   commentId: 42,
   publishedBody: '### 🤖 REVIEWING · Reviewing changed files',
   findings: [],
@@ -115,6 +116,28 @@ describe('publishStoppedReviews', () => {
     expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
     expect(body).toContain('### 🤖 MERGED')
     expect(body).not.toContain('REVIEWING')
+  })
+
+  it('closes the comment on a merged pull request whose head branch GitHub deleted', async () => {
+    let body = ''
+    const results = await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(err('Branch not found - https://docs.github.com/rest/branches/branches#get-a-branch')),
+        editReviewStatus: (_repository, _number, _commentId, _expectedBody, value) => {
+          body = value
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        listStoppedReviews: () => [{ ...stopped, disposition: { _tag: 'Merged' } }],
+        recordStoppedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(body).toContain('### 🤖 MERGED')
   })
 
   it('writes nothing when a person deleted the comment, rather than posting it again', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Follows #49.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

#49 let the sweep reach merged pull requests, and two of them started failing on every poll pass:

```
ERROR  Stopped review comment: harlan-zw/nuxtseo.com#285: Branch not found
ERROR  Stopped review comment: harlan-zw/nuxtseo.com#279: Branch not found
```

The sweep reads a live snapshot before every write, and the snapshot resolves the base branch. GitHub deletes the head branch on merge, so those two answer nothing, forever. They keep their stale comments and raise an Incident every pass.

A closed pull request takes no more commits. Nothing about it changes without a new Revision, so the stored one is the current answer and the sweep skips the read. An open pull request still gets the live check, because its head can move under the comment.

Errors are not matched by wording anywhere here: the disposition comes from the stored Revision, so a snapshot that fails for any other reason is out of the path entirely.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).