### PR TITLE
fix(agent): record no incidents for a poll pass a shutdown aborted

### DIFF
--- a/packages/harlan-github-agent/src/index.ts
+++ b/packages/harlan-github-agent/src/index.ts
@@ -33,7 +33,7 @@ export { DEFAULT_CATCH_UP_MINUTES, DEFAULT_MISSED_HORIZON_MINUTES, dueRoutine, m
 export type { CronExpression, DueRoutine } from './routine-schedule.ts'
 export { parseRoutineSpec, ROUTINE_MODES, ROUTINE_NAMES, ROUTINE_SPEC_PATH } from './routine-spec.ts'
 export { startAgentServer } from './server.ts'
-export { startAgentService } from './service.ts'
+export { createPassIncidentRecorder, replaceServiceIncidents, startAgentService } from './service.ts'
 export { openJournalStore } from './store.ts'
 export { createTaskScheduler } from './task-scheduler.ts'
 export type * from './types.ts'

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -89,6 +89,27 @@ function recordServiceIncident(
   })
 }
 
+/**
+ * Records one poll pass's failures, unless the pass was aborted.
+ *
+ * Stopping the service aborts every request still in flight, and each one
+ * rejects with an abort. Those rejects are the shutdown, not a fault. Recording
+ * them filled the System pane with dozens of Incidents on every restart and
+ * buried the real ones, so an aborted pass reports nothing and the next pass
+ * records the truth.
+ */
+export function createPassIncidentRecorder(options: {
+  now: () => Date
+  signal: AbortSignal
+  store: Pick<JournalStore, 'recordIncident' | 'resolveIncidents'>
+}): (operation: string, messages: readonly string[]) => void {
+  return (operation, messages) => {
+    if (options.signal.aborted)
+      return
+    replaceServiceIncidents(options.store, options.now().toISOString(), operation, messages)
+  }
+}
+
 /** Replaces one controller pass's Service Incidents with its current failures. */
 export function replaceServiceIncidents(
   store: Pick<JournalStore, 'recordIncident' | 'resolveIncidents'>,
@@ -541,6 +562,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     intervalMilliseconds: config.pollIntervalSeconds * 1_000,
     timeoutMilliseconds: Math.max(5 * 60_000, config.pollIntervalSeconds * 4_000),
     poll: async (signal) => {
+      const recordPassIncidents = createPassIncidentRecorder({ store, now, signal })
       const results = await reconcileAllRepositories(config.repositories, {
         ...(mutationSchedulers === undefined
           ? {}
@@ -587,7 +609,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         if (outcome._tag === 'Synced' && outcome.routines.length > 0)
           options.logger.info(`${repository}: ${outcome.routines.length} routines declared.`)
       })
-      replaceServiceIncidents(store, now().toISOString(), 'routine_spec', routineFailures)
+      recordPassIncidents('routine_spec', routineFailures)
 
       if (config.mutationsEnabled) {
         const planned = planRoutineRuns({ now, store })
@@ -610,12 +632,12 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           options.logger.info(`${result.value.repository}: queued a requested review rerun.`)
         }
       })
-      replaceServiceIncidents(store, now().toISOString(), 'review_rerun', reruns.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+      recordPassIncidents('review_rerun', reruns.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       const statusSync = await pullRequestStatuses.sync(store.getDashboardSnapshot(now().toISOString()), signal)
       statusSync.errors.forEach((error) => {
         options.logger.error(`Pull request status: ${error}`)
       })
-      replaceServiceIncidents(store, now().toISOString(), 'pull_request_status', statusSync.errors)
+      recordPassIncidents('pull_request_status', statusSync.errors)
       if (mutationSchedulers !== undefined) {
         const stopped = await publishStoppedReviews({
           github: workerGithub,
@@ -635,7 +657,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
             options.logger.error(`Stopped review comment: ${result.error}`)
           }
         })
-        replaceServiceIncidents(store, now().toISOString(), 'stopped_review_comment', stopped.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+        recordPassIncidents('stopped_review_comment', stopped.flatMap(result => result._tag === 'Err' ? [result.error] : []))
         const positions = await publishQueuePositions({
           github: workerGithub,
           now,
@@ -656,7 +678,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
             options.logger.error(`Queue position comment: ${result.error}`)
           }
         })
-        replaceServiceIncidents(store, now().toISOString(), 'queue_position_comment', positions.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+        recordPassIncidents('queue_position_comment', positions.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       }
       // Only a pass where nothing succeeded describes an outage. Throwing for a
       // partial failure backed the poller off to its 15 minute ceiling and held
@@ -690,6 +712,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   const worktreeSweeper = createPoller({
     intervalMilliseconds: 5 * 60_000,
     poll: async (signal) => {
+      const recordSweepIncidents = createPassIncidentRecorder({ store, now, signal })
       const checkouts = [...new Set(config.repositories.map(repository => repository.checkout))]
       const failures: string[] = []
       for (const checkout of checkouts) {
@@ -710,7 +733,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           failures.push(message)
         })
       }
-      replaceServiceIncidents(store, now().toISOString(), 'agent_worktree_sweep', failures)
+      recordSweepIncidents('agent_worktree_sweep', failures)
     },
     onError: error => options.logger.error(error),
   })

--- a/packages/harlan-github-agent/test/pass-incidents.test.ts
+++ b/packages/harlan-github-agent/test/pass-incidents.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { createPassIncidentRecorder } from '../src/service.ts'
+import { openJournalStore } from '../src/store.ts'
+
+const now = () => new Date('2026-08-27T06:00:00.000Z')
+
+describe('recording one poll pass failures', () => {
+  it('records what a finished pass failed at', () => {
+    const store = openJournalStore(':memory:')
+    try {
+      const record = createPassIncidentRecorder({ now, signal: new AbortController().signal, store })
+
+      record('stopped_review_comment', ['harlan-zw/example#1: GitHub returned 502.'])
+
+      expect(store.listIncidents().map(incident => incident.operation)).toEqual(['stopped_review_comment'])
+    }
+    finally {
+      store.close()
+    }
+  })
+
+  it('records nothing for an aborted pass, because a shutdown is not a fault', () => {
+    const store = openJournalStore(':memory:')
+    try {
+      const controller = new AbortController()
+      const record = createPassIncidentRecorder({ now, signal: controller.signal, store })
+      controller.abort()
+
+      record('stopped_review_comment', Array.from(
+        { length: 40 },
+        (_unused, index) => `harlan-zw/example#${index}: This operation was aborted`,
+      ))
+
+      expect(store.listIncidents()).toEqual([])
+    }
+    finally {
+      store.close()
+    }
+  })
+
+  it('leaves an Incident an earlier pass recorded, so an abort hides nothing', () => {
+    const store = openJournalStore(':memory:')
+    try {
+      const controller = new AbortController()
+      createPassIncidentRecorder({ now, signal: new AbortController().signal, store })(
+        'stopped_review_comment',
+        ['harlan-zw/example#1: GitHub returned 502.'],
+      )
+      controller.abort()
+      createPassIncidentRecorder({ now, signal: controller.signal, store })('stopped_review_comment', [])
+
+      expect(store.listIncidents()).toHaveLength(1)
+    }
+    finally {
+      store.close()
+    }
+  })
+
+  it('clears an Incident once a finished pass stops failing', () => {
+    const store = openJournalStore(':memory:')
+    try {
+      const record = createPassIncidentRecorder({ now, signal: new AbortController().signal, store })
+      record('stopped_review_comment', ['harlan-zw/example#1: GitHub returned 502.'])
+
+      record('stopped_review_comment', [])
+
+      expect(store.listIncidents()).toEqual([])
+    }
+    finally {
+      store.close()
+    }
+  })
+})


### PR DESCRIPTION
### 📚 Description

Restarting the service just now produced forty incidents in one go:

    40 x stopped_review_comment | network | Retrying
    harlan-zw/nuxtseo.com#260: This operation was aborted
    harlan-zw/harlan-agent-kit#36: This operation was aborted
    ...

Stopping aborts every request still in flight. Each one rejects with an abort,
and the poll pass recorded all of them. So every restart buries whatever real
incidents were on the System pane under a wall of its own shutdown.

An aborted pass now reports nothing and the next pass records the truth. The
guard sits in one recorder shared by every incident write in both the poll pass
and the worktree sweep, rather than at six call sites where the seventh would
eventually be missed.

Incidents an earlier pass recorded survive an abort, since an aborted pass also
resolves nothing.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).