### PR TITLE
fix(agent): say how long a running agent has been on one thing

### DIFF
--- a/packages/harlan-github-agent/src/agent-progress.ts
+++ b/packages/harlan-github-agent/src/agent-progress.ts
@@ -19,6 +19,24 @@ const resultLabel: Record<AgentProgressWork, string> = {
   baseline: 'Checking the default branch repair',
 }
 
+/**
+ * How long the current phase has run, in the fewest words that answer it.
+ *
+ * Empty under a minute, because a phase that just started says nothing useful
+ * and every comment would carry noise.
+ */
+export function formatPhaseDuration(since: string | undefined, at: string): string {
+  if (since === undefined)
+    return ''
+  const minutes = Math.floor((new Date(at).getTime() - new Date(since).getTime()) / 60_000)
+  if (!Number.isFinite(minutes) || minutes < 1)
+    return ''
+  if (minutes < 60)
+    return ` for ${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  return ` for ${hours} h ${minutes - hours * 60} min`
+}
+
 export function formatProgressBar(percent: number): string {
   const complete = Math.round(percent / 20)
   return `${'▓'.repeat(complete)}${'░'.repeat(5 - complete)} ${percent}%`

--- a/packages/harlan-github-agent/src/agent-turn.ts
+++ b/packages/harlan-github-agent/src/agent-turn.ts
@@ -12,6 +12,16 @@ import { addAgentTokenUsage } from './agent-provider.ts'
 import { contextBudgetExhaustedReason } from './failure.ts'
 import { err, ok } from './result.ts'
 
+/**
+ * How often one unchanged phase restates itself on the pull request.
+ *
+ * Progress only moves forward, so a Repair that edits files for forty minutes
+ * publishes one line and then goes quiet. A reader could not tell that from an
+ * agent that had died. A slow beat proves the agent is still producing events,
+ * and stays far below the noise of a comment per file.
+ */
+const PROGRESS_HEARTBEAT_MILLISECONDS = 15 * 60_000
+
 export interface AgentTurnOptions {
   activityLog?: Pick<AgentActivityLog, 'record'>
   now: () => Date
@@ -26,7 +36,8 @@ export interface AgentTurnInput {
   /** Issue or pull request number the session belongs to. */
   number: number
   progress?: {
-    currentPercent: number
+    /** The phase the caller already reported, which the turn continues from. */
+    current: AgentProgress
     report: (progress: AgentProgress) => Promise<Result<void, string>> | Result<void, string>
     work: AgentProgressWork
   }
@@ -98,7 +109,9 @@ export async function runAgentTurn(
   let currentSessionId = sessionId
   let failure: string | undefined
   let usage: AgentTokenUsage = { _tag: 'Unavailable' }
-  let currentPercent = input.progress?.currentPercent ?? 0
+  let current = input.progress?.current
+  let phaseSince = options.now().toISOString()
+  let reportedAt = phaseSince
   for await (const event of events) {
     if (event._tag === 'SessionStarted') {
       currentSessionId = event.sessionId
@@ -122,13 +135,27 @@ export async function runAgentTurn(
     const activity = agentActivityFromEvent(event, options.now().toISOString())
     if (activity !== undefined)
       options.activityLog?.record(input.taskId, activity)
-    const progress = input.progress === undefined ? undefined : agentEventProgress(event, input.progress.work)
-    if (progress !== undefined && progress.percent > currentPercent) {
-      const reported = await input.progress!.report(progress)
-      if (reported._tag === 'Err')
-        failure ??= reported.error
-      else
-        currentPercent = progress.percent
+    if (input.progress !== undefined) {
+      const at = options.now().toISOString()
+      const next = agentEventProgress(event, input.progress.work)
+      // A new phase restates the line. Otherwise the same phase restates it on
+      // a slow beat, so a reader can see the agent is alive without a comment
+      // for every file it touches.
+      const advanced = next !== undefined && current !== undefined && next.percent > current.percent
+      const stale = new Date(at).getTime() - new Date(reportedAt).getTime() >= PROGRESS_HEARTBEAT_MILLISECONDS
+      if (advanced || stale) {
+        const phase = advanced ? next as AgentProgress : current as AgentProgress
+        if (advanced)
+          phaseSince = at
+        const reported = await input.progress.report({ ...phase, since: phaseSince })
+        if (reported._tag === 'Err') {
+          failure ??= reported.error
+        }
+        else {
+          current = phase
+          reportedAt = at
+        }
+      }
     }
   }
 
@@ -169,7 +196,7 @@ export async function runParsedAgentTurn<Value>(
     ...input,
     prompt: repairPrompt(input.schema, turn.value.response, parsed.error),
     // The work is done, so this turn reports no progress of its own.
-    ...(input.progress === undefined ? {} : { progress: { ...input.progress, currentPercent: 100 } }),
+    ...(input.progress === undefined ? {} : { progress: { ...input.progress, current: { percent: 100, label: input.progress.current.label } } }),
   }, signal)
   if (repaired._tag === 'Err')
     return err(parsed.error)

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -207,7 +207,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
       const turn = await runAgentTurn(options, {
         freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
-        progress: { currentPercent: 35, report: progress, work: 'baseline' },
+        progress: { current: { percent: 35, label: 'Git worktree ready' }, report: progress, work: 'baseline' },
         prompt: prompt(task, checks, template.value),
         repository: task.repository,
         role: 'baseline_repair',

--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -127,7 +127,7 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
       const turn = await runAgentTurn(options, {
         freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
-        progress: { currentPercent: 35, report: reportProgress, work: 'conflict' },
+        progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'conflict' },
         prompt: workerPrompt(currentTask),
         repository: task.repository,
         role: 'conflict_resolution',

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -300,7 +300,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       const turn = await runAgentTurn(options, {
         freshSession: task.state.fence > 1,
         number: task.issueNumber,
-        progress: { currentPercent: 35, report: reportProgress, work: 'fix' },
+        progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'fix' },
         prompt: workerPrompt(task, snapshot.value.body, snapshot.value.comments, template.value),
         repository: task.repository,
         role: 'issue_work',

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -19,7 +19,7 @@ import type {
 } from './types.ts'
 import type { AgentWorkspaceManager } from './worktree.ts'
 import { createHash, randomUUID } from 'node:crypto'
-import { formatProgressBar } from './agent-progress.ts'
+import { formatPhaseDuration, formatProgressBar } from './agent-progress.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { currentGitHubChecks } from './github-agent-source.ts'
 import { issueTriageComment } from './issue-triage-comment.ts'
@@ -639,7 +639,7 @@ export function reviewOutcome(gates: ReviewGates): ReviewOutcomeName {
 function progressComment(headSha: string, progress: AgentProgress, at: string): string {
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${headSha} -->
-### 🤖 REVIEWING · ${progress.label}
+### 🤖 REVIEWING · ${progress.label}${formatPhaseDuration(progress.since, at)}
 
 ${automatedDisclosure({ kind: 'review', updatedAt: updatedAtLabel(at) })}
 
@@ -919,7 +919,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         number: task.pullRequestNumber,
         prompt: reviewPrompt(task, snapshot.value, workspace.value.path, preflight, repairedHeadFindings),
         progress: {
-          currentPercent: 35,
+          current: { percent: 35, label: 'Git worktree ready' },
           report: progress => reportReviewProgress(options, task, 'review', progress, signal),
           work: 'review',
         },
@@ -1075,7 +1075,7 @@ export function createIssueTriageWorker(options: ItemAgentOptions): IssueTriageW
         number: task.issueNumber,
         prompt: issuePrompt(task, snapshot.value, workspace.value.path),
         progress: {
-          currentPercent: 35,
+          current: { percent: 35, label: 'Git worktree ready' },
           report: progress => Promise.resolve(saveAgentProgress(options, task, progress)),
           work: 'issue',
         },

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -173,7 +173,7 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
       const turn = await runParsedAgentTurn({ ...options, parse: parseResponse }, {
         freshSession: true,
         number: task.pullRequestNumber,
-        progress: { currentPercent: 35, report: progress, work: 'fix' },
+        progress: { current: { percent: 35, label: 'Repair worktree ready' }, report: progress, work: 'fix' },
         prompt: prompt(task, findings),
         repository: task.repository,
         role: 'review_fix',

--- a/packages/harlan-github-agent/src/review-status-controller.ts
+++ b/packages/harlan-github-agent/src/review-status-controller.ts
@@ -2,7 +2,7 @@ import type { GitHubAgentSource, PublishedReviewStatus } from './github-agent-so
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedAdversarialReviewTask, ClaimedReviewFixTask, ReviewStatusTaskPhase } from './types.ts'
-import { formatProgressBar } from './agent-progress.ts'
+import { formatPhaseDuration, formatProgressBar } from './agent-progress.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 import { updatedAtLabel } from './text.ts'
@@ -35,7 +35,7 @@ function repairProgressComment(headSha: string, progress: AgentProgress, at: str
           : 'Repair creates its Git worktree.'
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${headSha} -->
-### 🤖 REPAIR · ${progress.label}
+### 🤖 REPAIR · ${progress.label}${formatPhaseDuration(progress.since, at)}
 
 ${automatedDisclosure({ kind: 'repair update', updatedAt: updatedAtLabel(at) })}
 

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -781,6 +781,14 @@ export type ActiveAgentState
 export interface AgentProgress {
   percent: number
   label: string
+  /**
+   * When this phase started, so a reader can tell a slow agent from a dead one.
+   *
+   * Progress only ever moves forward, so a long phase reports nothing after its
+   * first line and the comment freezes. A frozen comment and a wedged agent
+   * looked identical on the pull request. Absent before the phase is known.
+   */
+  since?: string
 }
 
 /**

--- a/packages/harlan-github-agent/test/agent-turn.test.ts
+++ b/packages/harlan-github-agent/test/agent-turn.test.ts
@@ -1,5 +1,6 @@
 import type { AgentEvent, AgentProvider } from '../src/agent-provider.ts'
 import type { Result } from '../src/result.ts'
+import type { AgentProgress } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { runAgentTurn, runParsedAgentTurn } from '../src/agent-turn.ts'
@@ -143,5 +144,71 @@ describe('an exhausted Context budget', () => {
     await runParsedAgentTurn(options(exhausts(capture)), input, new AbortController().signal)
 
     expect(capture.prompts).toHaveLength(1)
+  })
+})
+
+describe('agent turn progress', () => {
+  /** Drives one clock the event stream advances, so each beat is exact. */
+  function scriptedTurn(steps: Array<{ afterMilliseconds: number, event: AgentEvent }>) {
+    let nowMilliseconds = new Date('2026-08-16T00:00:00.000Z').getTime()
+    const provider: AgentProvider = {
+      name: 'opencode',
+      runTurn: () => (async function* () {
+        for (const step of steps) {
+          nowMilliseconds += step.afterMilliseconds
+          yield step.event
+        }
+      })(),
+    }
+    return { provider, now: () => new Date(nowMilliseconds) }
+  }
+
+  function reportingInput(reported: AgentProgress[]) {
+    return {
+      ...input,
+      progress: {
+        current: { percent: 35, label: 'Git worktree ready' },
+        report: (progress: AgentProgress) => {
+          reported.push(progress)
+          return ok(undefined)
+        },
+        work: 'fix' as const,
+      },
+    }
+  }
+
+  it('restates one unchanged phase on a slow beat and keeps its start time', async () => {
+    const reported: AgentProgress[] = []
+    const { provider, now } = scriptedTurn([
+      { afterMilliseconds: 0, event: { _tag: 'SessionStarted', sessionId: 'session-1' } as AgentEvent },
+      { afterMilliseconds: 1_000, event: { _tag: 'FileChanged', changes: [{ path: 'a.ts', kind: 'update' }] } as AgentEvent },
+      { afterMilliseconds: 60_000, event: { _tag: 'FileChanged', changes: [{ path: 'b.ts', kind: 'update' }] } as AgentEvent },
+      { afterMilliseconds: 40 * 60_000, event: { _tag: 'FileChanged', changes: [{ path: 'c.ts', kind: 'update' }] } as AgentEvent },
+      { afterMilliseconds: 1_000, event: { _tag: 'Message', text: '{"outcome":"resolved"}' } as AgentEvent },
+    ])
+
+    const result = await runAgentTurn({ ...options(provider), now }, reportingInput(reported), new AbortController().signal)
+
+    expect(result._tag).toBe('Ok')
+    // The first edit advances the phase. The second is inside the beat, so it
+    // stays quiet. The third restates the same phase, from the same start.
+    expect(reported).toEqual([
+      { percent: 70, label: 'Editing files', since: '2026-08-16T00:00:01.000Z' },
+      { percent: 70, label: 'Editing files', since: '2026-08-16T00:00:01.000Z' },
+    ])
+  })
+
+  it('says nothing extra while one phase stays inside the beat', async () => {
+    const reported: AgentProgress[] = []
+    const { provider, now } = scriptedTurn([
+      { afterMilliseconds: 0, event: { _tag: 'SessionStarted', sessionId: 'session-1' } as AgentEvent },
+      { afterMilliseconds: 1_000, event: { _tag: 'FileChanged', changes: [{ path: 'a.ts', kind: 'update' }] } as AgentEvent },
+      { afterMilliseconds: 60_000, event: { _tag: 'FileChanged', changes: [{ path: 'b.ts', kind: 'update' }] } as AgentEvent },
+      { afterMilliseconds: 60_000, event: { _tag: 'Message', text: '{"outcome":"resolved"}' } as AgentEvent },
+    ])
+
+    await runAgentTurn({ ...options(provider), now }, reportingInput(reported), new AbortController().signal)
+
+    expect(reported).toHaveLength(1)
   })
 })

--- a/packages/harlan-github-agent/test/review-status-controller.test.ts
+++ b/packages/harlan-github-agent/test/review-status-controller.test.ts
@@ -5,7 +5,7 @@ import { createReviewStatusController } from '../src/review-status-controller.ts
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
 describe('review status controller', () => {
-  it('replaces the blocked review comment with repair progress', async () => {
+  function harness() {
     const repository = repositoryMapping()
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const task: ClaimedReviewFixTask = {
@@ -70,8 +70,40 @@ describe('review status controller', () => {
       workerId: 'status-worker',
     })
 
+    return { controller, task, read: () => ({ body, replaced }) }
+  }
+
+  it('replaces the blocked review comment with repair progress', async () => {
+    const { controller, task, read } = harness()
+
     expect(await controller.publishRepair(task, { percent: 35, label: 'Git worktree ready' }, new AbortController().signal)).toEqual(ok(undefined))
-    expect(replaced).toBe(true)
-    expect(body).toContain('### 🤖 REPAIR · Git worktree ready')
+
+    expect(read().replaced).toBe(true)
+    expect(read().body).toContain('### 🤖 REPAIR · Git worktree ready')
+  })
+
+  it('says how long one phase has run, so a slow agent reads as alive', async () => {
+    const { controller, task, read } = harness()
+
+    // The clock reads 01:00, so this phase started 35 minutes ago.
+    expect(await controller.publishRepair(
+      task,
+      { percent: 70, label: 'Editing files', since: '2026-08-13T00:25:00.000Z' },
+      new AbortController().signal,
+    )).toEqual(ok(undefined))
+
+    expect(read().body).toContain('### 🤖 REPAIR · Editing files for 35 min')
+  })
+
+  it('leaves a phase that just started without a duration', async () => {
+    const { controller, task, read } = harness()
+
+    expect(await controller.publishRepair(
+      task,
+      { percent: 70, label: 'Editing files', since: '2026-08-13T00:59:40.000Z' },
+      new AbortController().signal,
+    )).toEqual(ok(undefined))
+
+    expect(read().body).toContain('### 🤖 REPAIR · Editing files\n')
   })
 })


### PR DESCRIPTION
## The question

`harlan-agent-kit#66` sat on `REPAIR · Editing files` for 35 minutes with a `Last updated: 11:53` that never moved. Nothing on the pull request said whether the agent was working or dead.

## Why the comment froze

Progress is five coarse buckets and only ever moves forward (`percent > current`). Once Repair reaches 70 percent, every later file edit and command still maps to 70 or less, so nothing publishes for the rest of the turn.

The lease cannot answer it either. Its heartbeat is a `setInterval` in the scheduler, so it renews whether or not the agent is producing anything.

## The fix

Not a log. A log of past phases ends at the same frozen timestamp and answers nothing.

- The phase line carries how long it has run: `REPAIR · Editing files for 35 min`.
- One unchanged phase restates itself every 15 minutes, but only when an agent event arrives.

So a moving `Last updated` on a long phase means alive and slow. A frozen one means stopped. At most a handful of comment edits per long turn, not one per file.

The turn now tracks the whole phase rather than its percent, so a restatement keeps the label and the start time it began with.

## Verified

- 856 tests pass, `tsc --noEmit` clean, eslint unchanged from `main`.
- New tests drive a scripted clock through one turn: the first edit advances the phase, an edit inside the beat stays quiet, and a later edit restates the same phase from the same start time.