### PR TITLE
fix(agent): skip Review for chore pull requests

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -19,7 +19,11 @@ Require an explicit configuration file. Start from `config.example.yml` only whe
 
 Use `github.allowed_owners` before GitHub App installation access. Ignore installations from every other GitHub owner. Scan only immediate directories under `~/pkg` and `~/sites` to find trusted local checkouts. Treat configured repositories as policy overrides. Never act on a checkout without matching its GitHub origin and App installation.
 
-Run low-cost Pull request triage for every tracked pull request authored by `harlan-zw`. Require an adversarial Review for code, tests, configuration, dependencies, workflows, schemas, generated runtime output, security boundaries, public APIs, performance-sensitive files, behavior claims, or uncertainty. Skip only clearly judgment-free prose, formatting, or comment-only changes. Stamp `harlan-agent-review-skipped` when Review is skipped.
+Skip a tracked pull request with a conventional non-breaking `chore:` title before starting an Agent.
+For every other tracked pull request authored by `harlan-zw`, run low-cost Pull request triage.
+Require an adversarial Review for code, tests, configuration, dependencies, workflows, schemas, generated runtime output, security boundaries, public APIs, performance-sensitive files, behavior claims, or uncertainty.
+Skip only clearly judgment-free prose, formatting, or comment-only changes.
+Stamp `harlan-agent-review-skipped` when Review is skipped.
 
 Treat `harlan-agent-review` as a manual override that always requires adversarial Review for the exact current head commit. For an outside contributor, create one fixed, self-identified instruction comment. Name the exact head commit. Require `harlan-agent-review` before review. Bind Approval to the exact head commit; never let the label approve a head commit twice.
 

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -43,7 +43,7 @@ did not cover it.
 | Issue triage comment | `issue_triage_comment_commands` | Controller | One canonical comment per issue | automated triage |
 | Issue triage label | `harlan-agent-ready-to-implement`, `harlan-agent-ready-to-spec`, `harlan-agent-needs-info`, or `harlan-agent-wait-to-implement` | GitHub | One per triaged issue Revision | triage route |
 | Issue work | `tasks.kind` | Scheduler | One authorized Task for one issue Revision | issue work |
-| Pull request triage | `pull_request_triage` Agent role | Runner | One low-cost decision per pull request head commit | pull request triage |
+| Pull request triage | Pull request title or `pull_request_triage` Agent role | Controller, Runner | One deterministic or low-cost decision per pull request head commit | pull request triage |
 | Take Ownership | `repositories.take_ownership` | Controller | One policy per Repository mapping | Take Ownership |
 | Publication command | `publication_commands` | Controller | One to one Task | none |
 | Review run | `review_runs` | Runner | N to 1 Revision, 1 to N Publications | review |
@@ -362,9 +362,11 @@ One self identified automated triage record on an issue. Re-runs update the cano
 
 ### Pull request triage
 
-One low-cost Agent decision for one exact pull request head commit.
+One routing decision for one exact pull request head commit.
 
-It requires or skips an adversarial Review. Any uncertainty requires Review.
+A conventional non-breaking `chore:` title skips Review without starting an Agent.
+
+Every other pull request uses a low-cost Agent decision. It requires or skips an adversarial Review. Any uncertainty requires Review.
 
 `harlan-agent-review` requires Review and is the manual override. `harlan-agent-review-skipped` records a skipped Review.
 

