### PR TITLE
fix(agent): read closed pull request status

### DIFF
--- a/packages/harlan-github-agent/src/github.ts
+++ b/packages/harlan-github-agent/src/github.ts
@@ -291,7 +291,10 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
         return octokit
       return octokit.value.rest.pulls.get({ owner, repo, pull_number: number, ...(signal === undefined ? {} : { request: { signal } }) })
         .then(async (response) => {
-          const baseSha = await currentBaseSha(octokit.value, owner, repo, response.data.base.ref, signal)
+          // A closed stacked pull request may outlive its deleted base branch.
+          const baseSha = response.data.state === 'closed'
+            ? response.data.base.sha
+            : await currentBaseSha(octokit.value, owner, repo, response.data.base.ref, signal)
           return ok(pullRequestItem(repository, response.data, baseSha, options.actorLogin(repository)))
         })
         .catch((error: unknown): Result<GitHubPullRequestItem, GitHubReadError> => {

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -56,6 +56,34 @@ describe('live pull request base', () => {
     expect(result).toEqual(ok(expect.objectContaining({ baseSha: liveBaseSha })))
   })
 
+  it('reads a closed pull request after its base branch was deleted', async () => {
+    const closed = {
+      ...pullRequest(),
+      state: 'closed',
+      merged_at: '2026-08-13T11:00:00.000Z',
+      base: { sha: historicBaseSha, ref: 'deleted-stack-base' },
+    }
+    const client = {
+      rest: {
+        pulls: { get: () => Promise.resolve({ data: closed }) },
+        repos: { getBranch: () => Promise.reject(new Error('Branch not found')) },
+      },
+    } as unknown as Octokit
+    const source = createGitHubSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      issueCutoff: '2026-07-01',
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequest(repositoryMapping(), 24)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      state: 'closed',
+      baseSha: historicBaseSha,
+    })))
+  })
+
   it('reads base checks from the current base branch commit', async () => {
     const checkedRefs: string[] = []
     const client = {


### PR DESCRIPTION
## Summary

- Use the stored base SHA when a pull request is closed.
- Keep live base branch reads for open pull requests.
- Cover deleted stack branches with a regression test.

This pull request was written by an agent.