### PR TITLE
fix(agent): ignore orphaned Routine tracking issues

### DIFF
--- a/packages/harlan-github-agent/src/external-watch.ts
+++ b/packages/harlan-github-agent/src/external-watch.ts
@@ -88,6 +88,7 @@ function issueItem(repository: string, issue: PublicIssueSnapshot): GitHubIssueI
     kind: 'issue',
     approvalLabels: [],
     routineFiled: false,
+    routineTracking: false,
     repository,
     number: issue.number,
     state: issue.state,

--- a/packages/harlan-github-agent/src/github.ts
+++ b/packages/harlan-github-agent/src/github.ts
@@ -13,6 +13,7 @@ import { currentBaseSha } from './github-base.ts'
 import { err, ok } from './result.ts'
 import { priorAutomatedReviewForHead } from './review-comment.ts'
 import { isReviewRerunCommand } from './review-rerun.ts'
+import { isRoutineTrackingIssue } from './routine-report-controller.ts'
 import { ROUTINE_SPEC_PATH } from './routine-spec.ts'
 
 export interface GitHubReadError {
@@ -357,6 +358,12 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
             // author allowlist never hides it from triage again.
             const labels = labelNames(issue.labels)
             const routineFiled = hasRoutineIssueLabel(labels)
+            const routineTracking = isRoutineTrackingIssue({
+              repository: repository.github,
+              title: issue.title,
+              body: issue.body,
+              labels,
+            })
             if (!isEligibleGitHubSubjectAuthor({
               login: issue.user?.login ?? 'ghost',
               type: issue.user?.type,
@@ -377,6 +384,7 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
               createdAt: issue.created_at,
               updatedAt: issue.updated_at,
               routineFiled,
+              routineTracking,
             }]
           })
 

--- a/packages/harlan-github-agent/src/routine-report-controller.ts
+++ b/packages/harlan-github-agent/src/routine-report-controller.ts
@@ -10,12 +10,34 @@ export function trackingIssueTitle(name: RoutineName, repository: string): strin
   return `${name}: run log for ${repository}`
 }
 
