### PR TITLE
fix(agent): show Agent reported progress

### DIFF
--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -409,18 +409,23 @@ def agent_role_label(agent):
     return AGENT_ROLE_LABELS[agent['role']]
 
 
-def agent_progress_percent(agent):
-    percent = (agent.get('progress') or {}).get('percent')
-    return percent if type(percent) is int and 0 <= percent <= 100 else 0
-
-
 def agent_progress_label(agent):
     progress = agent.get('progress') or {}
-    return f"{agent_progress_percent(agent)}% · {progress.get('label') or 'Starting'}"
+    return progress.get('label') or 'Starting'
+
+
+def agent_reported_progress_percent(agent):
+    for item in reversed(agent.get('activity') or []):
+        percent = item.get('percent')
+        if item.get('_tag') == 'Progress' and type(percent) is int and 0 <= percent <= 100:
+            return percent
+    return None
 
 
 def active_agent_label(agent):
-    return f"🟢 {agent_role_label(agent)} · {agent_progress_percent(agent)}% · {agent['repository']} #{agent['itemNumber']}"
+    percent = agent_reported_progress_percent(agent)
+    progress = '' if percent is None else f' · {percent}%'
+    return f"🟢 {agent_role_label(agent)}{progress} · {agent['repository']} #{agent['itemNumber']}"
 
 
 def active_routine_runs(dashboard):
@@ -460,6 +465,10 @@ def active_agent_activity_label(agent):
         return concise_activity_text(f'Edited {paths[0]}' if len(paths) == 1 else f'Edited {len(paths)} files')
     if kind == 'Reasoning':
         return concise_activity_text(latest.get('text') or 'Planning the next step')
+    if kind == 'Progress':
+        percent = latest.get('percent')
+        if type(percent) is int and 0 <= percent <= 100:
+            return concise_activity_text(f"{percent}% · {latest.get('text') or 'Working'}")
     return None
 
 

