### PR TITLE
fix(agent): restore OpenCode service launches

### DIFF
--- a/packages/harlan-github-agent/src/agent-context.ts
+++ b/packages/harlan-github-agent/src/agent-context.ts
@@ -1,7 +1,7 @@
 import type { Result } from './result.ts'
 import { readdir, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { delimiter, join, resolve } from 'node:path'
 import process from 'node:process'
 import { err, ok } from './result.ts'
 
@@ -35,6 +35,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function unique(values: readonly string[]): string[] {
   return [...new Set(values)]
+}
+
+function opencodePath(environment: NodeJS.ProcessEnv): string {
+  const installationDirectory = join(environment.HOME ?? homedir(), '.opencode', 'bin')
+  const configuredDirectories = (environment.PATH ?? '')
+    .split(delimiter)
+    .filter(directory => directory.length > 0)
+  return unique([installationDirectory, ...configuredDirectories]).join(delimiter)
 }
 
 /** Resolves the context shared by every local Agent provider. */
@@ -131,6 +139,7 @@ export function opencodeAgentEnvironment(input: {
 
   return ok({
     ...input.environment,
+    PATH: opencodePath(input.environment),
     OPENCODE_CONFIG_CONTENT: JSON.stringify({
       ...configuration,
       instructions: unique([...instructions.value, ...input.context.instructionPaths]),

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -924,7 +924,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   const dashboardShutdown = new AbortController()
   const app = createAgentApp({
     activityLog,
-    ejectAgent: createTerminalSessionLauncher({ onError: error => options.logger.error(error) }),
+    ejectAgent: createTerminalSessionLauncher({ environment: opencodeEnvironment.value, onError: error => options.logger.error(error) }),
     store: {
       approveIssueWork: store.approveIssueWork,
       approvePullRequest: store.approvePullRequest,

--- a/packages/harlan-github-agent/src/terminal-session.ts
+++ b/packages/harlan-github-agent/src/terminal-session.ts
@@ -17,6 +17,7 @@ export interface TerminalSessionInput {
 
 interface TerminalSessionOptions {
   codexPath?: string
+  environment?: NodeJS.ProcessEnv
   opencodePath?: string
   delayMilliseconds?: number
   terminalPath?: string
@@ -45,8 +46,8 @@ async function executable(path: string): Promise<Result<string, string>> {
     .catch(() => err(`Executable is unavailable: ${path}`))
 }
 
-async function executableOnPath(command: string): Promise<Result<string, string>> {
-  const directories = (process.env.PATH ?? '').split(delimiter).filter(directory => directory.length > 0)
+async function executableOnPath(command: string, environment: NodeJS.ProcessEnv): Promise<Result<string, string>> {
+  const directories = (environment.PATH ?? '').split(delimiter).filter(directory => directory.length > 0)
   for (const directory of directories) {
     const found = await executable(join(directory, command))
     if (found._tag === 'Ok')
@@ -56,6 +57,7 @@ async function executableOnPath(command: string): Promise<Result<string, string>
 }
 
 export function createTerminalSessionLauncher(options: TerminalSessionOptions = {}) {
+  const environment = options.environment ?? process.env
   const terminalPath = options.terminalPath ?? '/usr/bin/ghostty'
   const agentOverrides: Partial<Record<AgentProviderName, string | undefined>> = {
     codex: options.codexPath,
@@ -69,7 +71,7 @@ export function createTerminalSessionLauncher(options: TerminalSessionOptions = 
     const override = agentOverrides[input.provider]
     const [terminal, agent] = await Promise.all([
       executable(terminalPath),
-      override === undefined ? executableOnPath(agentCommands[input.provider]) : executable(override),
+      override === undefined ? executableOnPath(agentCommands[input.provider], environment) : executable(override),
     ])
     if (terminal._tag === 'Err')
       return terminal
@@ -86,7 +88,7 @@ export function createTerminalSessionLauncher(options: TerminalSessionOptions = 
         ...resumeArguments,
       ], {
         detached: true,
-        env: process.env,
+        env: environment,
         stdio: 'ignore',
       })
       child.on('error', error => options.onError?.(error))

--- a/packages/harlan-github-agent/test/agent-context.test.ts
+++ b/packages/harlan-github-agent/test/agent-context.test.ts
@@ -58,6 +58,18 @@ describe('loadAgentContext', () => {
 })
 
 describe('opencodeAgentEnvironment', () => {
+  it('keeps the standard OpenCode install reachable with a restricted service PATH', () => {
+    const result = opencodeAgentEnvironment({
+      context: { instructionPaths: ['/global/AGENTS.md'], skillDirectories: ['/skills/pr'] },
+      environment: { HOME: '/agent-home', PATH: '/usr/bin:/bin' },
+    })
+
+    expect(result._tag).toBe('Ok')
+    if (result._tag === 'Err')
+      return
+    expect(result.value.PATH).toBe('/agent-home/.opencode/bin:/usr/bin:/bin')
+  })
+
   it('adds global instructions and every skill without dropping existing configuration', () => {
     const result = opencodeAgentEnvironment({
       context: {
@@ -65,6 +77,7 @@ describe('opencodeAgentEnvironment', () => {
         skillDirectories: ['/kit/skills/pr', '/kit/skills/unit-tests'],
       },
       environment: {
+        HOME: '/agent-home',
         PATH: '/bin',
         OPENCODE_CONFIG_CONTENT: JSON.stringify({
           instructions: ['/repo/CONTRIBUTING.md'],
@@ -77,7 +90,7 @@ describe('opencodeAgentEnvironment', () => {
     expect(result._tag).toBe('Ok')
     if (result._tag === 'Err')
       return
-    expect(result.value.PATH).toBe('/bin')
+    expect(result.value.PATH).toBe('/agent-home/.opencode/bin:/bin')
     expect(JSON.parse(result.value.OPENCODE_CONFIG_CONTENT ?? '')).toEqual({
       instructions: ['/repo/CONTRIBUTING.md', '/home/harlan/.codex/AGENTS.md'],
       share: 'disabled',


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

systemd's restricted PATH could not reach the standard OpenCode install, so every worker failed at launch after #84 deployed. The prepared agent environment now includes that install directory, and Eject uses the same environment.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).