### PR TITLE
fix(agent): exclude Routine tracking issues from Issue triage

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3092,11 +3092,11 @@ function supersedeWorkerTasks(
   const rows = database.prepare(`
     SELECT id, state_tag, fence FROM worker_tasks
     WHERE subject_id = ? AND kind = ?
-      AND state_tag IN ('Queued', 'ActionRequired', 'Running')
+      AND state_tag IN ('Queued', 'ActionRequired', 'Running', 'Failed')
       AND (? IS NULL OR revision_id != ?)
   `).all(subjectId, kind, exceptRevisionId ?? null, exceptRevisionId ?? null) as unknown as Array<{
     id: string
-    state_tag: 'Queued' | 'ActionRequired' | 'Running'
+    state_tag: 'Queued' | 'ActionRequired' | 'Running' | 'Failed'
     fence: number
   }>
   rows.forEach((row) => {
@@ -3347,7 +3347,13 @@ function planIssueTriage(
   observedAt: string,
   mapping: RepositoryMapping,
 ): void {
-  const eligible = subject.kind === 'issue' && subject.state === 'open' && canWorkIssues(mapping)
+  const routineTrackingIssue = subject.kind === 'issue' && database.prepare(`
+    SELECT 1 FROM routines WHERE repository = ? AND tracking_issue_number = ?
+  `).get(subject.repository, subject.number) !== undefined
+  const eligible = subject.kind === 'issue'
+    && subject.state === 'open'
+    && !routineTrackingIssue
+    && canWorkIssues(mapping)
   if (!eligible) {
     supersedeWorkerTasks(database, subjectId, 'issue_triage', observedAt, 'The issue no longer needs triage.')
     supersedeTasks(database, subjectId, observedAt, 'The issue no longer authorizes work.', undefined, 'issue_work')

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -68,7 +68,7 @@ describe('gitHub reconciliation', () => {
     store.close()
   })
 
-  it('records our own Routine issue even when the allowlist lists only humans', async () => {
+  it('keeps a Routine candidate issue eligible for Issue triage', async () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
@@ -85,6 +85,7 @@ describe('gitHub reconciliation', () => {
       _tag: 'Ok',
       value: { repository: repository.github, subjects: 1, inserted: 1, duplicates: 0, stale: 0, closed: 0 },
     })
+    expect(store.claimNextIssueTriageTask('triage', '2026-08-13T01:00:01.000Z', 10_000)).not.toBeNull()
     store.close()
   })
 

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -147,6 +147,91 @@ describe('journal store', () => {
     expect(store.getDashboardSnapshot('2026-08-28T21:00:07.000Z').routineRuns[0]?.reportState).toBe('Published')
   })
 
+  it('supersedes failed Issue triage when the issue becomes a Routine tracking issue', () => {
+    const store = createStore()
+    const repository = repositoryMapping()
+    const trackingIssue = issueItem({
+      number: 42,
+      author: 'harlan-github-agent[bot]',
+      routineFiled: true,
+    })
+    store.syncRepositories([repository], '2026-08-28T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'routine-tracking-issue-before-registration',
+      observedAt: '2026-08-28T00:01:00.000Z',
+      source: 'poll',
+      subject: trackingIssue,
+    })
+    for (const attempt of [1, 2, 3]) {
+      const at = `2026-08-28T00:01:0${attempt}.000Z`
+      const task = store.claimNextIssueTriageTask(`triage-${attempt}`, at, 10_000)
+      if (task === null)
+        throw new Error(`Expected Issue triage attempt ${attempt}.`)
+      store.failWorkerTask({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at,
+        reason: 'The issue changed before triage started.',
+      })
+    }
+    expect(store.listIncidents()).toHaveLength(1)
+
+    const [routine] = store.syncRoutines({
+      repository: repository.github,
+      specSha: 'abc123',
+      entries: [{
+        name: 'sentry-checkin',
+        crons: ['0 7 * * *'],
+        timeZone: 'Australia/Melbourne',
+        mode: 'report',
+        enabled: true,
+      }],
+      at: '2026-08-28T00:02:00.000Z',
+    })
+    if (routine === undefined)
+      throw new Error('Expected a stored Routine.')
+    const run = store.openRoutineRun({
+      routineId: routine.id,
+      scheduledFor: '2026-08-28T07:00:00.000Z',
+      specSha: routine.specSha,
+      at: '2026-08-28T07:00:00.000Z',
+    })
+    if (run === null)
+      throw new Error('Expected a Routine run.')
+    store.stageRoutineReport({
+      command: routineReportCommand({
+        repository: routine.repository,
+        routineId: routine.id,
+        routineName: routine.name,
+        run: { id: run.id, scheduledFor: run.scheduledFor },
+        report: { _tag: 'Completed', evidence: 'No open Sentry issues.' },
+      }),
+      at: '2026-08-28T07:00:01.000Z',
+    })
+    store.setRepositoryWritesEnabled(repository.github, true)
+    const report = store.claimNextRoutineReport('reporter', '2026-08-28T07:00:02.000Z', 60_000)
+    if (report === null)
+      throw new Error('Expected a Routine report.')
+    store.completeRoutineReport({
+      commandId: report.id,
+      workerId: report.workerId,
+      fence: report.fence,
+      at: '2026-08-28T07:00:03.000Z',
+      commentId: 1234,
+      trackingIssueNumber: trackingIssue.number,
+    })
+
+    store.recordObservation({
+      externalId: 'routine-tracking-issue-after-registration',
+      observedAt: '2026-08-28T07:01:00.000Z',
+      source: 'poll',
+      subject: trackingIssue,
+    })
+
+    expect(store.listIncidents()).toEqual([])
+  })
+
   it('persists Pause and reports when restart is safe', () => {
     const directory = mkdtempSync(join(tmpdir(), 'harlan-github-agent-'))
     temporaryDirectories.push(directory)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Routine tracking issues stay visible so reports can update them. They also entered Issue triage, which left stale Incidents. The planner now excludes stored tracking issue numbers and supersedes old Issue triage Tasks. Routine candidate issues still enter Issue triage.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.
