### PR TITLE
fix(github-agent): report Routine-only service health

### DIFF
--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -4,6 +4,7 @@ import type { AgentProviderName } from './agent-provider.ts'
 import type { GitIdentity } from './git-identity.ts'
 import type { GitHubUserAccess } from './github-user-access.ts'
 import type { Result } from './result.ts'
+import type { RoutineSyncOutcome } from './routine-controller.ts'
 import type { JournalStore } from './store.ts'
 import type { ClaimedAgentTask, RepositoryMapping, ValidatedAgentConfig } from './types.ts'
 import { randomUUID } from 'node:crypto'
@@ -75,6 +76,24 @@ export interface StartAgentServiceOptions {
   gitIdentity: GitIdentity
   logger: Pick<ConsolaInstance, 'error' | 'info'>
   now?: () => Date
+}
+
+/** Records the repository observation that replaces GitHub polling on a Routine-only host. */
+export function recordRoutineOnlyRepositoryHealth(input: {
+  at: string
+  outcome: RoutineSyncOutcome
+  repository: string
+  store: Pick<JournalStore, 'recordPollFailure' | 'recordPollSuccess'>
+}): void {
+  if (input.outcome._tag === 'Unread') {
+    input.store.recordPollFailure(
+      input.repository,
+      input.at,
+      `The Routine spec could not be read. ${input.outcome.reason}`,
+    )
+    return
+  }
+  input.store.recordPollSuccess(input.repository, input.at)
 }
 
 function recordServiceIncident(
@@ -699,6 +718,15 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         if (outcome._tag === 'Synced' && outcome.routines.length > 0)
           options.logger.info(`${repository}: ${outcome.routines.length} routines declared.`)
       })
+      if (!config.triggers.includes('github')) {
+        const observedAt = now().toISOString()
+        syncedRoutines.forEach(({ repository, outcome }) => recordRoutineOnlyRepositoryHealth({
+          at: observedAt,
+          outcome,
+          repository,
+          store,
+        }))
+      }
       recordPassIncidents('routine_spec', routineFailures)
 
       // Candidate issues are filed on the same pass, a few at a time. A scan

--- a/packages/harlan-github-agent/test/service-triggers.test.ts
+++ b/packages/harlan-github-agent/test/service-triggers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { parseConfigText } from '../src/config.ts'
+import { recordRoutineOnlyRepositoryHealth } from '../src/service.ts'
 
 const base = `
 github:
@@ -60,5 +61,37 @@ describe('which triggers one machine answers', () => {
     const parsed = parse('triggers: [routine, routine]\n')
 
     expect(parsed).toEqual({ _tag: 'Err', error: [{ path: '$.triggers', message: 'List every trigger once.' }] })
+  })
+
+  it('becomes ready after a Routine-only repository sync', () => {
+    const observations: string[] = []
+
+    recordRoutineOnlyRepositoryHealth({
+      at: '2026-08-28T01:00:00.000Z',
+      outcome: { _tag: 'Synced', routines: [] },
+      repository: 'harlan-zw/example',
+      store: {
+        recordPollFailure: () => observations.push('failure'),
+        recordPollSuccess: repository => observations.push(`success:${repository}`),
+      },
+    })
+
+    expect(observations).toEqual(['success:harlan-zw/example'])
+  })
+
+  it('reports an unreadable Routine spec as repository failure', () => {
+    const observations: string[] = []
+
+    recordRoutineOnlyRepositoryHealth({
+      at: '2026-08-28T01:00:00.000Z',
+      outcome: { _tag: 'Unread', reason: 'GitHub timed out.' },
+      repository: 'harlan-zw/example',
+      store: {
+        recordPollFailure: (repository, _at, reason) => observations.push(`failure:${repository}:${reason}`),
+        recordPollSuccess: () => observations.push('success'),
+      },
+    })
+
+    expect(observations).toEqual(['failure:harlan-zw/example:The Routine spec could not be read. GitHub timed out.'])
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A Routine-only host does not poll GitHub. Its repositories therefore kept an empty `lastSuccessAt`, and `/health` stayed at `starting` after Routine sync finished. Routine sync now records repository health on that host. An unreadable spec remains a failure.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.