### PR TITLE
fix(service): wait for Hogwild agents to drain

### DIFF
--- a/scripts/hogwild-service.sh
+++ b/scripts/hogwild-service.sh
@@ -8,6 +8,8 @@ HOGWILD_ORIGIN="${HARLAN_GITHUB_AGENT_HOGWILD_ORIGIN:-https://hogwild.tailcad325
 REMOTE_HOME="${HARLAN_GITHUB_AGENT_HOGWILD_HOME:-/home/harlan}"
 CONTEXT_FILE="${HARLAN_GITHUB_AGENT_CONTEXT_FILE:-$HOME/.codex/AGENTS.md}"
 PASSWORD_FILE="${HARLAN_GITHUB_AGENT_PASSWORD_FILE:-$HOME/.config/harlan-github-agent/dashboard-password}"
+readonly DRAIN_POLL_SECONDS=2
+readonly MAXIMUM_DRAIN_SECONDS=$((50 * 60))
 REMOTE_CHECKOUT="$REMOTE_HOME/.local/share/harlan-github-agent/service"
 REMOTE_CONTEXT="$REMOTE_HOME/.codex/AGENTS.md"
 REMOTE_CONTEXT_NEXT="$REMOTE_CONTEXT.next"
@@ -62,12 +64,13 @@ prepare_restart() {
       exit 1
       ;;
   esac
+  # Agent leases last up to 45 minutes. Keep five minutes for publication.
   local attempt
-  for attempt in $(seq 1 60); do
+  for attempt in $(seq 1 $((MAXIMUM_DRAIN_SECONDS / DRAIN_POLL_SECONDS))); do
     if controller_request "$HOGWILD_ORIGIN/api/state" | jq --exit-status '.agentControl.safeToRestart == true' >/dev/null; then
       return
     fi
-    sleep 2
+    sleep "$DRAIN_POLL_SECONDS"
   done
   echo "Hogwild did not become safe to restart." >&2
   exit 1

--- a/scripts/hogwild-service.test.sh
+++ b/scripts/hogwild-service.test.sh
@@ -10,7 +10,9 @@ export HOME="$test_root/home"
 export HOGWILD_SERVICE_TEST_CALLS="$test_root/calls"
 export HOGWILD_SERVICE_TEST_HASH=''
 export HOGWILD_SERVICE_TEST_OVERRIDE_HASH=''
+export HOGWILD_SERVICE_TEST_SAFE_AFTER=1
 export HOGWILD_SERVICE_TEST_STATE="$test_root/control-state"
+export HOGWILD_SERVICE_TEST_STATE_POLLS="$test_root/state-polls"
 
 mkdir -p "$HOME/.codex" "$HOME/.config/harlan-github-agent" "$test_root/bin"
 printf '%s\n' '# Global Agent instructions' > "$HOME/.codex/AGENTS.md"
@@ -20,6 +22,7 @@ expected_override_hash=$(/usr/bin/sha256sum "$script_dir/hogwild-service.conf" |
 export HOGWILD_SERVICE_TEST_HASH="$expected_hash"
 export HOGWILD_SERVICE_TEST_OVERRIDE_HASH="$expected_override_hash"
 printf '%s\n' 'Running' > "$HOGWILD_SERVICE_TEST_STATE"
+printf '%s\n' '0' > "$HOGWILD_SERVICE_TEST_STATE_POLLS"
 
 printf '%s\n' \
   '#!/usr/bin/env bash' \
@@ -35,7 +38,18 @@ printf '%s\n' \
   'printf '\''curl %s\n'\'' "$*" >> "$HOGWILD_SERVICE_TEST_CALLS"' \
   'if [[ "$*" == *api/agents/pause* ]]; then printf '\''Paused\n'\'' > "$HOGWILD_SERVICE_TEST_STATE"; printf '\''{"_tag":"Paused"}\n'\''; exit; fi' \
   'if [[ "$*" == *api/agents/resume* ]]; then printf '\''Running\n'\'' > "$HOGWILD_SERVICE_TEST_STATE"; printf '\''{"_tag":"Running"}\n'\''; exit; fi' \
-  'if [[ "$*" == *api/state* ]]; then state=$(cat "$HOGWILD_SERVICE_TEST_STATE"); if [[ "$state" == Paused ]]; then printf '\''{"agentControl":{"_tag":"Paused","safeToRestart":true}}\n'\''; else printf '\''{"agentControl":{"_tag":"Running"}}\n'\''; fi; fi' \
+  'if [[ "$*" == *api/state* ]]; then' \
+  '  state=$(cat "$HOGWILD_SERVICE_TEST_STATE")' \
+  '  if [[ "$state" == Paused ]]; then' \
+  '    polls=$(($(cat "$HOGWILD_SERVICE_TEST_STATE_POLLS") + 1))' \
+  '    printf '\''%s\n'\'' "$polls" > "$HOGWILD_SERVICE_TEST_STATE_POLLS"' \
+  '    safe=false' \
+  '    if ((polls >= HOGWILD_SERVICE_TEST_SAFE_AFTER)); then safe=true; fi' \
+  '    printf '\''{"agentControl":{"_tag":"Paused","safeToRestart":%s}}\n'\'' "$safe"' \
+  '  else' \
+  '    printf '\''{"agentControl":{"_tag":"Running"}}\n'\''' \
+  '  fi' \
+  'fi' \
   > "$test_root/bin/curl"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$test_root/bin/sleep"
 chmod +x "$test_root/bin/ssh" "$test_root/bin/scp" "$test_root/bin/curl" "$test_root/bin/sleep"
@@ -76,6 +90,16 @@ export HOGWILD_SERVICE_TEST_HASH="$expected_hash"
 PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" update >/dev/null
 if grep -E '/api/agents/(pause|resume)' "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
   printf '%s\n' 'Hogwild update changed an existing Pause' >&2
+  exit 1
+fi
+
+: > "$HOGWILD_SERVICE_TEST_CALLS"
+printf '%s\n' 'Running' > "$HOGWILD_SERVICE_TEST_STATE"
+printf '%s\n' '0' > "$HOGWILD_SERVICE_TEST_STATE_POLLS"
+export HOGWILD_SERVICE_TEST_SAFE_AFTER=61
+PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" update >/dev/null
+if [ "$(cat "$HOGWILD_SERVICE_TEST_STATE_POLLS")" -lt 61 ]; then
+  printf '%s\n' 'Hogwild update stopped waiting before the Agent drained' >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A deployment aborted while two healthy Agents exceeded the two minute drain limit.

The deploy now allows 50 minutes. This covers the 45 minute Agent lease and publication time.

> 🤖 AI disclosure: [Codex](https://openai.com/codex/) modified this description.
