### PR TITLE
fix(agent): bound the stopped-review sweep to a budget it can finish

### DIFF
--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -14,11 +14,32 @@ export type StoppedReviewOutcome
 
 export type { StoppedReviewDisposition }
 
+/**
+ * What one pass of the sweep did, and what it left behind.
+ *
+ * `remaining` is never silent. A sweep that closes three comments out of a
+ * hundred and says nothing reads exactly like a sweep with nothing to do.
+ */
+export interface StoppedReviewSweep {
+  results: Array<Result<StoppedReviewOutcome, string>>
+  remaining: number
+}
+
 export interface ReviewStopSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
   store: Pick<JournalStore, 'listStoppedReviews' | 'recordDeletedReviewComment' | 'recordStoppedReviewStatus'>
+  /**
+   * How long one pass may spend closing comments.
+   *
+   * Every row costs a GitHub round trip, and the whole list used to run inside
+   * a pass that has a fixed deadline. A backlog of 139 rows spent that deadline
+   * and the poller aborted the sweep at the same place every pass, so two
+   * comments closed and the rest never ran. The sweep stops on its own budget
+   * now and the next pass carries on.
+   */
+  budgetMilliseconds?: number
 }
 
 export function stoppedReviewComment(
@@ -84,7 +105,7 @@ Push a new commit to start a new review. To review this commit again, comment \`
 export async function publishStoppedReviews(
   options: ReviewStopSweepOptions,
   signal: AbortSignal,
-): Promise<Array<Result<StoppedReviewOutcome, string>>> {
+): Promise<StoppedReviewSweep> {
   const mappings = new Map(options.repositories.map(mapping => [mapping.github.toLowerCase(), mapping]))
   const reviews = options.store.listStoppedReviews()
   const publish = async (review: StoppedReview): Promise<Result<StoppedReviewOutcome, string>> => {
@@ -143,12 +164,18 @@ export async function publishStoppedReviews(
       : err(`${review.repository}#${review.pullRequestNumber}: the final review comment could not be saved.`)
   }
 
+  const budgetMilliseconds = options.budgetMilliseconds ?? 30_000
+  const startedAt = options.now().getTime()
   const results: Array<Result<StoppedReviewOutcome, string>> = []
+  let index = 0
   for (const review of reviews) {
+    if (signal.aborted || options.now().getTime() - startedAt >= budgetMilliseconds)
+      break
+    index += 1
     // One row must not take the rest of the sweep with it. A throw here used
     // to abandon every row behind it, and the pass reported nothing at all.
     results.push(await publish(review).catch((error: unknown) =>
       err(`${review.repository}#${review.pullRequestNumber}: ${error instanceof Error ? error.message : 'The stopped review comment failed unexpectedly.'}`)))
   }
-  return results
+  return { results, remaining: reviews.length - index }
 }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -689,9 +689,12 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         }, signal)
         // The list size, every pass. A sweep that reports three outcomes while
         // its list holds a hundred rows is invisible without this line.
