### PR TITLE
fix(agent): load global context in OpenCode workers

### DIFF
--- a/packages/harlan-github-agent/src/agent-context.ts
+++ b/packages/harlan-github-agent/src/agent-context.ts
@@ -1,0 +1,143 @@
+import type { Result } from './result.ts'
+import { readdir, stat } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { err, ok } from './result.ts'
+
+export interface AgentContextPaths {
+  instructionsPath: string
+  skillsRoot: string
+}
+
+export interface AgentContext {
+  instructionPaths: readonly string[]
+  skillDirectories: readonly string[]
+}
+
+interface OpencodeConfiguration {
+  [key: string]: unknown
+  instructions?: unknown
+  skills?: unknown
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isMissingPath(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)]
+}
+
+/** Resolves the context shared by every local Agent provider. */
+export function defaultAgentContextPaths(
+  environment: NodeJS.ProcessEnv = process.env,
+  workingDirectory = process.cwd(),
+): AgentContextPaths {
+  const codexHome = environment.CODEX_HOME === undefined
+    ? join(homedir(), '.codex')
+    : resolve(environment.CODEX_HOME)
+  return {
+    instructionsPath: join(codexHome, 'AGENTS.md'),
+    skillsRoot: join(workingDirectory, 'harlan-agent-kit', 'skills'),
+  }
+}
+
+/** Loads every canonical Harlan skill, or refuses to start with partial context. */
+export async function loadAgentContext(paths: AgentContextPaths): Promise<Result<AgentContext, string>> {
+  const instructions = await stat(paths.instructionsPath)
+    .then(metadata => ok(metadata.isFile()))
+    .catch((error: unknown) => isMissingPath(error)
+      ? ok(false)
+      : err(`The global Agent instructions could not be read: ${errorMessage(error)}`))
+  if (instructions._tag === 'Err')
+    return instructions
+  if (!instructions.value)
+    return err(`The global Agent instructions do not exist: ${paths.instructionsPath}`)
+
+  const entries = await readdir(paths.skillsRoot, { withFileTypes: true })
+    .then(ok)
+    .catch((error: unknown) => err(`The Harlan skill directory could not be read: ${errorMessage(error)}`))
+  if (entries._tag === 'Err')
+    return entries
+
+  const candidates = entries.value
+    .filter(entry => entry.isDirectory())
+    .map(entry => join(paths.skillsRoot, entry.name))
+    .sort()
+  const checked = await Promise.all(candidates.map(directory => stat(join(directory, 'SKILL.md'))
+    .then(metadata => ok(metadata.isFile()))
+    .catch((error: unknown) => isMissingPath(error)
+      ? ok(false)
+      : err(`The Harlan skill could not be read: ${errorMessage(error)}`))))
+  const failed = checked.find(result => result._tag === 'Err')
+  if (failed?._tag === 'Err')
+    return failed
+  const skillDirectories = candidates.filter((_, index) => checked[index]?._tag === 'Ok' && checked[index].value)
+  if (skillDirectories.length === 0)
+    return err(`No Harlan skills exist under ${paths.skillsRoot}.`)
+
+  return ok({ instructionPaths: [paths.instructionsPath], skillDirectories })
+}
+
+function parseConfiguration(value: string | undefined): Result<OpencodeConfiguration, string> {
+  if (value === undefined)
+    return ok({})
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed)
+      ? ok(parsed)
+      : err('OPENCODE_CONFIG_CONTENT must contain one JSON object.')
+  }
+  catch {
+    return err('OPENCODE_CONFIG_CONTENT must contain one JSON object.')
+  }
+}
+
+function stringList(value: unknown, field: string): Result<string[], string> {
+  if (value === undefined)
+    return ok([])
+  return Array.isArray(value) && value.every(item => typeof item === 'string')
+    ? ok(value)
+    : err(`OPENCODE_CONFIG_CONTENT ${field} must contain only strings.`)
+}
+
+/** Adds the canonical context to OpenCode without dropping local configuration. */
+export function opencodeAgentEnvironment(input: {
+  context: AgentContext
+  environment: NodeJS.ProcessEnv
+}): Result<NodeJS.ProcessEnv, string> {
+  const parsed = parseConfiguration(input.environment.OPENCODE_CONFIG_CONTENT)
+  if (parsed._tag === 'Err')
+    return parsed
+  const configuration = parsed.value
+  const instructions = stringList(configuration.instructions, 'instructions')
+  if (instructions._tag === 'Err')
+    return instructions
+  if (configuration.skills !== undefined && !isRecord(configuration.skills))
+    return err('OPENCODE_CONFIG_CONTENT skills must contain one JSON object.')
+  const skills = (configuration.skills ?? {}) as Record<string, unknown>
+  const paths = stringList(skills.paths, 'skills.paths')
+  if (paths._tag === 'Err')
+    return paths
+
+  return ok({
+    ...input.environment,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      ...configuration,
+      instructions: unique([...instructions.value, ...input.context.instructionPaths]),
+      skills: {
+        ...skills,
+        paths: unique([...paths.value, ...input.context.skillDirectories]),
+      },
+    }),
+  })
+}

