### PR TITLE
fix(agent): accept fractional Hogwild CPU time

### DIFF
--- a/packages/harlan-github-agent/dashboard/app/utils/hogwild-status.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/hogwild-status.ts
@@ -260,12 +260,12 @@ function parseServiceState(value: unknown): HogwildServiceState | undefined {
     return { _tag: value._tag }
   if (value._tag !== 'Active' || !isRecord(value.metrics))
     return undefined
-  const cpuTimeSeconds = count(value.metrics.cpuTimeSeconds)
+  const cpuTimeSeconds = value.metrics.cpuTimeSeconds
   const memoryBytes = count(value.metrics.memoryBytes)
   const restarts = count(value.metrics.restarts)
   const tasks = count(value.metrics.tasks)
   const uptimeSeconds = count(value.metrics.uptimeSeconds)
-  if (cpuTimeSeconds === undefined
+  if (!nonNegativeNumber(cpuTimeSeconds)
     || memoryBytes === undefined
     || restarts === undefined
     || tasks === undefined

--- a/packages/harlan-github-agent/test/hogwild-status.test.ts
+++ b/packages/harlan-github-agent/test/hogwild-status.test.ts
@@ -61,6 +61,19 @@ describe('hogwild status boundary', () => {
     })
   })
 
+  it('accepts fractional CPU time reported by systemd', () => {
+    const payload = structuredClone(activeStatus)
+    const jellyfin = payload.privateDetails.services[0]
+    if (jellyfin?.state._tag !== 'Active')
+      throw new Error('Expected an active Jellyfin fixture.')
+    jellyfin.state.metrics.cpuTimeSeconds = 8.25
+
+    expect(parseHogwildStatus(JSON.stringify(payload))).toEqual({
+      _tag: 'Ok',
+      value: payload.privateDetails,
+    })
+  })
+
   it('rejects public, malformed, and partial messages', () => {
     expect(parseHogwildStatus('{}')).toEqual({ _tag: 'Err', reason: 'Private Hogwild status is unavailable.' })
     expect(parseHogwildStatus('{')).toEqual({ _tag: 'Err', reason: 'Hogwild sent invalid JSON.' })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The dashboard rejected valid Hogwild service metrics because systemd reports cumulative CPU time as fractional seconds. It now accepts finite, non-negative CPU time while retaining integer checks for counts.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).