### PR TITLE
fix(agent): contain opencode launch failures

### DIFF
--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -2,8 +2,6 @@ import type { ChildProcessByStdio } from 'node:child_process'
 import type { Readable } from 'node:stream'
 import type { AgentEvent, AgentProvider, AgentTokenUsage, AgentTurnRequest } from './agent-provider.ts'
 import { spawn } from 'node:child_process'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import process from 'node:process'
 import { createInterface } from 'node:readline'
 import { agentProviderFailureReason, DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
@@ -15,6 +13,10 @@ const searchTools = new Set(['webfetch', 'websearch'])
 const maximumErrorCharacters = 600
 
 export type OpencodeProcess = ChildProcessByStdio<null, Readable, Readable>
+
+type OpencodeExit
+  = | { _tag: 'Exited', code: number | null, signal: NodeJS.Signals | null }
+    | { _tag: 'SpawnFailed', error: Error }
 
 export interface OpencodeProviderOptions {
   binaryPath?: string
@@ -164,7 +166,7 @@ export function opencodeArguments(request: AgentTurnRequest, prompt: string): st
 }
 
 export function createOpencodeProvider(options: OpencodeProviderOptions = {}): AgentProvider {
-  const binaryPath = options.binaryPath ?? join(homedir(), '.opencode', 'bin', 'opencode')
+  const binaryPath = options.binaryPath ?? 'opencode'
   const idleTimeoutMilliseconds = options.idleTimeoutMilliseconds ?? 10 * 60_000
   const cachedContextBudget = options.cachedContextBudget ?? DEFAULT_CACHED_CONTEXT_BUDGET
   const spawnOpencode = options.spawnOpencode ?? ((args, workspace) => spawn(binaryPath, args, {
@@ -182,9 +184,9 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
     child.stderr.on('data', (chunk: string) => {
       standardError = `${standardError}${chunk}`.slice(-maximumErrorCharacters)
     })
-    const exited = new Promise<{ code: number | null, signal: NodeJS.Signals | null }>((resolve, reject) => {
-      child.once('error', reject)
-      child.once('close', (code, signal) => resolve({ code, signal }))
+    const exited = new Promise<OpencodeExit>((resolve) => {
+      child.once('error', error => resolve({ _tag: 'SpawnFailed', error }))
+      child.once('close', (code, signal) => resolve({ _tag: 'Exited', code, signal }))
     })
 
     // A silent run means a wedged agent, and its Task holds its lease until the
@@ -255,6 +257,10 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
         }
       }
       const exit = await exited
+      if (exit._tag === 'SpawnFailed') {
+        yield { _tag: 'Failed', reason: agentProviderFailureReason('opencode', exit.error.message) }
+        return
+      }
       if (overBudget) {
         yield { _tag: 'ContextBudgetExhausted', cachedTokensRead }
         return

--- a/packages/harlan-github-agent/src/terminal-session.ts
+++ b/packages/harlan-github-agent/src/terminal-session.ts
@@ -3,8 +3,7 @@ import type { Result } from './result.ts'
 import { spawn } from 'node:child_process'
 import { constants } from 'node:fs'
 import { access } from 'node:fs/promises'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
+import { delimiter, join } from 'node:path'
 import process from 'node:process'
 import { err, ok } from './result.ts'
 
@@ -34,24 +33,44 @@ const providerLabels: Record<AgentProviderName, string> = {
   opencode: 'opencode',
 }
 
+/** Launch turns through PATH, so the terminal resumes the same binary. */
+const agentCommands: Record<AgentProviderName, string> = {
+  codex: 'codex',
+  opencode: 'opencode',
+}
+
 async function executable(path: string): Promise<Result<string, string>> {
   return access(path, constants.X_OK)
     .then(() => ok(path))
     .catch(() => err(`Executable is unavailable: ${path}`))
 }
 
+async function executableOnPath(command: string): Promise<Result<string, string>> {
+  const directories = (process.env.PATH ?? '').split(delimiter).filter(directory => directory.length > 0)
+  for (const directory of directories) {
+    const found = await executable(join(directory, command))
+    if (found._tag === 'Ok')
+      return found
+  }
+  return err(`Executable is unavailable: ${command}`)
+}
+
 export function createTerminalSessionLauncher(options: TerminalSessionOptions = {}) {
   const terminalPath = options.terminalPath ?? '/usr/bin/ghostty'
-  const agentPaths: Record<AgentProviderName, string> = {
-    codex: options.codexPath ?? join(homedir(), '.local', 'bin', 'codex'),
-    opencode: options.opencodePath ?? join(homedir(), '.opencode', 'bin', 'opencode'),
+  const agentOverrides: Partial<Record<AgentProviderName, string | undefined>> = {
+    codex: options.codexPath,
+    opencode: options.opencodePath,
   }
   const delayMilliseconds = options.delayMilliseconds ?? 6_000
 
   return async (input: TerminalSessionInput): Promise<Result<void, string>> => {
     if (!sessionPatterns[input.provider].test(input.sessionId))
       return err('The agent session ID is invalid.')
-    const [terminal, agent] = await Promise.all([executable(terminalPath), executable(agentPaths[input.provider])])
+    const override = agentOverrides[input.provider]
+    const [terminal, agent] = await Promise.all([
+      executable(terminalPath),
+      override === undefined ? executableOnPath(agentCommands[input.provider]) : executable(override),
+    ])
     if (terminal._tag === 'Err')
       return terminal
     if (agent._tag === 'Err')

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -1,5 +1,8 @@
 import type { AgentEvent, AgentTurnRequest } from '../src/agent-provider.ts'
 import { spawn } from 'node:child_process'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { extractJsonObject } from '../src/agent-provider.ts'
@@ -128,6 +131,38 @@ describe('opencodeAgentEvent', () => {
 })
 
 describe('createOpencodeProvider', () => {
+  it('finds the installed opencode command through PATH', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'opencode-provider-'))
+    const binary = join(workspace, 'opencode')
+    const originalPath = process.env.PATH
+    await writeFile(binary, `#!/bin/sh
+printf '%s\\n' '${JSON.stringify(textLine)}'
+`)
+    await chmod(binary, 0o755)
+    process.env.PATH = workspace
+
+    try {
+      const provider = createOpencodeProvider()
+
+      expect(await collect(provider.runTurn(request({ workspace })))).toEqual([
+        { _tag: 'SessionStarted', sessionId: 'ses_abc12345' },
+        { _tag: 'Message', text: '{"outcome":"resolved"}' },
+      ])
+    }
+    finally {
+      process.env.PATH = originalPath
+      await rm(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a missing command as a turn failure', async () => {
+    const binaryPath = '/missing/opencode'
+    const provider = createOpencodeProvider({ binaryPath })
+
+    expect(await collect(provider.runTurn(request({ workspace: process.cwd() }))))
+      .toEqual([{ _tag: 'Failed', reason: `The opencode session failed: spawn ${binaryPath} ENOENT` }])
+  })
+
   it('reports the session before the events it produced', async () => {
     const provider = createOpencodeProvider({ spawnOpencode: replay([bashLine, textLine]) })
 

--- a/packages/harlan-github-agent/test/terminal-session.test.ts
+++ b/packages/harlan-github-agent/test/terminal-session.test.ts
@@ -1,0 +1,106 @@
+import type { TerminalSessionInput } from '../src/terminal-session.ts'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+import { createTerminalSessionLauncher } from '../src/terminal-session.ts'
+
+function input(overrides: Partial<TerminalSessionInput> = {}): TerminalSessionInput {
+  return {
+    taskId: '101',
+    sessionId: 'ses_abc12345',
+    provider: 'opencode',
+    repository: 'harlan-zw/harlan-agent-kit',
+    itemNumber: 82,
+    ...overrides,
+  }
+}
+
+/** The fake terminal records the arguments ghostty would receive, one per line. */
+async function recordedArguments(terminalPath: string): Promise<string[] | undefined> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    // The argv file exists only once the terminal has spawned, so a missing
+    // file is the normal state while polling.
+    const content = await readFile(`${terminalPath}.argv`, 'utf8').catch(() => {
+      // Ignored: the poll below retries until the terminal records its arguments.
+      return undefined
+    })
+    const lines = content?.split('\n').filter(line => line.length > 0)
+    if (lines !== undefined && lines.at(-1) === 'done')
+      return lines.slice(0, -1)
+    await new Promise(resolve => setTimeout(resolve, 50))
+  }
+  return undefined
+}
+
+describe('createTerminalSessionLauncher', () => {
+  it('finds the installed opencode command through PATH', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'terminal-session-'))
+    const binary = join(workspace, 'bin', 'opencode')
+    const terminal = join(workspace, 'ghostty')
+    const originalPath = process.env.PATH
+    const originalHome = process.env.HOME
+    await mkdir(join(workspace, 'bin'))
+    await writeFile(terminal, '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$0.argv"\necho done >> "$0.argv"\n')
+    await chmod(terminal, 0o755)
+    await writeFile(binary, '#!/bin/sh\nexit 0\n')
+    await chmod(binary, 0o755)
+    process.env.HOME = workspace
+    process.env.PATH = join(workspace, 'bin')
+
+    try {
+      const launcher = createTerminalSessionLauncher({ terminalPath: terminal, delayMilliseconds: 0 })
+
+      expect(await launcher(input())).toEqual({ _tag: 'Ok', value: undefined })
+      expect(await recordedArguments(terminal)).toEqual([
+        '--title=opencode · harlan-zw/harlan-agent-kit #82',
+        '-e',
+        binary,
+        '--session',
+        'ses_abc12345',
+      ])
+    }
+    finally {
+      process.env.PATH = originalPath
+      process.env.HOME = originalHome
+      await rm(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('finds the installed codex command through PATH', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'terminal-session-'))
+    const binary = join(workspace, 'bin', 'codex')
+    const terminal = join(workspace, 'ghostty')
+    const originalPath = process.env.PATH
+    const originalHome = process.env.HOME
+    await mkdir(join(workspace, 'bin'))
+    await writeFile(terminal, '#!/bin/sh\nprintf \'%s\\n\' "$@" > "$0.argv"\necho done >> "$0.argv"\n')
+    await chmod(terminal, 0o755)
+    await writeFile(binary, '#!/bin/sh\nexit 0\n')
+    await chmod(binary, 0o755)
+    process.env.HOME = workspace
+    process.env.PATH = join(workspace, 'bin')
+
+    try {
+      const launcher = createTerminalSessionLauncher({ terminalPath: terminal, delayMilliseconds: 0 })
+
+      expect(await launcher(input({ provider: 'codex', sessionId: '0f0e0d0c-0b0a-4968-8956-2631d0c871f9' })))
+        .toEqual({ _tag: 'Ok', value: undefined })
+      expect(await recordedArguments(terminal)).toEqual([
+        '--title=Codex · harlan-zw/harlan-agent-kit #82',
+        '-e',
+        binary,
+        'resume',
+        '0f0e0d0c-0b0a-4968-8956-2631d0c871f9',
+        '-c',
+        'tui.resume_cwd="session"',
+      ])
+    }
+    finally {
+      process.env.PATH = originalPath
+      process.env.HOME = originalHome
+      await rm(workspace, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hogwild's OpenCode install moved, but the service still launched the old absolute path.
The provider now uses PATH and records a failed Agent turn when launch fails.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.