### PR TITLE
fix(github-agent): keep Review state recoverable

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -24,6 +24,8 @@ For every other tracked pull request authored by `harlan-zw`, run low-cost Pull 
 Require an adversarial Review for code, tests, configuration, dependencies, workflows, schemas, generated runtime output, security boundaries, public APIs, performance-sensitive files, behavior claims, or uncertainty.
 Skip only clearly judgment-free prose, formatting, or comment-only changes.
 Stamp `harlan-agent-review-skipped` when Review is skipped.
+Stamp `harlan-agent-review-required` when Pull request triage requires Review.
+Replace that route label with exactly one Review outcome label when Review finishes.
 
 Treat `harlan-agent-review` as a manual override that always requires adversarial Review for the exact current head commit. For an outside contributor, create one fixed, self-identified instruction comment. Name the exact head commit. Require `harlan-agent-review` before review. Bind Approval to the exact head commit; never let the label approve a head commit twice.
 
@@ -190,6 +192,10 @@ Record duration and Agent provider token usage for every completed Review run. S
 Carry Approval to the exact commit published by that approved repair. Do not carry it to any other new head commit.
 
 When a pull request review starts, create its single marked bot comment. Edit it in place as phases change. Never add separate progress comments.
+
+Treat GitHub as the durable workflow record. Publish each Review gate, the next action, and the exact head and base commits.
+
+If GitHub closes a pull request, publish `MERGED` or `CLOSED`. Clear every Agent status label.
 
 Before dispatch, detect trusted marked comments for the current head commit. A terminal comment completes the queued review unless Harlan explicitly requests a rerun. An active comment is status only. Use local Task ownership to decide whether an Agent still runs.
 

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -378,7 +378,11 @@ A conventional non-breaking `chore:` title skips Review without starting an Agen
 
 Every other pull request uses a low-cost Agent decision. It requires or skips an adversarial Review. Any uncertainty requires Review.
 
-`harlan-agent-review` requires Review and is the manual override. `harlan-agent-review-skipped` records a skipped Review.
+`harlan-agent-review-required` records the automatic route to Review. `harlan-agent-review-skipped` records a skipped Review.
+
+`harlan-agent-review` is the manual override. The service consumes it after it records Approval.
+
+The final Review outcome replaces the route label. The canonical comment records every Review gate and the next action.
 
 ### Take Ownership
 

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -70,6 +70,11 @@ Review decides the pull request premise once. A sound premise permits Repair. A 
 
 GitHub status, comments, and labels hold durable workflow truth. The local journal coordinates leases, Agent sessions, Recovery, and Review usage.
 
+Pull request triage uses `harlan-agent-review-required` or `harlan-agent-review-skipped`.
+The final Review replaces that route with one outcome label: `ready`, `pending`, or `blocked`.
+The canonical comment lists every Review gate and the next action.
+After GitHub merges or closes the pull request, the comment records that state and Agent labels clear.
+
 Every published Repair head SHA gets a fresh Review. A repeated finding stops with Action required.
 
 If Repair stops, the canonical review comment changes to `BLOCKED`. It lists every finding and next action.

--- a/packages/harlan-github-agent/src/agent-label.ts
+++ b/packages/harlan-github-agent/src/agent-label.ts
@@ -1,6 +1,7 @@
 import type { IssueTriageState } from './issue-triage.ts'
 import type { PullRequestTriageState } from './pull-request-triage.ts'
 import type { RepositoryMapping, ReviewOutcomeName } from './types.ts'
