### PR TITLE
fix(agent): stop OpenCode after a completed turn

### DIFF
--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -189,7 +189,7 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
     })
     const exited = new Promise<OpencodeExit>((resolve) => {
       child.once('error', error => resolve({ _tag: 'SpawnFailed', error }))
-      child.once('close', (code, signal) => resolve({ _tag: 'Exited', code, signal }))
+      child.once('exit', (code, signal) => resolve({ _tag: 'Exited', code, signal }))
     })
 
     // A silent run means a wedged agent, and its Task holds its lease until the
@@ -210,6 +210,7 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
     let usage: Extract<AgentTokenUsage, { _tag: 'Available' }> = { _tag: 'Available', input: 0, cachedInput: 0, cacheWrite: 0, output: 0, reasoning: 0 }
     let usageAvailable = false
     let overBudget = false
+    let completed = false
     try {
       for await (const raw of createInterface({ input: child.stdout, crlfDelay: Number.POSITIVE_INFINITY })) {
         const line = raw.trim()
@@ -245,10 +246,16 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
         if (event !== undefined) {
           if (event._tag === 'Failed')
             failed = true
-          if (event._tag === 'TurnCompleted' && usageAvailable)
-            yield { _tag: 'Usage', usage }
+          if (event._tag === 'TurnCompleted') {
+            completed = true
+            if (usageAvailable)
+              yield { _tag: 'Usage', usage }
+            child.kill('SIGTERM')
+          }
           yield event
         }
+        if (completed)
+          break
         // A stopping step ends the turn by itself, so the budget never discards
         // an answer the session already paid for. Every other step means one
         // more full read of the context, so stop paying for it now. SIGKILL,
@@ -272,7 +279,7 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
         yield { _tag: 'Failed', reason: 'The opencode session stopped sending output.' }
         return
       }
-      if (exit.code !== 0 && !failed)
+      if (exit.code !== 0 && !failed && !completed)
         yield { _tag: 'Failed', reason: opencodeFailureReason(standardError, exit) }
     }
     finally {

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -224,6 +224,25 @@ printf '%s\\n' '${JSON.stringify(textLine)}'
       { _tag: 'Failed', reason: 'The opencode session stopped sending output.' },
     ])
   })
+
+  it('ends a completed turn even when the opencode process stays alive', async () => {
+    const provider = createOpencodeProvider({
+      idleTimeoutMilliseconds: 1_000,
+      spawnOpencode: () => spawn(process.execPath, ['-e', `
+        process.stdout.write(${JSON.stringify([
+          `${JSON.stringify(textLine)}\n`,
+          `${JSON.stringify({ type: 'step_finish', sessionID: 'ses_abc12345', part: { reason: 'stop' } })}\n`,
+        ].join(''))})
+        setInterval(() => {}, 1000)
+      `], { stdio: ['ignore', 'pipe', 'pipe'] }),
+    })
+
+    expect(await collect(provider.runTurn(request()))).toEqual([
+      { _tag: 'SessionStarted', sessionId: 'ses_abc12345' },
+      { _tag: 'Message', text: '{"outcome":"resolved"}' },
+      { _tag: 'TurnCompleted' },
+    ])
+  })
 })
 
 describe('extractJsonObject', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

An OpenCode process stayed alive after its session recorded `step-finish`, leaving the Task green in the System pane. The provider now closes that process at the terminal event.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.