### PR TITLE
feat(github-agent): show Agent and Routine history

### DIFF
--- a/.claude/context/jobs/agent-history-visibility-0828-0104/build-contract.md
+++ b/.claude/context/jobs/agent-history-visibility-0828-0104/build-contract.md
@@ -1,0 +1,42 @@
+# Agent history visibility
+
+## What will be built
+
+- Replace running completion percentages with the current agent phase.
+- Explain each Review outcome on History and Recently finished.
+- Keep superseded Tasks separate from failures and Review findings.
+- Show the last reported phase and terminal reason for finished Tasks.
+
+## Testable behaviors
+
+- [C1] GIVEN a running agent, WHEN the Board renders, THEN its current phase is visible without a completion percentage.
+- [C2] GIVEN a running agent with activity, WHEN Terminal opens, THEN the recent redacted activity is visible.
+- [C3] GIVEN two minutes without progress, WHEN the Board renders, THEN it warns that progress stopped.
+- [C4] GIVEN a BLOCKED Review with findings, WHEN History renders, THEN it states the finding count.
+- [C5] GIVEN a PENDING Review, WHEN History renders, THEN it names the unsettled Review gate and reason.
+- [C6] GIVEN a failed Task, WHEN History renders, THEN it shows the last phase and exact failure reason.
+- [C7] GIVEN a superseded Task, WHEN History filters apply, THEN it appears only in All or Superseded.
+- [C8] GIVEN recently finished work, WHEN System renders, THEN each row explains its outcome.
+- [C9] GIVEN no matching history, WHEN a filter applies, THEN the empty state remains visible.
+- [C10] GIVEN state loading or request failure, WHEN the Board renders, THEN existing loading and error states remain visible.
+- [C11] GIVEN a 375px or 768px viewport, WHEN the pages render, THEN rows wrap without horizontal scrolling.
+- [C12] GIVEN dark mode, WHEN the pages render, THEN status text keeps the existing semantic tokens.
+- [C13] GIVEN keyboard navigation, WHEN a filter or disclosure receives focus, THEN its label and state are announced.
+- [C14] GIVEN server rendering, WHEN History loads, THEN headings and filter labels exist in HTML.
+- [C15] GIVEN declared Routines, WHEN System renders, THEN each repository schedule is visible.
+- [C16] GIVEN several runs for one Routine, WHEN System renders, THEN its newest run is shown.
+- [C17] GIVEN a failed or skipped run, WHEN System renders, THEN its durable reason is visible.
+- [C18] GIVEN a tracking issue, WHEN System renders, THEN the Routine links to that issue.
+
+## Design expectations
+
+- Keep the quiet control room design.
+- Use typography and exact copy for hierarchy.
+- Keep evidence behind disclosures.
+- Use semantic color only for state.
+
+## Out of scope
+
+- Persisting full terminal activity.
+- Changing scheduler recovery behavior.
+- Changing GitHub review comments.

--- a/.claude/context/jobs/agent-history-visibility-0828-0104/build-handoff.json
+++ b/.claude/context/jobs/agent-history-visibility-0828-0104/build-handoff.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 4,
+  "job_id": "agent-history-visibility-0828-0104",
+  "created": "2026-08-27T15:33:40Z",
+  "git_hash": "63e0b98d42d610511a5c03cf7fbbeb753fa9021d",
+  "dev_port": 43829,
+  "pages_changed": [
+    "packages/harlan-github-agent/dashboard/app/pages/index.vue",
+    "packages/harlan-github-agent/dashboard/app/pages/history.vue"
+  ],
+  "components_created": [],
+  "routes_to_test": [
+    "/",
+    "/history"
+  ],
+  "design_system_changes": false,
+  "theme_name": "minimal-control-room",
+  "contract_path": ".claude/context/jobs/agent-history-visibility-0828-0104/build-contract.md",
+  "contract_criteria_status": {
+    "C1": "met",
+    "C2": "met",
+    "C3": "met",
+    "C4": "met",
+    "C5": "met",
+    "C6": "met",
+    "C7": "met",
+    "C8": "met",
+    "C9": "met",
+    "C10": "met",
+    "C11": "met",
+    "C12": "met",
+    "C13": "met",
+    "C14": "met",
+    "C15": "met",
+    "C16": "met",
+    "C17": "met",
+    "C18": "met"
+  },
+  "self_assessment": {
+    "confidence": "medium",
+    "weakest_area": "The Tailscale URL needs the merged service on Hogwild before its final browser check.",
+    "hardest_decision": "Kept each Routine to one compact row with its newest durable run."
+  },
+  "has_client_animations": false,
+  "known_limitations": ["Tailscale access is configured after this change reaches Hogwild."],
+  "next_steps": ["Deploy to Hogwild and enable Tailscale Serve."],
+  "dark_mode_relevant": true
+}

--- a/.claude/context/jobs/agent-history-visibility-0828-0104/build-progress.md
+++ b/.claude/context/jobs/agent-history-visibility-0828-0104/build-progress.md
@@ -1,0 +1,7 @@
+## Agent history visibility
+
+- Modified the Board, History, System pane, snapshot types, store, and behavior tests.
+- Replaced running percentages with current phases.
+- Added direct Review outcome, Task failure, and superseded explanations.
+- C1 through C14 met.
+- C15 through C18 met.

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -22,6 +22,8 @@ did not cover it.
 | Revision | `revisions` | Journal | N to 1 Item, 1 to N Review runs | none |
 | Agent | `worker_sessions` | Runner | N to 1 Item, 1 to N Review runs | agent |
 | Task | `tasks`, `worker_tasks` | Scheduler | N to 1 Item and Revision | task |
