### PR TITLE
fix(github-agent): retire stale review state

### DIFF
--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -129,6 +129,7 @@ export async function publishQueuePositions(
         taskId: status.taskId,
         commentId: status.commentId,
         at,
+        reason: 'A person deleted the comment.',
       })
       return ok({ _tag: 'CommentGone', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
     }

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -137,11 +137,20 @@ export async function publishStoppedReviews(
         taskId: review.taskId,
         commentId: review.commentId,
         at,
+        reason: 'A person deleted the comment.',
       })
       return ok({ _tag: 'CommentGone', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     }
-    if (edited.value._tag === 'Changed')
+    if (edited.value._tag === 'Changed') {
+      options.store.recordDeletedReviewComment({
+        taskKind: review.taskKind,
+        taskId: review.taskId,
+        commentId: review.commentId,
+        at,
+        reason: 'Another Task replaced the canonical comment.',
+      })
       return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
+    }
     const recorded = options.store.recordStoppedReviewStatus({
       taskId: review.taskId,
       taskKind: review.taskKind,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -729,19 +729,13 @@ export interface JournalStore {
    * sweep that sees false here has lost the comment to the claimed agent.
    */
   isQueuedReviewStatus: (input: { taskId: string, taskKind: 'adversarial_review' | 'review_fix' }) => boolean
-  /**
-   * Retires the canonical comment a person deleted.
-   *
-   * A sweep refuses to open a deleted comment again, which is right: deleting
-   * it is how a person answers it. Refusing was the whole response though, so
-   * the row stayed in the sweep's list and asked GitHub again every pass,
-   * forever. Retiring the publication takes the row out of every sweep.
-   */
+  /** Retires a publication after its canonical comment disappeared or moved on. */
   recordDeletedReviewComment: (input: {
     taskKind: 'adversarial_review' | 'review_fix'
     taskId: string
     commentId: number
     at: string
+    reason: 'A person deleted the comment.' | 'Another Task replaced the canonical comment.'
   }) => boolean
   recordStoppedReviewStatus: (input: {
     taskId: string
@@ -8654,9 +8648,9 @@ export function openJournalStore(
 
   const recordDeletedReviewComment: JournalStore['recordDeletedReviewComment'] = input => database.prepare(`
     UPDATE review_status_commands
-    SET state_tag = 'Superseded', reason = 'A person deleted the comment.', updated_at = ?
+    SET state_tag = 'Superseded', reason = ?, updated_at = ?
     WHERE task_kind = ? AND task_id = ? AND state_tag = 'Published' AND github_comment_id = ?
-  `).run(input.at, input.taskKind, input.taskId, input.commentId).changes > 0
+  `).run(input.reason, input.at, input.taskKind, input.taskId, input.commentId).changes > 0
 
   const recordStoppedReviewStatus: JournalStore['recordStoppedReviewStatus'] = (input) => {
     const bodySha256 = digest(input.body)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4839,6 +4839,16 @@ export function openJournalStore(
           )
           return
         }
+        if (input.subject.kind === 'pull_request') {
+          supersedeTasks(
+            database,
+            subject.id,
+            input.observedAt,
+            'A newer pull request Revision replaced this Repair.',
+            revisionId,
+            'review_fix',
+          )
+        }
         if (input.subject.kind === 'pull_request' && requiresPullRequestApproval(database, mapping, input.subject.author)) {
           const approvedRepair = database.prepare(`
             SELECT 1

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -729,7 +729,13 @@ export interface JournalStore {
    * sweep that sees false here has lost the comment to the claimed agent.
    */
   isQueuedReviewStatus: (input: { taskId: string, taskKind: 'adversarial_review' | 'review_fix' }) => boolean
-  /** Retires a publication after its canonical comment disappeared or moved on. */
+  /**
+   * Retires a publication after its canonical comment disappeared or moved on.
+   *
+   * The match is the comment identity alone. A stopped Repair inherits the
+   * sibling Review's canonical comment, so the Task pair on the sweep row does
+   * not name the row that carried the comment; the comment id does.
+   */
   recordDeletedReviewComment: (input: {
     taskKind: 'adversarial_review' | 'review_fix'
     taskId: string
@@ -8649,8 +8655,8 @@ export function openJournalStore(
   const recordDeletedReviewComment: JournalStore['recordDeletedReviewComment'] = input => database.prepare(`
     UPDATE review_status_commands
     SET state_tag = 'Superseded', reason = ?, updated_at = ?
-    WHERE task_kind = ? AND task_id = ? AND state_tag = 'Published' AND github_comment_id = ?
-  `).run(input.reason, input.at, input.taskKind, input.taskId, input.commentId).changes > 0
+    WHERE state_tag = 'Published' AND github_comment_id = ?
+  `).run(input.reason, input.at, input.commentId).changes > 0
 
   const recordStoppedReviewStatus: JournalStore['recordStoppedReviewStatus'] = (input) => {
     const bodySha256 = digest(input.body)

--- a/packages/harlan-github-agent/test/review-repair-claim.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-claim.test.ts
@@ -123,6 +123,50 @@ describe('review Repair queue', () => {
     })._tag).toBe('Staged')
   })
 
+  it('stops an active Repair when the pull request base commit changes', () => {
+    const store = createStore()
+    const { review, revisionId } = runningReview(store, 'fix/base-moved')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
+    const queued = store.queueReviewFixTaskForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:04.000Z',
+    })
+    if (queued._tag !== 'Queued')
+      throw new Error(queued.reason)
+    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:05.000Z', 600_000)
+    if (repair === null)
+      throw new Error('Expected the Repair Task.')
+
+    const moved = store.recordObservation({
+      externalId: 'repair-base-moved',
+      observedAt: '2026-08-13T01:00:06.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        headRef: repair.pullRequest.headRef,
+        headSha: repair.pullRequest.headSha,
+        baseSha: 'new-base-commit',
+        mergeState: 'clean',
+        updatedAt: '2026-08-13T01:00:06.000Z',
+      }),
+    })
+    if (moved._tag !== 'Inserted')
+      throw new Error('Expected the base move to create a new Revision.')
+
+    expect(store.heartbeatTask({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:00:07.000Z',
+      leaseMilliseconds: 600_000,
+    })).toBe(false)
+    expect(store.getDashboardSnapshot('2026-08-13T01:00:07.000Z').tasks.find(task => task.id === repair.id)?.state).toEqual({
+      _tag: 'Superseded',
+      reason: 'A newer pull request Revision replaced this Repair.',
+    })
+  })
+
   it('retires a disputed Repair after a fresh Review finds no defect', () => {
     const store = createStore()
     const { review, revisionId } = runningReview(store, 'fix/disputed-finding')

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -258,6 +258,30 @@ describe('publishStoppedReviews', () => {
     expect(recorded).toBe(0)
     expect(retired).toEqual([42])
   })
+
+  it('retires a stale publication after another Task replaces its comment', async () => {
+    const retired: number[] = []
+    const { results } = await publishStoppedReviews({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Changed' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        recordDeletedReviewComment: (input) => {
+          retired.push(input.commentId)
+          return true
+        },
+        listStoppedReviews: () => [stopped],
+        recordStoppedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Superseded', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(retired).toEqual([42])
+  })
+
   it('leaves the comment alone once the pull request moves on', async () => {
     let writes = 0
     const { results } = await publishStoppedReviews({

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1655,6 +1655,7 @@ describe('journal store', () => {
       taskId: review.id,
       commentId: 42,
       at: '2026-08-13T01:03:00.000Z',
+      reason: 'A person deleted the comment.',
     })).toBe(true)
     expect(store.listStoppedReviews()).toEqual([])
   })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1660,6 +1660,105 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
+  it('retires the inherited sibling comment of a stopped Repair', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const observed = store.recordObservation({
+      externalId: 'inherited-comment-pr',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request Revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'review',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 REVIEWING · Git worktree ready',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    const gates = passedReviewGates()
+    gates.review = { _tag: 'Failed', reason: 'The boundary accepts invalid input.', evidence: [] }
+    store.recordReviewRun({
+      id: 'inherited-comment-attempt',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: review.revisionId,
+      headSha: pullRequest.headSha,
+      provider: 'codex',
+      sessionId: 'inherited-comment-session',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:02:03.000Z',
+      completedAt: '2026-08-13T01:02:30.000Z',
+      gates,
+      findings: [{ _tag: 'Open', summary: 'Invalid input crosses the boundary.', nextAction: 'Parse the input before use.' }],
+    })
+    expect(store.queueReviewFixTaskForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:03:00.000Z',
+    })._tag).toBe('Queued')
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:03:01.000Z',
+      evidence: 'Waiting for Repair repair-task.',
+    })).toBe(true)
+    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:03:02.000Z', 600_000)
+    if (repair === null)
+      throw new Error('Expected the Repair Task.')
+    // The Repair stops before publishing any progress of its own, so the
+    // sweep row carries the Repair Task identity and the Review's comment.
+    expect(store.failTask({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:04:00.000Z',
+      reason: 'Repository policy does not authorize an automated repair.',
+    })).toBe('Failed')
+    const stopped = store.listStoppedReviews()
+    expect(stopped).toEqual([expect.objectContaining({
+      taskKind: 'review_fix',
+      taskId: repair.id,
+      commentId: 42,
+    })])
+
+    expect(store.recordDeletedReviewComment({
+      taskKind: stopped[0]!.taskKind,
+      taskId: stopped[0]!.taskId,
+      commentId: stopped[0]!.commentId,
+      at: '2026-08-13T01:05:00.000Z',
+      reason: 'A person deleted the comment.',
+    })).toBe(true)
+    expect(store.listStoppedReviews()).toEqual([])
+  })
+
   it('keeps a stopped Review eligible after GitHub closes its pull request Revision', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Repair kept working after `main` moved, then could not publish because its Revision was stale. Old review rows also kept checking comments a newer Task had replaced. Stale Repair now stops immediately, and replaced comments retire their old rows without a purge cron.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.