--- a/packages/harlan-github-agent/dashboard/app/pages/index.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/index.vue
@@ -508,6 +508,9 @@ useHead({
                     <span class="text-dimmed">edited</span>
                     {{ item.changes.map(change => change.path).join(', ') }}
                   </p>
+                  <p v-else-if="item._tag === 'Progress'" class="text-dimmed">
+                    {{ item.percent }}% · {{ item.text }}
+                  </p>
                   <p v-else class="text-dimmed">
                     {{ item.text }}
                   </p>
@@ -917,6 +920,9 @@ useHead({
                   <p v-else-if="item._tag === 'FileChange'">
                     <span class="text-dimmed">edited</span>
                     {{ item.changes.map(change => change.path).join(', ') }}
+                  </p>
+                  <p v-else-if="item._tag === 'Progress'" class="text-dimmed">
+                    {{ item.percent }}% · {{ item.text }}
                   </p>
                   <p v-else class="text-dimmed">
                     {{ item.text }}

--- a/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
@@ -265,6 +265,14 @@ export function activeAgentActivity(agent: ActiveAgent): AgentActivityPresentati
     return { at: activity.at, text: conciseActivityText(text), tone: 'muted' }
   }
 
+  if (activity._tag === 'Progress') {
+    return {
+      at: activity.at,
+      text: conciseActivityText(`${activity.percent}% · ${activity.text}`),
+      tone: 'muted',
+    }
+  }
+
   return {
     at: activity.at,
     text: conciseActivityText(activity.text) || 'Planning the next step',

--- a/packages/harlan-github-agent/src/agent-activity.ts
+++ b/packages/harlan-github-agent/src/agent-activity.ts
@@ -36,6 +36,8 @@ export function truncateOutput(text: string): string {
  * Returns undefined for events that say nothing about what the agent is doing.
  */
 export function agentActivityFromEvent(event: AgentEvent, at: string): AgentActivityItem | undefined {
+  if (event._tag === 'Progress')
+    return { _tag: 'Progress', at, percent: event.percent, text: redactSecrets(event.text) }
   if (event._tag === 'CommandCompleted') {
     return {
       _tag: 'Command',

--- a/packages/harlan-github-agent/src/agent-provider.ts
+++ b/packages/harlan-github-agent/src/agent-provider.ts
@@ -42,6 +42,7 @@ export type AgentEvent
     | { _tag: 'CommandCompleted', command: string, output: string, exitCode: number | null }
     | { _tag: 'FileChanged', changes: Array<{ path: string, kind: 'add' | 'delete' | 'update' }> }
     | { _tag: 'Reasoning', text: string }
+    | { _tag: 'Progress', percent: number, text: string }
     | { _tag: 'WebSearch' }
     | { _tag: 'Message', text: string }
     | { _tag: 'Usage', usage: Extract<AgentTokenUsage, { _tag: 'Available' }> }
@@ -49,6 +50,21 @@ export type AgentEvent
     /** The session read its whole Context budget, so the provider stopped it. */
     | { _tag: 'ContextBudgetExhausted', cachedTokensRead: number }
     | { _tag: 'Failed', reason: string }
+
+const agentProgressPrefix = /^[▓░]+[ \t]+(\d{1,3})%[ \t]+/
+
+/** Separates an Agent progress report from its final result message. */
+export function agentTextEvent(text: string): Extract<AgentEvent, { _tag: 'Message' | 'Progress' }> {
+  const candidate = text.trim()
+  const match = agentProgressPrefix.exec(candidate)
+  const percent = Number(match?.[1])
+  if (match === null || !Number.isInteger(percent) || percent < 0 || percent > 100)
+    return { _tag: 'Message', text }
+  const detail = candidate.slice(match[0].length).trim()
+  return detail.length > 0 && !detail.includes('\n') && !detail.includes('\r')
+    ? { _tag: 'Progress', percent, text: detail }
+    : { _tag: 'Message', text }
+}
 
 export interface AgentTurnRequest {
   /** Provider-specific model identifier taken from the worker profile. */

--- a/packages/harlan-github-agent/src/codex-provider.ts
+++ b/packages/harlan-github-agent/src/codex-provider.ts
@@ -1,7 +1,7 @@
 import type { CodexOptions, ThreadEvent, ThreadOptions } from '@openai/codex-sdk'
 import type { AgentEvent, AgentProvider, AgentTokenUsage, AgentTurnRequest } from './agent-provider.ts'
 import { Codex } from '@openai/codex-sdk'
-import { agentProviderFailureReason } from './agent-provider.ts'
+import { agentProviderFailureReason, agentTextEvent } from './agent-provider.ts'
 
 interface CodexThread {
   runStreamed: (prompt: string, options: { outputSchema: unknown, signal: AbortSignal }) => Promise<{ events: AsyncIterable<ThreadEvent> }>
@@ -46,7 +46,7 @@ export function codexAgentEvent(event: ThreadEvent): AgentEvent | undefined {
     if (event.item.type === 'reasoning')
       return { _tag: 'Reasoning', text: event.item.text }
     if (event.item.type === 'agent_message')
-      return { _tag: 'Message', text: event.item.text }
+      return agentTextEvent(event.item.text)
   }
   if (event.type === 'turn.completed')
     return { _tag: 'TurnCompleted' }

--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -4,7 +4,7 @@ import type { AgentEvent, AgentProvider, AgentTokenUsage, AgentTurnRequest } fro
 import { spawn } from 'node:child_process'
 import process from 'node:process'
 import { createInterface } from 'node:readline'
-import { agentProviderFailureReason, DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
+import { agentProviderFailureReason, agentTextEvent, DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
 
 /** Tools that write files, so activity shows a file change instead of a command. */
 const fileTools = new Set(['edit', 'write', 'patch', 'multiedit'])
@@ -113,8 +113,12 @@ export function opencodeAgentEvent(line: OpencodeLine): AgentEvent | undefined {
     return { _tag: 'Failed', reason: agentProviderFailureReason('opencode', errorMessage(line.error)) }
   if (line.type === 'reasoning')
     return { _tag: 'Reasoning', text: text(line.part?.text) }
-  if (line.type === 'text')
-    return { _tag: 'Message', text: extractJsonObject(text(line.part?.text)) }
+  if (line.type === 'text') {
+    const event = agentTextEvent(text(line.part?.text))
+    return event._tag === 'Message'
+      ? { ...event, text: extractJsonObject(event.text) }
+      : event
+  }
   if (line.type === 'step_finish' && text(line.part?.reason) === 'stop')
     return { _tag: 'TurnCompleted' }
   if (line.type === 'tool_use' && line.part !== undefined) {

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -878,6 +878,7 @@ export interface AgentProgress {
 export type AgentActivityItem
   = | { _tag: 'Command', at: string, command: string, output: string, exitCode: number | null }
     | { _tag: 'FileChange', at: string, changes: Array<{ path: string, kind: 'add' | 'delete' | 'update' }> }
+    | { _tag: 'Progress', at: string, percent: number, text: string }
     | { _tag: 'Reasoning', at: string, text: string }
 
 export interface ActiveAgent {

--- a/packages/harlan-github-agent/test/agent-activity.test.ts
+++ b/packages/harlan-github-agent/test/agent-activity.test.ts
@@ -49,6 +49,18 @@ describe('agentActivityFromEvent', () => {
   it('ignores events that say nothing about what the agent is doing', () => {
     expect(agentActivityFromEvent({ _tag: 'SessionStarted', sessionId: 'session-1' }, '2026-08-14T00:00:00.000Z')).toBeUndefined()
   })
+
+  it('records the percentage the Agent reported', () => {
+    expect(agentActivityFromEvent(
+      { _tag: 'Progress', percent: 25, text: 'next-step (waitlist flow read).' },
+      '2026-08-14T00:00:00.000Z',
+    )).toEqual({
+      _tag: 'Progress',
+      at: '2026-08-14T00:00:00.000Z',
+      percent: 25,
+      text: 'next-step (waitlist flow read).',
+    })
+  })
 })
 
 describe('createAgentActivityLog', () => {

--- a/packages/harlan-github-agent/test/codex-provider.test.ts
+++ b/packages/harlan-github-agent/test/codex-provider.test.ts
@@ -51,6 +51,17 @@ describe('codexAgentEvent', () => {
     expect(codexAgentEvent({ type: 'turn.failed', error: { message: 'Usage limit reached.' } } as ThreadEvent))
       .toEqual({ _tag: 'Failed', reason: 'The codex session failed: Usage limit reached.' })
   })
+
+  it('reads the Agent percentage from an intermediate progress message', () => {
+    expect(codexAgentEvent({
+      type: 'item.completed',
+      item: { id: 'message-1', type: 'agent_message', text: '▓▓▓░░ 57% next-step (reviewed API routes).' },
+    } as ThreadEvent)).toEqual({
+      _tag: 'Progress',
+      percent: 57,
+      text: 'next-step (reviewed API routes).',
+    })
+  })
 })
 
 describe('createCodexProvider', () => {

--- a/packages/harlan-github-agent/test/dashboard-view.test.ts
+++ b/packages/harlan-github-agent/test/dashboard-view.test.ts
@@ -515,6 +515,21 @@ describe('activeAgentActivity', () => {
     })
   })
 
+  it('shows the percentage the Agent reported', () => {
+    expect(activeAgentActivity(activeAgent({
+      activity: [{
+        _tag: 'Progress',
+        at: '2026-08-14T11:59:00.000Z',
+        percent: 25,
+        text: 'next-step (waitlist flow read).',
+      }],
+    }))).toEqual({
+      at: '2026-08-14T11:59:00.000Z',
+      text: '25% · next-step (waitlist flow read).',
+      tone: 'muted',
+    })
+  })
+
   it('stays absent until the Agent reports structured activity', () => {
     expect(activeAgentActivity(activeAgent())).toBeUndefined()
   })

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -459,13 +459,37 @@ class IndicatorDisplayTest(unittest.TestCase):
         agent = {
             'role': 'issue_triage',
             'progress': {'percent': 57, 'label': 'Checking issue context'},
+            'activity': [],
             'repository': 'harlan-zw/example',
             'itemNumber': 12,
         }
 
         self.assertEqual(
             indicator.active_agent_label(agent),
-            '🟢 Issue triage · 57% · harlan-zw/example #12',
+            '🟢 Issue triage · harlan-zw/example #12',
+        )
+
+    def test_labels_active_agents_with_the_percentage_the_agent_reported(self):
+        agent = {
+            'role': 'issue_triage',
+            'progress': {'percent': 70, 'label': 'Running tests and checks'},
+            'activity': [{
+                '_tag': 'Progress',
+                'at': '2026-08-14T00:00:00.000Z',
+                'percent': 25,
+                'text': 'next-step (waitlist flow read).',
+            }],
+            'repository': 'harlan-zw/example',
+            'itemNumber': 12,
+        }
+
+        self.assertEqual(
+            indicator.active_agent_label(agent),
+            '🟢 Issue triage · 25% · harlan-zw/example #12',
+        )
+        self.assertEqual(
+            indicator.active_agent_activity_label(agent),
+            '25% · next-step (waitlist flow read).',
         )
 
     def test_reads_live_activity_without_inventing_completion(self):
@@ -524,7 +548,7 @@ class IndicatorDisplayTest(unittest.TestCase):
             if item.get_label().startswith('🟢 Issue triage') and item.get_submenu() is not None
         )
         labels = menu_labels(active.get_submenu())
-        self.assertEqual(labels[:2], ['70% · Running tests and checks', 'Running pnpm test'])
+        self.assertEqual(labels[:2], ['Running tests and checks', 'Running pnpm test'])
 
     def test_system_pane_shows_a_running_routine_and_its_live_activity(self):
         run = {
@@ -567,7 +591,7 @@ class IndicatorDisplayTest(unittest.TestCase):
         )
         self.assertEqual(
             menu_labels(routine.get_submenu()),
-            ['55% · Checking the repository', 'Reading Sentry issues.', 'Open repository'],
+            ['Checking the repository', 'Reading Sentry issues.', 'Open repository'],
         )
         self.assertIn('🟢 1 agent running · Queue empty', menu_labels(stub.menus[0]))
 

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -120,6 +120,24 @@ describe('opencodeAgentEvent', () => {
     expect(opencodeAgentEvent(textLine)).toEqual({ _tag: 'Message', text: '{"outcome":"resolved"}' })
   })
 
+  it('reads the Agent percentage from an intermediate progress message', () => {
+    expect(opencodeAgentEvent({
+      type: 'text',
+      part: { type: 'text', text: '▓▓▓░░ 25% next-step (waitlist flow read). Now inspect the runtime.' },
+    })).toEqual({
+      _tag: 'Progress',
+      percent: 25,
+      text: 'next-step (waitlist flow read). Now inspect the runtime.',
+    })
+  })
+
+  it('keeps the final JSON when it follows a quoted progress line', () => {
+    expect(opencodeAgentEvent({
+      type: 'text',
+      part: { type: 'text', text: '▓▓▓░░ 25% quoted evidence\n{"outcome":"resolved"}' },
+    })).toEqual({ _tag: 'Message', text: '{"outcome":"resolved"}' })
+  })
+
   it('reports a session error as a turn failure', () => {
     expect(opencodeAgentEvent({ type: 'error', error: { name: 'ProviderError', data: { message: 'Rate limited.' } } }))
       .toEqual({ _tag: 'Failed', reason: 'The opencode session failed: Rate limited.' })


### PR DESCRIPTION
## Summary

- Read progress reports from Codex and opencode output.
- Show the Agent percentage in the System pane and dashboard.
- Keep controller phase ranks internal.

This pull request was written by an agent.