+import { APPROVAL_LABELS } from './approval-labels.ts'
 
 /**
  * What one Agent label says about an Item right now.
@@ -49,9 +50,9 @@ export const AGENT_LABELS = {
     description: 'The automated Review found a material defect in this head commit.',
   },
   ADVERSARIAL_REVIEW_REQUIRED: {
-    name: 'harlan-agent-review',
+    name: 'harlan-agent-review-required',
     color: 'd73a4a',
-    description: 'Pull request triage requires an adversarial Review. Adding this label manually always forces one.',
+    description: 'Pull request triage requires an adversarial Review for this head commit.',
   },
   ADVERSARIAL_REVIEW_SKIPPED: {
     name: 'harlan-agent-review-skipped',
@@ -95,16 +96,16 @@ export interface AgentLabelPlan {
 const reviewStates = ['RUNNING', 'READY', 'PENDING', 'BLOCKED'] as const satisfies readonly AgentLabelState[]
 const issueTriageStates = ['READY_TO_IMPLEMENT', 'READY_TO_SPEC', 'NEEDS_INFO', 'WAIT_TO_IMPLEMENT'] as const satisfies readonly AgentLabelState[]
 const pullRequestTriageStates = ['ADVERSARIAL_REVIEW_REQUIRED', 'ADVERSARIAL_REVIEW_SKIPPED'] as const satisfies readonly AgentLabelState[]
-const ownedLabels = new Set(Object.entries(AGENT_LABELS)
-  .filter(([state]) => state !== 'ADVERSARIAL_REVIEW_REQUIRED')
-  .map(([, label]) => label.name.toLowerCase()))
+const ownedLabels = new Set(Object.values(AGENT_LABELS).map(label => label.name.toLowerCase()))
 
 function mutuallyExclusiveLabels(state: AgentLabelState): Set<string> {
   const states = (issueTriageStates as readonly AgentLabelState[]).includes(state)
     ? issueTriageStates
-    : (pullRequestTriageStates as readonly AgentLabelState[]).includes(state)
-        ? pullRequestTriageStates
-        : reviewStates
+    : (['READY', 'PENDING', 'BLOCKED'] as readonly AgentLabelState[]).includes(state)
+        ? [...reviewStates, ...pullRequestTriageStates]
+        : (pullRequestTriageStates as readonly AgentLabelState[]).includes(state)
+            ? pullRequestTriageStates
+            : reviewStates
   return new Set(states.map(value => AGENT_LABELS[value].name.toLowerCase()))
 }
 
@@ -112,7 +113,7 @@ export function planAgentLabels(state: AgentLabelState, current: string[]): Agen
   const wanted = AGENT_LABELS[state]
   const present = current.map(label => label.toLowerCase())
   const exclusive = mutuallyExclusiveLabels(state)
-  if (state === 'ADVERSARIAL_REVIEW_SKIPPED' && present.includes(AGENT_LABELS.ADVERSARIAL_REVIEW_REQUIRED.name)) {
+  if (state === 'ADVERSARIAL_REVIEW_SKIPPED' && present.includes(APPROVAL_LABELS.review)) {
     return {
       add: null,
       remove: current.filter(label => label.toLowerCase() === wanted.name.toLowerCase()),
@@ -120,8 +121,8 @@ export function planAgentLabels(state: AgentLabelState, current: string[]): Agen
   }
   return {
     add: present.includes(wanted.name.toLowerCase()) ? null : wanted,
-    // Review progress and issue triage answer different questions. Each axis
-    // keeps one label, and the two labels may coexist while Issue work runs.
+    // Review progress and Issue triage answer different questions. A final
+    // Review outcome replaces its temporary Pull request triage route.
     remove: current.filter(label =>
       exclusive.has(label.toLowerCase()) && label.toLowerCase() !== wanted.name.toLowerCase()),
   }

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -697,7 +697,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
                   authorLogin: comment.user.login,
                   body: comment.body,
                   url: comment.html_url,
-                }]), pull.data.head.sha, options.actorLogin(repository)),
+                }]), pull.data.head.sha, options.actorLogin(repository), liveBaseSha),
           pullRequest: pullRequestItem(repository, pull.data, liveBaseSha, options.actorLogin(repository)),
           requiredChecks,
           reviews: chronologicalPullRequestComments(reviews.flatMap(review => review.body === undefined || review.body === null
@@ -793,7 +793,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
               && comment.body?.includes(AUTOMATED_REVIEW_MARKER)
               && automatedReviewHead(comment.body)?.toLowerCase() === headSha.toLowerCase())
           : undefined
-        if (priorReview._tag === 'Found' && adoptablePrior === undefined && !replacePriorReview)
+        if (priorReview._tag === 'Found' && priorReview.authorLogin.toLowerCase() !== actor && adoptablePrior === undefined && !replacePriorReview)
           return err(`The current head commit already has an automated review by @${priorReview.authorLogin}: ${priorReview.url}`)
         const existing = commentId === null
           ? adoptablePrior ?? comments

--- a/packages/harlan-github-agent/src/github.ts
+++ b/packages/harlan-github-agent/src/github.ts
@@ -411,7 +411,7 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
                     authorLogin: comment.user.login,
                     body: comment.body,
                     url: comment.html_url,
-                  }]), detail.head.sha, options.actorLogin(repository)),
+                  }]), detail.head.sha, options.actorLogin(repository), baseSha),
           }
         })
 

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -79,9 +79,11 @@ export interface ReviewWorkerOptions extends Omit<ItemAgentOptions, 'workspaces'
   workspaces: Pick<AgentWorkspaceManager, 'prepareIssue' | 'prepareReview' | 'verifyReview'>
 }
 
-function reviewSkippedComment(headSha: string, result: PullRequestTriageResult, at: string): string {
+function reviewSkippedComment(headSha: string, baseSha: string, result: PullRequestTriageResult, at: string): string {
+  const workflow = JSON.stringify({ _tag: 'ReviewSkipped', headSha, baseSha })
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${headSha} -->
+<!-- workflow-state: ${workflow} -->
 ### 🤖 REVIEW SKIPPED
 
 ${automatedDisclosure({ kind: 'triage', updatedAt: at })}
@@ -638,9 +640,11 @@ export function reviewOutcome(gates: ReviewGates): ReviewOutcomeName {
   return states.includes('Failed') ? 'BLOCKED' : states.includes('Pending') ? 'PENDING' : 'READY'
 }
 
-function progressComment(headSha: string, progress: AgentProgress, at: string): string {
+function progressComment(headSha: string, baseSha: string, progress: AgentProgress, at: string): string {
+  const workflow = JSON.stringify({ _tag: 'Reviewing', headSha, baseSha, progress: progress.percent })
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${headSha} -->
+<!-- workflow-state: ${workflow} -->
 ### 🤖 REVIEWING · ${progress.percent}% · ${progress.label}${formatPhaseDuration(progress.since, at)}
 
 ${automatedDisclosure({ kind: 'review', updatedAt: updatedAtLabel(at) })}
@@ -662,31 +666,56 @@ Base branch CI fails at \`${baseSha.slice(0, 12)}\`.
 Next: merge or repair the marked Baseline repair pull request.`
 }
 
-export function terminalComment(headSha: string, gates: ReviewGates, findings: ReviewFinding[], confidence: number | undefined, reportedChecks: string[]): string {
+function gateSummary(name: 'Merge' | 'Review' | 'CI', gate: ReviewGateState, findings: ReviewFinding[]): string {
+  if (gate._tag === 'Passed')
+    return `- **${name} gate:** Passed.${name === 'Review' && findings.length === 0 ? ' No material issues.' : ''}`
+  const outcome = gate._tag === 'Pending' ? 'PENDING' : 'BLOCKED'
+  return `- **${name} gate:** ${outcome}. ${cleanLine(gate.reason)}`
+}
+
+export function terminalComment(headSha: string, baseSha: string, gates: ReviewGates, findings: ReviewFinding[], confidence: number | undefined, reportedChecks: string[]): string {
   const result = reviewOutcome(gates)
   const heading = result === 'READY' && confidence !== undefined ? `${result} · ${confidence}/100` : result
-  const reason = result === 'PENDING'
-    ? Object.values(gates).find(gate => gate._tag === 'Pending')
-    : undefined
-  const blocked = result === 'BLOCKED'
-    ? [gates.merge, gates.ci].find(gate => gate._tag === 'Failed')
-    : undefined
+  const workflow = JSON.stringify({
+    _tag: 'Review',
+    headSha,
+    baseSha,
+    outcome: result,
+    gates: {
+      merge: gates.merge._tag,
+      review: gates.review._tag,
+      ci: gates.ci._tag,
+    },
+  })
   const disclosure = automatedDisclosure({
     kind: 'review',
     disclaimer: `It is not Harlan's personal review or approval.`,
-    notes: [
-      'A person still decides the merge.',
-      ...(reason?._tag === 'Pending' ? [`Waiting: ${cleanLine(reason.reason)}`] : []),
-      ...(blocked?._tag === 'Failed' ? [`Blocked: ${cleanLine(blocked.reason)}`] : []),
-    ],
+    notes: ['A person still decides the merge.'],
   })
+  const gateLines = [
+    gateSummary('Merge', gates.merge, findings),
+    gateSummary('Review', gates.review, findings),
+    gateSummary('CI', gates.ci, findings),
+  ]
   const findingLines = findings.map(finding => finding._tag === 'Fixed'
     ? `- **Fixed:** ${cleanLine(finding.summary)}`
     : finding.resolution === 'Dismissal'
       ? `- **Dismissal recommended:** ${cleanLine(finding.summary)}. Next: ${cleanLine(finding.nextAction)}`
       : `- **Open:** ${cleanLine(finding.summary)}. Next: ${cleanLine(finding.nextAction)}`)
   const checkLines = reportedChecks.map(line => `- **Reported:** ${cleanLine(line)}`)
-  return [AUTOMATED_REVIEW_MARKER, `<!-- reviewed-sha: ${headSha} -->`, `### 🤖 ${heading}`, '', disclosure, ...[...findingLines, ...checkLines].flatMap(line => ['', line])].join('\n')
+  const next = result === 'PENDING' ? ['', 'Next: The controller updates this comment when a Review gate changes.'] : []
+  return [
+    AUTOMATED_REVIEW_MARKER,
+    `<!-- reviewed-sha: ${headSha} -->`,
+    `<!-- workflow-state: ${workflow} -->`,
+    `### 🤖 ${heading}`,
+    '',
+    disclosure,
+    '',
+    ...gateLines,
+    ...[...findingLines, ...checkLines].flatMap(line => ['', line]),
+    ...next,
+  ].join('\n')
 }
 
 function saveAgentProgress(options: ItemAgentOptions, task: ClaimedAgentTask, progress: AgentProgress): Result<void, string> {
@@ -721,7 +750,7 @@ async function reportReviewProgress(
   const saved = saveAgentProgress(options, task, progress)
   if (saved._tag === 'Err')
     return saved
-  const posted = await options.status.publish(task, phase, progressComment(task.pullRequest.headSha, progress, options.now().toISOString()), signal)
+  const posted = await options.status.publish(task, phase, progressComment(task.pullRequest.headSha, task.pullRequest.baseSha, progress, options.now().toISOString()), signal)
   if (posted._tag === 'Err' && !signal.aborted)
     options.onProgressPublishFailure?.(task, posted.error)
   else
@@ -903,7 +932,7 @@ async function projectReviewRun(
 
   const outcome = reviewOutcome(gates)
   const confidence = outcome === 'READY' ? run.outcome.confidence : undefined
-  const body = terminalComment(task.pullRequest.headSha, gates, findings, confidence, refreshed.reportedChecks)
+  const body = terminalComment(task.pullRequest.headSha, task.pullRequest.baseSha, gates, findings, confidence, refreshed.reportedChecks)
   const published = await options.status.publish(task, 'terminal', body, signal)
   const at = options.now().toISOString()
   if (published._tag === 'Err') {
@@ -1040,7 +1069,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
               const published = await options.status.publish(
                 task,
                 'terminal',
-                reviewSkippedComment(task.pullRequest.headSha, triage.value, options.now().toISOString()),
+                reviewSkippedComment(task.pullRequest.headSha, task.pullRequest.baseSha, triage.value, options.now().toISOString()),
                 signal,
               )
               if (published._tag === 'Ok') {

--- a/packages/harlan-github-agent/src/reconcile.ts
+++ b/packages/harlan-github-agent/src/reconcile.ts
@@ -25,7 +25,7 @@ export interface ReconciliationError {
 export interface ReconciliationDependencies {
   approvals?: ApprovalController
   autoMerge?: AutoMergeController
-  github: Pick<GitHubSource, 'listOpenItems'>
+  github: Pick<GitHubSource, 'getPullRequest' | 'listOpenItems'>
   store: JournalStore
   now: () => Date
   signal?: AbortSignal
@@ -63,7 +63,20 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
       ? { kind: 'issue', routineFiled: subject.routineFiled }
       : { kind: 'pull_request', allowedAuthors: repository.writablePullRequestAuthors },
   ))
-  const writes = eligibleItems.map(subject => dependencies.store.recordObservation({
+  const seenPullRequests = new Set(eligibleItems.flatMap(subject => subject.kind === 'pull_request' ? [subject.number] : []))
+  const missingPullRequestNumbers = dependencies.store.listOpenPullRequestNumbers(repository.github)
+    .filter(number => !seenPullRequests.has(number))
+  const finalPullRequestReads = await Promise.all(missingPullRequestNumbers.map(number =>
+    dependencies.github.getPullRequest(repository, number, dependencies.signal)))
+  const failedFinalRead = finalPullRequestReads.find(read => read._tag === 'Err')
+  if (failedFinalRead?._tag === 'Err') {
+    if (dependencies.signal?.aborted !== true)
+      dependencies.store.recordPollFailure(repository.github, observedAt, failedFinalRead.error.message, failedFinalRead.error.status)
+    return err({ repository: repository.github, message: failedFinalRead.error.message })
+  }
+  const finalPullRequests = finalPullRequestReads.flatMap(read => read._tag === 'Ok' ? [read.value] : [])
+  const observedItems = [...eligibleItems, ...finalPullRequests]
+  const writes = observedItems.map(subject => dependencies.store.recordObservation({
     externalId: observationId(repository.github, subject),
     observedAt,
     source: 'poll',
@@ -100,9 +113,9 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     )))
   }
 
-  const closed = dependencies.store.closeMissingItems(
+  const closed = finalPullRequests.filter(pullRequest => pullRequest.state === 'closed').length + dependencies.store.closeMissingItems(
     repository.github,
-    eligibleItems.map(subject => ({ kind: subject.kind, number: subject.number })),
+    observedItems.map(subject => ({ kind: subject.kind, number: subject.number })),
     observedAt,
   )
   dependencies.store.recordPollSuccess(repository.github, observedAt)
@@ -110,7 +123,7 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     repository: repository.github,
     subjects: eligibleItems.length,
     closed,
-    ...countResults(writes),
+    ...countResults(writes.slice(0, eligibleItems.length)),
   })
 }
 

--- a/packages/harlan-github-agent/src/review-comment.ts
+++ b/packages/harlan-github-agent/src/review-comment.ts
@@ -51,6 +51,49 @@ export interface AutomatedReviewComment {
 
 const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR'])
 
+interface ReviewWorkflowState {
+  _tag: 'Review'
+  headSha: string
+  baseSha: string
+  outcome: 'READY' | 'PENDING' | 'BLOCKED'
+}
+
+interface ReviewSkippedWorkflowState {
+  _tag: 'ReviewSkipped'
+  headSha: string
+  baseSha: string
+}
+
+type AutomatedReviewWorkflowState = ReviewWorkflowState | ReviewSkippedWorkflowState
+
+function automatedReviewWorkflowState(body: string): AutomatedReviewWorkflowState | undefined {
+  const encoded = body.match(/<!-- workflow-state: (\{[^\n]+\}) -->/)?.[1]
+  if (encoded === undefined)
+    return undefined
+  let value: unknown
+  try {
+    value = JSON.parse(encoded)
+  }
+  catch {
+    // GitHub comment text is untrusted. A malformed marker carries no state.
+    return undefined
+  }
+  if (typeof value !== 'object' || value === null || !('_tag' in value) || !('headSha' in value) || !('baseSha' in value))
+    return undefined
+  if (typeof value.headSha !== 'string' || typeof value.baseSha !== 'string')
+    return undefined
+  if (value._tag === 'ReviewSkipped')
+    return { _tag: value._tag, headSha: value.headSha, baseSha: value.baseSha }
+  if (value._tag !== 'Review' || !('outcome' in value) || !['READY', 'PENDING', 'BLOCKED'].includes(String(value.outcome)))
+    return undefined
+  return {
+    _tag: value._tag,
+    headSha: value.headSha,
+    baseSha: value.baseSha,
+    outcome: value.outcome as ReviewWorkflowState['outcome'],
+  }
+}
+
 export function automatedReviewHead(body: string): string | undefined {
   const current = body.match(/<!-- reviewed-sha: ([a-f\d]{40,64}) -->/i)?.[1]
   if (current !== undefined)
@@ -59,7 +102,7 @@ export function automatedReviewHead(body: string): string | undefined {
 }
 
 function reviewState(body: string): 'active' | 'complete' {
-  return /^### 🤖 (?:READY|WAITING|BLOCKED)\b/m.test(body)
+  return /^### 🤖 (?:READY|BLOCKED|REVIEW SKIPPED)\b/m.test(body)
     || /^\*\*(?:PASS|PENDING|BLOCKED)\b/m.test(body)
     ? 'complete'
     : 'active'
@@ -69,12 +112,19 @@ export function priorAutomatedReviewForHead(
   comments: AutomatedReviewComment[],
   headSha: string,
   currentAgentLogin: string,
+  baseSha?: string,
 ): PriorAutomatedReview {
-  const found = comments.findLast(comment =>
-    comment.authorLogin.toLowerCase() !== currentAgentLogin.toLowerCase()
-    && trustedAssociations.has(comment.authorAssociation.toUpperCase())
-    && comment.body.includes(AUTOMATED_REVIEW_MARKER)
-    && automatedReviewHead(comment.body)?.toLowerCase() === headSha.toLowerCase())
+  const currentAgent = currentAgentLogin.toLowerCase()
+  const found = comments.findLast((comment) => {
+    if (!comment.body.includes(AUTOMATED_REVIEW_MARKER) || automatedReviewHead(comment.body)?.toLowerCase() !== headSha.toLowerCase())
+      return false
+    if (comment.authorLogin.toLowerCase() !== currentAgent)
+      return trustedAssociations.has(comment.authorAssociation.toUpperCase())
+    const workflow = automatedReviewWorkflowState(comment.body)
+    if (workflow === undefined || workflow.headSha.toLowerCase() !== headSha.toLowerCase() || (baseSha !== undefined && workflow.baseSha.toLowerCase() !== baseSha.toLowerCase()))
+      return false
+    return workflow._tag === 'ReviewSkipped' || workflow.outcome !== 'PENDING'
+  })
 
   return found === undefined
     ? { _tag: 'None' }

--- a/packages/harlan-github-agent/src/review-gate-sweep.ts
+++ b/packages/harlan-github-agent/src/review-gate-sweep.ts
@@ -64,7 +64,7 @@ export async function refreshReviewGates(
     }
 
     const confidence = outcome === 'READY' ? review.confidence : undefined
-    const body = terminalComment(review.headSha, gates, review.findings, confidence, reportedChecks)
+    const body = terminalComment(review.headSha, live.value.pullRequest.baseSha, gates, review.findings, confidence, reportedChecks)
     const at = options.now().toISOString()
     const reviewRunId = randomUUID()
     // Write GitHub first. The compare and swap is idempotent when this body

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -25,7 +25,7 @@ export interface StoppedReviewSweep {
 }
 
 export interface ReviewStopSweepOptions {
-  github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
+  github: Pick<GitHubAgentSource, 'clearAgentLabels' | 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
   store: Pick<JournalStore, 'listStoppedReviews' | 'recordDeletedReviewComment' | 'recordStoppedReviewStatus'>
@@ -59,7 +59,7 @@ export function stoppedReviewComment(
 
 ${automatedDisclosure({ kind: 'review', disclaimer: `It is not Harlan's personal review or approval.`, updatedAt: updatedAtLabel(at) })}
 
-GitHub ${action} this pull request. The unfinished automated review stopped.`
+GitHub ${action} this pull request. No further automated Review will run.`
   }
   if (review.taskKind === 'review_fix') {
     const findings = review.findings.map(finding => finding._tag === 'Fixed'
@@ -151,6 +151,9 @@ export async function publishStoppedReviews(
       })
       return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     }
+    const labels = await options.github.clearAgentLabels(mapping, review.pullRequestNumber, signal)
+    if (labels._tag === 'Err')
+      return err(`${review.repository}#${review.pullRequestNumber}: ${labels.error}`)
     const recorded = options.store.recordStoppedReviewStatus({
       taskId: review.taskId,
       taskKind: review.taskKind,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -639,6 +639,8 @@ export interface JournalStore {
   updateRoutineRunProgress: (input: { taskId: string, workerId: string, fence: number, progress: AgentProgress, at: string }) => boolean
   completeRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
   failRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
+  /** Pull requests absent from the next open snapshot need one exact final GitHub read. */
+  listOpenPullRequestNumbers: (github: string) => number[]
   closeMissingItems: (github: string, seen: Array<{ kind: GitHubItem['kind'], number: number }>, observedAt: string) => number
   completeTask: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
   completeWorkerTask: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