--- a/packages/harlan-github-agent/src/pull-request-triage.ts
+++ b/packages/harlan-github-agent/src/pull-request-triage.ts
@@ -80,9 +80,21 @@ ${JSON.stringify({
 })}`
 }
 
+function deterministicRoute(title: string): PullRequestTriageResult | null {
+  return /^chore(?:\([^)]+\))?:\s/.test(title)
+    ? {
+        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
+        reason: 'The pull request uses the conventional non-breaking chore type.',
+      }
+    : null
+}
+
 export function createPullRequestTriageAgent(options: PullRequestTriageAgentOptions): PullRequestTriageAgent {
   return {
     async run(task, input, signal) {
+      const routed = deterministicRoute(task.pullRequest.title)
+      if (routed !== null)
+        return ok(routed)
       const scopeDigest = createHash('sha256')
         .update(JSON.stringify({ headSha: task.pullRequest.headSha, ...input }))
         .digest('hex')

--- a/packages/harlan-github-agent/test/pull-request-triage.test.ts
+++ b/packages/harlan-github-agent/test/pull-request-triage.test.ts
@@ -5,13 +5,60 @@ import { createPullRequestTriageAgent } from '../src/pull-request-triage.ts'
 import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
 describe('pull request triage Agent', () => {
+  it('skips a conventional chore without starting an Agent', async () => {
+    const capture: ProviderCapture = { requests: [] }
+    const agent = createPullRequestTriageAgent({
+      now: () => new Date('2026-08-28T01:00:00.000Z'),
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([], capture)),
+      store: {
+        getWorkerSession: () => null,
+        saveWorkerSession: () => undefined,
+      },
+      workspace: '/tmp/harlan-github-agent',
+    })
+
+    const result = await agent.run({
+      id: 'review-task',
+      kind: 'adversarial_review',
+      repository: 'harlan-zw/gscdump',
+      pullRequestNumber: 35,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-28T02:00:00.000Z' },
+      updatedAt: '2026-08-28T01:00:00.000Z',
+      repositoryMapping: repositoryMapping(),
+      pullRequest: pullRequestItem({
+        mergeState: 'clean',
+        title: 'chore: update workspace dependencies',
+      }),
+      rerun: { _tag: 'NotRequested' },
+    }, {
+      body: 'Refresh the workspace dependencies.',
+      changedFiles: [
+        'package.json',
+        'packages/engine/test/icebird-bigint-stringify.test.ts',
+        'patches/icebird@0.8.26.patch',
+        'pnpm-lock.yaml',
+        'pnpm-workspace.yaml',
+      ],
+    }, new AbortController().signal)
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: {
+        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
+        reason: 'The pull request uses the conventional non-breaking chore type.',
+      },
+    })
+    expect(capture.requests).toEqual([])
+  })
+
   it('uses the cheap profile and returns one conservative route', async () => {
     const capture: ProviderCapture = { requests: [] }
     const agent = createPullRequestTriageAgent({
       now: () => new Date('2026-08-28T01:00:00.000Z'),
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
-        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
-        reason: 'Only prose documentation changed.',
+        _tag: 'ADVERSARIAL_REVIEW_REQUIRED',
+        reason: 'The pull request declares a breaking change.',
       }), capture)),
       store: {
         getWorkerSession: () => null,
@@ -29,18 +76,21 @@ describe('pull request triage Agent', () => {
       state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-28T02:00:00.000Z' },
       updatedAt: '2026-08-28T01:00:00.000Z',
       repositoryMapping: repositoryMapping(),
-      pullRequest: pullRequestItem({ mergeState: 'clean' }),
+      pullRequest: pullRequestItem({
+        mergeState: 'clean',
+        title: 'chore!: replace the deployment contract',
+      }),
       rerun: { _tag: 'NotRequested' },
     }, {
-      body: 'Correct a typo in the guide.',
-      changedFiles: ['docs/guide.md'],
+      body: 'Replace the deployment contract.',
+      changedFiles: ['src/deployment.ts'],
     }, new AbortController().signal)
 
     expect(result).toEqual({
       _tag: 'Ok',
       value: {
-        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
-        reason: 'Only prose documentation changed.',
+        _tag: 'ADVERSARIAL_REVIEW_REQUIRED',
+        reason: 'The pull request declares a breaking change.',
       },
     })
     expect(capture.requests).toEqual([expect.objectContaining({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`harlan-zw/gscdump#35` started an adversarial Review for a dependency chore. Conventional non-breaking `chore:` titles now skip Review before any Agent starts. The manual `harlan-agent-review` label still overrides the route.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.