### PR TITLE
feat(agent): let one machine answer only the triggers it owns

### DIFF
--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -32,6 +32,11 @@ webhook:
   secret_path: /home/harlan/.config/harlan-github-agent/webhook-secret
 storage:
   path: /home/harlan/.local/share/harlan-github-agent/state.sqlite
+# What may start work on this machine. Defaults to every trigger.
+# An always-on second machine runs [routine] while the desktop keeps [github].
+# The two sets never overlap, so neither machine can claim the other's task and
+# they need no lock between them.
+triggers: [github, routine]
 mutations_enabled: false
 # The controller merges a pull request labelled harlan-agent-auto-merge after a
 # READY review at or above minimum_confidence. Everything else waits for Harlan.

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -1,7 +1,7 @@
 import type { AgentProviderName } from './agent-provider.ts'
 import type { AutoMergePolicy } from './auto-merge.ts'
 import type { Result } from './result.ts'
-import type { AgentConfig, ExternalRepositoryWatch, RepositoryMapping, RepositoryOwnership, TakeOwnershipConfig, ValidatedAgentConfig, WebhookConfig } from './types.ts'
+import type { AgentConfig, ExternalRepositoryWatch, RepositoryMapping, RepositoryOwnership, ServiceTrigger, TakeOwnershipConfig, ValidatedAgentConfig, WebhookConfig } from './types.ts'
 import { execFile } from 'node:child_process'
 import { lstat, readFile, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
@@ -283,6 +283,38 @@ export async function loadWebhookSecret(path: string): Promise<Result<string, Co
     }]))
 }
 
