### PR TITLE
feat(github-agent): add durable safe restarts

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -124,15 +124,19 @@ Dismiss an Item to stop every planner for it. A Dismissal is durable and belongs
 
 Treat the SQLite journal as service-owned state. Do not edit it manually.
 
-Before restarting, pause new agent work through the authenticated controller API. Keep polling active. Let active agents and controller writes finish. Restart only when `/api/state` reports `agentControl.safeToRestart: true`. Pause persists across restart, so resume explicitly afterward.
+Restart through a durable Restart request. The service stops new Task claims, lets active Agents and controller writes finish, then exits. Systemd starts the next process. The new process completes the request after its health listener starts. The requesting client may disconnect after the API accepts the request. Never use Pause to coordinate a restart.
 
 ```bash
 agent_config=/absolute/path/to/harlan-github-agent.yml
 agent_password=$(< "$(dirname "$agent_config")/dashboard-password")
-curl --fail --silent --user "agent:$agent_password" --header 'Origin: https://harlan-github-agent.localhost' --request POST https://harlan-github-agent.localhost/api/agents/pause
-curl --fail --silent --user "agent:$agent_password" https://harlan-github-agent.localhost/api/state | jq '.agentControl'
-systemctl --user restart harlan-github-agent
-curl --fail --silent --user "agent:$agent_password" --header 'Origin: https://harlan-github-agent.localhost' --request POST https://harlan-github-agent.localhost/api/agents/resume
+curl --fail --silent --user "agent:$agent_password" \
+  --header 'Origin: https://harlan-github-agent.localhost' \
+  --header 'Content-Type: application/json' \
+  --request POST \
+  --data '{"source":"helper"}' \
+  https://harlan-github-agent.localhost/api/service/restart
+curl --fail --silent --user "agent:$agent_password" \
+  https://harlan-github-agent.localhost/api/state | jq '.restartRequest'
 ```
 
 `conflict_resolution: true` permits a repository to queue conflict work. `mutations_enabled: true` lets the controller run and publish it.

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -28,6 +28,7 @@ did not cover it.
 | Queue | derived dashboard state | Controller | Orders active Tasks and actionable Items | queue |
 | Stats | derived from Journal records | Dashboard | N completed records per date range | Stats |
 | Pause | `agent_control` | Controller | Stops new agent Tasks from starting | Pause |
+| Restart request | `restart_requests` | Controller | N per service, one active | Restart after current work |
 | Selection mode | `agent_control.selection_mode` | Controller | One per service | Selection mode |
 | Dismissal | `item_dismissals` | Controller | One per Item | Dismiss |
 | Eject | dashboard and System pane action | Controller | Transfers one active agent session to Harlan's terminal | Eject |
@@ -263,6 +264,18 @@ Use Stats for the page and route. Do not use analytics, insights, value score, o
 A durable service control that stops new agent Tasks from starting. Active agents and controller Publications finish.
 
 Use `Pause` in controls and procedures. Never use drain or maintenance mode for this control.
+
+### Restart request
+
+One durable request to finish active work, restart the service, and verify the new process.
+
+The service owns an accepted Restart request. It survives the requesting client and a process exit.
+
+A Restart request stops new agent Tasks from starting. Active agents and controller Publications finish.
+
+Pause remains unchanged. A service that was Paused stays Paused after the restart.
+
+Use Restart request for the record and `Restart after current work` for the control. Do not use restart queue or drain mode.
 
 ### Selection mode
 
@@ -550,6 +563,7 @@ Evidence that a skill, policy, or workflow should change.
 | reasoning variant, thinking level, effort level | Reasoning effort | Codex's own name for the setting |
 | PR Owner, PR ownership, deployment ownership | Take Ownership | One workflow |
 | risk level, skip review, review waiver, review exemption | Auto merge | Auto merge never affects whether review runs |
+| restart queue, drain mode | Restart request | Queue and Pause already name different service concepts |
 | journal, lease, fence, mutation, publication, revision, snapshot, item, agent role | rewrite the sentence | Internal machinery, never user-visible |
 
 ## Open questions

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -114,8 +114,8 @@ A provider that publishes no limit always passes. When no provider may spend, th
 
 Use the Agent provider control in the header to switch the Agent provider, model, or reasoning effort. A switch starts the next agent turn. An agent already running keeps the model it started with. Switching the provider returns the model and the reasoning effort to that provider's defaults.
 
-Select `Pause` before restarting the service. Poll `/api/state` until `agentControl.safeToRestart` is `true`.
-Pause persists across restarts. Select `Resume` after the service returns.
+Select `Restart after current work` to restart the service. The Restart request stops new Task claims and lets active Agents finish.
+The service owns the request after acceptance. Manual Pause stays unchanged.
 
 Read one pull request's local review history from:
 

--- a/packages/harlan-github-agent/bin/harlan-github-agent-indicator
+++ b/packages/harlan-github-agent/bin/harlan-github-agent-indicator
@@ -77,6 +77,21 @@ def request_agent_control(action):
         return json.load(response)
 
 
