### PR TITLE
fix(agent): keep one bad row from ending the stopped-review sweep

### DIFF
--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -144,7 +144,11 @@ export async function publishStoppedReviews(
   }
 
   const results: Array<Result<StoppedReviewOutcome, string>> = []
-  for (const review of reviews)
-    results.push(await publish(review))
+  for (const review of reviews) {
+    // One row must not take the rest of the sweep with it. A throw here used
+    // to abandon every row behind it, and the pass reported nothing at all.
+    results.push(await publish(review).catch((error: unknown) =>
+      err(`${review.repository}#${review.pullRequestNumber}: ${error instanceof Error ? error.message : 'The stopped review comment failed unexpectedly.'}`)))
+  }
   return results
 }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -669,6 +669,10 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           repositories: config.repositories,
           store,
         }, signal)
+        // The list size, every pass. A sweep that reports three outcomes while
+        // its list holds a hundred rows is invisible without this line.
+        if (stopped.length > 0)
+          options.logger.info(`Stopped review comments: ${stopped.length} to close.`)
         stopped.forEach((result) => {
           if (result._tag === 'Ok') {
             options.logger.info(result.value._tag === 'CommentGone'


### PR DESCRIPTION
### 🔗 Linked issue

Follows #68.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

The stopped-review sweep reports one outcome per pass while its list holds 137 rows. #68 fixed the reason the list grows; this is about not being able to see what the sweep is doing.

Two things made that invisible. A throw inside the loop abandoned every row behind it and the pass logged nothing at all, which reads exactly like an empty list. And nothing ever stated how long the list was, so one outcome and a hundred looked the same from outside.

Each row settles on its own now, and the pass says how many rows it has to close.

I have not found what stops the other 137 yet. Running the real sweep over the real rows processes all of them, the repositories are all configured and enabled, no error is logged, and journald is not suppressing anything. Rather than guess a fifth cause, this makes the next pass say it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).