-export function trackingIssueBody(name: RoutineName): string {
+function trackingIssueBodyText(name: string): string {
   return `Every run of the \`${name}\` routine reports here, including the runs that found nothing and the runs that were skipped.
 
 Close a proposal's own issue to reject it. Closing this one stops the log, not the routine.
 
 > The Harlan Agent Kit opened this issue automatically. It is not Harlan's own report.`
+}
+
+export function trackingIssueBody(name: RoutineName): string {
+  return trackingIssueBodyText(name)
+}
+
+/** Recognises a run log even when another controller filed it. */
+export function isRoutineTrackingIssue(input: {
+  repository: string
+  title: string
+  body: string | null | undefined
+  labels: readonly string[]
+}): boolean {
+  const prefix = 'routine:'
+  return input.labels.some((label) => {
+    if (!label.toLowerCase().startsWith(prefix))
+      return false
+    const routineName = label.slice(prefix.length)
+    return routineName.length > 0
+      && input.title.toLowerCase() === `${routineName}: run log for ${input.repository}`.toLowerCase()
+      && input.body === trackingIssueBodyText(routineName)
+  })
 }
 
 /** What one finished run did, in the words the log records. */

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -2361,7 +2361,7 @@ function githubSubjectFromRow(row: SubjectRow): GitHubItem {
   }
 
   if (row.kind === 'issue')
-    return { ...base, kind: 'issue', approvalLabels: [], routineFiled: false }
+    return { ...base, kind: 'issue', approvalLabels: [], routineFiled: false, routineTracking: false }
 
   if (row.draft === null || row.base_sha === null || row.head_sha === null || row.head_repository === null || row.head_ref === null || row.merge_state === null)
     throw new Error(`Pull request ${row.repository}#${row.github_number} has incomplete state.`)
@@ -3347,9 +3347,12 @@ function planIssueTriage(
   observedAt: string,
   mapping: RepositoryMapping,
 ): void {
-  const routineTrackingIssue = subject.kind === 'issue' && database.prepare(`
-    SELECT 1 FROM routines WHERE repository = ? AND tracking_issue_number = ?
-  `).get(subject.repository, subject.number) !== undefined
+  const routineTrackingIssue = subject.kind === 'issue' && (
+    subject.routineTracking === true
+    || database.prepare(`
+      SELECT 1 FROM routines WHERE repository = ? AND tracking_issue_number = ?
+    `).get(subject.repository, subject.number) !== undefined
+  )
   const eligible = subject.kind === 'issue'
     && subject.state === 'open'
     && !routineTrackingIssue
@@ -5065,6 +5068,7 @@ export function openJournalStore(
             kind: 'issue',
             approvalLabels: [],
             routineFiled: false,
+            routineTracking: false,
             repository: current.repository,
             number: current.number,
             state: 'closed',

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -140,6 +140,8 @@ export interface GitHubIssueItem extends GitHubItemBase {
    * again before triage ever read it, because the agent filed it.
    */
   routineFiled: boolean
+  /** True when this is a Routine run log, including one filed by another controller. */
+  routineTracking: boolean
 }
 
 export interface GitHubPullRequestItem extends GitHubItemBase {

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -199,6 +199,7 @@ describe('dashboard HTTP app', () => {
         kind: 'issue',
         approvalLabels: [],
         routineFiled: false,
+        routineTracking: false,
         dismissed: false,
         repository: 'harlan-zw/example',
         number: 12,

--- a/packages/harlan-github-agent/test/fixtures.ts
+++ b/packages/harlan-github-agent/test/fixtures.ts
@@ -33,6 +33,7 @@ export function issueItem(overrides: Partial<GitHubIssueItem> = {}): GitHubIssue
     kind: 'issue',
     approvalLabels: [],
     routineFiled: false,
+    routineTracking: false,
     repository: 'harlan-zw/example',
     number: 12,
     state: 'open',

--- a/packages/harlan-github-agent/test/github.test.ts
+++ b/packages/harlan-github-agent/test/github.test.ts
@@ -4,6 +4,7 @@ import { approvalLabels } from '../src/approval-labels.ts'
 import { BASELINE_REPAIR_MARKER, pullRequestPurpose } from '../src/baseline-repair-state.ts'
 import { createGitHubSource, isAutomatedGitHubActor, isIssueAtOrAfterCutoff } from '../src/github.ts'
 import { ok } from '../src/result.ts'
+import { trackingIssueBody } from '../src/routine-report-controller.ts'
 import { repositoryMapping } from './fixtures.ts'
 
 describe('gitHub subjects', () => {
@@ -60,6 +61,43 @@ describe('gitHub subjects', () => {
     const repository = repositoryMapping({ writablePullRequestAuthors: ['harlan-zw', 'harlan-github-agent[bot]'] })
 
     expect(await source.listOpenItems(repository)).toEqual(ok([]))
+  })
+
+  it('marks a canonical Routine run log as a tracking issue', async () => {
+    const listIssues = () => undefined
+    const listPulls = () => undefined
+    const client = {
+      paginate: (method: unknown) => Promise.resolve(method === listIssues
+        ? [{
+            number: 23,
+            state: 'open',
+            title: 'sentry-checkin: run log for harlan-zw/example',
+            body: trackingIssueBody('sentry-checkin'),
+            user: { login: 'harlan-github-agent[bot]', type: 'Bot' },
+            html_url: 'https://github.com/harlan-zw/example/issues/23',
+            created_at: '2026-08-01T00:00:00.000Z',
+            updated_at: '2026-08-13T00:00:00.000Z',
+            labels: [{ name: 'routine:sentry-checkin' }],
+          }]
+        : []),
+      rest: {
+        issues: { listForRepo: listIssues },
+        pulls: { list: listPulls },
+      },
+    } as unknown as Octokit
+    const source = createGitHubSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      issueCutoff: '2026-07-01',
+      tokens: {
+        getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T02:00:00.000Z' })),
+        invalidate: () => undefined,
+      },
+    })
+
+    expect(await source.listOpenItems(repositoryMapping())).toEqual(ok([
+      expect.objectContaining({ number: 23, routineFiled: true, routineTracking: true }),
+    ]))
   })
 
   it('uses one fixed inclusive issue cutoff', () => {

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -89,6 +89,54 @@ describe('gitHub reconciliation', () => {
     store.close()
   })
 
+  it('keeps an orphaned Routine tracking issue out of Issue triage', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    const trackingIssue = issueItem({
+      number: 42,
+      author: AGENT_ACTOR_LOGIN,
+      title: 'sentry-checkin: run log for harlan-zw/example',
+      routineFiled: true,
+    })
+    store.recordObservation({
+      externalId: 'orphaned-routine-tracking-issue',
+      observedAt: '2026-08-13T00:01:00.000Z',
+      source: 'poll',
+      subject: trackingIssue,
+    })
+    for (const attempt of [1, 2, 3]) {
+      const at = `2026-08-13T00:01:0${attempt}.000Z`
+      const task = store.claimNextIssueTriageTask(`triage-${attempt}`, at, 10_000)
+      if (task === null)
+        throw new Error(`Expected Issue triage attempt ${attempt}.`)
+      store.failWorkerTask({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at,
+        reason: 'The issue changed before triage started.',
+      })
+    }
+    expect(store.listIncidents()).toHaveLength(1)
+
+    const result = await reconcileRepository(repository, {
+      github: { listOpenItems: () => Promise.resolve(ok([
+        { ...trackingIssue, routineTracking: true },
+      ])) },
+      store,
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: { repository: repository.github, subjects: 1, inserted: 1, duplicates: 0, stale: 0, closed: 0 },
+    })
+    expect(store.claimNextIssueTriageTask('triage', '2026-08-13T01:00:01.000Z', 10_000)).toBeNull()
+    expect(store.listIncidents()).toEqual([])
+    store.close()
+  })
+
   it('counts only open pull requests in enabled repositories', async () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()

--- a/packages/harlan-github-agent/test/routine-report.test.ts
+++ b/packages/harlan-github-agent/test/routine-report.test.ts
@@ -2,7 +2,7 @@ import type { GitHubIssuePublisher } from '../src/github.ts'
 import type { Candidate } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
 import { ok } from '../src/result.ts'
-import { createRoutineReportController, routineReportBody, routineReportCommand, trackingIssueTitle } from '../src/routine-report-controller.ts'
+import { createRoutineReportController, isRoutineTrackingIssue, routineReportBody, routineReportCommand, trackingIssueBody, trackingIssueTitle } from '../src/routine-report-controller.ts'
 import { openJournalStore } from '../src/store.ts'
 import { repositoryMapping } from './fixtures.ts'
 
@@ -108,6 +108,22 @@ describe('writing what one run did', () => {
   it('names the tracking issue after the routine and its repository', () => {
     expect(trackingIssueTitle('sentry-checkin', 'harlan-zw/example'))
       .toBe('sentry-checkin: run log for harlan-zw/example')
+  })
+
+  it('recognises only the canonical tracking issue for a Routine label', () => {
+    const labels = ['routine:sentry-checkin']
+    expect(isRoutineTrackingIssue({
+      repository: 'harlan-zw/example',
+      title: trackingIssueTitle('sentry-checkin', 'harlan-zw/example'),
+      body: trackingIssueBody('sentry-checkin'),
+      labels,
+    })).toBe(true)
+    expect(isRoutineTrackingIssue({
+      repository: 'harlan-zw/example',
+      title: trackingIssueTitle('sentry-checkin', 'harlan-zw/example'),
+      body: 'Candidate details.',
+      labels,
+    })).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

- recognise canonical Routine tracking issues from their title, body, and Routine label
- keep cross-controller or orphaned run logs out of Issue triage
- clear failed Issue triage Incidents when a later poll identifies the run log

## Verification

- `pnpm test`, 967 tests
- `pnpm typecheck`
- `pnpm build`
- scoped ESLint passes

Repository-wide ESLint still reports unrelated existing failures outside this change.