### PR TITLE
fix(github-agent): continue reviews after auth handoff

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -223,6 +223,11 @@ export interface GitHubAgentSourceOptions {
   /** The login the controller posts as, which depends on how the repository authenticates. */
   actorLogin: (repository: RepositoryMapping) => string
   createClient?: (token: string) => Octokit
+  /** A former writer whose active marked comments remain canonical after an authentication change. */
+  legacyActor?: {
+    login: string
+    tokens: GitHubTokenProvider
+  }
   tokens: GitHubTokenProvider
   userAgent?: string
 }
@@ -328,8 +333,8 @@ function pullRequestItem(
 }
 
 export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitHubAgentSource {
-  const client = async (repository: string, access: GitHubRepositoryAccess, signal: AbortSignal): Promise<Result<Octokit, string>> => {
-    const token = await options.tokens.getToken(repository, access, signal)
+  const clientWith = async (tokens: GitHubTokenProvider, repository: string, access: GitHubRepositoryAccess, signal: AbortSignal): Promise<Result<Octokit, string>> => {
+    const token = await tokens.getToken(repository, access, signal)
     return token._tag === 'Err'
       ? err(token.error.message)
       : ok(options.createClient?.(token.value.token) ?? createAuthenticatedClient({
@@ -337,10 +342,12 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
           repository,
           signal,
           token: token.value.token,
-          tokens: options.tokens,
+          tokens,
           userAgent: options.userAgent ?? 'harlan-github-agent/0.0.0',
         }))
   }
+  const client = (repository: string, access: GitHubRepositoryAccess, signal: AbortSignal): Promise<Result<Octokit, string>> =>
+    clientWith(options.tokens, repository, access, signal)
 
   return {
     async listPullRequestFiles(repository, pullRequestNumber, signal) {
@@ -747,6 +754,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
         const headSha = automatedReviewHead(body)
         if (headSha === undefined)
           return err('The automated review comment is missing its head commit marker.')
+        const actor = options.actorLogin(repository).toLowerCase()
         const priorReview = priorAutomatedReviewForHead(comments.flatMap(comment =>
           comment.body === undefined || comment.body === null || comment.user?.login === undefined
             ? []
@@ -756,23 +764,41 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
                 body: comment.body,
                 url: comment.html_url,
               }]), headSha, options.actorLogin(repository))
-        if (priorReview._tag === 'Found' && !replacePriorReview)
+        const legacyActor = options.legacyActor
+        const adoptablePrior = priorReview._tag === 'Found'
+          && legacyActor !== undefined
+          && priorReview.authorLogin.toLowerCase() === legacyActor.login.toLowerCase()
+          && (priorReview.state === 'active' || replacePriorReview)
+          ? comments.findLast(comment =>
+              comment.html_url === priorReview.url
+              && comment.user?.login.toLowerCase() === legacyActor.login.toLowerCase()
+              && comment.body?.includes(AUTOMATED_REVIEW_MARKER)
+              && automatedReviewHead(comment.body)?.toLowerCase() === headSha.toLowerCase())
+          : undefined
+        if (priorReview._tag === 'Found' && adoptablePrior === undefined && !replacePriorReview)
           return err(`The current head commit already has an automated review by @${priorReview.authorLogin}: ${priorReview.url}`)
         const existing = commentId === null
-          ? comments
-            .filter(comment => comment.user?.login.toLowerCase() === options.actorLogin(repository).toLowerCase() && comment.body?.includes(AUTOMATED_REVIEW_MARKER))
+          ? adoptablePrior ?? comments
+            .filter(comment => comment.user?.login.toLowerCase() === actor && comment.body?.includes(AUTOMATED_REVIEW_MARKER))
             .sort((left, right) => right.id - left.id)[0]
           : comments.find(comment => comment.id === commentId)
-        if (existing !== undefined && existing.user?.login.toLowerCase() !== options.actorLogin(repository).toLowerCase())
+        const adopted = existing !== undefined && existing.id === adoptablePrior?.id
+        if (existing !== undefined && existing.user?.login.toLowerCase() !== actor && !adopted)
           return err('The stored automated review comment belongs to another GitHub actor.')
         if (existing !== undefined && existing.body === body && existing.html_url !== undefined)
           return ok({ commentId: existing.id, url: existing.html_url })
+        const writer = adopted && legacyActor !== undefined
+          ? await clientWith(legacyActor.tokens, repository.github, 'item_write', signal)
+          : octokit
+        if (writer._tag === 'Err')
+          return writer
         const written = existing === undefined
-          ? await octokit.value.rest.issues.createComment({ owner, repo, issue_number: pullRequestNumber, body, ...requestOptions })
-          : await octokit.value.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body, ...requestOptions })
-        const confirmed = await octokit.value.rest.issues.getComment({ owner, repo, comment_id: written.data.id, ...requestOptions })
+          ? await writer.value.rest.issues.createComment({ owner, repo, issue_number: pullRequestNumber, body, ...requestOptions })
+          : await writer.value.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body, ...requestOptions })
+        const confirmed = await writer.value.rest.issues.getComment({ owner, repo, comment_id: written.data.id, ...requestOptions })
+        const writerLogin = adopted && legacyActor !== undefined ? legacyActor.login.toLowerCase() : actor
         if (
-          confirmed.data.user?.login.toLowerCase() !== options.actorLogin(repository).toLowerCase()
+          confirmed.data.user?.login.toLowerCase() !== writerLogin
           || confirmed.data.body !== body
           || !confirmed.data.body.includes(AUTOMATED_REVIEW_MARKER)
         ) {

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -2,6 +2,7 @@ import type { ConsolaInstance } from 'consola'
 import type { Server } from 'srvx'
 import type { AgentProviderName } from './agent-provider.ts'
 import type { GitIdentity } from './git-identity.ts'
+import type { GitHubTokenProvider } from './github-auth.ts'
 import type { GitHubUserAccess } from './github-user-access.ts'
 import type { Result } from './result.ts'
 import type { RoutineSyncOutcome } from './routine-controller.ts'
@@ -309,17 +310,19 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   }
   // A repository the App cannot reach is answered with Harlan's own account.
   const actorLogin = (repository: RepositoryMapping): string => repository.authentication === 'user' ? userLogin : AGENT_ACTOR_LOGIN
