### PR TITLE
fix(github-agent): close reviews after auth handoff

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -716,20 +716,38 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
       const actor = options.actorLogin(repository).toLowerCase()
       return octokit.value.rest.issues.getComment({ owner, repo, comment_id: commentId, ...requestOptions })
         .then(async (existing) => {
-          if (existing.data.user?.login.toLowerCase() !== actor)
-            return err('The stored automated review comment belongs to another GitHub actor.')
           if (existing.data.issue_url !== undefined && !existing.data.issue_url.endsWith(`/${pullRequestNumber}`))
             return err('The stored automated review comment belongs to another pull request.')
+          const legacyActor = options.legacyActor
+          const existingHead = automatedReviewHead(existing.data.body ?? '')?.toLowerCase()
+          const expectedHead = automatedReviewHead(expectedBody)?.toLowerCase()
+          const nextHead = automatedReviewHead(body)?.toLowerCase()
+          const legacyOwned = legacyActor !== undefined
+            && existing.data.user?.login.toLowerCase() === legacyActor.login.toLowerCase()
+            && existing.data.body?.includes(AUTOMATED_REVIEW_MARKER)
+            && expectedBody.includes(AUTOMATED_REVIEW_MARKER)
+            && body.includes(AUTOMATED_REVIEW_MARKER)
+            && existingHead !== undefined
+            && existingHead === expectedHead
+            && existingHead === nextHead
+          if (existing.data.user?.login.toLowerCase() !== actor && !legacyOwned)
+            return err('The stored automated review comment belongs to another GitHub actor.')
           if (existing.data.body === body && existing.data.html_url !== undefined)
             return ok({ _tag: 'Edited' as const, commentId: existing.data.id, url: existing.data.html_url })
           if (existing.data.body !== expectedBody)
             return ok({ _tag: 'Changed' as const })
-          await octokit.value.rest.issues.updateComment({ owner, repo, comment_id: commentId, body, ...requestOptions })
+          const writer = legacyOwned && legacyActor !== undefined
+            ? await clientWith(legacyActor.tokens, repository.github, 'item_write', signal)
+            : octokit
+          if (writer._tag === 'Err')
+            return writer
+          await writer.value.rest.issues.updateComment({ owner, repo, comment_id: commentId, body, ...requestOptions })
           // The compare and swap above is a client side read then write, so a
           // concurrent writer can land between the two. Reading back is the
           // only way to see that the written body no longer holds.
-          const confirmed = await octokit.value.rest.issues.getComment({ owner, repo, comment_id: commentId, ...requestOptions })
-          if (confirmed.data.user?.login.toLowerCase() !== actor)
+          const confirmed = await writer.value.rest.issues.getComment({ owner, repo, comment_id: commentId, ...requestOptions })
+          const writerLogin = legacyOwned && legacyActor !== undefined ? legacyActor.login.toLowerCase() : actor
+          if (confirmed.data.user?.login.toLowerCase() !== writerLogin)
             return err('GitHub did not confirm the edited automated review comment.')
           if (confirmed.data.body !== body)
             return ok({ _tag: 'Changed' as const })

--- a/packages/harlan-github-agent/test/upsert-review-status.test.ts
+++ b/packages/harlan-github-agent/test/upsert-review-status.test.ts
@@ -12,52 +12,77 @@ const newBody = `<!-- harlan-agent-kit:pr-triage -->
 <!-- reviewed-sha: ${headSha} -->
 ### 🤖 READY · Adversarial review`
 
-describe('upsertReviewStatus actor handoff', () => {
-  it('updates an active automated review through its original user actor', async () => {
-    const comment = {
-      id: 5,
-      author_association: 'OWNER',
-      body: oldBody,
-      html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
-      issue_url: 'https://api.github.com/repos/harlan-zw/example/issues/24',
-      user: { login: 'harlan-zw' },
-    }
-    const appUpdate = vi.fn((_input: { body: string }) => Promise.resolve({ data: comment }))
-    const userUpdate = vi.fn((input: { body: string }) => {
-      comment.body = input.body
-      return Promise.resolve({ data: comment })
-    })
-    const client = (updateComment: typeof userUpdate) => ({
-      paginate: () => Promise.resolve([comment]),
-      rest: {
-        issues: {
-          createComment: vi.fn(),
-          getComment: () => Promise.resolve({ data: comment }),
-          listComments: vi.fn(),
-          updateComment,
-        },
+function legacySource(initialBody = oldBody) {
+  const comment = {
+    id: 5,
+    author_association: 'OWNER',
+    body: initialBody,
+    html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
+    issue_url: 'https://api.github.com/repos/harlan-zw/example/issues/24',
+    user: { login: 'harlan-zw' },
+  }
+  const appUpdate = vi.fn((_input: { body: string }) => Promise.resolve({ data: comment }))
+  const userUpdate = vi.fn((input: { body: string }) => {
+    comment.body = input.body
+    return Promise.resolve({ data: comment })
+  })
+  const client = (updateComment: typeof userUpdate) => ({
+    paginate: () => Promise.resolve([comment]),
+    rest: {
+      issues: {
+        createComment: vi.fn(),
+        getComment: () => Promise.resolve({ data: comment }),
+        listComments: vi.fn(),
+        updateComment,
       },
-    }) as unknown as Octokit
-    const source = createGitHubAgentSource({
-      actorLogin: () => 'harlan-github-agent[bot]',
-      createClient: token => token === 'user-token' ? client(userUpdate) : client(appUpdate),
-      legacyActor: {
-        login: 'harlan-zw',
-        tokens: {
-          getToken: () => Promise.resolve(ok({ token: 'user-token', expiresAt: '2026-08-30T00:00:00.000Z' })),
-          invalidate: () => undefined,
-        },
-      },
+    },
+  }) as unknown as Octokit
+  const source = createGitHubAgentSource({
+    actorLogin: () => 'harlan-github-agent[bot]',
+    createClient: token => token === 'user-token' ? client(userUpdate) : client(appUpdate),
+    legacyActor: {
+      login: 'harlan-zw',
       tokens: {
-        getToken: () => Promise.resolve(ok({ token: 'app-token', expiresAt: '2026-08-30T00:00:00.000Z' })),
+        getToken: () => Promise.resolve(ok({ token: 'user-token', expiresAt: '2026-08-30T00:00:00.000Z' })),
         invalidate: () => undefined,
       },
-    })
+    },
+    tokens: {
+      getToken: () => Promise.resolve(ok({ token: 'app-token', expiresAt: '2026-08-30T00:00:00.000Z' })),
+      invalidate: () => undefined,
+    },
+  })
+  return { appUpdate, comment, source, userUpdate }
+}
+
+describe('review status actor handoff', () => {
+  it('updates an active automated review through its original user actor', async () => {
+    const { appUpdate, comment, source, userUpdate } = legacySource()
 
     const result = await source.upsertReviewStatus(repositoryMapping(), 24, null, newBody, false, new AbortController().signal)
 
     expect(result).toEqual(ok({ commentId: 5, url: comment.html_url }))
     expect(userUpdate).toHaveBeenCalledWith(expect.objectContaining({ comment_id: 5, body: newBody }))
+    expect(appUpdate).not.toHaveBeenCalled()
+  })
+
+  it('closes a stopped automated review through its original user actor', async () => {
+    const { appUpdate, comment, source, userUpdate } = legacySource()
+
+    const result = await source.editReviewStatus(repositoryMapping(), 24, 5, oldBody, newBody, new AbortController().signal)
+
+    expect(result).toEqual(ok({ _tag: 'Edited', commentId: 5, url: comment.html_url }))
+    expect(userUpdate).toHaveBeenCalledWith(expect.objectContaining({ comment_id: 5, body: newBody }))
+    expect(appUpdate).not.toHaveBeenCalled()
+  })
+
+  it('refuses an unmarked comment from the original user actor', async () => {
+    const { appUpdate, source, userUpdate } = legacySource('Human review comment')
+
+    const result = await source.editReviewStatus(repositoryMapping(), 24, 5, 'Human review comment', newBody, new AbortController().signal)
+
+    expect(result).toEqual({ _tag: 'Err', error: 'The stored automated review comment belongs to another GitHub actor.' })
+    expect(userUpdate).not.toHaveBeenCalled()
     expect(appUpdate).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

After repository authentication moves to the GitHub App, the stale review sweep still refuses comments created through the user token. Hundreds of stopped comments remain stuck as REVIEWING and retry every pass. The sweep now uses the original credential only for exact, marked review comments on the same head.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.