### PR TITLE
fix(github-agent): hide disabled Routine history

### DIFF
--- a/.claude/context/jobs/routine-trigger-ui-0828-0203/build-contract.md
+++ b/.claude/context/jobs/routine-trigger-ui-0828-0203/build-contract.md
@@ -1,0 +1,22 @@
+# Routine trigger visibility
+
+## What will be built
+
+The dashboard state boundary will expose Routine data only when this service answers the Routine trigger.
+
+## Testable behaviours
+
+- [C1] GIVEN stored Routine history on a GitHub-only host, WHEN the dashboard reads state, THEN it receives no Routines or Routine runs.
+- [C2] GIVEN a Routine-enabled host, WHEN the dashboard reads state, THEN it receives its stored Routines and Routine runs.
+- [C3] GIVEN no Routine records in dashboard state, WHEN the board renders, THEN the System pane omits the Routines section.
+- [C4] GIVEN stale Routine rows in the desktop Journal, WHEN the desktop remains GitHub-only, THEN those rows never appear in its UI.
+
+## Design expectations
+
+Keep the existing quiet control-room design. Remove irrelevant state without adding controls, copy, or empty panels.
+
+## Out of scope
+
+- Deleting stale Journal rows.
+- Changing Routine schedules.
+- Changing trigger configuration from the dashboard.

--- a/.claude/context/jobs/routine-trigger-ui-0828-0203/build-handoff.json
+++ b/.claude/context/jobs/routine-trigger-ui-0828-0203/build-handoff.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 4,
+  "job_id": "routine-trigger-ui-0828-0203",
+  "created": "2026-08-27T16:19:58Z",
+  "git_hash": "ac88bda00d1c321b648d9422bd44987af21b237f",
+  "dev_port": 43127,
+  "pages_changed": [],
+  "components_created": [],
+  "routes_to_test": ["/"],
+  "design_system_changes": false,
+  "theme_name": "neutral-control-room",
+  "contract_path": ".claude/context/jobs/routine-trigger-ui-0828-0203/build-contract.md",
+  "contract_criteria_status": {
+    "C1": "met",
+    "C2": "met",
+    "C3": "met",
+    "C4": "met"
+  },
+  "self_assessment": {
+    "confidence": "high",
+    "weakest_area": "Live hosts need the merged revision before their dashboards diverge.",
+    "hardest_decision": "Filtering at the service boundary preserves Journal history while preventing disabled features from leaking into the UI."
+  },
+  "has_client_animations": false,
+  "known_limitations": [],
+  "next_steps": ["Merge and deploy the same revision to desktop and Hogwild."],
+  "dark_mode_relevant": false
+}

--- a/.claude/context/jobs/routine-trigger-ui-0828-0203/build-progress.md
+++ b/.claude/context/jobs/routine-trigger-ui-0828-0203/build-progress.md
@@ -1,0 +1,8 @@
+# Build progress
+
+## Routine trigger visibility
+
+- Changed the dashboard state boundary in `src/service.ts`.
+- Added regression coverage in `test/service-triggers.test.ts`.
+- Updated the System pane design decision.
+- Met C1, C2, C3, and C4.

--- a/packages/harlan-github-agent/dashboard/DESIGN.md
+++ b/packages/harlan-github-agent/dashboard/DESIGN.md
@@ -247,7 +247,7 @@ Panels use plain utilities (`border border-default rounded-md bg-elevated`) rath
 - The tab title carries the decision count and the favicon carries its colour, because this page is meant to be watched from another window. Notifications are opt in behind the bell, and the first snapshot after load only seeds the baseline so opening the page never fires one.
 - Agent activity is ephemeral and in process. It answers what an agent is doing now, not what it did. Keeping it out of the journal means no schema, no retention policy, and nothing to leak after a restart.
 - Recently finished repeats the three newest History records in the System pane. It confirms recent movement without exposing evidence or replacing History.
-- The System pane lists each Routine schedule with its latest durable run. Each host shows only the Routines in its own Journal.
+- The System pane lists each Routine schedule with its latest durable run only when that host answers the Routine trigger.
 - Command output is redacted in the service before it reaches the dashboard. Loopback binding and a dashboard password are not a reason to ship raw stdout that can contain installation tokens.
 - Keyboard: `j` and `k` move through the Needs you column and `a` approves the focused card, listed under the board. `/` focuses the repository filter on Watching, where that filter lives.
 - Notifications fire on a new decision. Failures are visible in Done and on History, so they raise a badge rather than a notification.

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -6,7 +6,7 @@ import type { GitHubUserAccess } from './github-user-access.ts'
 import type { Result } from './result.ts'
 import type { RoutineSyncOutcome } from './routine-controller.ts'
 import type { JournalStore } from './store.ts'