+  const appTokens = createGitHubAppTokenProvider({
+    appId: config.github.appId,
+    privateKey: options.githubPrivateKey,
+  })
+  const userTokens = createUserTokenProvider({ readToken: signal => userAccess.token(signal) })
   const routedTokens = createRoutedTokenProvider({
-    app: createGitHubAppTokenProvider({
-      appId: config.github.appId,
-      privateKey: options.githubPrivateKey,
-    }),
-    user: createUserTokenProvider({ readToken: signal => userAccess.token(signal) }),
+    app: appTokens,
+    user: userTokens,
     usesUserToken: repository => userRepositoryNames.has(repository.toLowerCase()),
   })
   // Write authority belongs at the credential boundary. Every current and
   // future mutation needs one of these write credentials before it can leave.
-  const tokens = createGitHubWriteGate({
+  const gatedTokens = (source: GitHubTokenProvider): GitHubTokenProvider => createGitHubWriteGate({
     mayWrite: github => store.mayWriteRepository(github),
     onRefused: (github) => {
       store.recordIncident({
@@ -332,8 +335,10 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         at: now().toISOString(),
       })
     },
-    source: routedTokens,
+    source,
   })
+  const tokens = gatedTokens(routedTokens)
+  const legacyUserTokens = gatedTokens(userTokens)
   const github = createGitHubSource({ actorLogin, tokens, issueCutoff: config.issueCutoff })
   const pullRequestStatuses = createPullRequestStatusController({
     github,
@@ -349,7 +354,11 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   })
   // Ephemeral: what each running agent is doing right now, never persisted.
   const activityLog = createAgentActivityLog()
-  const workerGithub = createGitHubAgentSource({ actorLogin, tokens })
+  const workerGithub = createGitHubAgentSource({
+    actorLogin,
+    legacyActor: { login: userLogin, tokens: legacyUserTokens },
+    tokens,
+  })
   const mutationSchedulers = await (async () => {
     if (!config.mutationsEnabled)
       return undefined

--- a/packages/harlan-github-agent/test/upsert-review-status.test.ts
+++ b/packages/harlan-github-agent/test/upsert-review-status.test.ts
@@ -1,0 +1,63 @@
+import type { Octokit } from 'octokit'
+import { describe, expect, it, vi } from 'vitest'
+import { createGitHubAgentSource } from '../src/github-agent-source.ts'
+import { ok } from '../src/result.ts'
+import { repositoryMapping } from './fixtures.ts'
+
+const headSha = '1031dc93dddca88266cb32a085c7b90dcd58ec23'
+const oldBody = `<!-- harlan-agent-kit:pr-triage -->
+<!-- reviewed-sha: ${headSha} -->
+### 🤖 REVIEWING · Adversarial review`
+const newBody = `<!-- harlan-agent-kit:pr-triage -->
+<!-- reviewed-sha: ${headSha} -->
+### 🤖 READY · Adversarial review`
+
+describe('upsertReviewStatus actor handoff', () => {
+  it('updates an active automated review through its original user actor', async () => {
+    const comment = {
+      id: 5,
+      author_association: 'OWNER',
+      body: oldBody,
+      html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
+      issue_url: 'https://api.github.com/repos/harlan-zw/example/issues/24',
+      user: { login: 'harlan-zw' },
+    }
+    const appUpdate = vi.fn((_input: { body: string }) => Promise.resolve({ data: comment }))
+    const userUpdate = vi.fn((input: { body: string }) => {
+      comment.body = input.body
+      return Promise.resolve({ data: comment })
+    })
+    const client = (updateComment: typeof userUpdate) => ({
+      paginate: () => Promise.resolve([comment]),
+      rest: {
+        issues: {
+          createComment: vi.fn(),
+          getComment: () => Promise.resolve({ data: comment }),
+          listComments: vi.fn(),
+          updateComment,
+        },
+      },
+    }) as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: token => token === 'user-token' ? client(userUpdate) : client(appUpdate),
+      legacyActor: {
+        login: 'harlan-zw',
+        tokens: {
+          getToken: () => Promise.resolve(ok({ token: 'user-token', expiresAt: '2026-08-30T00:00:00.000Z' })),
+          invalidate: () => undefined,
+        },
+      },
+      tokens: {
+        getToken: () => Promise.resolve(ok({ token: 'app-token', expiresAt: '2026-08-30T00:00:00.000Z' })),
+        invalidate: () => undefined,
+      },
+    })
+
+    const result = await source.upsertReviewStatus(repositoryMapping(), 24, null, newBody, false, new AbortController().signal)
+
+    expect(result).toEqual(ok({ commentId: 5, url: comment.html_url }))
+    expect(userUpdate).toHaveBeenCalledWith(expect.objectContaining({ comment_id: 5, body: newBody }))
+    expect(appUpdate).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

HGA can switch a repository from user authentication to the GitHub App while a review runs. The new actor then refuses to update the existing status comment, so the finished review loops forever. Active marked comments now keep using their original credential, with the repository write gate still applied.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.