--- a/packages/harlan-github-agent/src/index.ts
+++ b/packages/harlan-github-agent/src/index.ts
@@ -1,3 +1,5 @@
+export { defaultAgentContextPaths, loadAgentContext, opencodeAgentEnvironment } from './agent-context.ts'
+export type { AgentContext, AgentContextPaths } from './agent-context.ts'
 export { createAgentPermitPool } from './agent-permit-pool.ts'
 export { AGENT_MODELS, AGENT_PROVIDER_NAMES, AGENT_ROLES, agentProfile, CODEX_AGENT_PROFILE, createAgentRuntimeSource, OPENCODE_AGENT_PROFILE, parseAgentSelection, providerAgentSelection, REASONING_EFFORTS, resolveAgentProfile, resolveAgentSelection, roleProfile } from './agent-profile.ts'
 export type { AgentRuntime, AgentRuntimeSource } from './agent-profile.ts'

--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -22,10 +22,12 @@ export interface OpencodeProviderOptions {
   binaryPath?: string
   /** Stops a run once its session has read this many cached context tokens. */
   cachedContextBudget?: number
+  /** Exact environment shared with every OpenCode process. */
+  environment?: NodeJS.ProcessEnv
   /** Kills a run that has printed nothing for this long. */
   idleTimeoutMilliseconds?: number
   /** Injected for tests. Returns the raw NDJSON line stream of one run. */
-  spawnOpencode?: (args: string[], workspace: string) => OpencodeProcess
+  spawnOpencode?: (args: string[], workspace: string, environment: NodeJS.ProcessEnv) => OpencodeProcess
 }
 
 interface OpencodeToolPart {
@@ -169,14 +171,15 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
   const binaryPath = options.binaryPath ?? 'opencode'
   const idleTimeoutMilliseconds = options.idleTimeoutMilliseconds ?? 10 * 60_000
   const cachedContextBudget = options.cachedContextBudget ?? DEFAULT_CACHED_CONTEXT_BUDGET
-  const spawnOpencode = options.spawnOpencode ?? ((args, workspace) => spawn(binaryPath, args, {
+  const environment = options.environment ?? process.env
+  const spawnOpencode = options.spawnOpencode ?? ((args, workspace, environment) => spawn(binaryPath, args, {
     cwd: workspace,
-    env: process.env,
+    env: environment,
     stdio: ['ignore', 'pipe', 'pipe'],
   }))
 
   async function* runOnce(request: AgentTurnRequest, prompt: string): AsyncGenerator<AgentEvent> {
-    const child = spawnOpencode(opencodeArguments(request, prompt), request.workspace)
+    const child = spawnOpencode(opencodeArguments(request, prompt), request.workspace, environment)
     const abort = () => child.kill('SIGTERM')
     request.signal.addEventListener('abort', abort, { once: true })
     let standardError = ''

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -10,6 +10,7 @@ import type { ClaimedAgentTask, DashboardSnapshot, RepositoryMapping, ServiceTri
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import { createAgentActivityLog } from './agent-activity.ts'
+import { defaultAgentContextPaths, loadAgentContext, opencodeAgentEnvironment } from './agent-context.ts'
 import { agentLabelItem } from './agent-label.ts'
 import { createAgentPermitPool } from './agent-permit-pool.ts'
 import { AGENT_PROVIDER_NAMES, agentProfile, createAgentRuntimeSource } from './agent-profile.ts'
@@ -193,6 +194,12 @@ export async function resolveUserLogin(
 
 export async function startAgentService(options: StartAgentServiceOptions): Promise<RunningAgentService> {
   const now = options.now ?? (() => new Date())
+  const agentContext = await loadAgentContext(defaultAgentContextPaths())
+  if (agentContext._tag === 'Err')
+    throw new Error(agentContext.error)
+  const opencodeEnvironment = opencodeAgentEnvironment({ context: agentContext.value, environment: process.env })
+  if (opencodeEnvironment._tag === 'Err')
+    throw new Error(opencodeEnvironment.error)
   const [installedRepositories, localCheckouts] = await Promise.all([
     discoverGitHubAppRepositories({
       appId: options.config.github.appId,
@@ -258,7 +265,10 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     chooseProvider,
     configuredProvider: configuredProfile.provider,
     maximumActiveAgents: configuredProfile.maximumActiveAgents,
-    providers: { codex: createCodexProvider(), opencode: createOpencodeProvider({ cachedContextBudget: DEFAULT_CACHED_CONTEXT_BUDGET }) },
+    providers: {
+      codex: createCodexProvider(),
+      opencode: createOpencodeProvider({ cachedContextBudget: DEFAULT_CACHED_CONTEXT_BUDGET, environment: opencodeEnvironment.value }),
+    },
     selection: store.getAgentSelection,
   })
   const profile = runtime().profile

--- a/packages/harlan-github-agent/test/agent-context.test.ts
+++ b/packages/harlan-github-agent/test/agent-context.test.ts
@@ -1,0 +1,100 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { defaultAgentContextPaths, loadAgentContext, opencodeAgentEnvironment } from '../src/agent-context.ts'
+
+describe('defaultAgentContextPaths', () => {
+  it('resolves the copied service context from its working directory', () => {
+    expect(defaultAgentContextPaths({ CODEX_HOME: '/agent-home' }, '/service')).toEqual({
+      instructionsPath: '/agent-home/AGENTS.md',
+      skillsRoot: '/service/harlan-agent-kit/skills',
+    })
+  })
+})
+
+describe('loadAgentContext', () => {
+  it('loads the global instructions and every installed Harlan skill', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'harlan-agent-context-'))
+    const instructionsPath = join(root, 'AGENTS.md')
+    const skillsRoot = join(root, 'skills')
+    await writeFile(instructionsPath, '# Global instructions\n')
+    await Promise.all(['pr', 'unit-tests'].map(async (name) => {
+      const directory = join(skillsRoot, name)
+      await mkdir(directory, { recursive: true })
+      await writeFile(join(directory, 'SKILL.md'), `---\nname: ${name}\ndescription: Test skill.\n---\n`)
+    }))
+
+    try {
+      await expect(loadAgentContext({ instructionsPath, skillsRoot })).resolves.toEqual({
+        _tag: 'Ok',
+        value: {
+          instructionPaths: [instructionsPath],
+          skillDirectories: [join(skillsRoot, 'pr'), join(skillsRoot, 'unit-tests')],
+        },
+      })
+    }
+    finally {
+      await rm(root, { recursive: true })
+    }
+  })
+
+  it('refuses to run without the global instructions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'harlan-agent-context-'))
+
+    try {
+      await expect(loadAgentContext({
+        instructionsPath: join(root, 'missing.md'),
+        skillsRoot: join(root, 'skills'),
+      })).resolves.toEqual({
+        _tag: 'Err',
+        error: `The global Agent instructions do not exist: ${join(root, 'missing.md')}`,
+      })
+    }
+    finally {
+      await rm(root, { recursive: true })
+    }
+  })
+})
+
+describe('opencodeAgentEnvironment', () => {
+  it('adds global instructions and every skill without dropping existing configuration', () => {
+    const result = opencodeAgentEnvironment({
+      context: {
+        instructionPaths: ['/home/harlan/.codex/AGENTS.md'],
+        skillDirectories: ['/kit/skills/pr', '/kit/skills/unit-tests'],
+      },
+      environment: {
+        PATH: '/bin',
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          instructions: ['/repo/CONTRIBUTING.md'],
+          share: 'disabled',
+          skills: { paths: ['/custom/skill'], urls: ['https://example.com/skills/'] },
+        }),
+      },
+    })
+
+    expect(result._tag).toBe('Ok')
+    if (result._tag === 'Err')
+      return
+    expect(result.value.PATH).toBe('/bin')
+    expect(JSON.parse(result.value.OPENCODE_CONFIG_CONTENT ?? '')).toEqual({
+      instructions: ['/repo/CONTRIBUTING.md', '/home/harlan/.codex/AGENTS.md'],
+      share: 'disabled',
+      skills: {
+        paths: ['/custom/skill', '/kit/skills/pr', '/kit/skills/unit-tests'],
+        urls: ['https://example.com/skills/'],
+      },
+    })
+  })
+
+  it('rejects malformed existing OpenCode configuration', () => {
+    expect(opencodeAgentEnvironment({
+      context: { instructionPaths: ['/global/AGENTS.md'], skillDirectories: ['/skills/pr'] },
+      environment: { OPENCODE_CONFIG_CONTENT: '{' },
+    })).toEqual({
+      _tag: 'Err',
+      error: 'OPENCODE_CONFIG_CONTENT must contain one JSON object.',
+    })
+  })
+})

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -163,6 +163,22 @@ printf '%s\\n' '${JSON.stringify(textLine)}'
       .toEqual([{ _tag: 'Failed', reason: `The opencode session failed: spawn ${binaryPath} ENOENT` }])
   })
 
+  it('starts OpenCode with the prepared Agent environment', async () => {
+    let launchedEnvironment: NodeJS.ProcessEnv | undefined
+    const environment = { PATH: '/bin', OPENCODE_CONFIG_CONTENT: '{"instructions":["/global/AGENTS.md"]}' }
+    const provider = createOpencodeProvider({
+      environment,
+      spawnOpencode: (args, workspace, receivedEnvironment) => {
+        launchedEnvironment = receivedEnvironment
+        return replay([textLine])(args)
+      },
+    })
+
+    await collect(provider.runTurn(request()))
+
+    expect(launchedEnvironment).toBe(environment)
+  })
+
   it('reports the session before the events it produced', async () => {
     const provider = createOpencodeProvider({ spawnOpencode: replay([bashLine, textLine]) })
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

OpenCode workers were told to use Harlan's global instructions and skills, but their resolved config had neither. The service now injects both before launch. A missing context file stops startup.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).