+| Routine | `routines` | Scheduler | N to 1 Repository mapping, 1 to N Routine runs | Routine |
+| Routine run | `routine_runs` | Scheduler | N to 1 Routine | run |
 | Lease holder | `tasks.worker_id` | Scheduler | One per Running Task | none |
 | Queue | derived dashboard state | Controller | Orders active Tasks and actionable Items | queue |
 | Pause | `agent_control` | Controller | Stops new agent Tasks from starting | Pause |
@@ -225,6 +227,18 @@ errors.
 One independently scheduled unit of work for an Item.
 
 GitHub Actions calls its unit a `job`. This service is not Actions, and a Task outlives a single run and carries its own lease, so Task stays. Never call a Task a job.
+
+### Routine
+
+One named recurring repository check declared in `.github/routines.yml`.
+
+A Routine answers a clock. It has no Item or Revision. Each due instant creates one Routine run.
+
+### Routine run
+
+One durable answer to one exact cron instant for a Routine.
+
+A skipped instant remains a Routine run. This keeps missed work visible.
 
 ### Queue
 
@@ -494,6 +508,7 @@ Evidence that a skill, policy, or workflow should change.
 | waiting, in progress | PENDING | GitHub's own check status and review state |
 | failed, as a Review outcome | BLOCKED | GitHub's own mergeable state |
 | job | Task | `job` is a GitHub Actions unit and must keep that meaning |
+| scheduled task, cron task | Routine | A Task belongs to an Item. A Routine answers a clock. |
 | bot | Agent | Reads as a GitHub App, which the agent is not |
 | ticket, card | issue | GitHub's word |
 | PR in prose | pull request | GitHub's word |

--- a/packages/harlan-github-agent/dashboard/DESIGN.md
+++ b/packages/harlan-github-agent/dashboard/DESIGN.md
@@ -234,7 +234,8 @@ Panels use plain utilities (`border border-default rounded-md bg-elevated`) rath
 - The status bar states only what is not the default. It said "agents running" beside "0/4 agents", which reads as a contradiction. Pause and manual selection speak; running and auto stay quiet.
 - A dismissed item leaves the board entirely and reappears only under `Dismissed` on Watching. A greyed row on the board would keep costing the attention the Dismissal was meant to reclaim, and `Restore` is rare enough to live one page away.
 - The content security policy allows `github.com` and `avatars.githubusercontent.com` under `img-src`. Without it every avatar falls back to a monogram, which is the one thing the cards are built around.
-- A running card shows work, elapsed time, author, subject, progress sentence, and progress bar. The terminal and the session identifier stay behind a disclosure.
+- A running card shows work, elapsed time, author, subject, and current phase. The terminal and session identifier stay behind a disclosure.
+- Agent percentages are milestones, not completion estimates. Never show them as progress bars or completion percentages.
 - Work the Queue calls Active with no agent session yet still lands in Running, so a task cannot vanish between starting and reporting.
 - The status bar carries only live state: connection, agent capacity, whether GitHub writes are enabled, and repository failures. Fixed configuration sits in the footer.
 - Queue order reflects engine priority. Position is always visible.
@@ -246,6 +247,7 @@ Panels use plain utilities (`border border-default rounded-md bg-elevated`) rath
 - The tab title carries the decision count and the favicon carries its colour, because this page is meant to be watched from another window. Notifications are opt in behind the bell, and the first snapshot after load only seeds the baseline so opening the page never fires one.
 - Agent activity is ephemeral and in process. It answers what an agent is doing now, not what it did. Keeping it out of the journal means no schema, no retention policy, and nothing to leak after a restart.
 - Recently finished repeats the three newest History records in the System pane. It confirms recent movement without exposing evidence or replacing History.
+- The System pane lists each Routine schedule with its latest durable run. Each host shows only the Routines in its own Journal.
 - Command output is redacted in the service before it reaches the dashboard. Loopback binding and a dashboard password are not a reason to ship raw stdout that can contain installation tokens.
 - Keyboard: `j` and `k` move through the Needs you column and `a` approves the focused card, listed under the board. `/` focuses the repository filter on Watching, where that filter lives.
 - Notifications fire on a new decision. Failures are visible in Done and on History, so they raise a badge rather than a notification.

--- a/packages/harlan-github-agent/dashboard/app/composables/useDashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/composables/useDashboard.ts
@@ -39,6 +39,8 @@ function emptySnapshot(): DashboardSnapshot {
     repositories: [],
     items: [],
     tasks: [],
+    routines: [],
+    routineRuns: [],
   }
 }
 

