### PR TITLE
feat(github-agent): allow personal account Issue work

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -17,7 +17,7 @@ Resolve the package from this skill directory:
 
 Require an explicit configuration file. Start from `config.example.yml` only when creating one.
 
-Use `github.allowed_owners` before GitHub App installation access. Ignore installations from every other GitHub owner. Scan only immediate directories under `~/pkg` and `~/sites` to find trusted local checkouts. Treat configured repositories as policy overrides. Never act on a checkout without matching its GitHub origin and App installation.
+Use `github.allowed_owners` before GitHub access. Ignore installations and personal-account repositories from every other GitHub owner. Scan only immediate directories under `~/pkg` and `~/sites` to find trusted local checkouts. Treat configured repositories as policy overrides. Never act on a checkout without matching its GitHub origin and discovered authentication.
 
 Skip a tracked pull request with a conventional non-breaking `chore:` title before starting an Agent.
 For every other tracked pull request authored by `harlan-zw`, run low-cost Pull request triage.
@@ -137,7 +137,7 @@ curl --fail --silent --user "agent:$agent_password" --header 'Origin: https://ha
 
 `conflict_resolution: true` permits a repository to queue conflict work. `mutations_enabled: true` lets the controller run and publish it.
 
-Require a GitHub App installation for selected repositories. Use App tokens for controller reads and writes. Workers may use Harlan's authenticated `gh` client for research.
+Prefer a GitHub App installation for selected repositories. If a maintained repository has no installation, require an explicit Repository mapping before Issue work. Use Harlan's authenticated GitHub account for that repository. Workers may use the authenticated `gh` client for research.
 
 Enable the global mutation switch only after repository mappings and publication checks pass.
 
@@ -221,7 +221,9 @@ After the push, invalidate old evidence and run `adversarial-review` again again
 
 Use fenced leases and durable Publication commands for every GitHub write.
 
-Use repository-scoped GitHub App tokens. Mint read and write tokens separately.
+Route controller credentials by Repository mapping. Use repository-scoped GitHub App tokens when installed. Use Harlan's authenticated GitHub account only for an explicitly configured maintained repository.
+
+Mint read and write App tokens separately.
 
 Publish only pinned controller artifacts. Recheck pull request state, branch protection, artifact integrity, and the database lease before each push.
 

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -60,7 +60,7 @@ Every tracked pull request is reviewed. The `harlan-agent-auto-merge` label deci
 
 No new issue work starts above `max_open_pull_requests` open pull requests. Review, repair, and conflict fixes continue, because they shorten that queue.
 
-Owned repositories selected in the GitHub App enable Issue triage by default. A maintained repository needs an explicit mapping with `issue_work: true` and its own GitHub App installation. Harlan's valid issues continue into Issue work automatically. An outside contributor's valid issue waits for `harlan-agent-review` or `Approve`. The service removes the label before saving Approval for that exact issue state.
+Owned repositories selected in the GitHub App enable Issue triage by default. A maintained repository needs an explicit mapping with `issue_work: true`. Without an installation, the controller uses Harlan's authenticated GitHub account. Harlan's valid issues continue into Issue work automatically. An outside contributor's valid issue waits for `harlan-agent-review` or `Approve`. The service removes the label before saving Approval for that exact issue state.
 
 The triage agent resumes its own session, selects the matching installed skills, implements the change, and runs focused checks. The agent chooses the commit message and pull request metadata. The controller commits and pushes the verified result before it opens one pull request ready for review. Conflict fixes also run by default on owned repositories. They remain disabled on maintained repositories.
 

--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -57,5 +57,6 @@ issue_cutoff: 2026-07-14
 external_repositories: []
 repositories: []
 # Owned repositories enable issue work and conflict resolution by default.
-# Maintained repositories need an explicit policy and GitHub App installation.
+# Maintained repositories need an explicit policy. Without an installation,
+# the controller uses the authenticated GitHub account.
 # Set repositories[].max_open_pull_requests to hold new Issue work for one busy repository.