+const SERVICE_TRIGGERS: readonly ServiceTrigger[] = ['github', 'routine']
+
+/**
+ * Which triggers this machine answers. Every trigger unless the file narrows it.
+ *
+ * A second machine set to `[routine]` runs the scheduled work while the desktop
+ * keeps `[github]`. Neither can claim the other's Task, so the two need no lock.
+ */
+function serviceTriggers(source: UnknownRecord, issues: ConfigIssue[]): readonly ServiceTrigger[] | undefined {
+  const value = source.triggers
+  if (value === undefined)
+    return SERVICE_TRIGGERS
+  if (!Array.isArray(value) || value.length === 0) {
+    issues.push({ path: '$.triggers', message: 'Expected at least one trigger.' })
+    return undefined
+  }
+  const triggers: ServiceTrigger[] = []
+  for (const entry of value) {
+    const trigger = SERVICE_TRIGGERS.find(candidate => candidate === entry)
+    if (trigger === undefined) {
+      issues.push({ path: '$.triggers', message: 'Expected github or routine.' })
+      return undefined
+    }
+    if (triggers.includes(trigger)) {
+      issues.push({ path: '$.triggers', message: 'List every trigger once.' })
+      return undefined
+    }
+    triggers.push(trigger)
+  }
+  return triggers
+}
+
 function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[]): RepositoryMapping | undefined {
   const path = `$.repositories[${index}]`
   if (!isRecord(value)) {
@@ -404,6 +436,7 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
   const issues: ConfigIssue[] = []
   const agent = agentSettings(document.value, issues)
   const webhook = webhookConfig(document.value, issues)
+  const triggers = serviceTriggers(document.value, issues)
   const github = requiredRecord(document.value, 'github', '$', issues)
   const server = requiredRecord(document.value, 'server', '$', issues)
   const storage = requiredRecord(document.value, 'storage', '$', issues)
@@ -503,6 +536,7 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
     issues.length > 0
     || agent === undefined
     || webhook === undefined
+    || triggers === undefined
     || host === undefined
     || appId === undefined
     || privateKeyPath === undefined
@@ -526,6 +560,7 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
     github: { appId, privateKeyPath, allowedOwners },
     server: { host, port, allowedOrigin },
     webhook,
+    triggers,
     storage: { path: storagePath },
     trustedCheckoutRoots,
     mutationsEnabled,

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -594,15 +594,17 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     timeoutMilliseconds: Math.max(5 * 60_000, config.pollIntervalSeconds * 4_000),
     poll: async (signal) => {
       const recordPassIncidents = createPassIncidentRecorder({ store, now, signal })
-      const results = await reconcileAllRepositories(config.repositories, {
-        ...(mutationSchedulers === undefined
-          ? {}
-          : { approvals: mutationSchedulers.approvals, autoMerge: mutationSchedulers.autoMerge }),
-        github,
-        store,
-        now,
-        signal,
-      })
+      const results = !config.triggers.includes('github')
+        ? []
+        : await reconcileAllRepositories(config.repositories, {
+            ...(mutationSchedulers === undefined
+              ? {}
+              : { approvals: mutationSchedulers.approvals, autoMerge: mutationSchedulers.autoMerge }),
+            github,
+            store,
+            now,
+            signal,
+          })
       if (signal.aborted)
         return
       results.forEach((result) => {
@@ -624,12 +626,14 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       // that observes GitHub. A repository declares its own schedule, and the
       // spec is read at the default branch commit only.
       const routineFailures: string[] = []
-      const syncedRoutines = await Promise.all(config.repositories
-        .filter(repository => repository.enabled)
-        .map(async repository => ({
-          repository: repository.github,
-          outcome: await syncRepositoryRoutines(repository, { github, store, now, signal }),
-        })))
+      const syncedRoutines = !config.triggers.includes('routine')
+        ? []
+        : await Promise.all(config.repositories
+            .filter(repository => repository.enabled)
+            .map(async repository => ({
+              repository: repository.github,
+              outcome: await syncRepositoryRoutines(repository, { github, store, now, signal }),
+            })))
       if (signal.aborted)
         return
       syncedRoutines.forEach(({ repository, outcome }) => {
@@ -644,7 +648,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
 
       // Candidate issues are filed on the same pass, a few at a time. A scan
       // that found twenty proposals must not open twenty issues at once.
-      if (config.mutationsEnabled) {
+      if (config.mutationsEnabled && config.triggers.includes('routine')) {
         const filed = await candidateIssues.publishPending(signal)
         filed.forEach((result) => {
           if (result._tag === 'Ok')
@@ -653,12 +657,16 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         recordPassIncidents('candidate_issue', filed.flatMap(result => result._tag === 'Err' ? [result.error] : []))
       }
 
-      if (config.mutationsEnabled) {
+      if (config.mutationsEnabled && config.triggers.includes('routine')) {
         const planned = planRoutineRuns({ now, store })
         planned.opened.forEach(run => options.logger.info(`${run.repository}: queued the ${run.name} routine for ${run.scheduledFor}.`))
         planned.skipped.forEach(run => options.logger.info(`${run.repository}: skipped the ${run.name} routine due at ${run.scheduledFor}.`))
       }
 
+      // Everything below answers a GitHub observation, so a routines-only
+      // machine skips it and never reads or writes another machine's work.
+      if (!config.triggers.includes('github'))
+        return
       const reruns = await syncOpenReviewRerunRequests(config.repositories, {
         allowedAuthors: config.github.allowedOwners,
         github,
@@ -854,17 +862,30 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         return null
       })
 
-  poller.start()
-  externalPoller.start()
+  // A machine answers only the triggers its configuration names. Starting a
+  // scheduler it does not own is what would let two machines claim one Task.
+  const answers = (trigger: 'github' | 'routine'): boolean => config.triggers.includes(trigger)
+  if (answers('github') || answers('routine'))
+    poller.start()
+  if (answers('github'))
+    externalPoller.start()
   worktreeSweeper.start()
-  mutationSchedulers?.tasks.start()
-  mutationSchedulers?.baselineRepairs.start()
-  mutationSchedulers?.issueWork.start()
-  mutationSchedulers?.publications.start()
-  mutationSchedulers?.repairs.forEach(scheduler => scheduler.start())
-  mutationSchedulers?.reviews.forEach(scheduler => scheduler.start())
-  mutationSchedulers?.issues.start()
-  mutationSchedulers?.routines.start()
+  if (answers('github'))
+    mutationSchedulers?.tasks.start()
+  if (answers('github'))
+    mutationSchedulers?.baselineRepairs.start()
+  if (answers('github'))
+    mutationSchedulers?.issueWork.start()
+  if (answers('github'))
+    mutationSchedulers?.publications.start()
+  if (answers('github'))
+    mutationSchedulers?.repairs.forEach(scheduler => scheduler.start())
+  if (answers('github'))
+    mutationSchedulers?.reviews.forEach(scheduler => scheduler.start())
+  if (answers('github'))
+    mutationSchedulers?.issues.start()
+  if (answers('routine'))
+    mutationSchedulers?.routines.start()
 
   return {
     server,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -47,6 +47,19 @@ export type WebhookConfig
   = | { _tag: 'Disabled' }
     | { _tag: 'Enabled', host: string, port: number, secretPath: string }
 
+/**
+ * What may start work on this machine.
+ *
+ * `github` covers everything a GitHub observation starts: review, repair,
+ * conflicts, issue triage, and issue work. `routine` covers everything a clock
+ * starts.
+ *
+ * Two machines running disjoint triggers need no lock and no protocol, because
+ * no Task is ever visible to both. That is what lets an always-on machine run
+ * the scheduled work while the desktop keeps the interactive work.
+ */
+export type ServiceTrigger = 'github' | 'routine'
+
 export interface AgentConfig {
   agent: {
     provider: AgentProviderName
@@ -72,6 +85,8 @@ export interface AgentConfig {
     port: number
     allowedOrigin: string
   }
+  /** Which triggers this machine answers. Defaults to every trigger. */
+  triggers: readonly ServiceTrigger[]
   /**
    * The GitHub webhook listener.
    *

--- a/packages/harlan-github-agent/test/service-triggers.test.ts
+++ b/packages/harlan-github-agent/test/service-triggers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { parseConfigText } from '../src/config.ts'
+
+const base = `
+github:
+  app_id: 12345
+  private_key_path: /home/harlan/.config/harlan-github-agent/app.pem
+  allowed_owners: [harlan-zw]
+server:
+  host: 127.0.0.1
+  port: 3210
+  allowed_origin: https://harlan-github-agent.localhost
+storage:
+  path: /home/harlan/.local/share/harlan-github-agent/state.sqlite
+mutations_enabled: false
+max_open_pull_requests: 8
+poll_interval_seconds: 60
+issue_cutoff: 2026-07-14
+external_repositories: []
+repositories: []
+`
+
+function parse(extra = ''): ReturnType<typeof parseConfigText> {
+  return parseConfigText(`${base}${extra}`)
+}
+
+describe('which triggers one machine answers', () => {
+  it('answers every trigger when the file says nothing', () => {
+    const parsed = parse()
+
+    expect(parsed._tag).toBe('Ok')
+    expect(parsed._tag === 'Ok' ? parsed.value.triggers : []).toEqual(['github', 'routine'])
+  })
+
+  it('answers routines only, which is what the second machine runs', () => {
+    const parsed = parse('triggers: [routine]\n')
+
+    expect(parsed._tag === 'Ok' ? parsed.value.triggers : []).toEqual(['routine'])
+  })
+
+  it('answers GitHub only, which is what the desktop keeps', () => {
+    const parsed = parse('triggers: [github]\n')
+
+    expect(parsed._tag === 'Ok' ? parsed.value.triggers : []).toEqual(['github'])
+  })
+
+  it('refuses an empty list, because a machine that answers nothing is a mistake', () => {
+    const parsed = parse('triggers: []\n')
+
+    expect(parsed).toEqual({ _tag: 'Err', error: [{ path: '$.triggers', message: 'Expected at least one trigger.' }] })
+  })
+
+  it('refuses a trigger the service does not have', () => {
+    const parsed = parse('triggers: [webhook]\n')
+
+    expect(parsed).toEqual({ _tag: 'Err', error: [{ path: '$.triggers', message: 'Expected github or routine.' }] })
+  })
+
+  it('refuses a repeated trigger', () => {
+    const parsed = parse('triggers: [routine, routine]\n')
+
+    expect(parsed).toEqual({ _tag: 'Err', error: [{ path: '$.triggers', message: 'List every trigger once.' }] })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Item 10 of `docs/plans/routines.md`. This is the last piece of running scheduled
work on a second machine.

### 📚 Description

Everything a Routine needs now exists, but a second instance would also poll,
review, repair and triage the same repositories as the desktop, and the two
would race for the same tasks. The fence is local to one SQLite file, so it
cannot stop that.

`triggers` fixes it without a lock. A machine answers `github`, `routine`, or
both, and it starts only the schedulers it owns. Set the always-on machine to
`[routine]` and the desktop to `[github]` and no task is ever visible to both,
so there is nothing to race over.

Gating is at the start calls and inside the poll pass, since one pass does both
jobs. A routines-only machine reconciles nothing, skips the review rerun,
status, stopped-review and queue-position sweeps, and starts none of the
GitHub-triggered schedulers.

Defaults to every trigger, so an existing configuration behaves exactly as it
does now.

This holds only while the sets stay disjoint. Giving both machines `github` needs
one shared journal, which is remote runners and a separate plan.

Untested: I have not actually run two instances. The gating is covered by
config tests and by reading, not by two machines racing.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).