### PR TITLE
fix(agent): name this service to the Worktrunk hooks

### DIFF
--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -187,12 +187,26 @@ function runGit(checkout: string, args: string[], signal: AbortSignal, githubTok
   })
 }
 
+/**
+ * Names this service to the Worktrunk hooks that run around a switch.
+ *
+ * A hook cannot tell a person's shell from this service, and the two want
+ * opposite things. Harlan's control checkout policy refuses a switch while the
+ * primary checkout sits off main or carries local changes, which is every
+ * repository this service works in. It stopped every worktree, so every Review
+ * and every Repair stopped with it.
+ *
+ * `gitEnvironment` is an allowlist, so this variable reaches a hook only when
+ * this function sets it.
+ */
+const AGENT_IDENTITY = { HARLAN_GITHUB_AGENT: '1' } as const
+
 function runWt(checkout: string, args: string[], signal: AbortSignal): Promise<CommandResult> {
   return new Promise((resolve) => {
     execFile(
       'wt',
       ['-C', checkout, ...args],
-      { encoding: 'utf8', env: gitEnvironment(), signal },
+      { encoding: 'utf8', env: { ...gitEnvironment(), ...AGENT_IDENTITY }, signal },
       (error, stdout, stderr) => resolve({
         exitCode: error === null ? 0 : typeof error.code === 'number' ? error.code : 1,
         stdout: stdout.trim(),

--- a/packages/harlan-github-agent/test/repository-discovery.test.ts
+++ b/packages/harlan-github-agent/test/repository-discovery.test.ts
@@ -44,7 +44,10 @@ describe('repository discovery', () => {
     writeFileSync(join(checkout, 'README.md'), 'test\n')
     execFileSync('git', ['-C', checkout, 'add', 'README.md'])
     execFileSync('git', ['-C', checkout, 'commit', '-m', 'test'])
-    execFileSync('wt', ['-C', checkout, 'switch', '--create', 'fix/review', '--yes'])
+    // Stands in for the service, so Worktrunk hooks read the same caller it does.
+    execFileSync('wt', ['-C', checkout, 'switch', '--create', 'fix/review', '--yes'], {
+      env: { ...process.env, HARLAN_GITHUB_AGENT: '1' },
+    })
 
     expect(await discoverLocalCheckouts([root])).toEqual([{
       github: 'harlan-zw/example',

--- a/packages/harlan-github-agent/test/worktree-sweep.test.ts
+++ b/packages/harlan-github-agent/test/worktree-sweep.test.ts
@@ -22,10 +22,11 @@ function git(checkout: string, ...args: string[]): string {
   }).trim()
 }
 
+/** Stands in for the service, so Worktrunk hooks read the same caller it does. */
 function wt(checkout: string, ...args: string[]): string {
   return execFileSync('wt', ['-C', checkout, ...args], {
     encoding: 'utf8',
-    env: { HOME: process.env.HOME, PATH: process.env.PATH },
+    env: { HOME: process.env.HOME, PATH: process.env.PATH, HARLAN_GITHUB_AGENT: '1' },
   }).trim()
 }
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Every Review and Repair is currently failing:

```
🤖 STOPPED
The automated review stopped. Reason: Could not create the agent worktree with wt:
◎ Running pre-switch user:primary @ ~/pkg/harlan-nuxt
Worktree switch stopped: the primary checkout must use main.
```

The new control checkout `pre-switch` hook refuses a switch while the primary checkout sits off main or carries local changes. `~/pkg/harlan-nuxt` is on `fix/self-hosted-pnpm-cache` with an untracked `.claude/`, which is an ordinary state for a checkout a person is working in, and the service creates its worktrees from that same checkout. So the rule that protects your control checkout stopped the service from doing any work at all.

A hook cannot tell your shell from the service, and the two want opposite things. The service sets `HARLAN_GITHUB_AGENT=1` in the environment it hands to `wt`, and the hook exits early on it. `gitEnvironment` is an allowlist, so nothing else reaches a hook with that name set.

The hook side of this lives in `~/.config/worktrunk/config.toml`, which is not in this repository. It is already in place on the machine, above the `remote get-url origin` check.

This also unblocks 22 tests. They shell out to `wt` against temporary repositories, whose primary checkout sits on whatever branch the fixture created, so the same hook stopped them. The two test helpers that stand in for the service now set the same variable.

Unrelated and still red on main: `runs DeepSeek at high reasoning when the provider is opencode`, from #48.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).