@@ -5109,6 +5111,17 @@ export function openJournalStore(
       AND json_extract(revisions.payload, '$.state') = 'open'
   `).get(repository, pullRequestNumber, revisionId, revisionId, kind) !== undefined
 
+  const listOpenPullRequestNumbers: JournalStore['listOpenPullRequestNumbers'] = github => (database.prepare(`
+    SELECT subjects.github_number
+    FROM subjects
+    JOIN repositories ON repositories.id = subjects.repository_id
+    JOIN revisions ON revisions.id = subjects.current_revision_id
+    WHERE repositories.github = ?
+      AND subjects.kind = 'pull_request'
+      AND json_extract(revisions.payload, '$.state') = 'open'
+    ORDER BY subjects.github_number
+  `).all(github) as unknown as Array<{ github_number: number }>).map(row => row.github_number)
+
   const closeMissingItems: JournalStore['closeMissingItems'] = (github, seen, observedAt) => {
     const seenKeys = new Set(seen.map(subject => `${subject.kind}:${subject.number}`))
     const rows = database.prepare(`
@@ -8588,11 +8601,19 @@ export function openJournalStore(
         LIMIT 1
       )
     )
-    -- The GitHub comment is nonterminal while its Task is terminal. Task
-    -- outcome does not change that contradiction, including legacy Tasks that
-    -- completed while waiting for separate work.
+    -- PENDING and WAITING end one Agent Task, but GitHub still owes the pull
+    -- request a final answer. A close or merge ends that remote state too.
     WHERE stopped.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