--- a/packages/harlan-github-agent/dashboard/app/pages/history.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/history.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import type { ReviewAgent } from '../../../src/types.ts'
+import type { HistoryCategory } from '../utils/dashboard.ts'
 import { useClipboard } from '@vueuse/core'
 import {
   buildHistory,
   gateTone,
+  historyCategory,
+  reviewOutcomeDetail,
   reviewOutcomeLabel,
   reviewOutcomeTone,
   reviewUsageLabel,
@@ -11,6 +14,7 @@ import {
   taskIsIssue,
   taskKindLabel,
   taskNumber,
+  taskProgressDetail,
   taskStateDetail,
   taskStateTone,
   taskSubjectUrl,
@@ -34,17 +38,23 @@ const reviewGateNames = ['head', 'merge', 'metadata', 'review', 'verification', 
 const { copy, isSupported: clipboardSupported } = useClipboard()
 const copiedSession = ref<string>()
 const expanded = ref<Record<string, boolean>>({})
-const outcomeFilter = ref<'all' | 'ready' | 'attention'>('all')
+const outcomeFilter = ref<'all' | HistoryCategory>('all')
+
+const outcomeFilters: Array<{ label: string, value: 'all' | HistoryCategory }> = [
+  { label: 'All', value: 'all' },
+  { label: 'Ready', value: 'ready' },
+  { label: 'Issues found', value: 'issues' },
+  { label: 'Pending', value: 'pending' },
+  { label: 'Failed', value: 'failed' },
+  { label: 'Superseded', value: 'superseded' },
+]
 
 const records = computed(() => buildHistory(reviewAgents.value, snapshot.value.tasks))
 
 const filtered = computed(() => records.value.filter((record) => {
   if (outcomeFilter.value === 'all')
     return true
-  const good = record._tag === 'Review'
-    ? record.agent.outcome._tag === 'Ready'
-    : record.task.state._tag === 'Completed'
-  return outcomeFilter.value === 'ready' ? good : !good
+  return historyCategory(record) === outcomeFilter.value
 }))
 
 function isExpanded(id: string): boolean {
@@ -83,11 +93,7 @@ useHead({
       </div>
       <div class="flex items-center gap-1" aria-label="Filter by outcome">
         <UButton
-          v-for="filter in [
-            { label: 'All', value: 'all' as const },
-            { label: 'Succeeded', value: 'ready' as const },
-            { label: 'Needs a look', value: 'attention' as const },
-          ]"
+          v-for="filter in outcomeFilters"
           :key="filter.value"
           size="xs"
           :color="outcomeFilter === filter.value ? 'primary' : 'neutral'"
@@ -122,9 +128,17 @@ useHead({
           <p class="font-mono text-xs text-dimmed md:text-right">
             {{ relativeTime(record.at) }}
           </p>
-          <p v-if="taskStateDetail(record.task)" class="text-sm text-muted md:col-span-2">
-            {{ taskStateDetail(record.task) }}
-          </p>
+          <div v-if="taskProgressDetail(record.task) || taskStateDetail(record.task)" class="flex min-w-0 flex-wrap gap-x-4 gap-y-1 text-sm md:col-span-2">
+            <p v-if="taskProgressDetail(record.task)" class="text-muted">
+              {{ taskProgressDetail(record.task) }}
+            </p>
+            <p
+              v-if="taskStateDetail(record.task)"
+              :class="record.task.state._tag === 'Failed' ? 'status-error' : 'text-muted'"
+            >
+              {{ taskStateDetail(record.task) }}
+            </p>
+          </div>
         </div>
 
         <article v-else>
@@ -181,6 +195,10 @@ useHead({
 
           <p v-if="rerunErrors[itemKey(record.agent.repository, record.agent.pullRequestNumber, record.agent.revisionId)]" role="alert" class="status-error pb-3 text-sm">
             {{ rerunErrors[itemKey(record.agent.repository, record.agent.pullRequestNumber, record.agent.revisionId)] }}
+          </p>
+
+          <p class="pb-3 text-sm text-muted">
+            {{ reviewOutcomeDetail(record.agent) }}
           </p>
 
           <div

--- a/packages/harlan-github-agent/dashboard/app/pages/index.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/index.vue
@@ -7,6 +7,8 @@ import {
   activeEntries,
   approvalConsequence,
   buildHistory,
+  historyCategory,
+  historyOutcomeDetail,
   incidentEntries,
   incidentKindLabel,
   incidentRecoveryLabel,
@@ -22,6 +24,9 @@ import {
   recentlyFinished,
   reviewOutcomeLabel,
   reviewOutcomeTone,
+  routineRunPresentation,
+  routineTrackingUrl,
+  scheduledRoutineRecords,
   stalledLabel,
   statusClass,
   systemState,
@@ -81,6 +86,11 @@ const providerCapacities = computed(() => snapshot.value.providerCapacities.map(
   presentation: providerCapacityPresentation(entry),
 })))
 const recentlyFinishedRecords = computed(() => recentlyFinished(reviewAgents.value, snapshot.value.tasks))
+const routineRecords = computed(() => scheduledRoutineRecords(snapshot.value.routines, snapshot.value.routineRuns).map(record => ({
+  ...record,
+  presentation: routineRunPresentation(record.latestRun),
+  trackingUrl: routineTrackingUrl(record.routine),
+})))
 
 /** Only offer a filter for work the board actually holds right now. */
 const availableWork = computed(() => {
@@ -132,11 +142,14 @@ const nothingQueuedReason = computed(() => {
     return { text: 'Manual selection. Approve a pull request on the left to queue it.', resume: false }
   return { text: 'Nothing queued.', resume: false }
 })
-const done = computed(() => buildHistory(reviewAgents.value, snapshot.value.tasks)
+const finished = computed(() => buildHistory(reviewAgents.value, snapshot.value.tasks)
+  .filter(record => historyCategory(record) !== 'superseded'))
+
+const done = computed(() => finished.value
   .filter(record => matchesFilter(record._tag === 'Review' ? 'adversarial_review' : taskWork(record.task)))
   .slice(0, doneOnBoard))
 
-const doneTotal = computed(() => buildHistory(reviewAgents.value, snapshot.value.tasks).length)
+const doneTotal = computed(() => finished.value.length)
 
 function entryKey(entry: QueueEntry): string {
   return `${entry.repository}:${entry.kind}:${entry.number}`
@@ -267,6 +280,64 @@ useHead({
         </li>
       </ul>
 
+      <section v-if="routineRecords.length > 0" class="mt-3" aria-labelledby="routines-heading">
+        <div class="zone-header">
+          <h3 id="routines-heading" class="field-label">
+            Routines
+          </h3>
+          <span class="font-mono text-xs text-dimmed">{{ routineRecords.length }}</span>
+          <hr class="zone-rule">
+        </div>
+
+        <ol class="divide-y divide-default border-y border-default">
+          <li
+            v-for="record in routineRecords"
+            :key="record.routine.id"
+            class="grid gap-x-4 gap-y-1 py-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+          >
+            <div class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+              <UBadge
+                size="sm"
+                :color="record.presentation.tone"
+                :class="record.presentation.tone === 'neutral' ? undefined : statusClass(record.presentation.tone)"
+                variant="subtle"
+              >
+                {{ record.presentation.label }}
+              </UBadge>
+              <span class="font-mono text-xs text-default">{{ record.routine.name }}</span>
+              <a
+                v-if="record.trackingUrl"
+                :href="record.trackingUrl"
+                target="_blank"
+                rel="noreferrer"
+                class="entity-link min-w-0 truncate font-mono text-xs text-muted"
+              >
+                {{ record.routine.repository }} #{{ record.routine.trackingIssueNumber }}
+              </a>
+              <span v-else class="min-w-0 truncate font-mono text-xs text-muted">
+                {{ record.routine.repository }}
+              </span>
+            </div>
+            <time
+              v-if="record.latestRun"
+              :datetime="record.latestRun.scheduledFor"
+              class="font-mono text-xs text-dimmed sm:text-right"
+            >
+              {{ relativeTime(record.latestRun.scheduledFor) }}
+            </time>
+            <span v-else class="font-mono text-xs text-dimmed sm:text-right">No runs</span>
+            <p class="font-mono text-xs text-muted sm:col-span-2">
+              {{ record.routine.crons.join(' · ') }} · {{ record.routine.timeZone }}<template v-if="!record.routine.enabled">
+                · disabled
+              </template>
+            </p>
+            <p v-if="record.presentation.detail" class="text-xs text-muted sm:col-span-2">
+              {{ record.presentation.detail }}
+            </p>
+          </li>
+        </ol>
+      </section>
+
       <section class="mt-3" aria-labelledby="recently-finished-heading">
         <div class="zone-header">
           <h3 id="recently-finished-heading" class="field-label">
@@ -326,6 +397,9 @@ useHead({
             <time :datetime="record.at" class="font-mono text-xs text-dimmed sm:text-right">
               {{ relativeTime(record.at) }}
             </time>
+            <p v-if="historyOutcomeDetail(record)" class="text-xs text-muted sm:col-span-2">
+              {{ historyOutcomeDetail(record) }}
+            </p>
           </li>
         </ol>
         <p v-else class="font-mono text-sm text-dimmed">
@@ -624,18 +698,9 @@ useHead({
               :number="agent.itemNumber"
             />
 
-            <p class="mt-2.5 line-clamp-2 text-xs text-muted">
+            <p class="mt-2.5 line-clamp-2 text-sm text-muted" :aria-label="`${activeAgentRole(agent)} current phase`">
               {{ activeAgentProgress(agent) }}
             </p>
-            <div class="mt-1.5 flex items-center gap-2">
-              <progress
-                class="min-w-0 flex-1"
-                :value="agent.progress.percent"
-                max="100"
-                :aria-label="`${activeAgentRole(agent)} progress`"
-              />
-              <span class="font-mono text-xs tabular-nums text-dimmed">{{ agent.progress.percent }}%</span>
-            </div>
             <!-- Only appears once silence is long enough to mean something. -->
             <p v-if="isProgressStalled(agent, now)" class="status-warning mt-1.5 font-mono text-xs">
               {{ stalledLabel(agent, now) }}

--- a/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
@@ -5,6 +5,7 @@ import type {
   AgentStartState,
   AgentTask,
   DashboardSnapshot,
+  DashboardTask,
   Incident,
   IncidentKind,
   ProviderCapacityStatus,
@@ -12,6 +13,8 @@ import type {
   RepositoryStatus,
   ReviewAgent,
   ReviewGateState,
+  Routine,
+  RoutineRun,
   SelectionMode,
 } from '../../../src/types.ts'
 import { hasSpendableCapacity } from '../../../src/capacity.ts'
@@ -45,6 +48,49 @@ export interface ProviderCapacityPresentation {
   value: string
   detail: string
   tone: StatusTone | 'neutral'
+}
+
+export interface ScheduledRoutineRecord {
+  routine: Routine
+  latestRun: RoutineRun | undefined
+}
+
+export interface RoutineRunPresentation {
+  label: string
+  tone: StatusTone | 'neutral'
+  detail?: string
+}
+
+/** Pairs each declared Routine with the newest run the snapshot retained. */
+export function scheduledRoutineRecords(routines: readonly Routine[], runs: readonly RoutineRun[]): ScheduledRoutineRecord[] {
+  const newest = new Map<string, RoutineRun>()
+  runs.forEach((run) => {
+    const current = newest.get(run.routineId)
+    if (current === undefined || run.scheduledFor > current.scheduledFor)
+      newest.set(run.routineId, run)
+  })
+  return routines.map(routine => ({ routine, latestRun: newest.get(routine.id) }))
+}
+
+/** Gives one Routine run a label, semantic tone, and durable outcome detail. */
+export function routineRunPresentation(run: RoutineRun | undefined): RoutineRunPresentation {
+  if (run === undefined)
+    return { label: 'Never run', tone: 'neutral' }
+  switch (run.state._tag) {
+    case 'Queued': return { label: 'Queued', tone: 'neutral' }
+    case 'Running': return { label: 'Running', tone: 'primary' }
+    case 'Completed': return { label: 'Completed', tone: 'success', detail: run.state.evidence }
+    case 'Failed': return { label: 'Failed', tone: 'error', detail: run.state.reason }
+    case 'Skipped': return { label: 'Skipped', tone: 'neutral', detail: run.state.reason }
+    case 'ActionRequired': return { label: 'Action required', tone: 'warning', detail: run.state.reason }
+    case 'Superseded': return { label: 'Superseded', tone: 'neutral', detail: run.state.reason }
+  }
+}
+
+export function routineTrackingUrl(routine: Routine): string | undefined {
+  return routine.trackingIssueNumber === null
+    ? undefined
+    : `https://github.com/${routine.repository}/issues/${routine.trackingIssueNumber}`
 }
 
 /** Human-readable live limit state for the System pane. */
@@ -255,6 +301,40 @@ export function reviewOutcomeLabel(agent: ReviewAgent): string {
   return agent.outcome.confidence === undefined ? 'READY' : `READY · ${agent.outcome.confidence}/100`
 }
 
+const reviewGateNames = ['head', 'merge', 'metadata', 'review', 'verification', 'ci'] as const
+
+function reviewGateLabel(gate: typeof reviewGateNames[number]): string {
+  return gate === 'ci' ? 'CI' : `${gate.charAt(0).toUpperCase()}${gate.slice(1)}`
+}
+
+function sentence(value: string): string {
+  return /[.!?]$/.test(value) ? value : `${value}.`
+}
+
+/** Explains a Review outcome without making Review findings read as agent failure. */
+export function reviewOutcomeDetail(agent: ReviewAgent): string {
+  if (agent.outcome._tag === 'Ready')
+    return 'No issues found.'
+
+  const openFindings = agent.findings.filter(finding => finding._tag === 'Open')
+  if (openFindings.length > 0) {
+    const count = `${openFindings.length} issue${openFindings.length === 1 ? '' : 's'} found.`
+    if (openFindings.every(finding => finding.resolution === 'Repair'))
+      return `${count} Repair follows automatically.`
+    if (openFindings.some(finding => finding.resolution === 'Dismissal'))
+      return `${count} Dismissal recommended.`
+    return count
+  }
+
+  const unsettledName = reviewGateNames.find(name => agent.gates[name]._tag !== 'Passed')
+  if (unsettledName === undefined)
+    return 'The Review outcome has no recorded explanation.'
+  const gate = agent.gates[unsettledName]
+  if (gate._tag === 'Passed')
+    return 'The Review outcome has no recorded explanation.'
+  return `${reviewGateLabel(unsettledName)} Review gate ${gate._tag.toLowerCase()}. ${sentence(gate.reason)}`
+}
+
 const incidentKindLabels: Record<IncidentKind, string> = {
   agent_provider: 'Agent provider',
   agent_result: 'Agent result',
@@ -361,21 +441,58 @@ export function taskStateTone(task: AgentTask): 'success' | 'error' | 'neutral' 
 }
 
 export function taskStateDetail(task: AgentTask): string | undefined {
+  if (task.state._tag === 'Completed')
+    return task.state.evidence
   if (task.state._tag === 'Failed' || task.state._tag === 'Superseded')
     return task.state.reason
   return undefined
 }
 
+export type HistoryCategory = 'ready' | 'issues' | 'pending' | 'failed' | 'superseded'
+
+export function taskHistoryCategory(task: AgentTask): HistoryCategory {
+  if (task.state._tag === 'Completed')
+    return 'ready'
+  if (task.state._tag === 'Failed')
+    return 'failed'
+  if (task.state._tag === 'Superseded')
+    return 'superseded'
+  return 'pending'
+}
+
+/** The last durable phase helps explain where a terminal Task stopped. */
+export function taskProgressDetail(task: DashboardTask): string | undefined {
+  if (task.progress.percent === 0 || task.progress.label === 'Starting')
+    return undefined
+  return `Last phase: ${task.progress.label}`
+}
+
 export type HistoryRecord
   = | { _tag: 'Review', key: string, at: string, agent: ReviewAgent }
-    | { _tag: 'Task', key: string, at: string, task: AgentTask }
+    | { _tag: 'Task', key: string, at: string, task: DashboardTask }
+
+export function historyCategory(record: HistoryRecord): HistoryCategory {
+  if (record._tag === 'Task')
+    return taskHistoryCategory(record.task)
+  if (record.agent.outcome._tag === 'Ready')
+    return 'ready'
+  return record.agent.outcome._tag === 'Blocked' ? 'issues' : 'pending'
+}
+
+export function historyOutcomeDetail(record: HistoryRecord): string | undefined {
+  if (record._tag === 'Review')
+    return reviewOutcomeDetail(record.agent)
+  if (record.task.state._tag === 'Completed')
+    return 'Completed successfully.'
+  return taskStateDetail(record.task)
+}
 
 /**
  * Everything that already finished, newest first. Reviews carry their own evidence.
  * Terminal tasks cover the work that produces no review, which would otherwise
  * finish and vanish without ever being recorded on screen.
  */
-export function buildHistory(reviewAgents: ReviewAgent[], tasks: AgentTask[]): HistoryRecord[] {
+export function buildHistory(reviewAgents: ReviewAgent[], tasks: DashboardTask[]): HistoryRecord[] {
   const reviewed = new Set(reviewAgents.map(agent => `${agent.repository}#${agent.pullRequestNumber}@${agent.revisionId}`))
   const reviews = reviewAgents.map((agent): HistoryRecord => ({ _tag: 'Review', key: agent.id, at: agent.completedAt, agent }))
   const settled = tasks
@@ -386,8 +503,10 @@ export function buildHistory(reviewAgents: ReviewAgent[], tasks: AgentTask[]): H
 }
 
 /** The System pane keeps only enough finished work to confirm recent movement. */
-export function recentlyFinished(reviewAgents: ReviewAgent[], tasks: AgentTask[]): HistoryRecord[] {
-  return buildHistory(reviewAgents, tasks).slice(0, 3)
+export function recentlyFinished(reviewAgents: ReviewAgent[], tasks: DashboardTask[]): HistoryRecord[] {
+  return buildHistory(reviewAgents, tasks)
+    .filter(record => historyCategory(record) !== 'superseded')
+    .slice(0, 3)
 }
 
 /**

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -188,6 +188,19 @@ function providerName(value: unknown): AgentProviderName | undefined {
   return value === 'codex' || value === 'opencode' ? value : undefined
 }
 
+/** Keeps the control UI on the local proxy or one private Tailscale HTTPS name. */
+function isDashboardOrigin(value: string): boolean {
+  if (!URL.canParse(value))
+    return false
+  const origin = new URL(value)
+  const allowedHost = origin.hostname === 'harlan-github-agent.localhost'
+    || (origin.hostname.endsWith('.ts.net') && origin.hostname.length > '.ts.net'.length)
+  return origin.protocol === 'https:'
+    && origin.port === ''
+    && origin.origin === value
+    && allowedHost
+}
+
 /** Defaults to Codex, so an existing configuration keeps its current agent. */
 function agentSettings(source: UnknownRecord, issues: ConfigIssue[]): AgentConfig['agent'] | undefined {
   const agent = source.agent
@@ -522,8 +535,8 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
 
   if (host !== '127.0.0.1' && host !== '::1')
     issues.push({ path: '$.server.host', message: 'Expected a loopback address.' })
-  if (allowedOrigin !== undefined && allowedOrigin !== 'https://harlan-github-agent.localhost')
-    issues.push({ path: '$.server.allowed_origin', message: 'Expected https://harlan-github-agent.localhost.' })
+  if (allowedOrigin !== undefined && !isDashboardOrigin(allowedOrigin))
+    issues.push({ path: '$.server.allowed_origin', message: 'Expected the local dashboard or an HTTPS Tailscale origin.' })
   if (storagePath !== undefined && storagePath !== ':memory:' && !isAbsolute(storagePath))
     issues.push({ path: '$.storage.path', message: 'Expected an absolute path or :memory:.' })
   if (mutationsEnabled === true && storagePath === ':memory:')

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -27,6 +27,7 @@ import type {
   ConflictResolutionTask,
   DashboardAgent,
   DashboardSnapshot,
+  DashboardTask,
   GitHubItem,
   GitHubPullRequestItem,
   Incident,
@@ -885,6 +886,8 @@ interface TaskRow {
   lease_expires_at: string | null
   updated_at: string
   recovery_attempts: number
+  progress_percent: number
+  progress_label: string
 }
 
 interface PublicationRow {
@@ -953,8 +956,6 @@ interface ActiveAgentRow extends TaskRow {
   head_repository: string | null
   session_id: string | null
   started_at: string
-  progress_percent: number
-  progress_label: string
 }
 
 interface ReviewPublicationRow {
@@ -2437,7 +2438,7 @@ function subjectFromRow(database: DatabaseSync, row: DashboardSubjectRow): ItemS
   }
 }
 
-function taskFromRow(row: TaskRow): AgentTask {
+function taskFromRow(row: TaskRow): DashboardTask {
   const base = {
     id: row.id,
     repository: row.repository,
@@ -2445,6 +2446,7 @@ function taskFromRow(row: TaskRow): AgentTask {
     state: taskStateFromRow(row),
     updatedAt: row.updated_at,
     recoveryAttempts: row.recovery_attempts,
+    progress: { percent: row.progress_percent, label: row.progress_label },
   }
   if (row.kind === 'issue_triage' || row.kind === 'issue_work')
     return { ...base, kind: row.kind, issueNumber: row.github_number } satisfies IssueTriageTask | IssueWorkTask
@@ -4233,7 +4235,9 @@ function taskRows(database: DatabaseSync): TaskRow[] {
       ${table}.fence,
       ${table}.lease_expires_at,
       ${table}.updated_at,
-      ${table}.recovery_attempts
+      ${table}.recovery_attempts,
+      ${table}.progress_percent,
+      ${table}.progress_label
     FROM ${table}
     JOIN subjects ON subjects.id = ${table}.subject_id
     JOIN repositories ON repositories.id = subjects.repository_id
@@ -7691,6 +7695,11 @@ export function openJournalStore(
       : repositories.some(repository => repository.lastSuccessAt === null) ? 'starting' : 'ready'
     const items = subjectRows.map(row => subjectFromRow(database, row))
     const tasks = taskRows(database).map(taskFromRow)
+    const routines = listRoutines()
+    const routineRuns = routines
+      .flatMap(routine => listRoutineRuns(routine.id, 5))
+      .sort((left, right) => right.scheduledFor.localeCompare(left.scheduledFor))
+      .slice(0, 50)
     const rejectedIssueWorkResults = new Map((database.prepare(`
       SELECT task_transitions.task_id, COUNT(*) AS occurrences
       FROM task_transitions
@@ -7756,6 +7765,8 @@ export function openJournalStore(
       repositories,
       items,
       tasks,
+      routines,
+      routineRuns,
     }
   }
 

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -501,6 +501,8 @@ export interface ClaimedIssueWorkTask extends IssueWorkTask {
 
 export type AgentTask = ConflictResolutionTask | ReviewFixTask | BaselineRepairTask | AdversarialReviewTask | IssueTriageTask | IssueWorkTask
 export type ClaimedAgentTask = ClaimedConflictResolutionTask | ClaimedReviewFixTask | ClaimedBaselineRepairTask | ClaimedAdversarialReviewTask | ClaimedIssueTriageTask | ClaimedIssueWorkTask
+/** A Task as shown by the dashboard, including its last durable phase. */
+export type DashboardTask = AgentTask & { progress: AgentProgress }
 export type AgentRole = 'conflict_resolution' | 'review_fix' | 'baseline_repair' | 'adversarial_review' | 'pull_request_triage' | 'issue_triage' | 'issue_work' | 'routine_scan' | 'routine_fix'
 
 /**
@@ -1133,7 +1135,9 @@ export interface DashboardSnapshot {
   queue: QueueEntry[]
   repositories: RepositoryStatus[]
   items: ItemSummary[]
-  tasks: AgentTask[]
+  tasks: DashboardTask[]
+  routines: Routine[]
+  routineRuns: RoutineRun[]
 }
 
 export type StoredAgentControl

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -50,6 +50,35 @@ describe('configuration boundary', () => {
     expect(parsed._tag === 'Ok' && parsed.value.server.allowedOrigin).toBe('https://harlan-github-agent.localhost')
   })
 
+  it('accepts an HTTPS Tailscale dashboard origin', () => {
+    const parsed = parseConfigText(configText.replace(
+      'https://harlan-github-agent.localhost',
+      'https://hogwild.tailcad325.ts.net',
+    ))
+
+    expect(parsed._tag === 'Ok' && parsed.value.server.allowedOrigin).toBe('https://hogwild.tailcad325.ts.net')
+  })
+
+  it('rejects a public or unencrypted dashboard origin', () => {
+    const publicOrigin = parseConfigText(configText.replace(
+      'https://harlan-github-agent.localhost',
+      'https://example.com',
+    ))
+    const unencrypted = parseConfigText(configText.replace(
+      'https://harlan-github-agent.localhost',
+      'http://hogwild.tailcad325.ts.net',
+    ))
+
+    expect(publicOrigin._tag === 'Err' && publicOrigin.error).toContainEqual({
+      path: '$.server.allowed_origin',
+      message: 'Expected the local dashboard or an HTTPS Tailscale origin.',
+    })
+    expect(unencrypted._tag === 'Err' && unencrypted.error).toContainEqual({
+      path: '$.server.allowed_origin',
+      message: 'Expected the local dashboard or an HTTPS Tailscale origin.',
+    })
+  })
+
   it('parses a precise repository policy', () => {
     const result = parseConfigText(configText)
 

--- a/packages/harlan-github-agent/test/dashboard-view.test.ts
+++ b/packages/harlan-github-agent/test/dashboard-view.test.ts
@@ -1,4 +1,4 @@
-import type { ActiveAgent, AgentTask, Incident, QueueEntry, ReviewAgent } from '../src/types.ts'
+import type { ActiveAgent, DashboardTask, Incident, QueueEntry, ReviewAgent, Routine, RoutineRun } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
 import {
   activeEntries,
@@ -21,10 +21,16 @@ import {
   queueWork,
   recentlyFinished,
   repositoryState,
+  reviewOutcomeDetail,
   reviewOutcomeLabel,
   reviewUsageLabel,
+  routineRunPresentation,
+  routineTrackingUrl,
+  scheduledRoutineRecords,
   systemState,
+  taskHistoryCategory,
   taskKindLabel,
+  taskProgressDetail,
   taskStateTone,
   taskSubjectUrl,
   waitingEntries,
@@ -53,6 +59,40 @@ function activeAgent(overrides: Partial<ActiveAgent> = {}): ActiveAgent {
     progress: { percent: 50, label: 'Working' },
     activity: [],
     state: { _tag: 'Working', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-14T12:30:00.000Z' },
+    ...overrides,
+  }
+}
+
+function routine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: 'harlan-zw/example:sentry-checkin',
+    repository: 'harlan-zw/example',
+    name: 'sentry-checkin',
+    crons: ['0 7 * * *'],
+    timeZone: 'Australia/Melbourne',
+    mode: 'report',
+    enabled: true,
+    specSha: 'abc123',
+    lastRunAt: '2026-08-27T21:00:00.000Z',
+    trackingIssueNumber: 42,
+    updatedAt: '2026-08-27T21:00:01.000Z',
+    ...overrides,
+  }
+}
+
+function routineRun(overrides: Partial<RoutineRun> = {}): RoutineRun {
+  return {
+    id: 'routine-run-1',
+    routineId: 'harlan-zw/example:sentry-checkin',
+    repository: 'harlan-zw/example',
+    name: 'sentry-checkin',
+    scheduledFor: '2026-08-27T21:00:00.000Z',
+    specSha: 'abc123',
+    state: { _tag: 'Completed', evidence: 'No open Sentry issues.' },
+    fence: 1,
+    attempts: 1,
+    createdAt: '2026-08-27T21:00:00.000Z',
+    updatedAt: '2026-08-27T21:01:00.000Z',
     ...overrides,
   }
 }
@@ -115,7 +155,7 @@ function reviewAgent(overrides: Partial<ReviewAgent> = {}): ReviewAgent {
   } as ReviewAgent
 }
 
-const reviewTask: AgentTask = {
+const reviewTask: DashboardTask = {
   id: 'task-review',
   kind: 'adversarial_review',
   repository: 'harlan-zw/nuxt-seo',
@@ -123,9 +163,10 @@ const reviewTask: AgentTask = {
   revisionId: 'rev-a',
   state: { _tag: 'Completed', evidence: 'done' },
   updatedAt: '2026-08-14T11:31:00.000Z',
+  progress: { percent: 95, label: 'Review complete' },
 }
 
-const triageTask: AgentTask = {
+const triageTask: DashboardTask = {
   id: 'task-triage',
   kind: 'issue_triage',
   repository: 'harlan-zw/unlighthouse',
@@ -133,6 +174,7 @@ const triageTask: AgentTask = {
   revisionId: 'rev-i',
   state: { _tag: 'Failed', reason: 'The focused test suite did not pass.' },
   updatedAt: '2026-08-14T11:45:00.000Z',
+  progress: { percent: 70, label: 'Running tests and checks' },
 }
 
 describe('buildHistory', () => {
@@ -148,7 +190,7 @@ describe('buildHistory', () => {
   })
 
   it('ignores work that has not finished', () => {
-    const running: AgentTask = { ...triageTask, state: { _tag: 'Queued' } }
+    const running: DashboardTask = { ...triageTask, state: { _tag: 'Queued' } }
     expect(buildHistory([], [running])).toEqual([])
   })
 
@@ -177,6 +219,60 @@ describe('recentlyFinished', () => {
       'task-3',
       'task-2',
     ])
+  })
+
+  it('keeps superseded work in History without letting it crowd out System outcomes', () => {
+    const superseded: DashboardTask = {
+      ...triageTask,
+      id: 'superseded',
+      updatedAt: '2026-08-14T11:59:00.000Z',
+      state: { _tag: 'Superseded', reason: 'A newer issue state replaced this Task.' },
+    }
+
+    expect(recentlyFinished([], [triageTask, superseded]).map(record => record.key)).toEqual(['task-triage'])
+  })
+})
+
+describe('history outcome visibility', () => {
+  it('states how many issues a blocked review found', () => {
+    const blocked = reviewAgent({
+      outcome: { _tag: 'Blocked' },
+      findings: [{
+        _tag: 'Open',
+        summary: 'The parser accepts an invalid state.',
+        nextAction: 'Reject the invalid state at the boundary.',
+        resolution: 'Repair',
+      }],
+    })
+
+    expect(reviewOutcomeDetail(blocked)).toBe('1 issue found. Repair follows automatically.')
+  })
+
+  it('names the unsettled gate and reason for a pending review', () => {
+    const pending = reviewAgent({
+      outcome: { _tag: 'Pending' },
+      gates: {
+        ...reviewAgent().gates,
+        ci: { _tag: 'Pending', reason: 'Required checks are still running.', evidence: [] },
+      },
+    })
+
+    expect(reviewOutcomeDetail(pending)).toBe('CI Review gate pending. Required checks are still running.')
+  })
+
+  it('keeps superseded work out of failure filters', () => {
+    const superseded = { ...reviewTask, state: { _tag: 'Superseded' as const, reason: 'A newer head commit replaced this review.' } }
+
+    expect(taskHistoryCategory(superseded)).toBe('superseded')
+  })
+
+  it('shows the last phase without presenting it as completion progress', () => {
+    const failed = {
+      ...triageTask,
+      progress: { percent: 70, label: 'Running tests and checks' },
+    }
+
+    expect(taskProgressDetail(failed)).toBe('Last phase: Running tests and checks')
   })
 })
 
@@ -517,5 +613,34 @@ describe('system pane', () => {
     })
 
     expect(systemState(snapshot)).toEqual({ label: 'Action required', tone: 'error' })
+  })
+
+  it('pairs each Routine with its newest run', () => {
+    const older = routineRun()
+    const newest = routineRun({
+      id: 'routine-run-2',
+      scheduledFor: '2026-08-28T21:00:00.000Z',
+      state: { _tag: 'Failed', reason: 'Sentry timed out.' },
+      updatedAt: '2026-08-28T21:01:00.000Z',
+    })
+
+    expect(scheduledRoutineRecords([routine()], [older, newest])).toEqual([{
+      routine: routine(),
+      latestRun: newest,
+    }])
+  })
+
+  it('presents Routine state and its durable detail', () => {
+    expect(routineRunPresentation(routineRun({ state: { _tag: 'Failed', reason: 'Sentry timed out.' } }))).toEqual({
+      label: 'Failed',
+      tone: 'error',
+      detail: 'Sentry timed out.',
+    })
+    expect(routineRunPresentation(undefined)).toEqual({ label: 'Never run', tone: 'neutral' })
+  })
+
+  it('links a Routine to its tracking issue', () => {
+    expect(routineTrackingUrl(routine())).toBe('https://github.com/harlan-zw/example/issues/42')
+    expect(routineTrackingUrl(routine({ trackingIssueNumber: null }))).toBeUndefined()
   })
 })

--- a/packages/harlan-github-agent/test/fixtures.ts
+++ b/packages/harlan-github-agent/test/fixtures.ts
@@ -98,6 +98,8 @@ export function dashboardSnapshot(overrides: Partial<DashboardSnapshot> = {}): D
     repositories: [],
     items: [],
     tasks: [],
+    routines: [],
+    routineRuns: [],
     ...overrides,
   }
 }

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -57,6 +57,38 @@ function passedReviewGates(): ReviewGates {
 }
 
 describe('journal store', () => {
+  it('includes Routines and their recent runs in the dashboard snapshot', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-28T00:00:00.000Z')
+    const [routine] = store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{
+        name: 'sentry-checkin',
+        crons: ['0 7 * * *'],
+        timeZone: 'Australia/Melbourne',
+        mode: 'report',
+        enabled: true,
+      }],
+      at: '2026-08-28T00:01:00.000Z',
+    })
+    if (routine === undefined)
+      throw new Error('Expected a stored Routine.')
+    const run = store.openRoutineRun({
+      routineId: routine.id,
+      scheduledFor: '2026-08-28T21:00:00.000Z',
+      specSha: routine.specSha,
+      at: '2026-08-28T21:00:00.000Z',
+    })
+    if (run === null)
+      throw new Error('Expected a Routine run.')
+
+    const snapshot = store.getDashboardSnapshot('2026-08-28T21:00:01.000Z')
+
+    expect(snapshot.routines).toEqual([expect.objectContaining({ id: routine.id, name: 'sentry-checkin' })])
+    expect(snapshot.routineRuns).toEqual([expect.objectContaining({ id: run.id, state: { _tag: 'Queued' } })])
+  })
+
   it('persists Pause and reports when restart is safe', () => {
     const directory = mkdtempSync(join(tmpdir(), 'harlan-github-agent-'))
     temporaryDirectories.push(directory)
@@ -639,6 +671,11 @@ describe('journal store', () => {
         state: expect.objectContaining({ _tag: 'Working', workerId: 'worker-1' }),
       }),
     ])
+    expect(store.getDashboardSnapshot('2026-08-13T01:02:00.000Z').tasks)
+      .toContainEqual(expect.objectContaining({
+        id: task.id,
+        progress: { percent: 70, label: 'Running tests and checks' },
+      }))
   })
 
   it('keeps active agents in stable positions when progress changes', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The Board hid why finished work stopped, and the Routine scheduler had no UI. System now shows recent Agent outcomes plus every local Routine schedule and latest run. History names terminal outcomes and the last durable phase. A loopback service may trust its Tailscale HTTPS name, so Hogwild can publish the same dashboard through Tailscale Serve.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.