### PR TITLE
fix(plugin): require PR skill for pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ codex plugin add harlan-agent-kit@personal
 Validate before reinstalling:
 
 ```bash
-python3 ~/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py ~/plugins/harlan-agent-kit
+claude plugin validate ~/plugins/harlan-agent-kit
+jq empty ~/plugins/harlan-agent-kit/hooks/codex.json
 codex plugin add harlan-agent-kit@personal
 ```
 
@@ -85,14 +86,15 @@ Start a new Codex thread after reinstalling so newly installed skills are loaded
 
 ## Hooks
 
-Claude Code loads hooks from `.claude-plugin/plugin.json`. Codex currently uses
-the skills only; the Claude hook config is not portable to Codex as-is.
+Claude Code loads hooks from `.claude-plugin/plugin.json`. Codex loads its hook
+config from `hooks/codex.json` through `.codex-plugin/plugin.json`.
 
 | Event | Hook | Description |
 |-------|------|-------------|
 | SessionStart | `session-start.sh` | Detect project type, show git status |
 | PreToolUse | `merged-branch-guard.sh` | Block commits on merged branches |
 | PreToolUse | `pnpm-only.sh` | Block npm/yarn commands |
+| PreToolUse | `pr-skill-only.sh` | Require the PR skill for creation and description changes |
 | PreToolUse | `wt-only.sh` | Keep worktrees under `wt` and off `.claude/worktrees` |
 | PreToolUse | `pre-commit-push.sh` | Run lint/typecheck/test before commit/push |
 | PostToolUse | `eslint.sh` | Auto-lint + fix after file changes |

--- a/harlan-agent-kit/.claude-plugin/plugin.json
+++ b/harlan-agent-kit/.claude-plugin/plugin.json
@@ -31,6 +31,10 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pr-skill-only.sh"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/merged-branch-guard.sh",
             "timeout": 10000
           },

--- a/harlan-agent-kit/.codex-plugin/plugin.json
+++ b/harlan-agent-kit/.codex-plugin/plugin.json
@@ -13,6 +13,7 @@
     "workflow"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks/codex.json",
   "interface": {
     "displayName": "Harlan Agent Kit",
     "shortDescription": "Nuxt, Vue, TypeScript, release, PR, and writing workflow skills.",

--- a/harlan-agent-kit/hooks/codex.json
+++ b/harlan-agent-kit/hooks/codex.json
@@ -1,0 +1,18 @@
+{
+  "description": "Require the PR skill for pull request creation and description changes.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pr-skill-only.sh",
+            "timeout": 10,
+            "statusMessage": "Checking pull request command"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/harlan-agent-kit/hooks/pr-skill-only.sh
+++ b/harlan-agent-kit/hooks/pr-skill-only.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PreToolUse (Bash): require the PR skill for creation and description changes.
+
+source "$(dirname "$0")/check-config.sh"
+is_hook_disabled "pr-skill-only" && exit 0
+
+input=$(cat)
+command=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
+
+[ -n "$command" ] || exit 0
+
+command_start='(^|[|&;\(][[:space:]]*)'
+pr_create="${command_start}gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)"
+pr_body_edit="${command_start}gh[[:space:]]+pr[[:space:]]+edit[[:space:]][^|&;]*(--body-file|--body|-b)(=|[[:space:]]|$)"
+skill_create="${command_start}HARLAN_AGENT_PR_SKILL=1[[:space:]]+gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)"
+skill_body_edit="${command_start}HARLAN_AGENT_PR_SKILL=1[[:space:]]+gh[[:space:]]+pr[[:space:]]+edit[[:space:]][^|&;]*(--body-file|--body|-b)(=|[[:space:]]|$)"
+
+if [[ "$command" =~ $skill_create ]] || [[ "$command" =~ $skill_body_edit ]]; then
+  exit 0
+fi
+
+if [[ "$command" =~ $pr_create ]] || [[ "$command" =~ $pr_body_edit ]]; then
+  reason="Use the pr skill to create pull requests or change descriptions. It loads the repository template and required disclosure."
+  jq -nc --arg reason "$reason" '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+fi
+
+exit 0

--- a/harlan-agent-kit/hooks/pr-skill-only.test.sh
+++ b/harlan-agent-kit/hooks/pr-skill-only.test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Verifies pull request descriptions can change only through the PR skill.
+set -uo pipefail
+
+hook="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pr-skill-only.sh"
+fail=0
+
+decision() {
+  local out
+  out="$(jq -nc --arg command "$1" '{tool_input:{command:$command}}' | bash "$hook")"
+  [ -n "$out" ] || { echo allow; return; }
+  printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision'
+}
+
+expect() {
+  local want="$1" command="$2" got
+  got="$(decision "$command")"
+  if [ "$got" != "$want" ]; then
+    printf 'FAIL  expected %s, got %s for: %s\n' "$want" "$got" "$command"
+    fail=1
+  fi
+}
+
+expect deny 'gh pr create --title "fix: example" --body "wrong"'
+expect deny 'cd /repo && gh pr create --fill'
+expect deny 'gh pr edit 42 --body "wrong"'
+expect deny 'gh pr edit 42 --body-file /tmp/pr.md'
+
+expect allow 'HARLAN_AGENT_PR_SKILL=1 gh pr create --title "fix: example" --body "right"'
+expect allow 'HARLAN_AGENT_PR_SKILL=1 gh pr edit 42 --body "right"'
+expect allow 'gh pr edit 42 --add-label ready'
+expect allow 'gh pr view 42 --json body'
+expect allow 'echo gh pr create'
+
+[ "$fail" -eq 0 ] && echo 'pr-skill-only hook tests passed'
+exit "$fail"

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -209,7 +209,7 @@ git push -u origin HEAD
 
 **If PR exists** -> update it:
 ```bash
-gh pr edit NUMBER --title "TITLE" --body "$(cat <<'EOF'
+HARLAN_AGENT_PR_SKILL=1 gh pr edit NUMBER --title "TITLE" --body "$(cat <<'EOF'
 BODY
 EOF
 )"
@@ -217,7 +217,7 @@ EOF
 
 **If no PR** -> create it:
 ```bash
-gh pr create --title "TITLE" --body "$(cat <<'EOF'
+HARLAN_AGENT_PR_SKILL=1 gh pr create --title "TITLE" --body "$(cat <<'EOF'
 BODY
 EOF
 )"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "service:restart": "bash scripts/service.sh restart",
     "service:status": "bash scripts/service.sh status",
     "test:worktree-claim": "bash harlan-agent-kit/scripts/worktree-claim.test.sh",
+    "test:pr-skill-only": "bash harlan-agent-kit/hooks/pr-skill-only.test.sh",
     "test:wt-only": "bash harlan-agent-kit/hooks/wt-only.test.sh",
     "test:sentry-checkin": "python3 -m unittest discover -s harlan-agent-kit/skills/sentry-checkin/scripts -p 'test_*.py'",
     "release": "node --experimental-strip-types scripts/release.ts"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Codex and Claude Code kept opening pull requests without loading the PR skill, so their descriptions skipped the repository template. A shared pre-tool hook blocks direct creation and description edits now.

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).