-      AND published.phase != 'terminal'
+      AND (
+        published.phase != 'terminal'
+        OR (
+          json_extract(current_revisions.payload, '$.state') = 'closed'
+          AND (
+            instr(published.body, '### 🤖 PENDING') > 0
+            OR instr(published.body, '### 🤖 WAITING') > 0
+          )
+        )
+      )
       AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
       -- A closed pull request takes no more work, so its last Task still owns
       -- the canonical comment however far the head moved first. An open one
@@ -8619,12 +8640,15 @@ export function openJournalStore(
         WHERE live.subject_id = stopped.subject_id AND live.kind = 'adversarial_review'
           AND live.state_tag IN ('Queued', 'Running')
       )
-      -- Any final status for this exact head already closed the canonical comment.
+      -- READY and BLOCKED are final Review outcomes. PENDING and WAITING are
+      -- terminal Task publications that still need a pull request outcome.
       AND NOT EXISTS (
         SELECT 1 FROM review_status_commands AS final
         WHERE final.phase = 'terminal' AND final.state_tag = 'Published'
           AND final.revision_id = stopped.revision_id
           AND final.expected_head_sha = json_extract(revisions.payload, '$.headSha')
+          AND instr(final.body, '### 🤖 PENDING') = 0
+          AND instr(final.body, '### 🤖 WAITING') = 0
       )
   `).all() as unknown as StoppedReviewRow[]).map(row => ({
     taskId: row.task_id,
@@ -9604,6 +9628,7 @@ export function openJournalStore(
     completeRoutineRun,
     failRoutineRun,
     isIssueWorkApprovalReady,
+    listOpenPullRequestNumbers,
     listOpenAgentPullRequests,
     listActiveTaskLeases,
     listRunningTaskItems,

--- a/packages/harlan-github-agent/test/agent-label.test.ts
+++ b/packages/harlan-github-agent/test/agent-label.test.ts
@@ -39,6 +39,13 @@ describe('planAgentLabels', () => {
     })
   })
 
+  it('takes the temporary Review route off when an outcome lands', () => {
+    expect(planAgentLabels('READY', ['harlan-agent-review-required'])).toEqual({
+      add: AGENT_LABELS.READY,
+      remove: ['harlan-agent-review-required'],
+    })
+  })
+
   it('takes a stale verdict off the moment an agent starts working', () => {
     expect(planAgentLabels('RUNNING', ['harlan-agent-blocked'])).toEqual({
       add: AGENT_LABELS.RUNNING,
@@ -69,14 +76,16 @@ describe('planAgentLabels', () => {
     })
   })
 
-  it('uses the existing Review label as the pull request triage override', () => {
+  it('keeps the pull request triage result separate from the manual Review override', () => {
     expect(planAgentLabels('ADVERSARIAL_REVIEW_REQUIRED', [
       'harlan-agent-review-skipped',
+      'harlan-agent-review',
       'bug',
     ])).toEqual({
       add: AGENT_LABELS.ADVERSARIAL_REVIEW_REQUIRED,
       remove: ['harlan-agent-review-skipped'],
     })
+    expect(AGENT_LABELS.ADVERSARIAL_REVIEW_REQUIRED.name).toBe('harlan-agent-review-required')
   })
 
   it('never replaces a manual Review override with Review skipped', () => {
@@ -89,9 +98,10 @@ describe('planAgentLabels', () => {
 
 describe('staleAgentLabels', () => {
   it('names every verdict on a pull request no Review has answered for', () => {
-    expect(staleAgentLabels(['harlan-agent-ready', 'harlan-agent-blocked'])).toEqual([
+    expect(staleAgentLabels(['harlan-agent-ready', 'harlan-agent-blocked', 'harlan-agent-review-required'])).toEqual([
       'harlan-agent-ready',
       'harlan-agent-blocked',
+      'harlan-agent-review-required',
     ])
   })
 

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -6,6 +6,10 @@ import { AGENT_ACTOR_LOGIN } from '../src/review-comment.ts'
 import { openJournalStore } from '../src/store.ts'
 import { issueItem, pullRequestItem, repositoryMapping } from './fixtures.ts'
 
+const noPullRequestRead = {
+  getPullRequest: () => Promise.reject(new Error('No pull request should need a final read.')),
+}
+
 describe('gitHub reconciliation', () => {
   it('ignores issues authored by automated accounts', async () => {
     const store = openJournalStore(':memory:')
@@ -13,7 +17,7 @@ describe('gitHub reconciliation', () => {
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([issueItem({ author: 'github-actions[bot]' })])) },
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([issueItem({ author: 'github-actions[bot]' })])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -54,7 +58,7 @@ describe('gitHub reconciliation', () => {
     expect(store.listIncidents()).toHaveLength(1)
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([botIssue])) },
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([botIssue])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -74,7 +78,7 @@ describe('gitHub reconciliation', () => {
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([
         issueItem({ number: 41, author: AGENT_ACTOR_LOGIN, routineFiled: true, url: 'https://github.com/harlan-zw/example/issues/41' }),
       ])) },
       store,
@@ -121,7 +125,7 @@ describe('gitHub reconciliation', () => {
     expect(store.listIncidents()).toHaveLength(1)
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([
         { ...trackingIssue, routineTracking: true },
       ])) },
       store,
@@ -144,6 +148,7 @@ describe('gitHub reconciliation', () => {
     expect(store.countOpenPullRequests()).toBe(0)
 
     const github = {
+      ...noPullRequestRead,
       listOpenItems: () => Promise.resolve(ok([
         pullRequestItem({ number: 24 }),
         pullRequestItem({ number: 25 }),
@@ -155,7 +160,14 @@ describe('gitHub reconciliation', () => {
 
     // A pull request that disappears from the open list closes, so it stops counting.
     await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([pullRequestItem({ number: 24 })])) },
+      github: {
+        getPullRequest: () => Promise.resolve(ok({
+          ...pullRequestItem({ number: 25 }),
+          state: 'closed' as const,
+          mergedAt: null,
+        })),
+        listOpenItems: () => Promise.resolve(ok([pullRequestItem({ number: 24 })])),
+      },
       store,
       now: () => new Date('2026-08-13T02:00:00.000Z'),
     })
@@ -166,13 +178,120 @@ describe('gitHub reconciliation', () => {
     store.close()
   })
 
+  it('reads a missing pull request before recording its final GitHub state', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'pull-request-before-merge',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 PENDING',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-agent', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:03.000Z',
+      evidence: 'Review completed with a PENDING CI gate.',
+    })
+
+    const result = await reconcileRepository(repository, {
+      github: {
+        listOpenItems: () => Promise.resolve(ok([])),
+        getPullRequest: () => Promise.resolve(ok({
+          ...pullRequest,
+          state: 'closed',
+          mergedAt: '2026-08-13T01:03:00.000Z',
+          updatedAt: '2026-08-13T01:03:00.000Z',
+        })),
+      },
+      store,
+      now: () => new Date('2026-08-13T01:04:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: { repository: repository.github, subjects: 0, inserted: 0, duplicates: 0, stale: 0, closed: 1 },
+    })
+    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
+      disposition: { _tag: 'Merged' },
+      pullRequestNumber: 24,
+    })])
+    store.close()
+  })
+
+  it('keeps a pull request open when its exact final read fails', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'pull-request-before-read-failure',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem(),
+    })
+
+    const result = await reconcileRepository(repository, {
+      github: {
+        listOpenItems: () => Promise.resolve(ok([])),
+        getPullRequest: () => Promise.resolve(err({
+          repository: repository.github,
+          message: 'GitHub did not return the pull request.',
+          status: 503,
+        })),
+      },
+      store,
+      now: () => new Date('2026-08-13T01:04:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      error: { repository: repository.github, message: 'GitHub did not return the pull request.' },
+    })
+    expect(store.countOpenPullRequests()).toBe(1)
+    expect(store.getDashboardSnapshot('2026-08-13T01:04:00.000Z').repositories[0]?.lastError)
+      .toBe('GitHub did not return the pull request.')
+    store.close()
+  })
+
   it('records a pull request from an explicitly allowed GitHub App', async () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping({ writablePullRequestAuthors: ['harlan-zw', 'harlan-github-agent[bot]'] })
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([pullRequestItem({ author: 'harlan-github-agent[bot]' })])) },
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([pullRequestItem({ author: 'harlan-github-agent[bot]' })])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -188,7 +307,7 @@ describe('gitHub reconciliation', () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
-    const github = { listOpenItems: () => Promise.resolve(ok([issueItem()])) }
+    const github = { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([issueItem()])) }
     const now = () => new Date('2026-08-13T01:00:00.000Z')
 
     const first = await reconcileRepository(repository, { github, store, now })
@@ -220,7 +339,7 @@ describe('gitHub reconciliation', () => {
           return Promise.resolve(ok(undefined))
         },
       },
-      github: { listOpenItems: () => Promise.resolve(ok([issue])) },
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([issue])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -234,7 +353,7 @@ describe('gitHub reconciliation', () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
-    const github = { listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'Rate limited' })) }
+    const github = { ...noPullRequestRead, listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'Rate limited' })) }
     const now = () => new Date('2026-08-13T01:00:00.000Z')
 
     const result = await reconcileRepository(repository, { github, store, now })
@@ -252,7 +371,7 @@ describe('gitHub reconciliation', () => {
     controller.abort()
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'This operation was aborted' })) },
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'This operation was aborted' })) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       signal: controller.signal,
@@ -280,7 +399,7 @@ describe('gitHub reconciliation', () => {
     })
 
     const result = await reconcileRepository(repository, {
-      github: { listOpenItems: () => Promise.resolve(ok([incoming])) },
+      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([incoming])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })

--- a/packages/harlan-github-agent/test/review-comment.test.ts
+++ b/packages/harlan-github-agent/test/review-comment.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { priorAutomatedReviewForHead } from '../src/review-comment.ts'
 
 const headSha = '69c7ef6eaf1ec7bb186f27f46fa343d3d38f1f23'
+const baseSha = 'a2bf631b82ed5c386bfa4c384a44720f67182513'
 
 describe('automated review comments', () => {
   it('recognizes the current format from a trusted maintainer', () => {
@@ -53,5 +54,33 @@ describe('automated review comments', () => {
         url: 'https://example.com/current-agent',
       },
     ], headSha, 'harlan-github-agent[bot]')).toEqual({ _tag: 'None' })
+  })
+
+  it('recovers a completed Review from the current Agent comment', () => {
+    expect(priorAutomatedReviewForHead([{
+      authorAssociation: 'NONE',
+      authorLogin: 'harlan-github-agent[bot]',
+      body: `<!-- harlan-agent-kit:pr-triage -->\n<!-- reviewed-sha: ${headSha} -->\n<!-- workflow-state: {"_tag":"Review","headSha":"${headSha}","baseSha":"${baseSha}","outcome":"READY","gates":{"merge":"Passed","review":"Passed","ci":"Passed"}} -->\n### 🤖 READY · 100/100`,
+      url: 'https://example.com/current-agent-ready',
+    }], headSha, 'harlan-github-agent[bot]', baseSha)).toEqual({
+      _tag: 'Found',
+      authorLogin: 'harlan-github-agent[bot]',
+      state: 'complete',
+      url: 'https://example.com/current-agent-ready',
+    })
+  })
+
+  it('does not treat PENDING or another base SHA as a completed Review', () => {
+    const comment = (outcome: 'READY' | 'PENDING', commentBaseSha: string) => ({
+      authorAssociation: 'NONE',
+      authorLogin: 'harlan-github-agent[bot]',
+      body: `<!-- harlan-agent-kit:pr-triage -->\n<!-- reviewed-sha: ${headSha} -->\n<!-- workflow-state: {"_tag":"Review","headSha":"${headSha}","baseSha":"${commentBaseSha}","outcome":"${outcome}","gates":{"merge":"Passed","review":"Passed","ci":"Passed"}} -->\n### 🤖 ${outcome}`,
+      url: `https://example.com/current-agent-${outcome.toLowerCase()}`,
+    })
+
+    expect(priorAutomatedReviewForHead([comment('PENDING', baseSha)], headSha, 'harlan-github-agent[bot]', baseSha))
+      .toEqual({ _tag: 'None' })
+    expect(priorAutomatedReviewForHead([comment('READY', 'other-base')], headSha, 'harlan-github-agent[bot]', baseSha))
+      .toEqual({ _tag: 'None' })
   })
 })

