### PR TITLE
feat(agent): show live progress in the System pane

### DIFF
--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -360,8 +360,18 @@ def agent_role_label(agent):
     return AGENT_ROLE_LABELS[agent['role']]
 
 
+def agent_progress_percent(agent):
+    percent = (agent.get('progress') or {}).get('percent')
+    return percent if type(percent) is int and 0 <= percent <= 100 else 0
+
+
+def agent_progress_label(agent):
+    progress = agent.get('progress') or {}
+    return f"{agent_progress_percent(agent)}% · {progress.get('label') or 'Starting'}"
+
+
 def active_agent_label(agent):
-    return f"🟢 {agent_role_label(agent)} · {agent['repository']} #{agent['itemNumber']}"
+    return f"🟢 {agent_role_label(agent)} · {agent_progress_percent(agent)}% · {agent['repository']} #{agent['itemNumber']}"
 
 
 def active_routine_runs(dashboard):
@@ -590,10 +600,9 @@ def build_menu(indicator, sources, action_error, refresh, set_agent_control, eje
         if selection_label is not None:
             menu.append(menu_item(selection_label, enabled=False))
         for agent in agents:
-            progress = agent.get('progress', {'percent': 0, 'label': 'Starting'})
             kind = 'issue' if agent.get('subjectKind') == 'issue' else 'pull request'
             links = [
-                menu_item(progress['label'], enabled=False),
+                menu_item(agent_progress_label(agent), enabled=False),
             ]
             activity_label = active_agent_activity_label(agent)
             if activity_label is not None:
@@ -610,8 +619,7 @@ def build_menu(indicator, sources, action_error, refresh, set_agent_control, eje
             menu.append(submenu_item(active_agent_label(agent), links))
 
         for run in routine_runs:
-            progress = run.get('progress', {'percent': 0, 'label': 'Starting'})
-            links = [menu_item(progress['label'], enabled=False)]
+            links = [menu_item(agent_progress_label(run), enabled=False)]
             activity_label = active_agent_activity_label(run)
             if activity_label is not None:
                 links.append(menu_item(activity_label, enabled=False))

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -463,7 +463,7 @@ class IndicatorDisplayTest(unittest.TestCase):
 
         self.assertEqual(
             indicator.active_agent_label(agent),
-            '🟢 Issue triage · harlan-zw/example #12',
+            '🟢 Issue triage · 57% · harlan-zw/example #12',
         )
 
     def test_reads_live_activity_without_inventing_completion(self):
@@ -522,8 +522,7 @@ class IndicatorDisplayTest(unittest.TestCase):
             if item.get_label().startswith('🟢 Issue triage') and item.get_submenu() is not None
         )
         labels = menu_labels(active.get_submenu())
-        self.assertEqual(labels[:2], ['Running tests and checks', 'Running pnpm test'])
-        self.assertFalse(any('%' in label or '▓' in label or '░' in label for label in labels))
+        self.assertEqual(labels[:2], ['70% · Running tests and checks', 'Running pnpm test'])
 
     def test_system_pane_shows_a_running_routine_and_its_live_activity(self):
         run = {
@@ -573,7 +572,7 @@ class IndicatorDisplayTest(unittest.TestCase):
         )
         self.assertEqual(
             menu_labels(routine.get_submenu()),
-            ['Checking the repository', 'Reading Sentry issues.', 'Open repository'],
+            ['55% · Checking the repository', 'Reading Sentry issues.', 'Open repository'],
         )
         self.assertIn('🟢 1 agent running · Queue empty', menu_labels(stub.menus[0]))
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Agent progress already came from the provider event stream, but the System pane only showed the phase text. It now shows the percentage beside each running Agent and Routine.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.