### PR TITLE
fix(agent): let a Publication command belong to a Routine run

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3637,6 +3637,85 @@ const routineMigration = `
   PRAGMA user_version = 38;
 `
 
+/**
+ * Lets a Publication command belong to a Routine run as well as a Task.
+ *
+ * Publication was bound to `tasks(id)`, and `tasks.subject_id` is NOT NULL, so
+ * a Routine run could never own one. A Routine answers a clock and has no
+ * Item, which is the third place that assumption has surfaced after agent
+ * sessions and progress.
+ *
+ * Both owners keep a real foreign key rather than sharing one column behind a
+ * discriminator string. The CHECK then makes "exactly one owner" a constraint,
+ * so a command owned by both or by neither cannot be written at all.
+ */
+const polymorphicPublicationMigration = `
+  DROP INDEX IF EXISTS publication_commands_state_tag;
+  DROP INDEX IF EXISTS one_live_publication_command_per_task;
+
+  CREATE TABLE publication_commands_v39 (
+    id TEXT PRIMARY KEY,
+    task_id TEXT REFERENCES tasks(id),
+    routine_run_id TEXT REFERENCES routine_runs(id),
+    state_tag TEXT NOT NULL CHECK (state_tag IN ('Pending', 'Running', 'Published', 'Failed', 'Superseded')),
+    commit_sha TEXT NOT NULL,
+    base_sha TEXT NOT NULL,
+    base_ref TEXT NOT NULL CHECK (base_ref != ''),
+    expected_head_sha TEXT NOT NULL,
+    head_ref TEXT NOT NULL,
+    artifact_ref TEXT NOT NULL,
+    patch_digest TEXT NOT NULL,
+    changed_files INTEGER NOT NULL CHECK (changed_files >= 0),
+    outcome_unknown INTEGER NOT NULL DEFAULT 0 CHECK (outcome_unknown IN (0, 1)),
+    reason TEXT,
+    worker_id TEXT,
+    fence INTEGER NOT NULL DEFAULT 0,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    lease_expires_at TEXT,
+    published_at TEXT,
+    updated_at TEXT NOT NULL,
+    pull_request_title TEXT,
+    pull_request_body TEXT,
+    -- Exactly one owner. Never both, never neither.
+    CHECK ((task_id IS NULL) != (routine_run_id IS NULL)),
+    -- A pull request cannot merge into itself, so a stack can never name its own head.
+    CHECK (base_ref != head_ref),
+    CHECK (
+      (state_tag = 'Running' AND worker_id IS NOT NULL AND lease_expires_at IS NOT NULL)
+      OR (state_tag != 'Running' AND worker_id IS NULL AND lease_expires_at IS NULL)
+    ),
+    CHECK (state_tag NOT IN ('Failed', 'Superseded') OR reason IS NOT NULL),
+    CHECK (state_tag != 'Published' OR published_at IS NOT NULL)
+  );
+
+  INSERT INTO publication_commands_v39 (
+    id, task_id, routine_run_id, state_tag, commit_sha, base_sha, base_ref, expected_head_sha,
+    head_ref, artifact_ref, patch_digest, changed_files, outcome_unknown, reason, worker_id,
+    fence, attempts, max_attempts, lease_expires_at, published_at, updated_at,
+    pull_request_title, pull_request_body
+  )
+  SELECT
+    id, task_id, NULL, state_tag, commit_sha, base_sha, base_ref, expected_head_sha,
+    head_ref, artifact_ref, patch_digest, changed_files, outcome_unknown, reason, worker_id,
+    fence, attempts, max_attempts, lease_expires_at, published_at, updated_at,
+    pull_request_title, pull_request_body
+  FROM publication_commands;
+
+  DROP TABLE publication_commands;
+  ALTER TABLE publication_commands_v39 RENAME TO publication_commands;
+
+  CREATE INDEX publication_commands_state_tag ON publication_commands(state_tag);
+  CREATE UNIQUE INDEX one_live_publication_command_per_task
+    ON publication_commands(task_id)
+    WHERE task_id IS NOT NULL AND state_tag IN ('Pending', 'Running', 'Published');
+  CREATE UNIQUE INDEX one_live_publication_command_per_routine_run
+    ON publication_commands(routine_run_id)
+    WHERE routine_run_id IS NOT NULL AND state_tag IN ('Pending', 'Running', 'Published');
+
+  PRAGMA user_version = 39;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -3662,7 +3741,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 38)
+  if (version === 39)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -3815,6 +3894,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 37) {
     applyMigration(database, routineMigration)
+    version = 38
+  }
+  if (version === 38) {
+    applyForeignKeyMigration(database, polymorphicPublicationMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -7829,7 +7829,10 @@ export function openJournalStore(
    *
    * A Routine the spec dropped is deleted, and its runs and Candidates go with
    * it through the cascade. Leaving them would let a Routine nobody declares
-   * keep answering a clock.
+   * keep answering a clock. Its Publications go too: the routine_runs foreign
+   * key on publication_commands has no cascade of its own, so a command left
+   * behind would wedge this delete forever, on every tick after a normal
+   * spec-file removal.
    *
    * `last_run_at` survives a rewrite. A schedule edit must not make every past
    * instant look unrun, which would fire a catch-up run on the next tick.
@@ -7850,6 +7853,21 @@ export function openJournalStore(
     try {
       const declared = input.entries.map(entry => `${input.repository}:${entry.name}`)
       const placeholders = declared.map(() => '?').join(', ')
+      const dropping = declared.length === 0
+        ? 'SELECT id FROM routines WHERE repository = ?'
+        : `SELECT id FROM routines WHERE repository = ? AND id NOT IN (${placeholders})`
+      database.prepare(`
+        DELETE FROM publication_events WHERE command_id IN (
+          SELECT publication_commands.id FROM publication_commands
+          JOIN routine_runs ON routine_runs.id = publication_commands.routine_run_id
+          WHERE routine_runs.routine_id IN (${dropping})
+        )
+      `).run(input.repository, ...declared)
+      database.prepare(`
+        DELETE FROM publication_commands WHERE routine_run_id IN (
+          SELECT id FROM routine_runs WHERE routine_id IN (${dropping})
+        )
+      `).run(input.repository, ...declared)
       database.prepare(
         `DELETE FROM routines WHERE repository = ?${declared.length === 0 ? '' : ` AND id NOT IN (${placeholders})`}`,
       ).run(input.repository, ...declared)

--- a/packages/harlan-github-agent/test/publication-owner.test.ts
+++ b/packages/harlan-github-agent/test/publication-owner.test.ts
@@ -123,6 +123,50 @@ describe('who owns one Publication command', () => {
     }
   })
 
+  it('removes a Routine whose run owns a Publication command', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path)
+    store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'pr-triage', crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+      at: '2026-08-27T00:00:00.000Z',
+    })
+    const run = store.openRoutineRun({
+      routineId: 'harlan-zw/example:pr-triage',
+      scheduledFor: '2026-08-27T07:00:00.000Z',
+      specSha: 'abc123',
+      at: '2026-08-27T07:00:05.000Z',
+    })
+    store.close()
+
+    const database = new DatabaseSync(path)
+    database.exec('PRAGMA foreign_keys = ON')
+    try {
+      database
+        .prepare(`INSERT INTO publication_commands (${columns}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(...values(null, run?.id ?? '') as never[])
+    }
+    finally {
+      database.close()
+    }
+
+    const reopened = openJournalStore(path)
+    try {
+      const routines = reopened.syncRoutines({
+        repository: 'harlan-zw/example',
+        specSha: 'def456',
+        entries: [],
+        at: '2026-08-27T08:00:00.000Z',
+      })
+
+      expect(routines).toEqual([])
+    }
+    finally {
+      reopened.close()
+    }
+  })
+
   it('keeps one live command per Routine run', () => {
     const path = join(directory, 'state.sqlite')
     const store = openJournalStore(path)

--- a/packages/harlan-github-agent/test/publication-owner.test.ts
+++ b/packages/harlan-github-agent/test/publication-owner.test.ts
@@ -1,0 +1,158 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { openJournalStore } from '../src/store.ts'
+
+let directory: string
+
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'harlan-agent-publication-'))
+})
+
+afterEach(() => {
+  rmSync(directory, { recursive: true, force: true })
+})
+
+function openRaw(): { database: DatabaseSync, close: () => void } {
+  const path = join(directory, 'state.sqlite')
+  const store = openJournalStore(path)
+  store.close()
+  const database = new DatabaseSync(path)
+  database.exec('PRAGMA foreign_keys = ON')
+  return { database, close: () => database.close() }
+}
+
+const columns = `
+  id, task_id, routine_run_id, state_tag, commit_sha, base_sha, base_ref,
+  expected_head_sha, head_ref, artifact_ref, patch_digest, changed_files, updated_at
+`
+
+function values(taskId: string | null, routineRunId: string | null): unknown[] {
+  return [
+    'command-1',
+    taskId,
+    routineRunId,
+    'Pending',
+    'a'.repeat(40),
+    'b'.repeat(40),
+    'main',
+    'b'.repeat(40),
+    'agent/routine',
+    'refs/agent/artifact',
+    'digest',
+    1,
+    '2026-08-27T07:00:00.000Z',
+  ]
+}
+
+describe('who owns one Publication command', () => {
+  it('refuses a command owned by nobody', () => {
+    const { database, close } = openRaw()
+    try {
+      expect(() => database
+        .prepare(`INSERT INTO publication_commands (${columns}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(...values(null, null) as never[]))
+        .toThrow()
+    }
+    finally {
+      close()
+    }
+  })
+
+  it('refuses a command owned by both a Task and a Routine run', () => {
+    const { database, close } = openRaw()
+    try {
+      expect(() => database
+        .prepare(`INSERT INTO publication_commands (${columns}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(...values('task-1', 'run-1') as never[]))
+        .toThrow()
+    }
+    finally {
+      close()
+    }
+  })
+
+  it('refuses a Routine run owner that does not exist', () => {
+    const { database, close } = openRaw()
+    try {
+      expect(() => database
+        .prepare(`INSERT INTO publication_commands (${columns}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(...values(null, 'run-that-never-existed') as never[]))
+        .toThrow()
+    }
+    finally {
+      close()
+    }
+  })
+
+  it('accepts a command a real Routine run owns', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path)
+    store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'pr-triage', crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+      at: '2026-08-27T00:00:00.000Z',
+    })
+    const run = store.openRoutineRun({
+      routineId: 'harlan-zw/example:pr-triage',
+      scheduledFor: '2026-08-27T07:00:00.000Z',
+      specSha: 'abc123',
+      at: '2026-08-27T07:00:05.000Z',
+    })
+    store.close()
+
+    const database = new DatabaseSync(path)
+    database.exec('PRAGMA foreign_keys = ON')
+    try {
+      database
+        .prepare(`INSERT INTO publication_commands (${columns}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+        .run(...values(null, run?.id ?? '') as never[])
+
+      const stored = database
+        .prepare('SELECT routine_run_id, task_id FROM publication_commands WHERE id = ?')
+        .get('command-1') as { routine_run_id: string, task_id: string | null }
+
+      expect(stored.routine_run_id).toBe(run?.id)
+      expect(stored.task_id).toBeNull()
+    }
+    finally {
+      database.close()
+    }
+  })
+
+  it('keeps one live command per Routine run', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path)
+    store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'pr-triage', crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+      at: '2026-08-27T00:00:00.000Z',
+    })
+    const run = store.openRoutineRun({
+      routineId: 'harlan-zw/example:pr-triage',
+      scheduledFor: '2026-08-27T07:00:00.000Z',
+      specSha: 'abc123',
+      at: '2026-08-27T07:00:05.000Z',
+    })
+    store.close()
+
+    const database = new DatabaseSync(path)
+    database.exec('PRAGMA foreign_keys = ON')
+    try {
+      const insert = database.prepare(`INSERT INTO publication_commands (${columns}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      insert.run(...values(null, run?.id ?? '') as never[])
+
+      expect(() => insert.run(...[
+        'command-2',
+        ...values(null, run?.id ?? '').slice(1),
+      ] as never[])).toThrow()
+    }
+    finally {
+      database.close()
+    }
+  })
+})

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -368,7 +368,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(38)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(39)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })


### PR DESCRIPTION
### 📚 Description

A Routine cannot open a pull request today, and the reason is structural rather
than missing code: `publication_commands.task_id` references `tasks(id)`, and
`tasks.subject_id` is `NOT NULL REFERENCES subjects(id)`. A Routine answers a
clock, so it has no subject, so it can never own a Publication command.

That is the third place the "all work belongs to an Item" assumption has
surfaced. Agent sessions and progress reporting both hit it too, and both were
worked around by going without. This one cannot be worked around, because the
constraint is doing real integrity work.

`publication_commands` now carries `task_id` and `routine_run_id`, each with its
own foreign key, and a CHECK that exactly one is set. A shared column behind a
discriminator string would have dropped both foreign keys to buy the same thing.
This way a command owned by both, by neither, or by a run that does not exist
cannot be written at all.

The one-live-command index is now two partial indexes, one per owner.

No routine publishes anything yet. This is the substrate that makes it possible.

While rewriting the table I dropped the comment explaining `CHECK (base_ref !=
head_ref)` and only noticed because a migration fixture greps for it. Restored.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).