--- a/packages/harlan-github-agent/test/review-gate-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-gate-sweep.test.ts
@@ -226,7 +226,7 @@ describe('refreshReviewGates', () => {
       pullRequestNumber: 24,
       outcome: 'BLOCKED',
     })])
-    expect(recorded.edited?.body).toContain('Blocked: The pull request has merge conflicts.')
+    expect(recorded.edited?.body).toContain('**Merge gate:** BLOCKED. The pull request has merge conflicts.')
     expect(recorded.runs).toHaveLength(1)
     expect(recorded.stamped).toEqual(['BLOCKED'])
   })

--- a/packages/harlan-github-agent/test/review-outcome.test.ts
+++ b/packages/harlan-github-agent/test/review-outcome.test.ts
@@ -28,10 +28,28 @@ describe('reviewOutcome', () => {
     const failedCi = gates({ ci: failed('test failed.') })
 
     expect(reviewOutcome(failedCi)).toBe('BLOCKED')
-    expect(terminalComment('abc123', failedCi, [], undefined, [])).toContain('Blocked: test failed.')
+    expect(terminalComment('abc123', 'base123', failedCi, [], undefined, [])).toContain('**CI gate:** BLOCKED. test failed.')
   })
 
   it('reports READY when every gate passed', () => {
     expect(reviewOutcome(gates())).toBe('READY')
+  })
+
+  it('shows every Review gate while CI is pending', () => {
+    const body = terminalComment(
+      'abc123',
+      'base123',
+      gates({ ci: pending('Base branch CI: deploy is still running.') }),
+      [],
+      undefined,
+      [],
+    )
+
+    expect(body).toContain('### 🤖 PENDING')
+    expect(body).toContain('<!-- workflow-state: {"_tag":"Review","headSha":"abc123","baseSha":"base123","outcome":"PENDING"')
+    expect(body).toContain('**Merge gate:** Passed.')
+    expect(body).toContain('**Review gate:** Passed. No material issues.')
+    expect(body).toContain('**CI gate:** PENDING. Base branch CI: deploy is still running.')
+    expect(body).toContain('Next: The controller updates this comment when a Review gate changes.')
   })
 })

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -4,6 +4,10 @@ import { err, ok } from '../src/result.ts'
 import { publishStoppedReviews, stoppedReviewComment } from '../src/review-stop-sweep.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
