### PR TITLE
fix(agent): show Hogwild Routine activity in System pane

### DIFF
--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -20,8 +20,8 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import AyatanaAppIndicator3, GLib, Gtk
 
 DASHBOARD_URL = 'https://harlan-github-agent.localhost/'
-DASHBOARD_API = f'{DASHBOARD_URL}api/state'
 DASHBOARD_ORIGIN = DASHBOARD_URL.rstrip('/')
+HOGWILD_DASHBOARD_URL = os.environ.get('HARLAN_GITHUB_AGENT_HOGWILD_URL', 'https://hogwild.tailcad325.ts.net/').rstrip('/') + '/'
 PASSWORD_FILE = Path.home() / '.config/harlan-github-agent/dashboard-password'
 APP_ICON = Path(__file__).resolve().parent.parent / 'assets/github-app-icon.png'
 WATCHER = Path(__file__).resolve().parent / 'harlan-github-agent-watch'
@@ -48,8 +48,8 @@ def dashboard_authorization():
     return f'Basic {credentials}'
 
 
-def request_dashboard():
-    request = urllib.request.Request(DASHBOARD_API, headers={'Authorization': dashboard_authorization()})
+def request_dashboard(url=DASHBOARD_URL):
+    request = urllib.request.Request(f'{url}api/state', headers={'Authorization': dashboard_authorization()})
     with urllib.request.urlopen(request, timeout=3) as response:
         return json.load(response)
 
@@ -100,25 +100,37 @@ def request_agent_eject(task_id):
         return json.load(response)
 
 
-def read_system_sources(fetch_dashboard):
+def read_system_sources(fetch_dashboard, fetch_hogwild_dashboard=None):
     try:
         harlan_github_agent = {'_tag': 'Available', 'dashboard': fetch_dashboard()}
     except Exception as caught:
         harlan_github_agent = {'_tag': 'Unavailable', 'message': str(caught)}
 