-        if (stopped.length > 0)
-          options.logger.info(`Stopped review comments: ${stopped.length} to close.`)
-        stopped.forEach((result) => {
+        if (stopped.results.length > 0 || stopped.remaining > 0) {
+          options.logger.info(stopped.remaining > 0
+            ? `Stopped review comments: closed ${stopped.results.length} this pass, ${stopped.remaining} left for the next.`
+            : `Stopped review comments: closed ${stopped.results.length}.`)
+        }
+        stopped.results.forEach((result) => {
           if (result._tag === 'Ok') {
             options.logger.info(result.value._tag === 'CommentGone'
               ? `${result.value.repository}#${result.value.pullRequestNumber}: the stopped review comment was deleted, so nothing was written.`
@@ -703,7 +706,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
             options.logger.error(`Stopped review comment: ${result.error}`)
           }
         })
-        recordPassIncidents('stopped_review_comment', stopped.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+        recordPassIncidents('stopped_review_comment', stopped.results.flatMap(result => result._tag === 'Err' ? [result.error] : []))
         const positions = await publishQueuePositions({
           github: workerGithub,
           now,

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -98,7 +98,7 @@ describe('publishStoppedReviews', () => {
   it('rewrites the canonical comment and records it once', async () => {
     let edited: { commentId: number, body: string } | undefined
     let recorded = 0
-    const results = await publishStoppedReviews({
+    const { results } = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
         editReviewStatus: (_repository, _number, commentId, _expectedBody, body) => {
@@ -126,7 +126,7 @@ describe('publishStoppedReviews', () => {
 
   it('closes a stale progress comment after GitHub merges the pull request', async () => {
     let body = ''
-    const results = await publishStoppedReviews({
+    const { results } = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({
           state: 'closed',
@@ -154,7 +154,7 @@ describe('publishStoppedReviews', () => {
 
   it('closes the comment on a merged pull request whose head branch GitHub deleted', async () => {
     let body = ''
-    const results = await publishStoppedReviews({
+    const { results } = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(err('Branch not found - https://docs.github.com/rest/branches/branches#get-a-branch')),
         editReviewStatus: (_repository, _number, _commentId, _expectedBody, value) => {
@@ -175,10 +175,65 @@ describe('publishStoppedReviews', () => {
     expect(body).toContain('### 🤖 MERGED')
   })
 
+  it('stops on its own budget and leaves the rest for the next pass', async () => {
+    const backlog = Array.from({ length: 5 }, (_, index) => ({
+      ...stopped,
+      taskId: `review-task-${index}`,
+      pullRequestNumber: 24 + index,
+      disposition: { _tag: 'Merged' as const },
+    }))
+    let edits = 0
+    // Every closed comment costs a GitHub round trip. This clock spends one
+    // second on each, so the budget runs out partway through the backlog.
+    let clock = Date.parse('2026-08-15T04:00:00.000Z')
+    const { results, remaining } = await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.reject(new Error('A merged pull request needs no snapshot.')),
+        editReviewStatus: () => {
+          edits += 1
+          clock += 1_000
+          return Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
+      },
+      now: () => new Date(clock),
+      repositories: [repositoryMapping()],
+      store: {
+        recordDeletedReviewComment: () => true,
+        listStoppedReviews: () => backlog,
+        recordStoppedReviewStatus: () => true,
+      },
+      budgetMilliseconds: 3_000,
+    }, new AbortController().signal)
+
+    expect(results).toHaveLength(3)
+    expect(remaining).toBe(2)
+    expect(edits).toBe(3)
+  })
+
+  it('reports a backlog it never started, so a spent pass is never silent', async () => {
+    const { results, remaining } = await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.reject(new Error('The budget was spent before any row ran.')),
+        editReviewStatus: () => Promise.reject(new Error('The budget was spent before any row ran.')),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        recordDeletedReviewComment: () => true,
+        listStoppedReviews: () => [stopped, stopped],
+        recordStoppedReviewStatus: () => true,
+      },
+      budgetMilliseconds: 0,
+    }, new AbortController().signal)
+
+    expect(results).toEqual([])
+    expect(remaining).toBe(2)
+  })
+
   it('retires the publication a person deleted, so no later pass asks again', async () => {
     const retired: number[] = []
     let recorded = 0
-    const results = await publishStoppedReviews({
+    const { results } = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
         editReviewStatus: () => Promise.resolve(ok({ _tag: 'Missing' })),
@@ -204,7 +259,7 @@ describe('publishStoppedReviews', () => {
   })
   it('leaves the comment alone once the pull request moves on', async () => {
     let writes = 0
-    const results = await publishStoppedReviews({
+    const { results } = await publishStoppedReviews({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({ headSha: 'def456' })),
         editReviewStatus: () => {


### PR DESCRIPTION
### 🔗 Linked issue

Follows #69.

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

#69 made the sweep say what it was doing, and the first pass answered the question:

```
Stopped review comments: 139 to close.
Stopped review comment: gscdump.com#127: This operation was aborted
Stopped review comment: gscdump.com#135: This operation was aborted
Stopped review comment: harlan-agent-kit#32: This operation was aborted
```

Every row costs a GitHub round trip, and the whole list ran inside a poll pass that has a fixed deadline (`max(5 min, interval × 4)`). 139 rows do not fit. The poller aborted the sweep in the same place every pass, so two comments closed and the rest never ran. The list grew faster than that drains.

Unbounded work with a fixed deadline can only end that way, so the sweep now owns a budget it can finish: 30 seconds, then it hands the rest to the next pass. The pass says how many it left, because a sweep that closes three of a hundred and stays quiet reads exactly like a sweep with nothing to do.

`publishStoppedReviews` returns `{ results, remaining }` rather than a bare array, so a caller cannot take the outcomes and miss the backlog behind them.

The queue position sweep is left alone. Its list is bounded by the queued Tasks, which the agent pool already caps.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).