+const githubStatus = {
+  clearAgentLabels: () => Promise.resolve(ok(undefined)),
+}
+
 const stopped: StoppedReview = {
   taskId: 'review-task',
   taskKind: 'adversarial_review',
@@ -75,6 +79,7 @@ describe('publishStoppedReviews', () => {
 
     await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: async () => {
           active += 1
           maximumActive = Math.max(maximumActive, active)
@@ -101,6 +106,7 @@ describe('publishStoppedReviews', () => {
     let recorded = 0
     const { results } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
         editReviewStatus: (_repository, _number, commentId, _expectedBody, body) => {
           edited = { commentId, body }
@@ -125,10 +131,39 @@ describe('publishStoppedReviews', () => {
     expect(recorded).toBe(1)
   })
 
-  it('closes a stale progress comment after GitHub merges the pull request', async () => {
-    let body = ''
+  it('does not finish while stale Agent labels remain', async () => {
+    let recorded = 0
     const { results } = await publishStoppedReviews({
       github: {
+        clearAgentLabels: () => Promise.resolve(err('GitHub did not clear the labels.')),
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        recordDeletedReviewComment: () => true,
+        listStoppedReviews: () => [stopped],
+        recordStoppedReviewStatus: () => {
+          recorded += 1
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([err('harlan-zw/example#24: GitHub did not clear the labels.')])
+    expect(recorded).toBe(0)
+  })
+
+  it('closes a stale progress comment after GitHub merges the pull request', async () => {
+    let body = ''
+    let labelsCleared = 0
+    const { results } = await publishStoppedReviews({
+      github: {
+        clearAgentLabels: () => {
+          labelsCleared += 1
+          return Promise.resolve(ok(undefined))
+        },
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({
           state: 'closed',
           mergedAt: '2026-08-15T03:00:00.000Z',
@@ -151,12 +186,14 @@ describe('publishStoppedReviews', () => {
     expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
     expect(body).toContain('### 🤖 MERGED')
     expect(body).not.toContain('REVIEWING')
+    expect(labelsCleared).toBe(1)
   })
 
   it('closes the comment on a merged pull request whose head branch GitHub deleted', async () => {
     let body = ''
     const { results } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.resolve(err('Branch not found - https://docs.github.com/rest/branches/branches#get-a-branch')),
         editReviewStatus: (_repository, _number, _commentId, _expectedBody, value) => {
           body = value
@@ -189,6 +226,7 @@ describe('publishStoppedReviews', () => {
     let clock = Date.parse('2026-08-15T04:00:00.000Z')
     const { results, remaining } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.reject(new Error('A merged pull request needs no snapshot.')),
         editReviewStatus: () => {
           edits += 1
@@ -214,6 +252,7 @@ describe('publishStoppedReviews', () => {
   it('reports a backlog it never started, so a spent pass is never silent', async () => {
     const { results, remaining } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.reject(new Error('The budget was spent before any row ran.')),
         editReviewStatus: () => Promise.reject(new Error('The budget was spent before any row ran.')),
       },
@@ -236,6 +275,7 @@ describe('publishStoppedReviews', () => {
     let recorded = 0
     const { results } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
         editReviewStatus: () => Promise.resolve(ok({ _tag: 'Missing' })),
       },
@@ -263,6 +303,7 @@ describe('publishStoppedReviews', () => {
     const retired: number[] = []
     const { results } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
         editReviewStatus: () => Promise.resolve(ok({ _tag: 'Changed' })),
       },
@@ -286,6 +327,7 @@ describe('publishStoppedReviews', () => {
     let writes = 0
     const { results } = await publishStoppedReviews({
       github: {
+        ...githubStatus,
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot({ headSha: 'def456' })),
         editReviewStatus: () => {
           writes += 1

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1761,7 +1761,7 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
-  it('keeps a stopped Review eligible after GitHub closes its pull request Revision', () => {
+  it('finalizes a completed PENDING Review after GitHub closes its pull request', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
@@ -1778,14 +1778,14 @@ describe('journal store', () => {
       throw new Error('Expected the Review Task.')
     const staged = store.stageReviewStatus({
       taskKind: 'adversarial_review',
-      phase: 'review',
+      phase: 'terminal',
       taskId: review.id,
       workerId: review.state.workerId,
       fence: review.state.fence,
       at: '2026-08-13T01:02:00.000Z',
       revisionId: review.revisionId,
       expectedHeadSha: pullRequest.headSha,
-      body: '### 🤖 REVIEWING · Git worktree ready',
+      body: '### 🤖 PENDING\n\n- **CI gate:** PENDING. Base branch CI is still running.',
     })
     if (staged._tag === 'Rejected')
       throw new Error(staged.reason)
@@ -1807,6 +1807,7 @@ describe('journal store', () => {
       at: '2026-08-13T01:02:03.000Z',
       evidence: 'Waiting for Baseline repair baseline-task.',
     })).toBe(true)
+    expect(store.listStoppedReviews()).toEqual([])
 
     store.recordObservation({
       externalId: 'review-merged',


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

PR #96 merged while its Review was waiting on base CI. GitHub kept showing PENDING because the open pull request poll never read the final PR state.

Missing pull requests now get one exact GitHub read. The canonical comment records each Review gate, MERGED or CLOSED replaces stale PENDING state, and final outcomes clear temporary Agent labels. Automatic triage uses `harlan-agent-review-required`; `harlan-agent-review` stays the manual Approval command.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).