-    return {
+    sources = {
         'harlanGithubAgent': harlan_github_agent,
     }
+    if fetch_hogwild_dashboard is not None:
+        try:
+            sources['hogwildAgent'] = {'_tag': 'Available', 'dashboard': fetch_hogwild_dashboard()}
+        except Exception as caught:
+            sources['hogwildAgent'] = {'_tag': 'Unavailable', 'message': str(caught)}
+    return sources
 
 
 def loading_system_sources():
     return {
         'harlanGithubAgent': {'_tag': 'Loading'},
+        'hogwildAgent': {'_tag': 'Loading'},
     }
 
 
 def source_dashboard(sources):
     source = sources['harlanGithubAgent']
+    return source['dashboard'] if source['_tag'] == 'Available' else None
+
+
+def source_hogwild_dashboard(sources):
+    source = sources.get('hogwildAgent', {'_tag': 'Loading'})
     return source['dashboard'] if source['_tag'] == 'Available' else None
 
 
@@ -352,6 +364,19 @@ def active_agent_label(agent):
     return f"🟢 {agent_role_label(agent)} · {agent['repository']} #{agent['itemNumber']}"
 
 
+def active_routine_runs(dashboard):
+    if dashboard is None:
+        return []
+    return [
+        run for run in dashboard.get('routineRuns', [])
+        if run.get('state', {}).get('_tag') == 'Running'
+    ]
+
+
+def active_routine_label(run):
+    return f"🟢 Routine · {run['name']} · {run['repository']}"
+
+
 def concise_activity_text(value):
     text = ' '.join(str(value).split())
     return text if len(text) <= 72 else f'{text[:71].rstrip()}…'
@@ -543,11 +568,16 @@ def build_menu(indicator, sources, action_error, refresh, set_agent_control, eje
     dashboard = source_dashboard(sources)
     dashboard_error = dashboard_source.get('message') if dashboard_source['_tag'] == 'Unavailable' else None
     agents = [] if dashboard is None else [agent for agent in dashboard.get('agents', []) if agent.get('_tag') == 'ActiveAgent']
+    hogwild_source = sources.get('hogwildAgent')
+    hogwild = source_hogwild_dashboard(sources)
+    routine_runs = [*active_routine_runs(dashboard), *active_routine_runs(hogwild)]
     queue = [] if dashboard is None else dashboard.get('queue', [])
     menu.append(section_item('Harlan GitHub Agent'))
-    menu.append(menu_item(harlan_github_agent_status_label(dashboard, agents, dashboard_error), enabled=False))
+    menu.append(menu_item(harlan_github_agent_status_label(dashboard, [*agents, *routine_runs], dashboard_error), enabled=False))
     if dashboard_error is not None:
         menu.append(menu_item(dashboard_error[:100], enabled=False))
+    if hogwild_source is not None and hogwild_source['_tag'] == 'Unavailable':
+        menu.append(menu_item(f"Hogwild unavailable · {hogwild_source['message'][:80]}", enabled=False))
     if action_error is not None:
         menu.append(menu_item(action_error[:100], enabled=False))
     menu.append(menu_item('Open dashboard', DASHBOARD_URL))
@@ -578,6 +608,15 @@ def build_menu(indicator, sources, action_error, refresh, set_agent_control, eje
             eject_item.connect('activate', lambda *_args, current=agent: confirm_agent_eject(current, eject_agent))
             links.append(eject_item)
             menu.append(submenu_item(active_agent_label(agent), links))
+
+        for run in routine_runs:
+            progress = run.get('progress', {'percent': 0, 'label': 'Starting'})
+            links = [menu_item(progress['label'], enabled=False)]
+            activity_label = active_agent_activity_label(run)
+            if activity_label is not None:
+                links.append(menu_item(activity_label, enabled=False))
+            links.append(menu_item('Open repository', f"https://github.com/{run['repository']}"))
+            menu.append(submenu_item(active_routine_label(run), links))
 
         incidents = dashboard.get('incidents', [])
         if incidents:
@@ -642,9 +681,10 @@ def main():
         refreshing['active'] = False
         dashboard = source_dashboard(sources)
         agents = [] if dashboard is None else [agent for agent in dashboard.get('agents', []) if agent.get('_tag') == 'ActiveAgent']
+        routine_runs = [*active_routine_runs(dashboard), *active_routine_runs(source_hogwild_dashboard(sources))]
         dashboard_source = sources['harlanGithubAgent']
         dashboard_error = dashboard_source.get('message') if dashboard_source['_tag'] == 'Unavailable' else None
-        label, title = indicator_summary(dashboard, agents, dashboard_error)
+        label, title = indicator_summary(dashboard, [*agents, *routine_runs], dashboard_error)
         indicator.set_label(label, '🟢 99')
         indicator.set_icon_full(str(APP_ICON), 'Harlan GitHub Agent')
         indicator.set_title(title)
@@ -667,7 +707,7 @@ def main():
                     request_agent_eject(action['taskId'])
             except Exception as caught:
                 control_error = f"{action['label']} failed: {caught}"
-        sources = read_system_sources(request_dashboard)
+        sources = read_system_sources(request_dashboard, lambda: request_dashboard(HOGWILD_DASHBOARD_URL))
         GLib.idle_add(apply_state, sources, control_error)
 
     def refresh(*_args):

--- a/packages/harlan-github-agent/dashboard/app/pages/index.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/index.vue
@@ -336,6 +336,30 @@ useHead({
             <p v-if="record.presentation.detail" class="text-xs text-muted sm:col-span-2">
               {{ record.presentation.detail }}
             </p>
+            <details v-if="record.latestRun && record.latestRun.activity.length > 0" class="text-xs sm:col-span-2">
+              <summary class="cursor-pointer font-mono text-dimmed">
+                Terminal · {{ record.latestRun.activity.length }} step{{ record.latestRun.activity.length === 1 ? '' : 's' }}
+              </summary>
+              <ol class="terminal mt-2 space-y-1 font-mono text-xs">
+                <li v-for="(item, itemIndex) in record.latestRun.activity" :key="itemIndex">
+                  <template v-if="item._tag === 'Command'">
+                    <p>
+                      <span class="mr-1.5 text-dimmed" aria-hidden="true">$</span>
+                      <span>{{ item.command }}</span>
+                      <span v-if="item.exitCode !== null && item.exitCode !== 0" class="status-error"> exit {{ item.exitCode }}</span>
+                    </p>
+                    <pre v-if="item.output.length > 0">{{ item.output }}</pre>
+                  </template>
+                  <p v-else-if="item._tag === 'FileChange'">
+                    <span class="text-dimmed">edited</span>
+                    {{ item.changes.map(change => change.path).join(', ') }}
+                  </p>
+                  <p v-else class="text-dimmed">
+                    {{ item.text }}
+                  </p>
+                </li>
+              </ol>
+            </details>
           </li>
         </ol>
       </section>

--- a/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
@@ -4,6 +4,7 @@ import type {
   AgentRole,
   AgentStartState,
   AgentTask,
+  DashboardRoutineRun,
   DashboardSnapshot,
   DashboardTask,
   Incident,
@@ -52,7 +53,7 @@ export interface ProviderCapacityPresentation {
 
 export interface ScheduledRoutineRecord {
   routine: Routine
-  latestRun: RoutineRun | undefined
+  latestRun: DashboardRoutineRun | undefined
 }
 
 export interface RoutineRunPresentation {
@@ -62,8 +63,8 @@ export interface RoutineRunPresentation {
 }
 
 /** Pairs each declared Routine with the newest run the snapshot retained. */
-export function scheduledRoutineRecords(routines: readonly Routine[], runs: readonly RoutineRun[]): ScheduledRoutineRecord[] {
-  const newest = new Map<string, RoutineRun>()
+export function scheduledRoutineRecords(routines: readonly Routine[], runs: readonly DashboardRoutineRun[]): ScheduledRoutineRecord[] {
+  const newest = new Map<string, DashboardRoutineRun>()
   runs.forEach((run) => {
     const current = newest.get(run.routineId)
     if (current === undefined || run.scheduledFor > current.scheduledFor)
@@ -78,7 +79,7 @@ export function routineRunPresentation(run: RoutineRun | undefined): RoutineRunP
     return { label: 'Never run', tone: 'neutral' }
   switch (run.state._tag) {
     case 'Queued': return { label: 'Queued', tone: 'neutral' }
-    case 'Running': return { label: 'Running', tone: 'primary' }
+    case 'Running': return { label: 'Running', tone: 'primary', detail: run.progress.label }
     case 'Completed': return { label: 'Completed', tone: 'success', detail: run.state.evidence }
     case 'Failed': return { label: 'Failed', tone: 'error', detail: run.state.reason }
     case 'Skipped': return { label: 'Skipped', tone: 'neutral', detail: run.state.reason }

--- a/packages/harlan-github-agent/src/agent-progress.ts
+++ b/packages/harlan-github-agent/src/agent-progress.ts
@@ -1,7 +1,7 @@
 import type { AgentEvent } from './agent-provider.ts'
 import type { AgentProgress } from './types.ts'
 
-export type AgentProgressWork = 'review' | 'issue' | 'conflict' | 'fix' | 'baseline'
+export type AgentProgressWork = 'review' | 'issue' | 'conflict' | 'fix' | 'baseline' | 'routine'
 
 const changedFilesLabel: Record<AgentProgressWork, string> = {
   review: 'Reviewing changed files',
@@ -9,6 +9,7 @@ const changedFilesLabel: Record<AgentProgressWork, string> = {
   conflict: 'Resolving merge conflicts',
   fix: 'Repairing review findings',
   baseline: 'Repairing the default branch',
+  routine: 'Checking the repository',
 }
 
 const resultLabel: Record<AgentProgressWork, string> = {
@@ -17,6 +18,7 @@ const resultLabel: Record<AgentProgressWork, string> = {
   conflict: 'Checking the conflict fix',
   fix: 'Checking the repair',
   baseline: 'Checking the default branch repair',
+  routine: 'Preparing the Routine result',
 }
 
 /**

--- a/packages/harlan-github-agent/src/app.ts
+++ b/packages/harlan-github-agent/src/app.ts
@@ -67,6 +67,7 @@ function dashboardSnapshot(options: AgentAppOptions): DashboardSnapshot {
     agents: snapshot.agents.map(agent => agent._tag === 'ActiveAgent'
       ? { ...agent, activity: activityLog.read(agent.id) }
       : agent),
+    routineRuns: snapshot.routineRuns.map(run => ({ ...run, activity: activityLog.read(run.id) })),
   }
 }
 

--- a/packages/harlan-github-agent/src/routine-worker.ts
+++ b/packages/harlan-github-agent/src/routine-worker.ts
@@ -1,3 +1,4 @@
+import type { AgentActivityLog } from './agent-activity.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
@@ -115,11 +116,12 @@ ${input.mode === 'report'
 }
 
 export interface RoutineScanWorkerOptions {
+  activityLog?: Pick<AgentActivityLog, 'record'>
   logger: { error: (message: string) => void, info: (message: string) => void }
   maximumChangedFiles?: number
   now: () => Date
   runtime: AgentRuntimeSource
-  store: Pick<JournalStore, 'listCandidates' | 'recordCandidates' | 'stageCandidateIssues' | 'stageRoutineReport'>
+  store: Pick<JournalStore, 'listCandidates' | 'recordCandidates' | 'stageCandidateIssues' | 'stageRoutineReport' | 'updateRoutineRunProgress'>
   workspaces: Pick<AgentWorkspaceManager, 'prepareRoutine'>
 }
 
@@ -153,8 +155,26 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
       if (workspace._tag === 'Err')
         return workspace
 
+      const reportProgress = (progress: { percent: number, label: string }): Result<void, string> => options.store.updateRoutineRunProgress({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        progress,
+        at: options.now().toISOString(),
+      })
+        ? ok(undefined)
+        : err('The Routine lease ended before progress could be saved.')
+      const ready = reportProgress({ percent: 35, label: 'Git worktree ready' })
+      if (ready._tag === 'Err')
+        return ready
+
       const turn = await runAgentTurn(
-        { now: options.now, runtime: options.runtime, store: sessionlessStore },
+        {
+          ...(options.activityLog === undefined ? {} : { activityLog: options.activityLog }),
+          now: options.now,
+          runtime: options.runtime,
+          store: sessionlessStore,
+        },
         {
           freshSession: true,
           // A Routine answers a clock, so it belongs to no issue or pull
@@ -171,6 +191,7 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
           schema: CANDIDATE_SCHEMA,
           taskId: task.id,
           workspace: workspace.value.path,
+          progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'routine' },
         },
         signal,
       )

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -520,6 +520,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         permits,
         // A scan is read only, so it needs no write access to start.
         worker: createRoutineScanWorker({
+          activityLog,
           logger: {
             error: message => options.logger.error(message),
             info: message => options.logger.info(message),

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -630,6 +630,7 @@ export interface JournalStore {
   failRoutineReport: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   claimNextRoutineRun: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedRoutineRun | null
   heartbeatRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, leaseMilliseconds: number }) => boolean
+  updateRoutineRunProgress: (input: { taskId: string, workerId: string, fence: number, progress: AgentProgress, at: string }) => boolean
   completeRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
   failRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
   closeMissingItems: (github: string, seen: Array<{ kind: GitHubItem['kind'], number: number }>, observedAt: string) => number
@@ -3992,6 +3993,14 @@ const routineRunLogMigration = `
   PRAGMA user_version = 43;
 `
 
+/** Gives Routine runs the same durable phase record as every Item-bound Agent task. */
+const routineProgressMigration = `
+  ALTER TABLE routine_runs ADD COLUMN progress_percent INTEGER NOT NULL DEFAULT 0 CHECK (progress_percent BETWEEN 0 AND 100);
+  ALTER TABLE routine_runs ADD COLUMN progress_label TEXT NOT NULL DEFAULT 'Starting';
+
+  PRAGMA user_version = 44;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -4017,7 +4026,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 43)
+  if (version === 44)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -4190,6 +4199,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 42) {
     applyMigration(database, routineRunLogMigration)
+    version = 43
+  }
+  if (version === 43) {
+    applyMigration(database, routineProgressMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -7700,6 +7713,7 @@ export function openJournalStore(
       .flatMap(routine => listRoutineRuns(routine.id, 5))
       .sort((left, right) => right.scheduledFor.localeCompare(left.scheduledFor))
       .slice(0, 50)
+      .map(run => ({ ...run, activity: [] }))
     const rejectedIssueWorkResults = new Map((database.prepare(`
       SELECT task_transitions.task_id, COUNT(*) AS occurrences
       FROM task_transitions
@@ -8492,6 +8506,8 @@ export function openJournalStore(
     lease_expires_at: string | null
     fence: number
     attempts: number
+    progress_percent: number
+    progress_label: string
     created_at: string
     updated_at: string
   }
@@ -8525,6 +8541,7 @@ export function openJournalStore(
     state: readRoutineRunState(row),
     fence: row.fence,
     attempts: row.attempts,
+    progress: { percent: row.progress_percent, label: row.progress_label },
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   })
@@ -8697,7 +8714,7 @@ export function openJournalStore(
     database.prepare(`
       UPDATE routine_runs
       SET state_tag = 'Queued', worker_id = NULL, lease_expires_at = NULL,
-        fence = fence + 1, updated_at = ?
+        fence = fence + 1, progress_percent = 0, progress_label = 'Starting', updated_at = ?
       WHERE state_tag = 'Running' AND lease_expires_at <= ?
     `).run(now, now)
   }
@@ -8748,7 +8765,7 @@ export function openJournalStore(
       const claimed = database.prepare(`
         UPDATE routine_runs
         SET state_tag = 'Running', worker_id = ?, lease_expires_at = ?, fence = ?,
-          attempts = attempts + 1, updated_at = ?
+          attempts = attempts + 1, progress_percent = 10, progress_label = 'Routine loaded', updated_at = ?
         WHERE id = ? AND state_tag = 'Queued' AND fence = ?
       `).run(workerId, leaseExpiresAt, fence, now, row.id, row.fence).changes === 1
       if (!claimed) {
@@ -8784,6 +8801,16 @@ export function openJournalStore(
     `).run(leaseExpiresAt, input.taskId, input.workerId, input.fence, input.at).changes === 1
   }
 
+  const updateRoutineRunProgress: JournalStore['updateRoutineRunProgress'] = (input) => {
+    if (!Number.isInteger(input.progress.percent) || input.progress.percent < 0 || input.progress.percent > 100)
+      return false
+    return database.prepare(`
+      UPDATE routine_runs
+      SET progress_percent = ?, progress_label = ?, updated_at = ?
+      WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
+    `).run(input.progress.percent, input.progress.label, input.at, input.taskId, input.workerId, input.fence).changes === 1
+  }
+
   const completeRoutineRun: JournalStore['completeRoutineRun'] = input =>
     database.prepare(`
       UPDATE routine_runs
@@ -8808,9 +8835,12 @@ export function openJournalStore(
     const retrying = row.attempts < row.max_attempts
     const changed = database.prepare(`
       UPDATE routine_runs
-      SET state_tag = ?, reason = ?, worker_id = NULL, lease_expires_at = NULL, updated_at = ?
+      SET state_tag = ?, reason = ?, worker_id = NULL, lease_expires_at = NULL,
+        progress_percent = CASE WHEN ? = 'Queued' THEN 0 ELSE progress_percent END,
+        progress_label = CASE WHEN ? = 'Queued' THEN 'Starting' ELSE progress_label END,
+        updated_at = ?
       WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
-    `).run(retrying ? 'Queued' : 'Failed', input.reason, input.at, input.taskId, input.workerId, input.fence).changes === 1
+    `).run(retrying ? 'Queued' : 'Failed', input.reason, retrying ? 'Queued' : 'Failed', retrying ? 'Queued' : 'Failed', input.at, input.taskId, input.workerId, input.fence).changes === 1
     if (!changed)
       return 'Rejected'
     return retrying ? 'Retrying' : 'Failed'
@@ -9116,6 +9146,7 @@ export function openJournalStore(
     failRoutineReport,
     claimNextRoutineRun,
     heartbeatRoutineRun,
+    updateRoutineRunProgress,
     completeRoutineRun,
     failRoutineRun,
     isIssueWorkApprovalReady,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -625,8 +625,14 @@ export interface RoutineRun {
   state: RoutineRunState
   fence: number
   attempts: number
+  progress: AgentProgress
   createdAt: string
   updatedAt: string
+}
+
+/** One Routine run as sent to the dashboard, with live process activity attached. */
+export interface DashboardRoutineRun extends RoutineRun {
+  activity: AgentActivityItem[]
 }
 
 /**
@@ -1138,7 +1144,7 @@ export interface DashboardSnapshot {
   items: ItemSummary[]
   tasks: DashboardTask[]
   routines: Routine[]
-  routineRuns: RoutineRun[]
+  routineRuns: DashboardRoutineRun[]
 }
 
 export type StoredAgentControl

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -37,6 +37,42 @@ function createApp(snapshot = dashboardSnapshot()) {
 }
 
 describe('dashboard HTTP app', () => {
+  it('attaches live activity to a running Routine', async () => {
+    const runId = 'routine-run-1'
+    const snapshot = dashboardSnapshot({
+      routineRuns: [{
+        id: runId,
+        routineId: 'harlan-zw/example:sentry-checkin',
+        repository: 'harlan-zw/example',
+        name: 'sentry-checkin',
+        scheduledFor: '2026-08-13T00:00:00.000Z',
+        specSha: 'abc123',
+        state: { _tag: 'Running', workerId: 'worker-1', leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+        fence: 1,
+        attempts: 1,
+        progress: { percent: 55, label: 'Checking the repository' },
+        activity: [],
+        createdAt: '2026-08-13T00:00:00.000Z',
+        updatedAt: now().toISOString(),
+      }],
+    })
+    const app = createAgentApp({
+      allowedOrigin,
+      dashboardPassword,
+      dashboardRoot,
+      now,
+      activityLog: { read: id => id === runId ? [{ _tag: 'Reasoning', at: now().toISOString(), text: 'Reading Sentry issues.' }] : [] },
+      store: { ...agentControls, approveIssueWork: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }), approvePullRequest: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }), cancelTask: () => ({ _tag: 'Rejected', reason: { _tag: 'TaskNotFound' } }), getDashboardSnapshot: () => snapshot, listReviewRuns: () => [], requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'ItemNotFound' } }) },
+    })
+
+    const response = await app.request(`http://${allowedHost}/api/state`, { headers: { authorization, host: allowedHost } })
+    const body = await response.json() as { routineRuns: Array<{ activity: unknown[] }> }
+
+    expect(body.routineRuns[0]?.activity).toEqual([
+      { _tag: 'Reasoning', at: now().toISOString(), text: 'Reading Sentry issues.' },
+    ])
+  })
+
   it('switches the Agent provider, model, and reasoning effort', async () => {
     const switches: unknown[] = []
     const app = createAgentApp({

--- a/packages/harlan-github-agent/test/dashboard-view.test.ts
+++ b/packages/harlan-github-agent/test/dashboard-view.test.ts
@@ -1,4 +1,4 @@
-import type { ActiveAgent, DashboardTask, Incident, QueueEntry, ReviewAgent, Routine, RoutineRun } from '../src/types.ts'
+import type { ActiveAgent, DashboardRoutineRun, DashboardTask, Incident, QueueEntry, ReviewAgent, Routine } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
 import {
   activeAgentActivity,
@@ -82,7 +82,7 @@ function routine(overrides: Partial<Routine> = {}): Routine {
   }
 }
 
-function routineRun(overrides: Partial<RoutineRun> = {}): RoutineRun {
+function routineRun(overrides: Partial<DashboardRoutineRun> = {}): DashboardRoutineRun {
   return {
     id: 'routine-run-1',
     routineId: 'harlan-zw/example:sentry-checkin',
@@ -93,6 +93,8 @@ function routineRun(overrides: Partial<RoutineRun> = {}): RoutineRun {
     state: { _tag: 'Completed', evidence: 'No open Sentry issues.' },
     fence: 1,
     attempts: 1,
+    progress: { percent: 85, label: 'Preparing the Routine result' },
+    activity: [],
     createdAt: '2026-08-27T21:00:00.000Z',
     updatedAt: '2026-08-27T21:01:00.000Z',
     ...overrides,
@@ -693,6 +695,11 @@ describe('system pane', () => {
       detail: 'Sentry timed out.',
     })
     expect(routineRunPresentation(undefined)).toEqual({ label: 'Never run', tone: 'neutral' })
+    expect(routineRunPresentation(routineRun({ state: { _tag: 'Running', workerId: 'worker-1', leaseExpiresAt: '2026-08-28T22:00:00.000Z' } }))).toEqual({
+      label: 'Running',
+      tone: 'primary',
+      detail: 'Preparing the Routine result',
+    })
   })
 
   it('links a Routine to its tracking issue', () => {

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -525,6 +525,58 @@ class IndicatorDisplayTest(unittest.TestCase):
         self.assertEqual(labels[:2], ['Running tests and checks', 'Running pnpm test'])
         self.assertFalse(any('%' in label or '▓' in label or '░' in label for label in labels))
 
+    def test_system_pane_shows_a_running_routine_and_its_live_activity(self):
+        run = {
+            'id': 'routine-run-1',
+            'repository': 'harlan-zw/example',
+            'name': 'sentry-checkin',
+            'state': {'_tag': 'Running'},
+            'progress': {'percent': 55, 'label': 'Checking the repository'},
+            'activity': [{
+                '_tag': 'Reasoning',
+                'at': '2026-08-14T00:00:00.000Z',
+                'text': 'Reading Sentry issues.',
+            }],
+        }
+        sources = {
+            'harlanGithubAgent': {'_tag': 'Available', 'dashboard': {
+                'status': 'ready',
+                'agentControl': {'_tag': 'Running'},
+                'agents': [],
+                'routineRuns': [],
+                'queue': [],
+                'incidents': [],
+            }},
+            'hogwildAgent': {'_tag': 'Available', 'dashboard': {
+                'status': 'ready',
+                'agents': [],
+                'routineRuns': [run],
+                'queue': [],
+                'incidents': [],
+            }},
+        }
+        stub = StubIndicator()
+
+        indicator.build_menu(
+            stub,
+            sources,
+            None,
+            lambda: None,
+            lambda *_args: None,
+            lambda *_args: None,
+            lambda *_args: None,
+        )
+
+        routine = next(
+            item for item in stub.menus[0].get_children()
+            if item.get_label().startswith('🟢 Routine')
+        )
+        self.assertEqual(
+            menu_labels(routine.get_submenu()),
+            ['Checking the repository', 'Reading Sentry issues.', 'Open repository'],
+        )
+        self.assertIn('🟢 1 agent running · Queue empty', menu_labels(stub.menus[0]))
+
     def test_uses_canonical_labels_for_every_agent_role(self):
         labels = {
             'adversarial_review': 'Adversarial review',

--- a/packages/harlan-github-agent/test/routine-worker.test.ts
+++ b/packages/harlan-github-agent/test/routine-worker.test.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent } from '../src/agent-provider.ts'
 import type { ClaimedRoutineRun } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
+import { createAgentActivityLog } from '../src/agent-activity.ts'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { ok } from '../src/result.ts'
 import { createRoutineScanWorker, routineScanPrompt } from '../src/routine-worker.ts'
@@ -9,20 +10,11 @@ import { repositoryMapping } from './fixtures.ts'
 
 const now = () => new Date('2026-08-27T07:05:00.000Z')
 
-function claimedRun(overrides: Partial<ClaimedRoutineRun> = {}): ClaimedRoutineRun {
-  return {
-    id: 'harlan-zw/example:pr-triage:2026-08-27T07:00:00.000Z',
-    routineId: 'harlan-zw/example:pr-triage',
-    repository: 'harlan-zw/example',
-    repositoryMapping: repositoryMapping(),
-    name: 'pr-triage',
-    mode: 'propose',
-    scheduledFor: '2026-08-27T07:00:00.000Z',
-    specSha: 'abc123',
-    attempts: 1,
-    state: { _tag: 'Running', fence: 1, workerId: 'worker-1', leaseExpiresAt: '2026-08-27T08:00:00.000Z' },
-    ...overrides,
-  }
+function claimStoredRun(store: ReturnType<typeof openJournalStore>, at = now().toISOString()): ClaimedRoutineRun {
+  const task = store.claimNextRoutineRun('worker-1', at, 60 * 60_000)
+  if (task === null)
+    throw new Error('Expected a queued Routine run.')
+  return task
 }
 
 function scanning(answer: unknown, capture?: { prompts: string[] }) {
@@ -39,8 +31,14 @@ function scanning(answer: unknown, capture?: { prompts: string[] }) {
   }
 }
 
-function workerFor(store: ReturnType<typeof openJournalStore>, provider: ReturnType<typeof scanning>, maximumChangedFiles?: number) {
+function workerFor(
+  store: ReturnType<typeof openJournalStore>,
+  provider: ReturnType<typeof scanning>,
+  maximumChangedFiles?: number,
+  activityLog?: ReturnType<typeof createAgentActivityLog>,
+) {
   return createRoutineScanWorker({
+    ...(activityLog === undefined ? {} : { activityLog }),
     logger: { error: () => undefined, info: () => undefined },
     ...(maximumChangedFiles === undefined ? {} : { maximumChangedFiles }),
     now,
@@ -141,12 +139,46 @@ describe('building the scan prompt', () => {
 })
 
 describe('running one scan', () => {
+  it('reports live progress and provider activity', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store)
+      const task = claimStoredRun(store)
+      const activityLog = createAgentActivityLog()
+      const provider = {
+        name: 'codex' as const,
+        runTurn: () => (async function* (): AsyncIterable<AgentEvent> {
+          yield { _tag: 'SessionStarted', sessionId: 'session-1' }
+          yield { _tag: 'Reasoning', text: 'Checking the repository.' }
+          yield { _tag: 'CommandCompleted', command: 'pnpm test', output: 'passed', exitCode: 0 }
+          yield { _tag: 'Message', text: JSON.stringify({ candidates: [] }) }
+          yield { _tag: 'TurnCompleted' }
+        })(),
+      }
+
+      const result = await workerFor(store, provider, undefined, activityLog)
+        .run(task, new AbortController().signal)
+
+      expect(result).toMatchObject({ _tag: 'Ok' })
+      expect(activityLog.read(task.id)).toEqual([
+        { _tag: 'Reasoning', at: now().toISOString(), text: 'Checking the repository.' },
+        { _tag: 'Command', at: now().toISOString(), command: 'pnpm test', output: 'passed', exitCode: 0 },
+      ])
+      expect(store.listRoutineRuns(task.routineId)[0]).toMatchObject({
+        progress: { percent: 85, label: 'Preparing the Routine result' },
+      })
+    }
+    finally {
+      store.close()
+    }
+  })
+
   it('records what the scan found', async () => {
     const store = openJournalStore(':memory:')
     try {
       seed(store)
       const result = await workerFor(store, scanning({ candidates: [candidate] }))
-        .run(claimedRun(), new AbortController().signal)
+        .run(claimStoredRun(store), new AbortController().signal)
 
       expect(result).toMatchObject({ _tag: 'Ok' })
       expect(store.listCandidates('harlan-zw/example:pr-triage')).toMatchObject([{ fingerprint: candidate.fingerprint }])
@@ -162,7 +194,7 @@ describe('running one scan', () => {
       seed(store)
       await workerFor(store, scanning({
         candidates: [candidate, { ...candidate, fingerprint: 'src/big.ts', estimatedChangedFiles: 40 }],
-      })).run(claimedRun(), new AbortController().signal)
+      })).run(claimStoredRun(store), new AbortController().signal)
 
       expect(store.listCandidates('harlan-zw/example:pr-triage').map(entry => entry.fingerprint))
         .toEqual([candidate.fingerprint])
@@ -177,7 +209,15 @@ describe('running one scan', () => {
     try {
       seed(store)
       const worker = workerFor(store, scanning({ candidates: [candidate] }))
-      await worker.run(claimedRun(), new AbortController().signal)
+      const firstTask = claimStoredRun(store)
+      await worker.run(firstTask, new AbortController().signal)
+      store.completeRoutineRun({
+        taskId: firstTask.id,
+        workerId: firstTask.state.workerId,
+        fence: firstTask.state.fence,
+        at: '2026-08-27T07:06:00.000Z',
+        evidence: 'First scan completed.',
+      })
 
       store.openRoutineRun({
         routineId: 'harlan-zw/example:pr-triage',
@@ -185,8 +225,9 @@ describe('running one scan', () => {
         specSha: 'abc123',
         at: '2026-08-28T07:00:05.000Z',
       })
+      const secondTask = claimStoredRun(store, '2026-08-28T07:05:00.000Z')
       const second = await worker.run(
-        claimedRun({ id: 'harlan-zw/example:pr-triage:2026-08-28T07:00:00.000Z' }),
+        secondTask,
         new AbortController().signal,
       )
 
@@ -204,7 +245,7 @@ describe('running one scan', () => {
       seed(store)
       const capture = { prompts: [] as string[] }
       await workerFor(store, scanning({ candidates: [candidate] }, capture))
-        .run(claimedRun(), new AbortController().signal)
+        .run(claimStoredRun(store), new AbortController().signal)
 
       expect(capture.prompts[0]).toContain('Nothing has been rejected yet.')
     }
@@ -224,7 +265,7 @@ describe('running one scan', () => {
           yield { _tag: 'TurnCompleted' }
         })(),
       }
-      const result = await workerFor(store, provider).run(claimedRun(), new AbortController().signal)
+      const result = await workerFor(store, provider).run(claimStoredRun(store), new AbortController().signal)
 
       expect(result._tag).toBe('Err')
     }

--- a/packages/harlan-github-agent/test/service-triggers.test.ts
+++ b/packages/harlan-github-agent/test/service-triggers.test.ts
@@ -51,6 +51,8 @@ describe('which triggers one machine answers', () => {
       state: { _tag: 'Completed', evidence: 'No open Sentry issues.' },
       fence: 1,
       attempts: 1,
+      progress: { percent: 85, label: 'Preparing the Routine result' },
+      activity: [],
       createdAt: '2026-08-28T21:00:00.000Z',
       updatedAt: '2026-08-28T21:01:00.000Z',
     }],

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -370,7 +370,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(43)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(44)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hogwild Routine runs reached the dashboard with no progress or provider activity, so the System pane stayed empty while they worked. The API, web dashboard, and desktop indicator now carry live Routine state.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).