### PR TITLE
fix(agent): retry stable triage decisions

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -5306,12 +5306,19 @@ export function openJournalStore(
     database.exec('BEGIN IMMEDIATE')
     try {
       const existing = database.prepare(`
-        SELECT content_digest FROM pull_request_triage_runs
+        SELECT head_sha, outcome_tag, reason FROM pull_request_triage_runs
         WHERE task_id = ? OR (subject_id = ? AND revision_id = ?)
-      `).get(input.taskId, revision.subject_id, input.revisionId) as { content_digest: string } | undefined
+      `).get(input.taskId, revision.subject_id, input.revisionId) as {
+        head_sha: string
+        outcome_tag: 'ReviewRequired' | 'ReviewSkipped' | 'ReviewRequiredAfterFailure'
+        reason: string
+      } | undefined
       if (existing !== undefined) {
         database.exec('COMMIT')
-        return existing.content_digest === contentDigest ? { _tag: 'Duplicate' } : { _tag: 'Conflict' }
+        const sameDecision = existing.head_sha === input.headSha
+          && existing.outcome_tag === input.outcome._tag
+          && existing.reason === input.outcome.reason
+        return sameDecision ? { _tag: 'Duplicate' } : { _tag: 'Conflict' }
       }
       database.prepare(`
         INSERT INTO pull_request_triage_runs (

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -5306,18 +5306,19 @@ export function openJournalStore(
     database.exec('BEGIN IMMEDIATE')
     try {
       const existing = database.prepare(`
-        SELECT head_sha, outcome_tag, reason FROM pull_request_triage_runs
+        SELECT head_sha, outcome_tag FROM pull_request_triage_runs
         WHERE task_id = ? OR (subject_id = ? AND revision_id = ?)
       `).get(input.taskId, revision.subject_id, input.revisionId) as {
         head_sha: string
         outcome_tag: 'ReviewRequired' | 'ReviewSkipped' | 'ReviewRequiredAfterFailure'
-        reason: string
       } | undefined
       if (existing !== undefined) {
         database.exec('COMMIT')
+        // The reason is Agent-authored prose, so a retry rewords it. Only the
+        // head commit and the outcome tag define the decision; the first
+        // stored reason stays authoritative for stats.
         const sameDecision = existing.head_sha === input.headSha
           && existing.outcome_tag === input.outcome._tag
-          && existing.reason === input.outcome.reason
         return sameDecision ? { _tag: 'Duplicate' } : { _tag: 'Conflict' }
       }
       database.prepare(`

--- a/packages/harlan-github-agent/test/stats.test.ts
+++ b/packages/harlan-github-agent/test/stats.test.ts
@@ -126,7 +126,15 @@ describe('pull request triage Stats', () => {
     }
 
     expect(store.recordPullRequestTriageRun(input)).toEqual({ _tag: 'Inserted' })
-    expect(store.recordPullRequestTriageRun(input)).toEqual({ _tag: 'Duplicate' })
+    expect(store.recordPullRequestTriageRun({
+      ...input,
+      startedAt: '2026-08-02T00:02:01.000Z',
+      completedAt: '2026-08-02T00:02:02.000Z',
+    })).toEqual({ _tag: 'Duplicate' })
+    expect(store.recordPullRequestTriageRun({
+      ...input,
+      outcome: { _tag: 'ReviewRequired', reason: 'Runtime code changed.' },
+    })).toEqual({ _tag: 'Conflict' })
     const stats = store.getStats({
       from: '2026-08-01T00:00:00.000Z',
       to: '2026-08-08T00:00:00.000Z',

--- a/packages/harlan-github-agent/test/stats.test.ts
+++ b/packages/harlan-github-agent/test/stats.test.ts
@@ -133,6 +133,12 @@ describe('pull request triage Stats', () => {
     })).toEqual({ _tag: 'Duplicate' })
     expect(store.recordPullRequestTriageRun({
       ...input,
+      startedAt: '2026-08-02T00:03:01.000Z',
+      completedAt: '2026-08-02T00:03:02.000Z',
+      outcome: { _tag: 'ReviewSkipped' as const, reason: 'A retry reworded the same skip verdict.' },
+    })).toEqual({ _tag: 'Duplicate' })
+    expect(store.recordPullRequestTriageRun({
+      ...input,
       outcome: { _tag: 'ReviewRequired', reason: 'Runtime code changed.' },
     })).toEqual({ _tag: 'Conflict' })
     const stats = store.getStats({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A service restart retried pull request triage with new timestamps, so the journal rejected the unchanged outcome as a conflicting decision and stranded the Review. Repeated outcomes now reuse the stored decision; a genuinely different outcome still fails closed.

> 🤖 AI disclosure: [Codex](https://openai.com/codex/) modified this description.