### PR TITLE
fix(agent): prevent Routine report queue starvation

### DIFF
--- a/packages/harlan-github-agent/src/routine-report-controller.ts
+++ b/packages/harlan-github-agent/src/routine-report-controller.ts
@@ -95,6 +95,7 @@ export function createRoutineReportController(options: RoutineReportControllerOp
   return {
     publishPending: async (signal, limit = 3) => {
       const results: Array<Result<{ repository: string, issueNumber: number }, string>> = []
+      const attemptedCommandIds: string[] = []
       for (let written = 0; written < limit; written += 1) {
         if (signal.aborted)
           return results
@@ -102,9 +103,11 @@ export function createRoutineReportController(options: RoutineReportControllerOp
           options.workerId,
           options.now().toISOString(),
           leaseMilliseconds,
+          attemptedCommandIds,
         )
         if (command === null)
           return results
+        attemptedCommandIds.push(command.id)
 
         const fail = (message: string): void => {
           if (signal.aborted)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -626,7 +626,7 @@ export interface JournalStore {
   failCandidateIssue: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   /** Requests the run log entry for one run. Answers false when it already exists. */
   stageRoutineReport: (input: { command: RoutineReportCommand, at: string }) => boolean
-  claimNextRoutineReport: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedRoutineReportCommand | null
+  claimNextRoutineReport: (workerId: string, now: string, leaseMilliseconds: number, excludedCommandIds?: readonly string[]) => ClaimedRoutineReportCommand | null
   completeRoutineReport: (input: { commandId: string, workerId: string, fence: number, at: string, commentId: number, trackingIssueNumber: number }) => boolean
   failRoutineReport: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   claimNextRoutineRun: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedRoutineRun | null
@@ -9031,7 +9031,7 @@ export function openJournalStore(
     input.at,
   ).changes === 1
 
-  const claimNextRoutineReport: JournalStore['claimNextRoutineReport'] = (workerId, now, leaseMilliseconds) => {
+  const claimNextRoutineReport: JournalStore['claimNextRoutineReport'] = (workerId, now, leaseMilliseconds, excludedCommandIds = []) => {
     database.exec('BEGIN IMMEDIATE')
     try {
       database.prepare(`
@@ -9041,6 +9041,9 @@ export function openJournalStore(
         WHERE state_tag = 'Running' AND lease_expires_at <= ?
       `).run(now, now)
 
+      const exclusion = excludedCommandIds.length === 0
+        ? ''
+        : `AND routine_report_commands.id NOT IN (${excludedCommandIds.map(() => '?').join(', ')})`
       const row = database.prepare(`
         SELECT
           routine_report_commands.id,
@@ -9058,19 +9061,20 @@ export function openJournalStore(
         WHERE routine_report_commands.state_tag = 'Pending'
           AND repositories.enabled = 1
           AND repositories.writes_enabled = 1
+          ${exclusion}
         ORDER BY routine_report_commands.created_at, routine_report_commands.id
         LIMIT 1
-      `).get() as unknown as {
-        id: string
-        routine_id: string
-        run_id: string
-        repository: string
-        routine_name: string
-        body: string
-        fence: number
-        tracking_issue_number: number | null
-        policy_json: string
-      } | undefined
+      `).get(...excludedCommandIds) as unknown as {
+            id: string
+            routine_id: string
+            run_id: string
+            repository: string
+            routine_name: string
+            body: string
+            fence: number
+            tracking_issue_number: number | null
+            policy_json: string
+          } | undefined
       if (row === undefined) {
         database.exec('COMMIT')
         return null

--- a/packages/harlan-github-agent/test/routine-report.test.ts
+++ b/packages/harlan-github-agent/test/routine-report.test.ts
@@ -193,7 +193,7 @@ describe('publishing the run log', () => {
     }
   })
 
-  it('remembers no tracking issue when the comment failed, so a retry does not log twice', async () => {
+  it('tries a failed report once per pass and remembers no tracking issue', async () => {
     const store = openJournalStore(':memory:')
     try {
       seed(store)
@@ -207,8 +207,68 @@ describe('publishing the run log', () => {
       const failed = await createRoutineReportController({ github: refusing, now, store, workerId: 'reporter' })
         .publishPending(new AbortController().signal)
 
+      expect(failed).toHaveLength(1)
       expect(failed[0]?._tag).toBe('Err')
       expect(store.listRoutines('harlan-zw/example')[0]?.trackingIssueNumber).toBeNull()
+    }
+    finally {
+      store.close()
+    }
+  })
+
+  it('publishes another repository after one report fails', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store)
+      stage(store, { _tag: 'Completed', evidence: 'first run' })
+      const working = repositoryMapping({ github: 'harlan-zw/working', checkout: '/home/harlan/pkg/working' })
+      store.syncRepositories([repositoryMapping(), working], '2026-08-27T07:10:01.000Z')
+      store.setRepositoryWritesEnabled(working.github, true)
+      store.syncRoutines({
+        repository: working.github,
+        specSha: 'def456',
+        entries: [{ name: 'pr-triage', crons: ['0 8 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+        at: '2026-08-27T07:10:02.000Z',
+      })
+      const workingRoutineId = `${working.github}:pr-triage`
+      const workingRun = store.openRoutineRun({
+        routineId: workingRoutineId,
+        scheduledFor: '2026-08-27T08:00:00.000Z',
+        specSha: 'def456',
+        at: '2026-08-27T07:10:03.000Z',
+      })
+      if (workingRun === null)
+        throw new Error('the second run must open')
+      store.stageRoutineReport({
+        command: routineReportCommand({
+          repository: working.github,
+          routineId: workingRoutineId,
+          routineName: 'pr-triage',
+          run: workingRun,
+          report: { _tag: 'Completed', evidence: 'second run' },
+        }),
+        at: '2026-08-27T07:10:04.000Z',
+      })
+      const comments: Calls['comments'] = []
+      const github: GitHubIssuePublisher = {
+        createIssue: async input => input.repository.github === 'harlan-zw/example'
+          ? { _tag: 'Err' as const, error: { repository: input.repository.github, message: 'Issues are disabled.' } }
+          : ok({ number: 42, url: 'https://github.com/harlan-zw/working/issues/42' }),
+        createComment: async (input) => {
+          comments.push({ issueNumber: input.issueNumber, body: input.body })
+          return ok({ id: 900 + comments.length })
+        },
+        findOpenIssueByFingerprint: async () => ok(null),
+      }
+
+      const results = await createRoutineReportController({ github, now, store, workerId: 'reporter' })
+        .publishPending(new AbortController().signal)
+
+      expect(results).toEqual([
+        { _tag: 'Err', error: 'harlan-zw/example: Issues are disabled.' },
+        { _tag: 'Ok', value: { repository: 'harlan-zw/working', issueNumber: 42 } },
+      ])
+      expect(comments).toHaveLength(1)
     }
     finally {
       store.close()


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A repository with GitHub Issues disabled spent every report retry in one pass, so later repositories stayed queued. Each pass now tries one report once and continues through the queue.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.