-import type { ClaimedAgentTask, RepositoryMapping, ValidatedAgentConfig } from './types.ts'
+import type { ClaimedAgentTask, DashboardSnapshot, RepositoryMapping, ServiceTrigger, ValidatedAgentConfig } from './types.ts'
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import { createAgentActivityLog } from './agent-activity.ts'
@@ -94,6 +94,16 @@ export function recordRoutineOnlyRepositoryHealth(input: {
     return
   }
   input.store.recordPollSuccess(input.repository, input.at)
+}
+
+/** Omits Routine history when this service does not answer the Routine trigger. */
+export function dashboardSnapshotForTriggers(
+  snapshot: DashboardSnapshot,
+  triggers: readonly ServiceTrigger[],
+): DashboardSnapshot {
+  return triggers.includes('routine')
+    ? snapshot
+    : { ...snapshot, routines: [], routineRuns: [] }
 }
 
 function recordServiceIncident(
@@ -909,7 +919,10 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       approvePullRequest: store.approvePullRequest,
       cancelTask: store.cancelTask,
       getDashboardSnapshot: (at) => {
-        const snapshot = pullRequestStatuses.apply(mergeExternalWatchSnapshot(store.getDashboardSnapshot(at), externalWatch.snapshot()))
+        const snapshot = dashboardSnapshotForTriggers(
+          pullRequestStatuses.apply(mergeExternalWatchSnapshot(store.getDashboardSnapshot(at), externalWatch.snapshot())),
+          config.triggers,
+        )
         const providerCapacities = AGENT_PROVIDER_NAMES.map(provider => ({
           provider,
           capacity: capacity.read(provider),

--- a/packages/harlan-github-agent/test/service-triggers.test.ts
+++ b/packages/harlan-github-agent/test/service-triggers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { parseConfigText } from '../src/config.ts'
-import { recordRoutineOnlyRepositoryHealth } from '../src/service.ts'
+import { dashboardSnapshotForTriggers, recordRoutineOnlyRepositoryHealth } from '../src/service.ts'
+import { dashboardSnapshot } from './fixtures.ts'
 
 const base = `
 github:
@@ -26,6 +27,35 @@ function parse(extra = ''): ReturnType<typeof parseConfigText> {
 }
 
 describe('which triggers one machine answers', () => {
+  const routineSnapshot = dashboardSnapshot({
+    routines: [{
+      id: 'harlan-zw/example:sentry-checkin',
+      repository: 'harlan-zw/example',
+      name: 'sentry-checkin',
+      crons: ['0 7 * * *'],
+      timeZone: 'Australia/Melbourne',
+      mode: 'report',
+      enabled: true,
+      specSha: 'abc123',
+      lastRunAt: '2026-08-28T21:00:00.000Z',
+      trackingIssueNumber: 42,
+      updatedAt: '2026-08-28T21:01:00.000Z',
+    }],
+    routineRuns: [{
+      id: 'routine-run-1',
+      routineId: 'harlan-zw/example:sentry-checkin',
+      repository: 'harlan-zw/example',
+      name: 'sentry-checkin',
+      scheduledFor: '2026-08-28T21:00:00.000Z',
+      specSha: 'abc123',
+      state: { _tag: 'Completed', evidence: 'No open Sentry issues.' },
+      fence: 1,
+      attempts: 1,
+      createdAt: '2026-08-28T21:00:00.000Z',
+      updatedAt: '2026-08-28T21:01:00.000Z',
+    }],
+  })
+
   it('answers every trigger when the file says nothing', () => {
     const parsed = parse()
 
@@ -43,6 +73,20 @@ describe('which triggers one machine answers', () => {
     const parsed = parse('triggers: [github]\n')
 
     expect(parsed._tag === 'Ok' ? parsed.value.triggers : []).toEqual(['github'])
+  })
+
+  it('hides stale Routine history from a GitHub-only dashboard', () => {
+    const visible = dashboardSnapshotForTriggers(routineSnapshot, ['github'])
+
+    expect(visible.routines).toEqual([])
+    expect(visible.routineRuns).toEqual([])
+  })
+
+  it('keeps Routine history on a Routine dashboard', () => {
+    const visible = dashboardSnapshotForTriggers(routineSnapshot, ['routine'])
+
+    expect(visible.routines.map(routine => routine.id)).toEqual(['harlan-zw/example:sentry-checkin'])
+    expect(visible.routineRuns.map(run => run.id)).toEqual(['routine-run-1'])
   })
 
   it('refuses an empty list, because a machine that answers nothing is a mistake', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Desktop kept showing old Routines after it stopped answering the Routine trigger. Dashboard state now omits Routine history on hosts that disable that trigger.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.