### PR TITLE
fix(agent): retire a canonical comment a person deleted

### DIFF
--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -59,7 +59,7 @@ export interface QueuePositionSweepOptions {
   github: Pick<GitHubAgentSource, 'clearReviewOutcome' | 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'isQueuedReviewStatus' | 'listQueuedReviewStatuses' | 'recordQueuedReviewStatus'>
+  store: Pick<JournalStore, 'isQueuedReviewStatus' | 'listQueuedReviewStatuses' | 'recordDeletedReviewComment' | 'recordQueuedReviewStatus'>
 }
 
 export type QueuePositionOutcome
@@ -124,8 +124,17 @@ export async function publishQueuePositions(
     const edited = await options.github.editReviewStatus(mapping, status.pullRequestNumber, status.commentId, status.publishedBody, body, signal)
     if (edited._tag === 'Err')
       return err(`${status.repository}#${status.pullRequestNumber}: ${edited.error}`)
-    if (edited.value._tag === 'Missing')
+    if (edited.value._tag === 'Missing') {
+      // Same as the stopped-review sweep: a deleted comment is answered, and
+      // the publication has to retire or every later pass asks again.
+      options.store.recordDeletedReviewComment({
+        taskKind: status.taskKind,
+        taskId: status.taskId,
+        commentId: status.commentId,
+        at,
+      })
       return ok({ _tag: 'CommentGone', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
+    }
     if (edited.value._tag === 'Changed')
       return ok({ _tag: 'Superseded', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
     const recorded = options.store.recordQueuedReviewStatus({

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -18,7 +18,7 @@ export interface ReviewStopSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listStoppedReviews' | 'recordStoppedReviewStatus'>
+  store: Pick<JournalStore, 'listStoppedReviews' | 'recordDeletedReviewComment' | 'recordStoppedReviewStatus'>
 }
 
 export function stoppedReviewComment(
@@ -115,8 +115,17 @@ export async function publishStoppedReviews(
     const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, review.publishedBody, body, signal)
     if (edited._tag === 'Err')
       return err(`${review.repository}#${review.pullRequestNumber}: ${edited.error}`)
-    if (edited.value._tag === 'Missing')
+    if (edited.value._tag === 'Missing') {
+      // Deleting the comment is how a person answers it. Retiring the
+      // publication is what stops this sweep asking again on every pass.
+      options.store.recordDeletedReviewComment({
+        taskKind: review.taskKind,
+        taskId: review.taskId,
+        commentId: review.commentId,
+        at,
+      })
       return ok({ _tag: 'CommentGone', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
+    }
     if (edited.value._tag === 'Changed')
       return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     const recorded = options.store.recordStoppedReviewStatus({

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -648,6 +648,20 @@ export interface JournalStore {
    * sweep that sees false here has lost the comment to the claimed agent.
    */
   isQueuedReviewStatus: (input: { taskId: string, taskKind: 'adversarial_review' | 'review_fix' }) => boolean
+  /**
+   * Retires the canonical comment a person deleted.
+   *
+   * A sweep refuses to open a deleted comment again, which is right: deleting
+   * it is how a person answers it. Refusing was the whole response though, so
+   * the row stayed in the sweep's list and asked GitHub again every pass,
+   * forever. Retiring the publication takes the row out of every sweep.
+   */
+  recordDeletedReviewComment: (input: {
+    taskKind: 'adversarial_review' | 'review_fix'
+    taskId: string
+    commentId: number
+    at: string
+  }) => boolean
   recordStoppedReviewStatus: (input: {
     taskId: string
     taskKind: 'adversarial_review' | 'review_fix'
@@ -7646,6 +7660,12 @@ export function openJournalStore(
     `).get(input.taskId, input.taskKind) !== undefined
   }
 
+  const recordDeletedReviewComment: JournalStore['recordDeletedReviewComment'] = input => database.prepare(`
+    UPDATE review_status_commands
+    SET state_tag = 'Superseded', reason = 'A person deleted the comment.', updated_at = ?
+    WHERE task_kind = ? AND task_id = ? AND state_tag = 'Published' AND github_comment_id = ?
+  `).run(input.at, input.taskKind, input.taskId, input.commentId).changes > 0
+
   const recordStoppedReviewStatus: JournalStore['recordStoppedReviewStatus'] = (input) => {
     const bodySha256 = digest(input.body)
     const commandId = digest(`${input.taskKind}:${input.taskId}:stopped:${bodySha256}`)
@@ -8269,6 +8289,7 @@ export function openJournalStore(
     listStoppedReviews,
     recordQueuedReviewStatus,
     isQueuedReviewStatus,
+    recordDeletedReviewComment,
     recordStoppedReviewStatus,
     approvePullRequest,
     authorizePublication,

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -100,6 +100,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => statuses,
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => true,
@@ -124,6 +125,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair()],
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: (input) => {
@@ -155,6 +157,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [{ ...unchanged, publishedBody: queuePositionComment(unchanged) }],
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => true,
@@ -180,6 +183,7 @@ describe('publishQueuePositions', () => {
       repositories: [repositoryMapping()],
       store: {
         isQueuedReviewStatus: () => true,
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair({ verdict: { _tag: 'Unanswered' } })],
         recordQueuedReviewStatus: () => true,
       },
@@ -203,6 +207,7 @@ describe('publishQueuePositions', () => {
       repositories: [repositoryMapping()],
       store: {
         isQueuedReviewStatus: () => true,
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair({ verdict: { _tag: 'Answered' } })],
         recordQueuedReviewStatus: () => true,
       },
@@ -211,7 +216,8 @@ describe('publishQueuePositions', () => {
     expect(cleared).toBe(0)
   })
 
-  it('writes nothing when a person deleted the comment, rather than posting it again', async () => {
+  it('retires the publication a person deleted, so no later pass asks again', async () => {
+    const retired: number[] = []
     let recorded = 0
     const results = await publishQueuePositions({
       github: {
@@ -222,6 +228,10 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: (input) => {
+          retired.push(input.commentId)
+          return true
+        },
         listQueuedReviewStatuses: () => [queuedRepair()],
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => {
@@ -233,8 +243,8 @@ describe('publishQueuePositions', () => {
 
     expect(results).toEqual([ok({ _tag: 'CommentGone', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
     expect(recorded).toBe(0)
+    expect(retired).toEqual([42])
   })
-
   it('leaves the comment alone once the head commit moves', async () => {
     let writes = 0
     const results = await publishQueuePositions({
@@ -249,6 +259,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair()],
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => true,
@@ -276,6 +287,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair()],
         // An agent claimed the Task between the Queue read and the write.
         isQueuedReviewStatus: () => false,
@@ -301,6 +313,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair()],
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => true,
@@ -323,6 +336,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair()],
         isQueuedReviewStatus: () => true,
         recordQueuedReviewStatus: () => {
@@ -352,6 +366,7 @@ describe('publishQueuePositions', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listQueuedReviewStatuses: () => [queuedRepair()],
         isQueuedReviewStatus: () => !claimed,
         recordQueuedReviewStatus: () => {

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -86,6 +86,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listStoppedReviews: () => reviews,
         recordStoppedReviewStatus: () => true,
       },
@@ -108,6 +109,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => {
           recorded += 1
@@ -139,6 +141,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => true,
       },
@@ -162,6 +165,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [{ ...stopped, disposition: { _tag: 'Merged' } }],
         recordStoppedReviewStatus: () => true,
       },
@@ -171,7 +175,8 @@ describe('publishStoppedReviews', () => {
     expect(body).toContain('### 🤖 MERGED')
   })
 
-  it('writes nothing when a person deleted the comment, rather than posting it again', async () => {
+  it('retires the publication a person deleted, so no later pass asks again', async () => {
+    const retired: number[] = []
     let recorded = 0
     const results = await publishStoppedReviews({
       github: {
@@ -181,6 +186,10 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: (input) => {
+          retired.push(input.commentId)
+          return true
+        },
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => {
           recorded += 1
@@ -191,8 +200,8 @@ describe('publishStoppedReviews', () => {
 
     expect(results).toEqual([ok({ _tag: 'CommentGone', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
     expect(recorded).toBe(0)
+    expect(retired).toEqual([42])
   })
-
   it('leaves the comment alone once the pull request moves on', async () => {
     let writes = 0
     const results = await publishStoppedReviews({
@@ -206,6 +215,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => true,
       },

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1402,6 +1402,63 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
+  it('drops a stopped Review for good once its comment is gone', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.recordObservation({
+      externalId: 'deleted-comment-pr',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'review',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 REVIEWING · Git worktree ready',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:03.000Z',
+      evidence: 'Waiting for Baseline repair baseline-task.',
+    })).toBe(true)
+    expect(store.listStoppedReviews()).toHaveLength(1)
+
+    // The sweep cannot close a comment GitHub no longer has, and refusing was
+    // its whole answer, so the row came back on every pass.
+    expect(store.recordDeletedReviewComment({
+      taskKind: 'adversarial_review',
+      taskId: review.id,
+      commentId: 42,
+      at: '2026-08-13T01:03:00.000Z',
+    })).toBe(true)
+    expect(store.listStoppedReviews()).toEqual([])
+  })
+
   it('keeps a stopped Review eligible after GitHub closes its pull request Revision', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### 🔗 Linked issue

Follows #49.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Both comment sweeps have the same hole. When GitHub reports the canonical comment gone, the sweep returns `CommentGone` and writes nothing, which is the correct answer: deleting the comment is how a person tells the service to stop. Refusing to write was the *whole* answer though. Nothing recorded that the comment was gone, so the row stayed in the sweep's list and the next pass asked GitHub again, and the next, with no end.

Measured on the live journal: `nuxtseo.com#579` was asked 21 times in one hour, and `listStoppedReviews` holds 138 rows. Every row costs a GitHub write attempt per pass and can never leave.

The fix retires the publication instead of only declining to write. Both sweeps join on a `Published` status command, so a retired one takes the row out of all of them permanently, and a comment a person deleted stays deleted.

### What this does not explain

The service logs one stopped-review line per pass, always #579, while the list holds 138. Running the real sweep over the real 138 rows locally processes all of them without stalling, so the loop is not the problem, and there is no journald suppression. I have not accounted for the other 137 yet. This fix is justified on its own evidence: #579's repetition is that leak, observed directly.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).