### PR TITLE
fix(agent): bound review command polling

### DIFF
--- a/packages/harlan-github-agent/src/review-rerun-controller.ts
+++ b/packages/harlan-github-agent/src/review-rerun-controller.ts
@@ -9,15 +9,17 @@ export interface ReviewRerunSync {
   results: ReviewRerunResult[]
 }
 
+export interface ReviewRerunDependencies {
+  github: Pick<GitHubSource, 'listReviewRerunRequests'>
+  store: Pick<JournalStore, 'getDashboardSnapshot' | 'requestReviewRerun'>
+  allowedAuthors: string[]
+  now: () => Date
+  signal?: AbortSignal
+}
+
 export function syncReviewRerunRequests(
   repository: RepositoryMapping,
-  dependencies: {
-    github: Pick<GitHubSource, 'listReviewRerunRequests'>
-    store: Pick<JournalStore, 'getDashboardSnapshot' | 'requestReviewRerun'>
-    allowedAuthors: string[]
-    now: () => Date
-    signal?: AbortSignal
-  },
+  dependencies: ReviewRerunDependencies,
 ): Promise<Result<ReviewRerunSync, string>> {
   return dependencies.github.listReviewRerunRequests(repository, dependencies.signal).then((requests) => {
     if (requests._tag === 'Err')
@@ -47,4 +49,31 @@ export function syncReviewRerunRequests(
     })
     return ok({ repository: repository.github, results })
   })
+}
+
+/**
+ * Reads review commands only where an open pull request can accept one.
+ *
+ * Repository discovery can expose hundreds of installations. Polling every
+ * repository once per minute exhausted the GitHub App request quota, even when
+ * almost all repositories had no open pull requests. Sequential reads also
+ * avoid a secondary-rate-limit burst when several repositories are active.
+ */
+export async function syncOpenReviewRerunRequests(
+  repositories: RepositoryMapping[],
+  dependencies: ReviewRerunDependencies,
+): Promise<Array<Result<ReviewRerunSync, string>>> {
+  const openRepositories = new Set(dependencies.store
+    .getDashboardSnapshot(dependencies.now().toISOString())
+    .items
+    .flatMap(item => item.kind === 'pull_request' && item.state === 'open'
+      ? [item.repository.toLowerCase()]
+      : []))
+  const eligible = repositories.filter(repository => repository.enabled
+    && repository.pullRequestReview
+    && openRepositories.has(repository.github.toLowerCase()))
+  const results: Array<Result<ReviewRerunSync, string>> = []
+  for (const repository of eligible)
+    results.push(await syncReviewRerunRequests(repository, dependencies))
+  return results
 }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -40,7 +40,7 @@ import { buildRepositoryMappings, discoverGitHubAppRepositories, discoverLocalCh
 import { err, ok } from './result.ts'
 import { AGENT_ACTOR_LOGIN } from './review-comment.ts'
 import { createReviewFixWorker } from './review-fix-worker.ts'
-import { syncReviewRerunRequests } from './review-rerun-controller.ts'
+import { syncOpenReviewRerunRequests } from './review-rerun-controller.ts'
 import { createReviewStatusController } from './review-status-controller.ts'
 import { publishStoppedReviews } from './review-stop-sweep.ts'
 import { startAgentServer } from './server.ts'
@@ -563,15 +563,13 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         if (retried > 0)
           options.logger.info(`Requeued ${retried} tasks after recoverable failures.`)
       }
-      const reruns = await Promise.all(config.repositories
-        .filter(repository => repository.enabled && repository.pullRequestReview)
-        .map(repository => syncReviewRerunRequests(repository, {
-          allowedAuthors: config.github.allowedOwners,
-          github,
-          store,
-          now,
-          signal,
-        })))
+      const reruns = await syncOpenReviewRerunRequests(config.repositories, {
+        allowedAuthors: config.github.allowedOwners,
+        github,
+        store,
+        now,
+        signal,
+      })
       reruns.forEach((result) => {
         if (result._tag === 'Err') {
           options.logger.error(`Review rerun command: ${result.error}`)

--- a/packages/harlan-github-agent/test/review-rerun-controller.test.ts
+++ b/packages/harlan-github-agent/test/review-rerun-controller.test.ts
@@ -1,9 +1,49 @@
 import { describe, expect, it } from 'vitest'
 import { ok } from '../src/result.ts'
-import { syncReviewRerunRequests } from '../src/review-rerun-controller.ts'
+import { syncOpenReviewRerunRequests, syncReviewRerunRequests } from '../src/review-rerun-controller.ts'
 import { dashboardSnapshot, pullRequestItem, repositoryMapping } from './fixtures.ts'
 
 describe('review rerun controller', () => {
+  it('polls only repositories with open pull requests, one at a time', async () => {
+    let active = 0
+    let maximumActive = 0
+    const repositories = Array.from({ length: 8 }, (_, index) => repositoryMapping({
+      github: `harlan-zw/example-${index}`,
+    }))
+    const quiet = repositoryMapping({ github: 'harlan-zw/quiet' })
+    const items = repositories.map((repository, index) => ({
+      ...pullRequestItem({ repository: repository.github, number: 24 + index }),
+      revisionId: `${index}`.repeat(64),
+      observedAt: '2026-08-13T01:00:00.000Z',
+      dismissed: false,
+      approval: { _tag: 'NotRequired' as const },
+    }))
+    const requested: string[] = []
+
+    const results = await syncOpenReviewRerunRequests([...repositories, quiet], {
+      allowedAuthors: ['harlan-zw'],
+      github: {
+        listReviewRerunRequests: async (repository) => {
+          active += 1
+          maximumActive = Math.max(maximumActive, active)
+          await new Promise(resolve => setTimeout(resolve, 5))
+          active -= 1
+          requested.push(repository.github)
+          return ok([])
+        },
+      },
+      store: {
+        getDashboardSnapshot: () => dashboardSnapshot({ items }),
+        requestReviewRerun: () => ({ _tag: 'Duplicate', taskId: 'b'.repeat(64) }),
+      },
+      now: () => new Date('2026-08-13T01:02:00.000Z'),
+    })
+
+    expect(results).toHaveLength(8)
+    expect(requested).toEqual(repositories.map(repository => repository.github))
+    expect(maximumActive).toBe(1)
+  })
+
   it('requests the current pull request head once for a GitHub command', async () => {
     const requests: unknown[] = []
     const subject = { ...pullRequestItem({ mergeState: 'clean' }), revisionId: 'a'.repeat(64), observedAt: '2026-08-13T01:00:00.000Z', dismissed: false, approval: { _tag: 'NotRequired' as const } }


### PR DESCRIPTION
## Summary

- poll rerun commands only for repositories with open pull requests
- serialize those repository reads to protect the GitHub App quota

## Verification

- 26 focused tests pass
- typecheck passes
- lint passes