--- a/packages/harlan-github-agent/src/failure.ts
+++ b/packages/harlan-github-agent/src/failure.ts
@@ -116,7 +116,6 @@ const permanentMessages = new Set<string>([
  * commit yet, and those must keep retrying.
  */
 const permanentPatterns: RegExp[] = [
-  /\bIssue work needs the GitHub App\b/i,
   /\bis still draft\b/i,
   // A quarantined repository stays quarantined until a person enables it, so
   // retrying only spends agent turns on a decision no agent can make.

--- a/packages/harlan-github-agent/src/repository-policy.ts
+++ b/packages/harlan-github-agent/src/repository-policy.ts
@@ -54,12 +54,11 @@ export function canRepairPullRequestHead(mapping: RepositoryMapping, pullRequest
 /**
  * True when the controller may open a pull request for an issue here.
  *
- * A maintained repository must opt in. The GitHub App keeps every write under
- * the repository-scoped identity instead of Harlan's own account.
+ * A maintained repository must opt in. Authentication decides which trusted
+ * controller credential publishes the branch and pull request.
  */
 export function canWorkIssues(mapping: RepositoryMapping): boolean {
   return mapping.enabled
-    && mapping.authentication === 'app'
     && canPushBranch(mapping)
     && mapping.issueWork
     && mapping.writablePullRequestHeadPrefixes.length > 0

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -160,22 +160,6 @@ export function replaceServiceIncidents(
   store.resolveIncidents({ _tag: 'Service' }, at, operation, currentMessages)
 }
 
-/** Shows configured Issue work that cannot run with a person's GitHub token. */
-export function replaceUnavailableIssueWorkIncidents(
-  store: Pick<JournalStore, 'recordIncident' | 'resolveIncidents'>,
-  repositories: readonly RepositoryMapping[],
-  at: string,
-): void {
-  replaceServiceIncidents(
-    store,
-    at,
-    'issue_work_access',
-    repositories
-      .filter(repository => repository.enabled && repository.issueWork && repository.authentication === 'user')
-      .map(repository => `${repository.github}: Issue work needs the GitHub App. Install the App for this repository, then restart the service.`),
-  )
-}
-
 /**
  * Reads Harlan's GitHub login, retrying a failure that describes the API and
  * not the account.
@@ -264,6 +248,8 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   // Capacity is normal System state now. Clear the legacy Incident once, so a
   // service upgraded while every provider was at its Reserve does not keep it.
   store.resolveIncidents({ _tag: 'Service' }, now().toISOString(), 'agent_capacity')
+  // Explicit Repository policy now permits personal-account Issue work.
+  store.resolveIncidents({ _tag: 'Service' }, now().toISOString(), 'issue_work_access')
   // A weekly window moves over hours, so a reading minutes old still decides
   // correctly. Refreshing on its own interval keeps a subprocess out of the
   // path of every agent turn.
@@ -291,7 +277,6 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
   options.logger.info(`Agent provider: ${profile.provider} with ${profile.roles.adversarial_review.model}.`)
   const startedAt = now().toISOString()
   store.syncRepositories(config.repositories, startedAt)
-  replaceUnavailableIssueWorkIncidents(store, config.repositories, startedAt)
   if (config.mutationsEnabled) {
     const recovered = store.recoverInterruptedAgentTasks(startedAt)
     if (recovered > 0)

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { contextBudgetExhaustedReason } from '../src/failure.ts'
-import { replaceServiceIncidents, replaceUnavailableIssueWorkIncidents } from '../src/service.ts'
+import { replaceServiceIncidents } from '../src/service.ts'
 import { openJournalStore } from '../src/store.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
@@ -10,27 +10,6 @@ function createStore() {
 }
 
 describe('incident log', () => {
-  it('shows when Issue work needs a GitHub App installation', () => {
-    const store = createStore()
-    const repository = repositoryMapping({ authentication: 'user' })
-    store.syncRepositories([repository], '2026-08-18T00:00:00.000Z')
-
-    replaceUnavailableIssueWorkIncidents(store, [repository], '2026-08-18T00:01:00.000Z')
-
-    expect(store.listIncidents()).toMatchObject([{
-      scope: { _tag: 'Service' },
-      kind: 'policy',
-      severity: 'error',
-      operation: 'issue_work_access',
-      message: 'harlan-zw/example: Issue work needs the GitHub App. Install the App for this repository, then restart the service.',
-      recovery: { _tag: 'ActionRequired' },
-    }])
-
-    replaceUnavailableIssueWorkIncidents(store, [{ ...repository, authentication: 'app' }], '2026-08-18T00:02:00.000Z')
-
-    expect(store.listIncidents()).toEqual([])
-  })
-
   it('clears a worktree sweep incident after the next clean sweep', () => {
     const store = createStore()
 

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -62,8 +62,8 @@ describe('issue work worker', () => {
     expect(committed).toBe(false)
   })
 
-  it('resumes triage, implements the issue, and prepares repository metadata', async () => {
-    const repository = repositoryMapping({ ownership: 'maintained', conflictResolution: false })
+  it('resumes triage through personal authentication and prepares repository metadata', async () => {
+    const repository = repositoryMapping({ authentication: 'user', ownership: 'maintained', conflictResolution: false })
     const issue = issueItem()
     const capture: ProviderCapture = { requests: [] }
     const worker = createIssueWorkWorker({

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1278,7 +1278,7 @@ describe('journal store', () => {
     )
   })
 
-  it('does not plan issue work through Harlan user authentication', () => {
+  it('plans explicitly enabled Issue work through personal authentication', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping({
       github: 'nuxt/scripts',
@@ -1293,7 +1293,9 @@ describe('journal store', () => {
       subject: issueItem({ repository: 'nuxt/scripts' }),
     })
 
-    expect(store.claimNextIssueTriageTask('issue-worker', '2026-08-13T01:01:00.000Z', 600_000)).toBeNull()
+    expect(store.claimNextIssueTriageTask('issue-worker', '2026-08-13T01:01:00.000Z', 600_000)).toEqual(
+      expect.objectContaining({ kind: 'issue_triage', issueNumber: 12 }),
+    )
   })
 
   it.each(['READY_TO_SPEC', 'NEEDS_INFO', 'WAIT_TO_IMPLEMENT'] as const)('does not queue issue work for the %s route', (route) => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`issue_work: true` did nothing for maintained repositories without the GitHub App. The scheduler now uses Harlan's authenticated GitHub account when the Repository mapping enables Issue work.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).