+def request_service_restart():
+    request = urllib.request.Request(
+        f'{DASHBOARD_URL}api/service/restart',
+        data=b'{"source":"tray"}',
+        method='POST',
+        headers={
+            'Authorization': dashboard_authorization(),
+            'Content-Type': 'application/json',
+            'Origin': DASHBOARD_ORIGIN,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=3) as response:
+        return json.load(response)
+
+
 def request_agent_select(selection):
     request = urllib.request.Request(
         f'{DASHBOARD_URL}api/agents/select',
@@ -552,6 +567,10 @@ def indicator_summary(dashboard, agents, error):
     attention = dashboard_attention(dashboard)
     if attention['_tag'] == 'ActionRequired':
         return ('🔴', 'Harlan GitHub Agent · Action required')
+    restart = dashboard.get('restartRequest')
+    if restart is not None and restart.get('_tag') in ('Requested', 'Restarting'):
+        status = 'Restarting' if restart.get('_tag') == 'Restarting' else 'Restart requested'
+        return ('🟡', f'{status} · {queue_label}')
     if dashboard.get('agentControl', {}).get('_tag') == 'Paused':
         parts = ['Agents paused']
         if agents:
@@ -582,6 +601,10 @@ def harlan_github_agent_status_label(dashboard, agents, error):
     agent_control = dashboard.get('agentControl', {'_tag': 'Running'})
     if attention['_tag'] == 'ActionRequired':
         return f'🔴 Action required · {queue_label}'
+    restart = dashboard.get('restartRequest')
+    if restart is not None and restart.get('_tag') in ('Requested', 'Restarting'):
+        status = 'Restarting' if restart.get('_tag') == 'Restarting' else 'Restart requested'
+        return f'🟡 {status} · {queue_label}'
     if agent_control.get('_tag') == 'Paused':
         finishing = counted(len(agents), 'agent finishing', 'agents finishing')
         return f'🟡 Paused · {finishing} · {queue_label}'
@@ -630,7 +653,7 @@ def incident_url(incident):
     return None if repository is None else f'https://github.com/{repository}'
 
 
-def build_menu(indicator, sources, action_error, refresh, set_agent_control, eject_agent, select_agent):
+def build_menu(indicator, sources, action_error, refresh, set_agent_control, eject_agent, select_agent, restart_service=None):
     menu = Gtk.Menu()
     dashboard_source = sources['harlanGithubAgent']
     dashboard = source_dashboard(sources)
@@ -710,6 +733,15 @@ def build_menu(indicator, sources, action_error, refresh, set_agent_control, eje
         control_item = menu_item(control_label)
         control_item.connect('activate', lambda *_args: set_agent_control(action))
         menu.append(control_item)
+        restart = dashboard.get('restartRequest')
+        restart_active = restart is not None and restart.get('_tag') in ('Requested', 'Restarting')
+        restart_item = menu_item(
+            '↻ Restart requested' if restart_active else '↻ Restart after current work',
+            enabled=not restart_active and restart_service is not None,
+        )
+        if restart_service is not None:
+            restart_item.connect('activate', lambda *_args: restart_service())
+        menu.append(restart_item)
 
     menu.append(separator())
     refresh_item = menu_item('Refresh')
@@ -750,7 +782,7 @@ def main():
         indicator.set_label(label, '🟢 99')
         indicator.set_icon_full(str(APP_ICON), 'Harlan GitHub Agent')
         indicator.set_title(title)
-        build_menu(indicator, sources, control_error, refresh, set_agent_control, eject_agent, select_agent)
+        build_menu(indicator, sources, control_error, refresh, set_agent_control, eject_agent, select_agent, restart_service)
         if pending_action['value'] is not None:
             refresh()
         return False
@@ -765,6 +797,8 @@ def main():
                     request_agent_control(action['action'])
                 elif action['_tag'] == 'AgentSelect':
                     request_agent_select(action['selection'])
+                elif action['_tag'] == 'ServiceRestart':
+                    request_service_restart()
                 else:
                     open_ejected_session(request_agent_eject(action['taskId']))
             except Exception as caught:
@@ -803,7 +837,14 @@ def main():
         }
         return refresh()
 
-    build_menu(indicator, loading_system_sources(), None, refresh, set_agent_control, eject_agent, select_agent)
+    def restart_service():
+        pending_action['value'] = {
+            '_tag': 'ServiceRestart',
+            'label': 'Restart request',
+        }
+        return refresh()
+
+    build_menu(indicator, loading_system_sources(), None, refresh, set_agent_control, eject_agent, select_agent, restart_service)
     refresh()
     GLib.timeout_add_seconds(5, refresh)
     Gtk.main()

--- a/packages/harlan-github-agent/dashboard/app/composables/useDashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/composables/useDashboard.ts
@@ -26,6 +26,7 @@ function emptySnapshot(): DashboardSnapshot {
     status: 'starting',
     mutationsEnabled: false,
     agentControl: { _tag: 'Running' },
+    restartRequest: null,
     selectionMode: 'auto',
     openPullRequests: 0,
     maxOpenPullRequests: 8,
@@ -170,6 +171,9 @@ function createDashboard() {
 
   const setSelectionMode = (mode: SelectionMode): Promise<void> =>
     control(() => $fetch('/api/agents/selection-mode', { method: 'POST', body: { mode } }))
+
+  const requestRestart = (): Promise<void> =>
+    control(() => $fetch('/api/service/restart', { method: 'POST', body: { source: 'dashboard' } }))
 
   /** A switch starts the next agent turn. Work already running keeps its model. */
   const switchAgent = (selection: AgentSelection): Promise<void> =>
@@ -456,6 +460,7 @@ function createDashboard() {
     loadState,
     start,
     setAgentControl,
+    requestRestart,
     setSelectionMode,
     switchAgent,
     setRepositoryPaused,

--- a/packages/harlan-github-agent/dashboard/app/layouts/default.vue
+++ b/packages/harlan-github-agent/dashboard/app/layouts/default.vue
@@ -22,6 +22,7 @@ const {
   loadState,
   start,
   setAgentControl,
+  requestRestart,
   setSelectionMode,
   switchAgent,
 } = useDashboard()
@@ -53,6 +54,19 @@ const agentControlLabel = computed(() => {
   if (snapshot.value.agentControl._tag === 'Running')
     return undefined
   return snapshot.value.agentControl.safeToRestart ? 'paused, safe to restart' : 'paused, finishing active work'
+})
+
+const restartActive = computed(() => snapshot.value.restartRequest?._tag === 'Requested'
+  || snapshot.value.restartRequest?._tag === 'Restarting')
+
+const restartLabel = computed(() => {
+  if (snapshot.value.restartRequest?._tag === 'Requested')
+    return 'restart requested, finishing active work'
+  if (snapshot.value.restartRequest?._tag === 'Restarting')
+    return 'restarting'
+  if (snapshot.value.restartRequest?._tag === 'ActionRequired')
+    return 'restart: Action required'
+  return undefined
 })
 
 const selectionModeHint = computed(() => snapshot.value.selectionMode === 'auto'
@@ -311,6 +325,19 @@ useHead({
             {{ snapshot.agentControl._tag === 'Running' ? 'Pause' : 'Resume' }}
           </UButton>
           <UButton
+            v-if="snapshot.mutationsEnabled"
+            icon="i-lucide-refresh-cw"
+            color="neutral"
+            variant="ghost"
+            :loading="controlPending || snapshot.restartRequest?._tag === 'Restarting'"
+            :disabled="controlPending || restartActive"
+            :aria-label="restartActive ? 'Restart requested' : 'Restart after current work'"
+            title="Finish active work, restart the service, then continue queued Tasks."
+            @click="requestRestart"
+          >
+            <span class="hidden xl:inline">{{ restartActive ? 'Restart requested' : 'Restart after current work' }}</span>
+          </UButton>
+          <UButton
             v-if="notificationsSupported"
             :icon="notificationsOn ? 'i-lucide-bell' : 'i-lucide-bell-off'"
             color="neutral"
@@ -348,6 +375,10 @@ useHead({
         <template v-if="agentControlLabel">
           <span aria-hidden="true" class="text-dimmed">·</span>
           <span :class="statusClass('warning')">{{ agentControlLabel }}</span>
+        </template>
+        <template v-if="restartLabel">
+          <span aria-hidden="true" class="text-dimmed">·</span>
+          <span :class="statusClass(snapshot.restartRequest?._tag === 'ActionRequired' ? 'error' : 'warning')">{{ restartLabel }}</span>
         </template>
         <template v-if="snapshot.selectionMode === 'auto' && snapshot.openPullRequests >= snapshot.maxOpenPullRequests">
           <span aria-hidden="true" class="text-dimmed">·</span>

--- a/packages/harlan-github-agent/dashboard/app/pages/index.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/index.vue
@@ -155,6 +155,8 @@ const nothingQueuedReason = computed(() => {
     return undefined
   if (queueContext.value.agentStart._tag === 'Paused')
     return { text: 'Agents are paused, so nothing will start.', resume: true }
+  if (queueContext.value.agentStart._tag === 'RestartRequested')
+    return { text: 'A Restart request is finishing active work.', resume: false }
   if (queueContext.value.agentStart._tag === 'WritesDisabled')
     return { text: 'GitHub writes are off, so no agent will start.', resume: false }
   if (queueContext.value.agentStart._tag === 'ReserveReached')

--- a/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
@@ -329,6 +329,8 @@ export function queueStateLabel(entry: QueueEntry, context: QueueContext): strin
         return 'Queued'
       if (context.agentStart._tag === 'Paused')
         return 'Agents paused'
+      if (context.agentStart._tag === 'RestartRequested')
+        return 'Restart requested'
       if (context.agentStart._tag === 'ReserveReached')
         return 'Reserve reached'
       return context.agentStart._tag === 'CapacityUnavailable' ? 'Agent provider unavailable' : 'Agents disabled'
@@ -361,6 +363,8 @@ export function queueDetail(entry: QueueEntry, context: QueueContext): string {
         return `${workLabel(entry.state.work)} will start when an agent is free.`
       if (context.agentStart._tag === 'Paused')
         return 'Pause is on. Select Resume to start this Task.'
+      if (context.agentStart._tag === 'RestartRequested')
+        return 'The Restart request will finish current work before this Task starts.'
       if (context.agentStart._tag === 'ReserveReached')
         return 'Every automatic Agent provider reached its Reserve. Work starts after a limit resets.'
       if (context.agentStart._tag === 'CapacityUnavailable')

--- a/packages/harlan-github-agent/src/app.ts
+++ b/packages/harlan-github-agent/src/app.ts
@@ -9,13 +9,13 @@ import { readFile } from 'node:fs/promises'
 import { dirname, extname, join, relative } from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
-import { createError, createEventStream, H3 } from 'h3'
+import { createError, createEventStream, H3, setResponseStatus } from 'h3'
 import { parseAgentFeedback } from './agent-feedback.ts'
 import { parseAgentSelection } from './agent-profile.ts'
 import { parseStatsRange } from './stats.ts'
 
 export interface AgentAppOptions {
-  store: Pick<JournalStore, 'approveIssueWork' | 'approvePullRequest' | 'cancelTask' | 'getDashboardSnapshot' | 'getStats' | 'listReviewRuns' | 'pauseAgents' | 'recordAgentFeedback' | 'requestReviewRerun' | 'resumeAgents' | 'selectAgent' | 'setRepositoryPaused' | 'setSelectionMode' | 'dismissItem' | 'restoreItem' | 'setRepositoryWritesEnabled'>
+  store: Pick<JournalStore, 'approveIssueWork' | 'approvePullRequest' | 'cancelTask' | 'getDashboardSnapshot' | 'getStats' | 'listReviewRuns' | 'pauseAgents' | 'recordAgentFeedback' | 'requestRestart' | 'requestReviewRerun' | 'resumeAgents' | 'selectAgent' | 'setRepositoryPaused' | 'setSelectionMode' | 'dismissItem' | 'restoreItem' | 'setRepositoryWritesEnabled'>
   settleTask?: (taskId: string) => Promise<boolean>
   ejectSettlementTimeoutMilliseconds?: number
   allowedOrigin: string
@@ -331,6 +331,22 @@ export function createAgentApp(options: AgentAppOptions): H3 {
   app.post('/api/agents/pause', () => options.store.pauseAgents(options.now().toISOString()))
 
   app.post('/api/agents/resume', () => options.store.resumeAgents(options.now().toISOString()))
+
+  app.post('/api/service/restart', async (event) => {
+    const body = await event.req.json().catch(() => {
+      // Parsing below reports malformed JSON as a bad request.
+      return undefined
+    }) as { source?: unknown } | undefined
+    if (body?.source !== 'dashboard' && body?.source !== 'tray' && body?.source !== 'helper')
+      throw createError({ status: 400, statusText: 'Bad Request', message: 'Restart source must be dashboard, tray, or helper.' })
+    const request = options.store.requestRestart({
+      id: randomUUID(),
+      source: body.source,
+      at: options.now().toISOString(),
+    })
+    setResponseStatus(event, 202)
+    return request
+  })
 
   app.post('/api/agents/selection-mode', async (event) => {
     const body = await event.req.json().catch(() => {

--- a/packages/harlan-github-agent/src/capacity.ts
+++ b/packages/harlan-github-agent/src/capacity.ts
@@ -1,5 +1,6 @@
 import type { AgentProviderName } from './agent-provider.ts'
-import type { AgentControl, AgentSelection, AgentStartState, ProviderCapacity, ProviderCapacityStatus } from './types.ts'
+import type { AgentControl, AgentSelection, AgentStartState, ProviderCapacity, ProviderCapacityStatus, RestartRequest } from './types.ts'
+import { restartAllowsTaskClaims } from './restart-request.ts'
 
 /** Whether unattended work may spend this provider's limit right now. */
 export function hasSpendableCapacity(capacity: ProviderCapacity, reservePercent: number): boolean {
@@ -25,6 +26,7 @@ export function chooseAgentProvider(input: {
 export function resolveAgentStartState(input: {
   mutationsEnabled: boolean
   agentControl: AgentControl
+  restartRequest: RestartRequest | null
   agentSelection: AgentSelection
   providerCapacities: readonly ProviderCapacityStatus[]
 }): AgentStartState {
@@ -32,6 +34,8 @@ export function resolveAgentStartState(input: {
     return { _tag: 'WritesDisabled' }
   if (input.agentControl._tag === 'Paused')
     return { _tag: 'Paused' }
+  if (!restartAllowsTaskClaims(input.restartRequest))
+    return { _tag: 'RestartRequested' }
   if (input.agentSelection._tag !== 'Automatic')
     return { _tag: 'Available' }
 

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -183,7 +183,7 @@ const command = defineCommand({
     consola.success(`Dashboard: ${validated.value.server.allowedOrigin}`)
     if (webhook._tag === 'Enabled')
       consola.success(`Webhooks: http://${webhook.host}:${webhook.port}/webhook`)
-    await waitForShutdown()
+    await Promise.race([waitForShutdown(), service.waitForRestart()])
     const stopped = await stopWithin(service.stop, 10_000)
     if (!stopped) {
       consola.warn('An agent ignored shutdown for 10 seconds. The next start will recover its task.')

--- a/packages/harlan-github-agent/src/restart-request.ts
+++ b/packages/harlan-github-agent/src/restart-request.ts
@@ -1,0 +1,73 @@
+import type { JournalStore } from './store.ts'
+import type { RestartRequest } from './types.ts'
+
+const DEFAULT_INTERVAL_MILLISECONDS = 2_000
+const DEFAULT_MAXIMUM_WAIT_MILLISECONDS = 50 * 60_000
+
+type RestartStore = Pick<JournalStore, 'beginRestart' | 'getRestartRequest' | 'isSafeToRestart' | 'requireRestartAction'>
+
+export interface RestartController {
+  start: () => void
+  stop: () => void
+  waitForRestart: () => Promise<void>
+}
+
+export function restartAllowsTaskClaims(request: RestartRequest | null): boolean {
+  return request?._tag !== 'Requested' && request?._tag !== 'Restarting'
+}
+
+export function createRestartController(options: {
+  store: RestartStore
+  processId: string
+  now: () => Date
+  onActionRequired: (reason: string) => void
+  intervalMilliseconds?: number
+  maximumWaitMilliseconds?: number
+}): RestartController {
+  const intervalMilliseconds = options.intervalMilliseconds ?? DEFAULT_INTERVAL_MILLISECONDS
+  const maximumWaitMilliseconds = options.maximumWaitMilliseconds ?? DEFAULT_MAXIMUM_WAIT_MILLISECONDS
+  let interval: ReturnType<typeof setInterval> | undefined
+  let resolveRestart: (() => void) | undefined
+  const restart = new Promise<void>((resolve) => {
+    resolveRestart = resolve
+  })
+
+  const check = (): void => {
+    const request = options.store.getRestartRequest()
+    if (request?._tag !== 'Requested')
+      return
+
+    const at = options.now().toISOString()
+    if (Date.parse(at) - Date.parse(request.requestedAt) >= maximumWaitMilliseconds) {
+      const minutes = Math.round(maximumWaitMilliseconds / 60_000)
+      const reason = `Active work did not finish within ${minutes} minutes.`
+      const required = options.store.requireRestartAction({ id: request.id, at, reason })
+      if (required !== null)
+        options.onActionRequired(reason)
+      return
+    }
+
+    if (!options.store.isSafeToRestart())
+      return
+    const restarting = options.store.beginRestart({ id: request.id, processId: options.processId, at })
+    if (restarting?._tag === 'Restarting')
+      resolveRestart?.()
+  }
+
+  return {
+    start: () => {
+      if (interval !== undefined)
+        return
+      check()
+      interval = setInterval(check, intervalMilliseconds)
+      interval.unref()
+    },
+    stop: () => {
+      if (interval === undefined)
+        return
+      clearInterval(interval)
+      interval = undefined
+    },
+    waitForRestart: () => restart,
+  }
+}

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -44,6 +44,7 @@ import { createPullRequestTriageAgent } from './pull-request-triage.ts'
 import { publishQueuePositions } from './queue-position-sweep.ts'
 import { reconcileAllRepositories } from './reconcile.ts'
 import { buildRepositoryMappings, discoverGitHubAppRepositories, discoverLocalCheckouts, discoverUserRepositories, installedWithoutCheckout } from './repository-discovery.ts'
+import { createRestartController, restartAllowsTaskClaims } from './restart-request.ts'
 import { err, ok } from './result.ts'
 import { AGENT_ACTOR_LOGIN } from './review-comment.ts'
 import { createReviewFixWorker } from './review-fix-worker.ts'
@@ -65,6 +66,7 @@ import { agentWorktreeLeaseKey, createAgentWorkspaceManager, createBaselineRepai
 export interface RunningAgentService {
   server: Server
   stop: () => Promise<void>
+  waitForRestart: () => Promise<void>
 }
 
 export interface StartAgentServiceOptions {
@@ -245,6 +247,25 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
 
   const configuredProfile = agentProfile(config.agent.provider)
   const store = openJournalStore(config.storage.path, config.mutationsEnabled, configuredProfile, config.maxOpenPullRequests)
+  const processId = randomUUID()
+  const restartController = createRestartController({
+    store,
+    processId,
+    now,
+    onActionRequired: (reason) => {
+      const at = now().toISOString()
+      const failure = classifyFailure({ message: reason })
+      store.recordIncident({
+        scope: { _tag: 'Service' },
+        kind: failure.kind,
+        severity: 'warning',
+        operation: 'restart',
+        message: reason,
+        recovery: { _tag: 'ActionRequired' },
+        at,
+      })
+    },
+  })
   // Capacity is normal System state now. Clear the legacy Incident once, so a
   // service upgraded while every provider was at its Reserve does not keep it.
   store.resolveIncidents({ _tag: 'Service' }, now().toISOString(), 'agent_capacity')
@@ -368,6 +389,8 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
      */
     const canClaim = (): boolean => {
       if (store.getAgentControl()._tag !== 'Running')
+        return false
+      if (!restartAllowsTaskClaims(store.getRestartRequest()))
         return false
       const selection = store.getAgentSelection()
       if (selection._tag !== 'Automatic')
@@ -973,6 +996,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       listReviewRuns: store.listReviewRuns,
       pauseAgents: store.pauseAgents,
       recordAgentFeedback: store.recordAgentFeedback,
+      requestRestart: store.requestRestart,
       requestReviewRerun: store.requestReviewRerun,
       resumeAgents: store.resumeAgents,
       selectAgent: store.selectAgent,
@@ -996,6 +1020,12 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     store.close()
     throw error
   })
+  const completedRestart = store.completeRestart(now().toISOString())
+  if (completedRestart?._tag === 'Completed') {
+    store.resolveIncidents({ _tag: 'Service' }, completedRestart.completedAt, 'restart')
+    options.logger.info(`Completed Restart request ${completedRestart.id}.`)
+  }
+  restartController.start()
   capacity.start()
   // A delivery says "read GitHub again", never what changed. Reconciliation
   // stays the only writer, so a missed, duplicated, or forged delivery can at
@@ -1069,7 +1099,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
 
   return {
     server,
+    waitForRestart: restartController.waitForRestart,
     stop: async () => {
+      restartController.stop()
       await Promise.all([
         capacity.stop(),
         reconcileHint.stop(),

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -59,6 +59,8 @@ import type {
   RecordReviewRunResult,
   RepositoryMapping,
   RepositoryStatus,
+  RestartRequest,
+  RestartRequestSource,
   ReviewFinding,
   ReviewFixQueueResult,
   ReviewFixTask,
@@ -120,6 +122,17 @@ interface IncidentRow {
   occurrences: number
   first_seen_at: string
   last_seen_at: string
+}
+
+interface RestartRequestRow {
+  id: string
+  source_tag: RestartRequestSource
+  state_tag: RestartRequest['_tag']
+  requested_at: string
+  restarting_at: string | null
+  completed_at: string | null
+  action_required_at: string | null
+  reason: string | null
 }
 
 function incidentScope(row: IncidentRow): IncidentScope {
@@ -770,6 +783,12 @@ export interface JournalStore {
   /** Open pull requests across enabled repositories, which is the work waiting on Harlan. */
   countOpenPullRequests: () => number
   needsAttentionTask: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string, evidence: string }) => boolean
+  requestRestart: (input: { id: string, source: RestartRequestSource, at: string }) => RestartRequest
+  getRestartRequest: () => RestartRequest | null
+  beginRestart: (input: { id: string, processId: string, at: string }) => RestartRequest | null
+  completeRestart: (at: string) => RestartRequest | null
+  requireRestartAction: (input: { id: string, at: string, reason: string }) => RestartRequest | null
+  isSafeToRestart: () => boolean
   pauseAgents: (at: string) => StoredAgentControl
   setRepositoryPaused: (github: string, paused: boolean) => boolean
   /** True when a person has trusted the controller to write to this repository. */
@@ -4071,6 +4090,41 @@ const agentFeedbackMigration = `
   PRAGMA user_version = 46;
 `
 
+/** Stores a restart independently from manual Pause, so the service owns completion. */
+const restartRequestMigration = `
+  CREATE TABLE restart_requests (
+    id TEXT PRIMARY KEY,
+    source_tag TEXT NOT NULL CHECK (source_tag IN ('dashboard', 'tray', 'helper')),
+    state_tag TEXT NOT NULL CHECK (state_tag IN ('Requested', 'Restarting', 'Completed', 'ActionRequired')),
+    requested_at TEXT NOT NULL,
+    restarting_at TEXT,
+    completed_at TEXT,
+    action_required_at TEXT,
+    reason TEXT,
+    process_id TEXT,
+    CHECK (
+      (state_tag = 'Requested'
+        AND restarting_at IS NULL AND completed_at IS NULL
+        AND action_required_at IS NULL AND reason IS NULL AND process_id IS NULL)
+      OR (state_tag = 'Restarting'
+        AND restarting_at IS NOT NULL AND completed_at IS NULL
+        AND action_required_at IS NULL AND reason IS NULL AND process_id IS NOT NULL)
+      OR (state_tag = 'Completed'
+        AND restarting_at IS NOT NULL AND completed_at IS NOT NULL
+        AND action_required_at IS NULL AND reason IS NULL AND process_id IS NOT NULL)
+      OR (state_tag = 'ActionRequired'
+        AND restarting_at IS NULL AND completed_at IS NULL
+        AND action_required_at IS NOT NULL AND reason IS NOT NULL AND process_id IS NULL)
+    )
+  );
+
+  CREATE UNIQUE INDEX restart_requests_active
+  ON restart_requests ((1))
+  WHERE state_tag IN ('Requested', 'Restarting');
+
+  PRAGMA user_version = 47;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -4096,7 +4150,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 46)
+  if (version === 47)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -4281,6 +4335,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 45) {
     applyMigration(database, agentFeedbackMigration)
+    version = 46
+  }
+  if (version === 46) {
+    applyMigration(database, restartRequestMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -7781,6 +7839,103 @@ export function openJournalStore(
     return row.state_tag === 'Running' ? { _tag: 'Running' } : { _tag: 'Paused', pausedAt: row.updated_at }
   }
 
+  const restartRequestFromRow = (row: RestartRequestRow): RestartRequest => {
+    const base = { id: row.id, source: row.source_tag, requestedAt: row.requested_at }
+    switch (row.state_tag) {
+      case 'Requested':
+        return { _tag: 'Requested', ...base }
+      case 'Restarting':
+        if (row.restarting_at === null)
+          throw new Error('A Restarting request needs its restart time.')
+        return { _tag: 'Restarting', ...base, restartingAt: row.restarting_at }
+      case 'Completed':
+        if (row.restarting_at === null || row.completed_at === null)
+          throw new Error('A Completed Restart request needs restart and completion times.')
+        return { _tag: 'Completed', ...base, restartingAt: row.restarting_at, completedAt: row.completed_at }
+      case 'ActionRequired':
+        if (row.action_required_at === null || row.reason === null)
+          throw new Error('An Action required Restart request needs its time and reason.')
+        return { _tag: 'ActionRequired', ...base, actionRequiredAt: row.action_required_at, reason: row.reason }
+    }
+  }
+
+  const restartRequestById = (id: string): RestartRequest | null => {
+    const row = database.prepare(`
+      SELECT id, source_tag, state_tag, requested_at, restarting_at, completed_at, action_required_at, reason
+      FROM restart_requests WHERE id = ?
+    `).get(id) as RestartRequestRow | undefined
+    return row === undefined ? null : restartRequestFromRow(row)
+  }
+
+  const getRestartRequest = (): RestartRequest | null => {
+    const row = database.prepare(`
+      SELECT id, source_tag, state_tag, requested_at, restarting_at, completed_at, action_required_at, reason
+      FROM restart_requests ORDER BY rowid DESC LIMIT 1
+    `).get() as RestartRequestRow | undefined
+    return row === undefined ? null : restartRequestFromRow(row)
+  }
+
+  const activeRestartRequest = (): RestartRequest | null => {
+    const row = database.prepare(`
+      SELECT id, source_tag, state_tag, requested_at, restarting_at, completed_at, action_required_at, reason
+      FROM restart_requests WHERE state_tag IN ('Requested', 'Restarting') LIMIT 1
+    `).get() as RestartRequestRow | undefined
+    return row === undefined ? null : restartRequestFromRow(row)
+  }
+
+  const requestRestart: JournalStore['requestRestart'] = (input) => {
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      const active = activeRestartRequest()
+      if (active !== null) {
+        database.exec('COMMIT')
+        return active
+      }
+      database.prepare(`
+        INSERT INTO restart_requests (id, source_tag, state_tag, requested_at)
+        VALUES (?, ?, 'Requested', ?)
+      `).run(input.id, input.source, input.at)
+      const created = restartRequestById(input.id)
+      if (created === null)
+        throw new Error('The Restart request was not stored.')
+      database.exec('COMMIT')
+      return created
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  const beginRestart: JournalStore['beginRestart'] = (input) => {
+    const result = database.prepare(`
+      UPDATE restart_requests
+      SET state_tag = 'Restarting', restarting_at = ?, process_id = ?
+      WHERE id = ? AND state_tag = 'Requested'
+    `).run(input.at, input.processId, input.id)
+    return result.changes === 0 ? null : restartRequestById(input.id)
+  }
+
+  const completeRestart: JournalStore['completeRestart'] = (at) => {
+    const restarting = activeRestartRequest()
+    if (restarting?._tag !== 'Restarting')
+      return null
+    database.prepare(`
+      UPDATE restart_requests SET state_tag = 'Completed', completed_at = ?
+      WHERE id = ? AND state_tag = 'Restarting'
+    `).run(at, restarting.id)
+    return restartRequestById(restarting.id)
+  }
+
+  const requireRestartAction: JournalStore['requireRestartAction'] = (input) => {
+    const result = database.prepare(`
+      UPDATE restart_requests
+      SET state_tag = 'ActionRequired', action_required_at = ?, reason = ?
+      WHERE id = ? AND state_tag = 'Requested'
+    `).run(input.at, input.reason, input.id)
+    return result.changes === 0 ? null : restartRequestById(input.id)
+  }
+
   /**
    * A Dismissal is a decision about the Item, not about one head commit.
    *
@@ -7891,7 +8046,7 @@ export function openJournalStore(
     return getAgentControl()
   }
 
-  const isSafeToRestart = (): boolean => {
+  const isSafeToRestart: JournalStore['isSafeToRestart'] = () => {
     const row = database.prepare(`
       SELECT (
         EXISTS (SELECT 1 FROM tasks WHERE state_tag IN ('Running', 'Publishing'))
@@ -8185,12 +8340,14 @@ export function openJournalStore(
     const agentControl = storedAgentControl._tag === 'Running'
       ? storedAgentControl
       : { ...storedAgentControl, safeToRestart: isSafeToRestart() }
+    const restartRequest = getRestartRequest()
 
     return {
       generatedAt,
       status,
       mutationsEnabled,
       agentControl,
+      restartRequest,
       selectionMode: currentSelectionMode,
       openPullRequests: countOpenPullRequests(),
       maxOpenPullRequests,
@@ -8200,7 +8357,9 @@ export function openJournalStore(
         ? { _tag: 'WritesDisabled' }
         : agentControl._tag === 'Paused'
           ? { _tag: 'Paused' }
-          : { _tag: 'Available' },
+          : restartRequest?._tag === 'Requested' || restartRequest?._tag === 'Restarting'
+            ? { _tag: 'RestartRequested' }
+            : { _tag: 'Available' },
       agentProviderOrder: AGENT_PROVIDER_NAMES,
       agentModels: AGENT_MODELS,
       reasoningEfforts: REASONING_EFFORTS,
@@ -9661,6 +9820,12 @@ export function openJournalStore(
     listReviewRuns,
     recordAgentFeedback,
     needsAttentionTask,
+    requestRestart,
+    getRestartRequest,
+    beginRestart,
+    completeRestart,
+    requireRestartAction,
+    isSafeToRestart,
     dismissItem,
     restoreItem,
     getSelectionMode,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -1043,6 +1043,7 @@ export interface ProviderCapacityStatus {
 export type AgentStartState
   = | { _tag: 'Available' }
     | { _tag: 'Paused' }
+    | { _tag: 'RestartRequested' }
     | { _tag: 'WritesDisabled' }
     | { _tag: 'ReserveReached' }
     | { _tag: 'CapacityUnavailable' }
@@ -1167,6 +1168,7 @@ export interface DashboardSnapshot {
   status: 'starting' | 'ready' | 'degraded'
   mutationsEnabled: boolean
   agentControl: AgentControl
+  restartRequest: RestartRequest | null
   selectionMode: SelectionMode
   /** Open pull requests across every enabled repository. */
   openPullRequests: number
@@ -1203,3 +1205,17 @@ export type SelectionMode = 'auto' | 'manual'
 export type AgentControl
   = | { _tag: 'Running' }
     | { _tag: 'Paused', pausedAt: string, safeToRestart: boolean }
+
+export type RestartRequestSource = 'dashboard' | 'tray' | 'helper'
+
+interface RestartRequestBase {
+  id: string
+  source: RestartRequestSource
+  requestedAt: string
+}
+
+export type RestartRequest
+  = | RestartRequestBase & { _tag: 'Requested' }
+    | RestartRequestBase & { _tag: 'Restarting', restartingAt: string }
+    | RestartRequestBase & { _tag: 'Completed', restartingAt: string, completedAt: string }
+    | RestartRequestBase & { _tag: 'ActionRequired', actionRequiredAt: string, reason: string }

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -35,6 +35,12 @@ function statsSnapshot(range: StatsRange, generatedAt: string): StatsSnapshot {
 const agentControls = {
   getStats: (range: StatsRange, generatedAt: string) => statsSnapshot(range, generatedAt),
   pauseAgents: (at: string) => ({ _tag: 'Paused' as const, pausedAt: at }),
+  requestRestart: (input: { id: string, source: 'dashboard' | 'tray' | 'helper', at: string }) => ({
+    _tag: 'Requested' as const,
+    id: input.id,
+    source: input.source,
+    requestedAt: input.at,
+  }),
   resumeAgents: (_at: string) => ({ _tag: 'Running' as const }),
   selectAgent: (selection: AgentSelection, _at: string) => selection,
   setRepositoryPaused: (_github: string, _paused: boolean) => true,
@@ -273,6 +279,39 @@ describe('dashboard HTTP app', () => {
     expect(await paused.json()).toEqual({ _tag: 'Paused', pausedAt: now().toISOString() })
     expect(await resumed.json()).toEqual({ _tag: 'Running' })
     expect(controls).toEqual([{ _tag: 'Pause', at: now().toISOString() }, { _tag: 'Resume', at: now().toISOString() }])
+  })
+
+  it('stores a dashboard Restart request', async () => {
+    const requests: unknown[] = []
+    const app = createAgentApp({
+      allowedOrigin,
+      dashboardPassword,
+      dashboardRoot,
+      now,
+      store: {
+        ...agentControls,
+        approveIssueWork: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }),
+        approvePullRequest: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }),
+        cancelTask: () => ({ _tag: 'Rejected', reason: { _tag: 'TaskNotFound' } }),
+        getDashboardSnapshot: () => dashboardSnapshot(),
+        listReviewRuns: () => [],
+        requestRestart(input) {
+          requests.push(input)
+          return { _tag: 'Requested', id: input.id, source: input.source, requestedAt: input.at }
+        },
+        requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'ItemNotFound' } }),
+      },
+    })
+
+    const response = await app.request(`http://${allowedHost}/api/service/restart`, {
+      method: 'POST',
+      headers: { 'authorization': authorization, 'host': allowedHost, 'origin': allowedOrigin, 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'dashboard' }),
+    })
+
+    expect(response.status).toBe(202)
+    expect(await response.json()).toEqual(expect.objectContaining({ _tag: 'Requested', source: 'dashboard' }))
+    expect(requests).toEqual([expect.objectContaining({ source: 'dashboard', at: now().toISOString() })])
   })
 
   it('reports read-only health', async () => {

--- a/packages/harlan-github-agent/test/fixtures.ts
+++ b/packages/harlan-github-agent/test/fixtures.ts
@@ -79,6 +79,7 @@ export function dashboardSnapshot(overrides: Partial<DashboardSnapshot> = {}): D
     status: 'ready',
     mutationsEnabled: false,
     agentControl: { _tag: 'Running' },
+    restartRequest: null,
     selectionMode: 'auto',
     openPullRequests: 0,
     maxOpenPullRequests: 8,

--- a/packages/harlan-github-agent/test/indicator_test.py
+++ b/packages/harlan-github-agent/test/indicator_test.py
@@ -876,6 +876,41 @@ class AgentControlRequestTest(unittest.TestCase):
         self.assertEqual(request.get_header('Authorization'), 'Basic YWdlbnQ6c2VjcmV0')
         self.assertEqual(timeout, 3)
 
+    def test_sends_a_durable_tray_restart_request(self):
+        requests = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"_tag":"Requested","id":"restart-1","source":"tray","requestedAt":"2026-08-14T00:00:00.000Z"}'
+
+        def open_request(request, timeout):
+            requests.append((request, timeout))
+            return Response()
+
+        with tempfile.TemporaryDirectory() as directory:
+            password_file = Path(directory) / 'dashboard-password'
+            password_file.write_text('secret\n')
+            with patch.object(indicator, 'PASSWORD_FILE', password_file), patch.object(
+                indicator.urllib.request,
+                'urlopen',
+                side_effect=open_request,
+            ):
+                result = indicator.request_service_restart()
+
+        request, timeout = requests[0]
+        self.assertEqual(result['_tag'], 'Requested')
+        self.assertEqual(request.full_url, 'https://hogwild.tailcad325.ts.net/api/service/restart')
+        self.assertEqual(request.data, b'{"source":"tray"}')
+        self.assertEqual(request.get_header('Content-type'), 'application/json')
+        self.assertEqual(request.get_header('Origin'), 'https://hogwild.tailcad325.ts.net')
+        self.assertEqual(timeout, 3)
+
     def test_sends_authenticated_eject_request_for_the_exact_agent(self):
         requests = []
 

--- a/packages/harlan-github-agent/test/provider-capacity.test.ts
+++ b/packages/harlan-github-agent/test/provider-capacity.test.ts
@@ -136,6 +136,7 @@ describe('resolving Agent start state', () => {
   const input = {
     mutationsEnabled: true,
     agentControl: { _tag: 'Running' as const },
+    restartRequest: null,
     agentSelection: { _tag: 'Automatic' as const, order: ['codex'] as const },
   }
 

--- a/packages/harlan-github-agent/test/restart-request.test.ts
+++ b/packages/harlan-github-agent/test/restart-request.test.ts
@@ -1,0 +1,239 @@
+import type { RestartRequest } from '../src/types.ts'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveAgentStartState } from '../src/capacity.ts'
+import { createRestartController } from '../src/restart-request.ts'
+import { openJournalStore } from '../src/store.ts'
+
+const stores: Array<ReturnType<typeof openJournalStore>> = []
+const directories: string[] = []
+
+afterEach(() => {
+  vi.useRealTimers()
+  stores.splice(0).forEach(store => store.close())
+  directories.splice(0).forEach(directory => rmSync(directory, { recursive: true, force: true }))
+})
+
+function createStore() {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  return store
+}
+
+describe('restart request', () => {
+  it('stops new Task claims without changing Pause', () => {
+    const state = resolveAgentStartState({
+      mutationsEnabled: true,
+      agentControl: { _tag: 'Running' },
+      restartRequest: {
+        _tag: 'Requested',
+        id: 'restart-1',
+        source: 'dashboard',
+        requestedAt: '2026-08-29T01:00:00.000Z',
+      },
+      agentSelection: { _tag: 'FollowsConfiguration' },
+      providerCapacities: [],
+    })
+
+    expect(state).toEqual({ _tag: 'RestartRequested' })
+  })
+
+  it('keeps one active request when two clients ask', () => {
+    const store = createStore()
+
+    const first = store.requestRestart({
+      id: 'restart-1',
+      source: 'dashboard',
+      at: '2026-08-29T01:00:00.000Z',
+    })
+    const duplicate = store.requestRestart({
+      id: 'restart-2',
+      source: 'tray',
+      at: '2026-08-29T01:00:01.000Z',
+    })
+
+    expect(first).toEqual({
+      _tag: 'Requested',
+      id: 'restart-1',
+      source: 'dashboard',
+      requestedAt: '2026-08-29T01:00:00.000Z',
+    })
+    expect(duplicate).toEqual(first)
+  })
+
+  it('uses insertion order when the system clock moves backwards', () => {
+    const store = createStore()
+    store.requestRestart({
+      id: 'restart-1',
+      source: 'dashboard',
+      at: '2026-08-29T01:00:00.000Z',
+    })
+    store.beginRestart({
+      id: 'restart-1',
+      processId: 'old-process',
+      at: '2026-08-29T01:00:01.000Z',
+    })
+    store.completeRestart('2026-08-29T01:00:02.000Z')
+
+    const latest = store.requestRestart({
+      id: 'restart-2',
+      source: 'tray',
+      at: '2026-08-29T00:59:00.000Z',
+    })
+
+    expect(store.getRestartRequest()).toEqual(latest)
+  })
+
+  it('continues an accepted request after the process disappears', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'harlan-restart-request-'))
+    directories.push(directory)
+    const path = join(directory, 'state.sqlite')
+    const firstProcess = openJournalStore(path)
+    firstProcess.requestRestart({
+      id: 'restart-1',
+      source: 'helper',
+      at: '2026-08-29T01:00:00.000Z',
+    })
+    firstProcess.close()
+
+    const nextProcess = openJournalStore(path)
+    stores.push(nextProcess)
+
+    expect(nextProcess.getRestartRequest()).toEqual({
+      _tag: 'Requested',
+      id: 'restart-1',
+      source: 'helper',
+      requestedAt: '2026-08-29T01:00:00.000Z',
+    })
+  })
+
+  it('preserves manual Pause across a completed restart', () => {
+    const store = createStore()
+    store.pauseAgents('2026-08-29T01:00:00.000Z')
+    store.requestRestart({
+      id: 'restart-1',
+      source: 'helper',
+      at: '2026-08-29T01:00:01.000Z',
+    })
+
+    store.beginRestart({
+      id: 'restart-1',
+      processId: 'old-process',
+      at: '2026-08-29T01:00:02.000Z',
+    })
+    const completed = store.completeRestart('2026-08-29T01:00:03.000Z')
+
+    expect(completed).toEqual({
+      _tag: 'Completed',
+      id: 'restart-1',
+      source: 'helper',
+      requestedAt: '2026-08-29T01:00:01.000Z',
+      restartingAt: '2026-08-29T01:00:02.000Z',
+      completedAt: '2026-08-29T01:00:03.000Z',
+    })
+    expect(store.getAgentControl()).toEqual({
+      _tag: 'Paused',
+      pausedAt: '2026-08-29T01:00:00.000Z',
+    })
+  })
+
+  it('finishes active work before asking the process to stop', async () => {
+    vi.useFakeTimers()
+    let safe = false
+    let request: RestartRequest = {
+      _tag: 'Requested' as const,
+      id: 'restart-1',
+      source: 'dashboard' as const,
+      requestedAt: '2026-08-29T01:00:00.000Z',
+    }
+    const controller = createRestartController({
+      processId: 'old-process',
+      now: () => new Date('2026-08-29T01:00:10.000Z'),
+      intervalMilliseconds: 1_000,
+      maximumWaitMilliseconds: 50 * 60_000,
+      store: {
+        getRestartRequest: () => request,
+        isSafeToRestart: () => safe,
+        beginRestart(input) {
+          request = {
+            _tag: 'Restarting',
+            id: request.id,
+            source: request.source,
+            requestedAt: request.requestedAt,
+            restartingAt: input.at,
+          }
+          return request
+        },
+        requireRestartAction: () => null,
+      },
+      onActionRequired: vi.fn(),
+    })
+
+    controller.start()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(request._tag).toBe('Requested')
+
+    safe = true
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await expect(controller.waitForRestart()).resolves.toBeUndefined()
+    expect(request).toEqual({
+      _tag: 'Restarting',
+      id: 'restart-1',
+      source: 'dashboard',
+      requestedAt: '2026-08-29T01:00:00.000Z',
+      restartingAt: '2026-08-29T01:00:10.000Z',
+    })
+    controller.stop()
+  })
+
+  it('requires action instead of stopping a long-running Agent', async () => {
+    vi.useFakeTimers()
+    const actionRequired = vi.fn()
+    let request: RestartRequest = {
+      _tag: 'Requested' as const,
+      id: 'restart-1',
+      source: 'dashboard' as const,
+      requestedAt: '2026-08-29T01:00:00.000Z',
+    }
+    const controller = createRestartController({
+      processId: 'old-process',
+      now: () => new Date('2026-08-29T01:50:01.000Z'),
+      intervalMilliseconds: 1_000,
+      maximumWaitMilliseconds: 50 * 60_000,
+      store: {
+        getRestartRequest: () => request,
+        isSafeToRestart: () => false,
+        beginRestart: () => null,
+        requireRestartAction(input) {
+          request = {
+            _tag: 'ActionRequired',
+            id: request.id,
+            source: request.source,
+            requestedAt: request.requestedAt,
+            actionRequiredAt: input.at,
+            reason: input.reason,
+          }
+          return request
+        },
+      },
+      onActionRequired: actionRequired,
+    })
+
+    controller.start()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(request).toEqual({
+      _tag: 'ActionRequired',
+      id: 'restart-1',
+      source: 'dashboard',
+      requestedAt: '2026-08-29T01:00:00.000Z',
+      actionRequiredAt: '2026-08-29T01:50:01.000Z',
+      reason: 'Active work did not finish within 50 minutes.',
+    })
+    expect(actionRequired).toHaveBeenCalledWith('Active work did not finish within 50 minutes.')
+    controller.stop()
+  })
+})

--- a/packages/harlan-github-agent/test/selection-mode.test.ts
+++ b/packages/harlan-github-agent/test/selection-mode.test.ts
@@ -203,6 +203,7 @@ describe('selection mode route', () => {
         listReviewRuns: () => [],
         pauseAgents: (at: string) => ({ _tag: 'Paused' as const, pausedAt: at }),
         recordAgentFeedback: () => ({ _tag: 'Rejected', reason: { _tag: 'ReviewRunNotFound' } }),
+        requestRestart: input => ({ _tag: 'Requested', id: input.id, source: input.source, requestedAt: input.at }),
         requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'ItemNotFound' } }),
         resumeAgents: () => ({ _tag: 'Running' as const }),
         selectAgent: selection => selection,

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 
 /** Rewinds past the Routine tables, which every version below 38 predates. */
 function dropRoutines(database: DatabaseSync): void {
+  database.exec('DROP TABLE IF EXISTS restart_requests')
   database.exec('DROP TABLE IF EXISTS agent_feedback')
   database.exec('DROP TABLE IF EXISTS routine_report_commands')
   database.exec('DROP TABLE IF EXISTS candidate_issue_commands')
@@ -371,7 +372,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(46)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(47)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/scripts/hogwild-service.sh
+++ b/scripts/hogwild-service.sh
@@ -8,8 +8,8 @@ HOGWILD_ORIGIN="${HARLAN_GITHUB_AGENT_HOGWILD_ORIGIN:-https://hogwild.tailcad325
 REMOTE_HOME="${HARLAN_GITHUB_AGENT_HOGWILD_HOME:-/home/harlan}"
 CONTEXT_FILE="${HARLAN_GITHUB_AGENT_CONTEXT_FILE:-$HOME/.codex/AGENTS.md}"
 PASSWORD_FILE="${HARLAN_GITHUB_AGENT_PASSWORD_FILE:-$HOME/.config/harlan-github-agent/dashboard-password}"
-readonly DRAIN_POLL_SECONDS=2
-readonly MAXIMUM_DRAIN_SECONDS=$((50 * 60))
+readonly RESTART_POLL_SECONDS=2
+readonly MAXIMUM_RESTART_SECONDS=$((55 * 60))
 REMOTE_CHECKOUT="$REMOTE_HOME/.local/share/harlan-github-agent/service"
 REMOTE_CONTEXT="$REMOTE_HOME/.codex/AGENTS.md"
 REMOTE_CONTEXT_NEXT="$REMOTE_CONTEXT.next"
@@ -17,8 +17,6 @@ SERVICE_OVERRIDE_FILE="$SCRIPT_DIR/hogwild-service.conf"
 REMOTE_OVERRIDE_DIR="$REMOTE_HOME/.config/systemd/user/harlan-github-agent.service.d"
 REMOTE_OVERRIDE="$REMOTE_OVERRIDE_DIR/hogwild.conf"
 REMOTE_OVERRIDE_NEXT="$REMOTE_OVERRIDE.next"
-
-resume_required=false
 
 require_inputs() {
   if [[ ! "$HOGWILD_HOST" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
@@ -50,47 +48,138 @@ controller_request() {
     "$@"
 }
 
-prepare_restart() {
-  local control
-  control=$(controller_request "$HOGWILD_ORIGIN/api/state" | jq --raw-output '.agentControl._tag')
-  case "$control" in
+request_restart() {
+  controller_request \
+    --header 'Content-Type: application/json' \
+    --request POST \
+    --data '{"source":"helper"}' \
+    "$HOGWILD_ORIGIN/api/service/restart" \
+    | jq --exit-status --raw-output '.id'
+}
+
+controller_supports_restart() {
+  local state
+  if ! state=$(controller_request "$HOGWILD_ORIGIN/api/state"); then
+    echo "Hogwild did not answer while checking Restart request support." >&2
+    return 1
+  fi
+  if jq --exit-status 'has("restartRequest")' <<< "$state" >/dev/null; then
+    return 0
+  fi
+  return 2
+}
+
+wait_for_restart() {
+  local restart_id=$1
+  local attempt state tag reason
+  for attempt in $(seq 1 $((MAXIMUM_RESTART_SECONDS / RESTART_POLL_SECONDS))); do
+    state=$(controller_request "$HOGWILD_ORIGIN/api/state" 2>/dev/null || true)
+    if [ -z "$state" ]; then
+      sleep "$RESTART_POLL_SECONDS"
+      continue
+    fi
+    tag=$(jq --exit-status --raw-output --arg id "$restart_id" \
+      'if .restartRequest.id == $id then .restartRequest._tag else "Unknown" end' <<< "$state")
+    case "$tag" in
+      Completed) return ;;
+      Requested|Restarting) ;;
+      ActionRequired)
+        reason=$(jq --raw-output '.restartRequest.reason' <<< "$state")
+        echo "Hogwild requires action before restart: $reason" >&2
+        exit 1
+        ;;
+      *)
+        echo "Hogwild lost Restart request $restart_id." >&2
+        exit 1
+        ;;
+    esac
+    sleep "$RESTART_POLL_SECONDS"
+  done
+  echo "Hogwild did not complete Restart request $restart_id." >&2
+  exit 1
+}
+
+restore_legacy_agent_control() {
+  local resume_required=$1
+  if [ "$resume_required" != true ]; then
+    return
+  fi
+  if ! controller_request --request POST "$HOGWILD_ORIGIN/api/agents/resume" >/dev/null; then
+    echo "Hogwild restarted, but could not restore Running Agent control." >&2
+    return 1
+  fi
+}
+
+# The deployed service before schema 47 has no Restart request endpoint.
+# Drain it once, preserve manual Pause, then let the new service own restarts.
+legacy_safe_restart() {
+  local state tag safe attempt
+  local resume_required=false
+  if ! state=$(controller_request "$HOGWILD_ORIGIN/api/state"); then
+    echo "Hogwild did not answer before its compatibility restart." >&2
+    return 1
+  fi
+  if ! tag=$(jq --exit-status --raw-output '.agentControl._tag' <<< "$state"); then
+    echo "Hogwild returned invalid Agent control state." >&2
+    return 1
+  fi
+  case "$tag" in
     Running)
-      controller_request --request POST "$HOGWILD_ORIGIN/api/agents/pause" >/dev/null
+      if ! controller_request --request POST "$HOGWILD_ORIGIN/api/agents/pause" >/dev/null; then
+        echo "Hogwild could not stop new Agent claims." >&2
+        return 1
+      fi
       resume_required=true
       ;;
     Paused) ;;
     *)
-      echo "Hogwild returned an unknown Agent control: $control" >&2
-      exit 1
+      echo "Hogwild returned unknown Agent control state: $tag" >&2
+      return 1
       ;;
   esac
-  # Agent leases last up to 45 minutes. Keep five minutes for publication.
-  local attempt
-  for attempt in $(seq 1 $((MAXIMUM_DRAIN_SECONDS / DRAIN_POLL_SECONDS))); do
-    if controller_request "$HOGWILD_ORIGIN/api/state" | jq --exit-status '.agentControl.safeToRestart == true' >/dev/null; then
+
+  for attempt in $(seq 1 $((MAXIMUM_RESTART_SECONDS / RESTART_POLL_SECONDS))); do
+    if ! state=$(controller_request "$HOGWILD_ORIGIN/api/state"); then
+      restore_legacy_agent_control "$resume_required" || true
+      echo "Hogwild stopped answering before its compatibility restart." >&2
+      return 1
+    fi
+    if ! safe=$(jq --raw-output \
+      'if .agentControl._tag == "Paused" then .agentControl.safeToRestart else false end' <<< "$state"); then
+      restore_legacy_agent_control "$resume_required" || true
+      echo "Hogwild returned invalid Agent restart state." >&2
+      return 1
+    fi
+    if [ "$safe" = true ]; then
+      if ! remote_service restart; then
+        restore_legacy_agent_control "$resume_required" || true
+        return 1
+      fi
+      restore_legacy_agent_control "$resume_required"
       return
     fi
-    sleep "$DRAIN_POLL_SECONDS"
+    sleep "$RESTART_POLL_SECONDS"
   done
-  echo "Hogwild did not become safe to restart." >&2
-  exit 1
+
+  restore_legacy_agent_control "$resume_required" || true
+  echo "Hogwild did not finish active work before its compatibility restart." >&2
+  return 1
 }
 
-resume_agents() {
-  if $resume_required; then
-    controller_request --request POST "$HOGWILD_ORIGIN/api/agents/resume" >/dev/null
-    resume_required=false
+safe_restart() {
+  local support_status restart_id
+  if controller_supports_restart; then
+    restart_id=$(request_restart)
+    wait_for_restart "$restart_id"
+    return
+  else
+    support_status=$?
   fi
-}
-
-resume_after_failure() {
-  local status=$?
-  trap - EXIT
-  if $resume_required && ! resume_agents; then
-    echo "Hogwild could not resume after the failed operation." >&2
-    status=1
+  if [ "$support_status" -ne 2 ]; then
+    return 1
   fi
-  exit "$status"
+  echo "Hogwild uses the compatibility restart for this update."
+  legacy_safe_restart
 }
 
 sync_context() {
@@ -131,7 +220,6 @@ remote_service() {
 }
 
 require_inputs
-trap resume_after_failure EXIT
 
 command="${1:-update}"
 case "$command" in
@@ -141,18 +229,17 @@ case "$command" in
       echo "The Git ref contains unsupported characters." >&2
       exit 1
     fi
-    prepare_restart
     sync_context
     sync_service_override
-    remote_service update "$ref"
-    resume_agents
+    remote_service prepare-update "$ref"
+    safe_restart
+    remote_service status
     ;;
   restart)
-    prepare_restart
     sync_context
     sync_service_override
-    remote_service restart
-    resume_agents
+    safe_restart
+    remote_service status
     ;;
   status)
     remote_service status
@@ -166,5 +253,3 @@ case "$command" in
     exit 1
     ;;
 esac
-
-trap - EXIT

--- a/scripts/hogwild-service.test.sh
+++ b/scripts/hogwild-service.test.sh
@@ -6,23 +6,27 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 
-export HOME="$test_root/home"
+test_home="$test_root/home"
+export HARLAN_GITHUB_AGENT_CONTEXT_FILE="$test_home/.codex/AGENTS.md"
+export HARLAN_GITHUB_AGENT_PASSWORD_FILE="$test_home/.config/harlan-github-agent/dashboard-password"
 export HOGWILD_SERVICE_TEST_CALLS="$test_root/calls"
 export HOGWILD_SERVICE_TEST_HASH=''
 export HOGWILD_SERVICE_TEST_OVERRIDE_HASH=''
-export HOGWILD_SERVICE_TEST_SAFE_AFTER=1
-export HOGWILD_SERVICE_TEST_STATE="$test_root/control-state"
+export HOGWILD_SERVICE_TEST_RESTART_AFTER=1
 export HOGWILD_SERVICE_TEST_STATE_POLLS="$test_root/state-polls"
+export HOGWILD_SERVICE_TEST_LEGACY=false
+export HOGWILD_SERVICE_TEST_LEGACY_SAFE_AFTER=1
+export HOGWILD_SERVICE_TEST_LEGACY_STATE="$test_root/legacy-state"
 
-mkdir -p "$HOME/.codex" "$HOME/.config/harlan-github-agent" "$test_root/bin"
-printf '%s\n' '# Global Agent instructions' > "$HOME/.codex/AGENTS.md"
-printf '%s\n' 'password' > "$HOME/.config/harlan-github-agent/dashboard-password"
-expected_hash=$(/usr/bin/sha256sum "$HOME/.codex/AGENTS.md" | cut -d' ' -f1)
+mkdir -p "$test_home/.codex" "$test_home/.config/harlan-github-agent" "$test_root/bin"
+printf '%s\n' '# Global Agent instructions' > "$HARLAN_GITHUB_AGENT_CONTEXT_FILE"
+printf '%s\n' 'password' > "$HARLAN_GITHUB_AGENT_PASSWORD_FILE"
+expected_hash=$(/usr/bin/sha256sum "$HARLAN_GITHUB_AGENT_CONTEXT_FILE" | cut -d' ' -f1)
 expected_override_hash=$(/usr/bin/sha256sum "$script_dir/hogwild-service.conf" | cut -d' ' -f1)
 export HOGWILD_SERVICE_TEST_HASH="$expected_hash"
 export HOGWILD_SERVICE_TEST_OVERRIDE_HASH="$expected_override_hash"
-printf '%s\n' 'Running' > "$HOGWILD_SERVICE_TEST_STATE"
 printf '%s\n' '0' > "$HOGWILD_SERVICE_TEST_STATE_POLLS"
+printf '%s\n' 'Running' > "$HOGWILD_SERVICE_TEST_LEGACY_STATE"
 
 printf '%s\n' \
   '#!/usr/bin/env bash' \
@@ -36,19 +40,28 @@ printf '%s\n' \
 printf '%s\n' \
   '#!/usr/bin/env bash' \
   'printf '\''curl %s\n'\'' "$*" >> "$HOGWILD_SERVICE_TEST_CALLS"' \
-  'if [[ "$*" == *api/agents/pause* ]]; then printf '\''Paused\n'\'' > "$HOGWILD_SERVICE_TEST_STATE"; printf '\''{"_tag":"Paused"}\n'\''; exit; fi' \
-  'if [[ "$*" == *api/agents/resume* ]]; then printf '\''Running\n'\'' > "$HOGWILD_SERVICE_TEST_STATE"; printf '\''{"_tag":"Running"}\n'\''; exit; fi' \
-  'if [[ "$*" == *api/state* ]]; then' \
-  '  state=$(cat "$HOGWILD_SERVICE_TEST_STATE")' \
-  '  if [[ "$state" == Paused ]]; then' \
-  '    polls=$(($(cat "$HOGWILD_SERVICE_TEST_STATE_POLLS") + 1))' \
-  '    printf '\''%s\n'\'' "$polls" > "$HOGWILD_SERVICE_TEST_STATE_POLLS"' \
+  'if [ "$HOGWILD_SERVICE_TEST_LEGACY" = true ]; then' \
+  '  if [[ "$*" == *api/agents/pause* ]]; then printf '\''Paused\n'\'' > "$HOGWILD_SERVICE_TEST_LEGACY_STATE"; printf '\''{"_tag":"Paused"}\n'\''; exit; fi' \
+  '  if [[ "$*" == *api/agents/resume* ]]; then printf '\''Running\n'\'' > "$HOGWILD_SERVICE_TEST_LEGACY_STATE"; printf '\''{"_tag":"Running"}\n'\''; exit; fi' \
+  '  if [[ "$*" == *api/state* ]]; then' \
+  '    control=$(cat "$HOGWILD_SERVICE_TEST_LEGACY_STATE")' \
   '    safe=false' \
-  '    if ((polls >= HOGWILD_SERVICE_TEST_SAFE_AFTER)); then safe=true; fi' \
-  '    printf '\''{"agentControl":{"_tag":"Paused","safeToRestart":%s}}\n'\'' "$safe"' \
-  '  else' \
-  '    printf '\''{"agentControl":{"_tag":"Running"}}\n'\''' \
+  '    if [ "$control" = Paused ]; then' \
+  '      polls=$(($(cat "$HOGWILD_SERVICE_TEST_STATE_POLLS") + 1))' \
+  '      printf '\''%s\n'\'' "$polls" > "$HOGWILD_SERVICE_TEST_STATE_POLLS"' \
+  '      if ((polls >= HOGWILD_SERVICE_TEST_LEGACY_SAFE_AFTER)); then safe=true; fi' \
+  '    fi' \
+  '    printf '\''{"agentControl":{"_tag":"%s","safeToRestart":%s}}\n'\'' "$control" "$safe"' \
+  '    exit' \
   '  fi' \
+  'fi' \
+  'if [[ "$*" == *api/service/restart* ]]; then printf '\''{"_tag":"Requested","id":"restart-1","source":"helper","requestedAt":"2026-08-29T01:00:00.000Z"}\n'\''; exit; fi' \
+  'if [[ "$*" == *api/state* ]]; then' \
+  '  polls=$(($(cat "$HOGWILD_SERVICE_TEST_STATE_POLLS") + 1))' \
+  '  printf '\''%s\n'\'' "$polls" > "$HOGWILD_SERVICE_TEST_STATE_POLLS"' \
+  '  status=Requested' \
+  '  if ((polls >= HOGWILD_SERVICE_TEST_RESTART_AFTER)); then status=Completed; fi' \
+  '  printf '\''{"agentControl":{"_tag":"Running"},"restartRequest":{"_tag":"%s","id":"restart-1","source":"helper","requestedAt":"2026-08-29T01:00:00.000Z"}}\n'\'' "$status"' \
   'fi' \
   > "$test_root/bin/curl"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$test_root/bin/sleep"
@@ -56,50 +69,84 @@ chmod +x "$test_root/bin/ssh" "$test_root/bin/scp" "$test_root/bin/curl" "$test_
 
 PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" update >/dev/null
 
-pause_line=$(grep -n '/api/agents/pause' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
 copy_line=$(grep -n '^scp .*AGENTS.md .*hogwild:/home/harlan/.codex/AGENTS.md.next$' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
 install_line=$(grep -nF "mv '/home/harlan/.codex/AGENTS.md.next' '/home/harlan/.codex/AGENTS.md'" "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
 limits_copy_line=$(grep -n '^scp .*hogwild-service.conf .*hogwild:/home/harlan/.config/systemd/user/harlan-github-agent.service.d/hogwild.conf.next$' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
 limits_install_line=$(grep -nF "mv '/home/harlan/.config/systemd/user/harlan-github-agent.service.d/hogwild.conf.next' '/home/harlan/.config/systemd/user/harlan-github-agent.service.d/hogwild.conf'" "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
-update_line=$(grep -nF "bash -s -- 'update' 'origin/main'" "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
-resume_line=$(grep -n '/api/agents/resume' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
+prepare_line=$(grep -nF "bash -s -- 'prepare-update' 'origin/main'" "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
+restart_line=$(grep -n '/api/service/restart' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
 
-if ! ((pause_line < copy_line && copy_line < install_line && install_line < limits_copy_line && limits_copy_line < limits_install_line && limits_install_line < update_line && update_line < resume_line)); then
-  printf '%s\n' 'Hogwild update did not pause, sync, update, and resume in order' >&2
+if ! ((copy_line < install_line && install_line < limits_copy_line && limits_copy_line < limits_install_line && limits_install_line < prepare_line && prepare_line < restart_line)); then
+  printf '%s\n' 'Hogwild update did not prepare files before its Restart request.' >&2
+  exit 1
+fi
+if grep -E '/api/agents/(pause|resume)' "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
+  printf '%s\n' 'Hogwild update changed manual Pause.' >&2
+  exit 1
+fi
+if grep -F "bash -s -- 'restart'" "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
+  printf '%s\n' 'Hogwild update used a client-owned restart.' >&2
   exit 1
 fi
 
 : > "$HOGWILD_SERVICE_TEST_CALLS"
 export HOGWILD_SERVICE_TEST_HASH='different'
 if PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" update >/dev/null 2>&1; then
-  printf '%s\n' 'Hogwild update accepted a context hash mismatch' >&2
+  printf '%s\n' 'Hogwild update accepted a context hash mismatch.' >&2
   exit 1
 fi
-if grep -F "bash -s -- 'update'" "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
-  printf '%s\n' 'Hogwild update restarted after a context hash mismatch' >&2
-  exit 1
-fi
-if [ "$(cat "$HOGWILD_SERVICE_TEST_STATE")" != Running ]; then
-  printf '%s\n' 'Hogwild remained paused after a context hash mismatch' >&2
+if grep -E "prepare-update|api/service/restart" "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
+  printf '%s\n' 'Hogwild updated or restarted after a context hash mismatch.' >&2
   exit 1
 fi
 
 : > "$HOGWILD_SERVICE_TEST_CALLS"
-printf '%s\n' 'Paused' > "$HOGWILD_SERVICE_TEST_STATE"
-export HOGWILD_SERVICE_TEST_HASH="$expected_hash"
-PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" update >/dev/null
-if grep -E '/api/agents/(pause|resume)' "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
-  printf '%s\n' 'Hogwild update changed an existing Pause' >&2
-  exit 1
-fi
-
-: > "$HOGWILD_SERVICE_TEST_CALLS"
-printf '%s\n' 'Running' > "$HOGWILD_SERVICE_TEST_STATE"
 printf '%s\n' '0' > "$HOGWILD_SERVICE_TEST_STATE_POLLS"
-export HOGWILD_SERVICE_TEST_SAFE_AFTER=61
-PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" update >/dev/null
+export HOGWILD_SERVICE_TEST_HASH="$expected_hash"
+export HOGWILD_SERVICE_TEST_RESTART_AFTER=61
+PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" restart >/dev/null
 if [ "$(cat "$HOGWILD_SERVICE_TEST_STATE_POLLS")" -lt 61 ]; then
-  printf '%s\n' 'Hogwild update stopped waiting before the Agent drained' >&2
+  printf '%s\n' 'Hogwild stopped observing before the Restart request completed.' >&2
+  exit 1
+fi
+if grep -E '/api/agents/(pause|resume)' "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
+  printf '%s\n' 'Hogwild restart changed manual Pause.' >&2
+  exit 1
+fi
+
+: > "$HOGWILD_SERVICE_TEST_CALLS"
+printf '%s\n' '0' > "$HOGWILD_SERVICE_TEST_STATE_POLLS"
+printf '%s\n' 'Running' > "$HOGWILD_SERVICE_TEST_LEGACY_STATE"
+export HOGWILD_SERVICE_TEST_LEGACY=true
+export HOGWILD_SERVICE_TEST_LEGACY_SAFE_AFTER=3
+PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" restart >/dev/null
+legacy_pause_line=$(grep -n '/api/agents/pause' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
+legacy_restart_line=$(grep -nF "bash -s -- 'restart'" "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
+legacy_resume_line=$(grep -n '/api/agents/resume' "$HOGWILD_SERVICE_TEST_CALLS" | cut -d: -f1)
+if ! ((legacy_pause_line < legacy_restart_line && legacy_restart_line < legacy_resume_line)); then
+  printf '%s\n' 'The compatibility restart did not drain, restart, and restore Agent control.' >&2
+  exit 1
+fi
+if [ "$(cat "$HOGWILD_SERVICE_TEST_LEGACY_STATE")" != Running ]; then
+  printf '%s\n' 'The compatibility restart did not restore Running Agent control.' >&2
+  exit 1
+fi
+if grep -F '/api/service/restart' "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
+  printf '%s\n' 'The compatibility restart called an unavailable endpoint.' >&2
+  exit 1
+fi
+
+: > "$HOGWILD_SERVICE_TEST_CALLS"
+printf '%s\n' '0' > "$HOGWILD_SERVICE_TEST_STATE_POLLS"
+printf '%s\n' 'Paused' > "$HOGWILD_SERVICE_TEST_LEGACY_STATE"
+export HOGWILD_SERVICE_TEST_LEGACY_SAFE_AFTER=1
+PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/hogwild-service.sh" restart >/dev/null
+if grep -E '/api/agents/(pause|resume)' "$HOGWILD_SERVICE_TEST_CALLS" >/dev/null; then
+  printf '%s\n' 'The compatibility restart changed an existing manual Pause.' >&2
+  exit 1
+fi
+if [ "$(cat "$HOGWILD_SERVICE_TEST_LEGACY_STATE")" != Paused ]; then
+  printf '%s\n' 'The compatibility restart did not preserve manual Pause.' >&2
   exit 1
 fi
 

--- a/scripts/service.sh
+++ b/scripts/service.sh
@@ -2,6 +2,7 @@
 # Controls the harlan-github-agent systemd service.
 #
 #   service.sh update [REF]   move to REF (default origin/main), rebuild, restart
+#   service.sh prepare-update [REF]   move to REF and rebuild without restarting
 #   service.sh restart        restart the revision already deployed
 #   service.sh status         report what is deployed and whether it answers
 #
@@ -95,33 +96,41 @@ restart_and_verify() {
   report
 }
 
+prepare_update() {
+  require_checkout
+  local pnpm_bin ref before
+  pnpm_bin=$(resolve_pnpm)
+  ref="${1:-origin/main}"
+  # The checkout is a deployment. Anything local in it is a mistake worth
+  # seeing rather than silently overwriting.
+  if [ -n "$(git -C "$SERVICE_CHECKOUT" status --porcelain)" ]; then
+    echo "The service checkout has local changes. Inspect it before updating:" >&2
+    git -C "$SERVICE_CHECKOUT" status --short >&2
+    exit 1
+  fi
+  echo "Fetching $ref"
+  git -C "$SERVICE_CHECKOUT" fetch --quiet origin
+  before="$(git -C "$SERVICE_CHECKOUT" rev-parse HEAD)"
+  git -C "$SERVICE_CHECKOUT" reset --hard --quiet "$ref"
+  if [ "$before" = "$(git -C "$SERVICE_CHECKOUT" rev-parse HEAD)" ]; then
+    echo "Already on $(deployed)"
+  else
+    echo "Moved to $(deployed)"
+  fi
+  echo "Installing dependencies"
+  (cd "$SERVICE_CHECKOUT" && "$pnpm_bin" install --frozen-lockfile >/dev/null)
+  echo "Building the dashboard"
+  (cd "$SERVICE_CHECKOUT/packages/harlan-github-agent" && "$pnpm_bin" dashboard:build >/dev/null 2>&1)
+}
+
 command="${1:-update}"
 case "$command" in
   update)
-    require_checkout
-    pnpm_bin=$(resolve_pnpm)
-    ref="${2:-origin/main}"
-    # The checkout is a deployment. Anything local in it is a mistake worth
-    # seeing rather than silently overwriting.
-    if [ -n "$(git -C "$SERVICE_CHECKOUT" status --porcelain)" ]; then
-      echo "The service checkout has local changes. Inspect it before updating:" >&2
-      git -C "$SERVICE_CHECKOUT" status --short >&2
-      exit 1
-    fi
-    echo "Fetching $ref"
-    git -C "$SERVICE_CHECKOUT" fetch --quiet origin
-    before="$(git -C "$SERVICE_CHECKOUT" rev-parse HEAD)"
-    git -C "$SERVICE_CHECKOUT" reset --hard --quiet "$ref"
-    if [ "$before" = "$(git -C "$SERVICE_CHECKOUT" rev-parse HEAD)" ]; then
-      echo "Already on $(deployed)"
-    else
-      echo "Moved to $(deployed)"
-    fi
-    echo "Installing dependencies"
-    (cd "$SERVICE_CHECKOUT" && "$pnpm_bin" install --frozen-lockfile >/dev/null)
-    echo "Building the dashboard"
-    (cd "$SERVICE_CHECKOUT/packages/harlan-github-agent" && "$pnpm_bin" dashboard:build >/dev/null 2>&1)
+    prepare_update "${2:-origin/main}"
     restart_and_verify
+    ;;
+  prepare-update)
+    prepare_update "${2:-origin/main}"
     ;;
   restart)
     require_checkout
@@ -139,7 +148,7 @@ case "$command" in
     ;;
   *)
     echo "Unknown command: $command" >&2
-    echo "Use update, restart, or status." >&2
+    echo "Use update, prepare-update, restart, or status." >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Hogwild scheduled work stayed paused after an Agent restarted the service, because the helper owned both Pause and Resume. The service now owns a durable Restart request, waits for current work, and preserves manual Pause.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.