### PR TITLE
fix(github-agent): recover final Review state

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -199,7 +199,11 @@ When a pull request review starts, create its single marked bot comment. Edit it
 
 Treat GitHub as the durable workflow record. Publish each Review gate, the next action, and the exact head and base commits.
 
+Treat the latest confirmed write to the canonical comment as its current state. This applies across every controller Publication path.
+
 If GitHub closes a pull request, publish `MERGED` or `CLOSED`. Clear every Agent status label.
+
+Before trusting a locally inferred close, read that exact pull request from GitHub. Store comment and label cleanup separately from the Task that last owned the comment. Resume incomplete cleanup after restart.
 
 Before dispatch, detect trusted marked comments for the current head commit. A terminal comment completes the queued review unless Harlan explicitly requests a rerun. An active comment is status only. Use local Task ownership to decide whether an Agent still runs.
 

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -475,6 +475,8 @@ One immutable record of a GitHub write: an automated review comment or a pushed 
 
 Store the exact Markdown and remote acknowledgement. Store failures with their reason.
 
+Several controller paths can update one canonical comment. Its newest confirmed Publication is the current GitHub workflow state.
+
 ### Approval
 
 One local decision for one exact issue or pull request Revision.

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -111,6 +111,8 @@ Deliveries within three seconds of each other cost one pass, so a busy repositor
 
 Keep polling on. It is the safety net for a delivery GitHub never sent.
 
+GitHub is the durable Review workflow record. The newest confirmed canonical comment state wins across Review and gate updates. Before finalizing `CLOSED`, the service reads the exact pull request. It then publishes `MERGED` or `CLOSED`, clears Agent labels, and stores completion for restart Recovery.
+
 Select `Automatic` in the Agent provider control to pick the provider by remaining capacity. It walks `agent.order` and takes the first provider whose window has more than its `agent.reserve_percent` left.
 
 Codex publishes a seven-day window, read from `codex app-server`. opencode publishes the GLM Coding Plan windows, read from `https://api.z.ai/api/monitor/usage/quota/limit` with the key in `~/.config/opencode/opencode.json`. The plan publishes a five-hour window and a weekly one, and the fuller of the two decides, because a spent five-hour window stalls the fleet for hours whatever the week has left.

--- a/packages/harlan-github-agent/src/reconcile.ts
+++ b/packages/harlan-github-agent/src/reconcile.ts
@@ -66,7 +66,10 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
   const seenPullRequests = new Set(eligibleItems.flatMap(subject => subject.kind === 'pull_request' ? [subject.number] : []))
   const missingPullRequestNumbers = dependencies.store.listOpenPullRequestNumbers(repository.github)
     .filter(number => !seenPullRequests.has(number))
-  const finalPullRequestReads = await Promise.all(missingPullRequestNumbers.map(number =>
+  const unverifiedClosedPullRequestNumbers = dependencies.store.listUnverifiedClosedPullRequestNumbers(repository.github)
+    .filter(number => !seenPullRequests.has(number))
+  const finalPullRequestNumbers = [...new Set([...missingPullRequestNumbers, ...unverifiedClosedPullRequestNumbers])]
+  const finalPullRequestReads = await Promise.all(finalPullRequestNumbers.map(number =>
     dependencies.github.getPullRequest(repository, number, dependencies.signal)))
   const failedFinalRead = finalPullRequestReads.find(read => read._tag === 'Err')
   if (failedFinalRead?._tag === 'Err') {
@@ -113,7 +116,8 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     )))
   }
 
-  const closed = finalPullRequests.filter(pullRequest => pullRequest.state === 'closed').length + dependencies.store.closeMissingItems(
+  const missingPullRequests = new Set(missingPullRequestNumbers)
+  const closed = finalPullRequests.filter(pullRequest => missingPullRequests.has(pullRequest.number) && pullRequest.state === 'closed').length + dependencies.store.closeMissingItems(
     repository.github,
     observedItems.map(subject => ({ kind: subject.kind, number: subject.number })),
     observedAt,

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -28,7 +28,7 @@ export interface ReviewStopSweepOptions {
   github: Pick<GitHubAgentSource, 'clearAgentLabels' | 'editReviewStatus' | 'getPullRequestReviewSnapshot'>
   now: () => Date
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listStoppedReviews' | 'recordDeletedReviewComment' | 'recordStoppedReviewStatus'>
+  store: Pick<JournalStore, 'listStoppedReviews' | 'recordDeletedReviewComment' | 'recordReviewClosure' | 'recordStoppedReviewStatus'>
   /**
    * How long one pass may spend closing comments.
    *
@@ -49,11 +49,13 @@ export function stoppedReviewComment(
   if (disposition._tag !== 'Stopped') {
     const workflow = JSON.stringify({
       _tag: disposition._tag === 'Merged' ? 'PullRequestMerged' : 'PullRequestClosed',
-      headSha: review.headSha,
+      workflowVersion: 2,
+      headSha: review.currentHeadSha,
+      baseSha: review.currentBaseSha,
     })
     const action = disposition._tag === 'Merged' ? 'merged' : 'closed'
     return `${AUTOMATED_REVIEW_MARKER}
-<!-- reviewed-sha: ${review.headSha} -->
+<!-- reviewed-sha: ${review.currentHeadSha} -->
 <!-- workflow-state: ${workflow} -->
 ### 🤖 ${disposition._tag.toUpperCase()}
 
@@ -125,13 +127,38 @@ export async function publishStoppedReviews(
         : live.value.pullRequest.mergedAt === null
           ? { _tag: 'Closed' }
           : { _tag: 'Merged' }
-    const body = stoppedReviewComment(review, at, disposition)
+    const statusReview = live !== null && live.value.pullRequest.state === 'closed'
+      ? {
+          ...review,
+          currentHeadSha: live.value.pullRequest.headSha,
+          currentBaseSha: live.value.pullRequest.baseSha,
+        }
+      : review
+    const body = stoppedReviewComment(statusReview, at, disposition)
     const edited = await options.github.editReviewStatus(mapping, review.pullRequestNumber, review.commentId, review.publishedBody, body, signal)
     if (edited._tag === 'Err')
       return err(`${review.repository}#${review.pullRequestNumber}: ${edited.error}`)
+    const closure = disposition._tag === 'Stopped' ? null : disposition
     if (edited.value._tag === 'Missing') {
-      // Deleting the comment is how a person answers it. Retiring the
-      // publication is what stops this sweep asking again on every pass.
+      if (closure !== null) {
+        const labels = await options.github.clearAgentLabels(mapping, review.pullRequestNumber, signal)
+        if (labels._tag === 'Err')
+          return err(`${review.repository}#${review.pullRequestNumber}: ${labels.error}`)
+        const recorded = options.store.recordReviewClosure({
+          repository: review.repository,
+          pullRequestNumber: review.pullRequestNumber,
+          revisionId: review.closureRevisionId,
+          headSha: review.currentHeadSha,
+          baseSha: review.currentBaseSha,
+          disposition: closure,
+          result: { _tag: 'CommentGone' },
+          at,
+        })
+        if (!recorded)
+          return err(`${review.repository}#${review.pullRequestNumber}: the final pull request state could not be saved.`)
+      }
+      // Retire the publication after closure succeeds. If label cleanup fails,
+      // the row stays eligible and the next sweep can try again.
       options.store.recordDeletedReviewComment({
         taskKind: review.taskKind,
         taskId: review.taskId,
@@ -142,6 +169,23 @@ export async function publishStoppedReviews(
       return ok({ _tag: 'CommentGone', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     }
     if (edited.value._tag === 'Changed') {
+      if (closure !== null) {
+        const labels = await options.github.clearAgentLabels(mapping, review.pullRequestNumber, signal)
+        if (labels._tag === 'Err')
+          return err(`${review.repository}#${review.pullRequestNumber}: ${labels.error}`)
+        const recorded = options.store.recordReviewClosure({
+          repository: review.repository,
+          pullRequestNumber: review.pullRequestNumber,
+          revisionId: review.closureRevisionId,
+          headSha: review.currentHeadSha,
+          baseSha: review.currentBaseSha,
+          disposition: closure,
+          result: { _tag: 'Superseded' },
+          at,
+        })
+        if (!recorded)
+          return err(`${review.repository}#${review.pullRequestNumber}: the final pull request state could not be saved.`)
+      }
       options.store.recordDeletedReviewComment({
         taskKind: review.taskKind,
         taskId: review.taskId,
@@ -164,9 +208,23 @@ export async function publishStoppedReviews(
       commentId: edited.value.commentId,
       url: edited.value.url,
     })
-    return recorded
-      ? ok({ _tag: 'Published', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
-      : err(`${review.repository}#${review.pullRequestNumber}: the final review comment could not be saved.`)
+    if (!recorded)
+      return err(`${review.repository}#${review.pullRequestNumber}: the final review comment could not be saved.`)
+    if (closure !== null) {
+      const closureRecorded = options.store.recordReviewClosure({
+        repository: review.repository,
+        pullRequestNumber: review.pullRequestNumber,
+        revisionId: review.closureRevisionId,
+        headSha: review.currentHeadSha,
+        baseSha: review.currentBaseSha,
+        disposition: closure,
+        result: { _tag: 'Published', body, commentId: edited.value.commentId, url: edited.value.url },
+        at,
+      })
+      if (!closureRecorded)
+        return err(`${review.repository}#${review.pullRequestNumber}: the final pull request state could not be saved.`)
+    }
+    return ok({ _tag: 'Published', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
   }
 
   const budgetMilliseconds = options.budgetMilliseconds ?? 30_000

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -393,6 +393,9 @@ interface StoppedReviewRow {
   github_number: number
   revision_id: string
   head_sha: string
+  closure_revision_id: string
+  current_head_sha: string
+  current_base_sha: string
   reason: string
   current_state: string
   current_merged_at: string | null
@@ -413,6 +416,13 @@ export type StoppedReviewDisposition
     | { _tag: 'Merged' }
     | { _tag: 'Closed' }
 
+export type ReviewClosureDisposition = Exclude<StoppedReviewDisposition, { _tag: 'Stopped' }>
+
+export type ReviewClosureResult
+  = | { _tag: 'Published', body: string, commentId: number, url: string }
+    | { _tag: 'CommentGone' }
+    | { _tag: 'Superseded' }
+
 export interface StoppedReview {
   taskId: string
   taskKind: 'adversarial_review' | 'review_fix'
@@ -420,6 +430,9 @@ export interface StoppedReview {
   pullRequestNumber: number
   revisionId: string
   headSha: string
+  closureRevisionId: string
+  currentHeadSha: string
+  currentBaseSha: string
   reason: string
   /**
    * Lets the sweep skip its GitHub read on a closed pull request.
@@ -654,6 +667,8 @@ export interface JournalStore {
   failRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
   /** Pull requests absent from the next open snapshot need one exact final GitHub read. */
   listOpenPullRequestNumbers: (github: string) => number[]
+  /** Old inferred closures need one exact read before GitHub becomes final truth. */
+  listUnverifiedClosedPullRequestNumbers: (github: string, limit?: number) => number[]
   closeMissingItems: (github: string, seen: Array<{ kind: GitHubItem['kind'], number: number }>, observedAt: string) => number
   completeTask: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
   completeWorkerTask: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
@@ -767,6 +782,17 @@ export interface JournalStore {
     at: string
     commentId: number
     url: string
+  }) => boolean
+  /** Records that GitHub comment and label cleanup finished for one exact closure Revision. */
+  recordReviewClosure: (input: {
+    repository: string
+    pullRequestNumber: number
+    revisionId: string
+    headSha: string
+    baseSha: string
+    disposition: ReviewClosureDisposition
+    result: ReviewClosureResult
+    at: string
   }) => boolean
   listReviewRuns: (repository: string, pullRequestNumber: number) => ReviewRun[]
   /** Replaces one person's explicit judgment about one Review run. */
@@ -4127,6 +4153,31 @@ const restartRequestMigration = `
   PRAGMA user_version = 47;
 `
 
+/** Separates final pull request cleanup from the Task that last owned its comment. */
+const reviewClosureMigration = `
+  CREATE TABLE review_closure_resolutions (
+    subject_id INTEGER NOT NULL REFERENCES subjects(id),
+    revision_id TEXT NOT NULL,
+    head_sha TEXT NOT NULL,
+    base_sha TEXT NOT NULL,
+    disposition_tag TEXT NOT NULL CHECK (disposition_tag IN ('Merged', 'Closed')),
+    result_tag TEXT NOT NULL CHECK (result_tag IN ('Published', 'CommentGone', 'Superseded')),
+    body TEXT,
+    github_comment_id INTEGER,
+    github_url TEXT,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (subject_id, revision_id),
+    FOREIGN KEY (revision_id, subject_id) REFERENCES revisions(id, subject_id),
+    CHECK (
+      (result_tag = 'Published' AND body IS NOT NULL AND github_comment_id IS NOT NULL AND github_url IS NOT NULL)
+      OR (result_tag != 'Published' AND body IS NULL AND github_comment_id IS NULL AND github_url IS NULL)
+    )
+  );
+
+  CREATE INDEX review_closure_resolutions_created ON review_closure_resolutions(created_at);
+  PRAGMA user_version = 48;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -4152,7 +4203,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 47)
+  if (version === 48)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -4341,6 +4392,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 46) {
     applyMigration(database, restartRequestMigration)
+    version = 47
+  }
+  if (version === 47) {
+    applyMigration(database, reviewClosureMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -5179,6 +5234,49 @@ export function openJournalStore(
       AND json_extract(revisions.payload, '$.state') = 'open'
     ORDER BY subjects.github_number
   `).all(github) as unknown as Array<{ github_number: number }>).map(row => row.github_number)
+
+  const listUnverifiedClosedPullRequestNumbers: JournalStore['listUnverifiedClosedPullRequestNumbers'] = (github, limit = 5) => {
+    const safeLimit = Math.max(0, Math.min(20, Math.trunc(limit)))
+    return (database.prepare(`
+      SELECT subjects.github_number
+      FROM subjects
+      JOIN repositories ON repositories.id = subjects.repository_id
+      JOIN revisions ON revisions.id = subjects.current_revision_id
+      WHERE repositories.github = ?
+        AND subjects.kind = 'pull_request'
+        AND json_extract(revisions.payload, '$.state') = 'closed'
+        AND NOT EXISTS (
+          SELECT 1 FROM review_closure_resolutions AS closure
+          WHERE closure.subject_id = subjects.id AND closure.revision_id = revisions.id
+        )
+        AND (
+          EXISTS (
+            SELECT 1 FROM review_status_commands AS status
+            JOIN revisions AS status_revision ON status_revision.id = status.revision_id
+            WHERE status_revision.subject_id = subjects.id AND status.state_tag = 'Published'
+          )
+          OR EXISTS (
+            SELECT 1 FROM review_publications AS publication
+            JOIN review_runs ON review_runs.id = publication.review_run_id
+            WHERE review_runs.subject_id = subjects.id AND publication.result_tag = 'Published'
+          )
+        )
+        AND (
+          EXISTS (
+            SELECT 1 FROM worker_tasks
+            WHERE worker_tasks.subject_id = subjects.id AND worker_tasks.kind = 'adversarial_review'
+              AND worker_tasks.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
+          )
+          OR EXISTS (
+            SELECT 1 FROM tasks
+            WHERE tasks.subject_id = subjects.id AND tasks.kind = 'review_fix'
+              AND tasks.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
+          )
+        )
+      ORDER BY revisions.observed_at DESC, subjects.github_number DESC
+      LIMIT ?
+    `).all(github, safeLimit) as unknown as Array<{ github_number: number }>).map(row => row.github_number)
+  }
 
   const closeMissingItems: JournalStore['closeMissingItems'] = (github, seen, observedAt) => {
     const seenKeys = new Set(seen.map(subject => `${subject.kind}:${subject.number}`))
@@ -8709,12 +8807,68 @@ export function openJournalStore(
   }))
 
   const listStoppedReviews: JournalStore['listStoppedReviews'] = () => (database.prepare(`
-    WITH stopped AS (
-      SELECT id, subject_id, revision_id, kind AS task_kind, state_tag, reason
-      FROM worker_tasks WHERE kind = 'adversarial_review'
+    WITH stopped_candidates AS (
+      SELECT worker_tasks.id, worker_tasks.subject_id, worker_tasks.revision_id,
+        worker_tasks.kind AS task_kind, worker_tasks.state_tag, worker_tasks.reason,
+        worker_tasks.updated_at, revisions.observed_at AS revision_observed_at
+      FROM worker_tasks
+      JOIN revisions ON revisions.id = worker_tasks.revision_id
+      WHERE worker_tasks.kind = 'adversarial_review'
       UNION ALL
-      SELECT id, subject_id, revision_id, kind AS task_kind, state_tag, reason
-      FROM tasks WHERE kind = 'review_fix'
+      SELECT tasks.id, tasks.subject_id, tasks.revision_id, tasks.kind AS task_kind,
+        tasks.state_tag, tasks.reason, tasks.updated_at,
+        revisions.observed_at AS revision_observed_at
+      FROM tasks
+      JOIN revisions ON revisions.id = tasks.revision_id
+      WHERE tasks.kind = 'review_fix'
+    ), stopped AS (
+      SELECT stopped_candidates.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY stopped_candidates.subject_id
+          ORDER BY stopped_candidates.revision_observed_at DESC,
+            CASE stopped_candidates.task_kind WHEN 'review_fix' THEN 1 ELSE 0 END DESC,
+            stopped_candidates.updated_at DESC,
+            stopped_candidates.id DESC
+        ) AS task_rank
+      FROM stopped_candidates
+      WHERE stopped_candidates.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
+    ), canonical_publications AS (
+      SELECT
+        'status:' || status.id AS publication_id,
+        status_revision.subject_id,
+        status.revision_id,
+        status.expected_head_sha,
+        status.phase,
+        status.body,
+        status.github_comment_id,
+        status.updated_at AS published_at,
+        0 AS source_rank
+      FROM review_status_commands AS status
+      JOIN revisions AS status_revision ON status_revision.id = status.revision_id
+      WHERE status.state_tag = 'Published'
+      UNION ALL
+      SELECT
+        'review:' || publication.id AS publication_id,
+        review_runs.subject_id,
+        review_runs.revision_id,
+        review_runs.head_sha AS expected_head_sha,
+        'terminal' AS phase,
+        publication.body,
+        publication.github_comment_id,
+        publication.created_at AS published_at,
+        1 AS source_rank
+      FROM review_publications AS publication
+      JOIN review_runs ON review_runs.id = publication.review_run_id
+      WHERE publication.result_tag = 'Published'
+    ), published AS (
+      SELECT canonical_publications.*,
+        ROW_NUMBER() OVER (
+          PARTITION BY canonical_publications.subject_id
+          ORDER BY canonical_publications.published_at DESC,
+            canonical_publications.source_rank DESC,
+            canonical_publications.publication_id DESC
+        ) AS publication_rank
+      FROM canonical_publications
     )
     SELECT
       stopped.id AS task_id,
@@ -8722,12 +8876,21 @@ export function openJournalStore(
       repositories.github AS repository,
       subjects.github_number,
       stopped.revision_id,
-      json_extract(revisions.payload, '$.headSha') AS head_sha,
+      json_extract(task_revisions.payload, '$.headSha') AS head_sha,
+      current_revisions.id AS closure_revision_id,
+      json_extract(current_revisions.payload, '$.headSha') AS current_head_sha,
+      json_extract(current_revisions.payload, '$.baseSha') AS current_base_sha,
       COALESCE(stopped.reason, 'The automated review stopped.') AS reason,
       json_extract(current_revisions.payload, '$.state') AS current_state,
       json_extract(current_revisions.payload, '$.mergedAt') AS current_merged_at,
-      published.github_comment_id,
-      published.body AS published_body,
+      CASE
+        WHEN json_extract(current_revisions.payload, '$.state') = 'closed' THEN published.github_comment_id
+        ELSE owned.github_comment_id
+      END AS github_comment_id,
+      CASE
+        WHEN json_extract(current_revisions.payload, '$.state') = 'closed' THEN published.body
+        ELSE owned.body
+      END AS published_body,
       COALESCE((
         SELECT review_runs.findings FROM review_runs
         WHERE review_runs.subject_id = stopped.subject_id
@@ -8738,9 +8901,10 @@ export function openJournalStore(
     FROM stopped
     JOIN subjects ON subjects.id = stopped.subject_id
     JOIN repositories ON repositories.id = subjects.repository_id
-    JOIN revisions ON revisions.id = stopped.revision_id
+    JOIN revisions AS task_revisions ON task_revisions.id = stopped.revision_id
     JOIN revisions AS current_revisions ON current_revisions.id = subjects.current_revision_id
-    JOIN review_status_commands AS published ON published.id = COALESCE(
+    JOIN published ON published.subject_id = stopped.subject_id AND published.publication_rank = 1
+    LEFT JOIN review_status_commands AS owned ON owned.id = COALESCE(
       (
         SELECT candidate.id FROM review_status_commands AS candidate
         WHERE candidate.task_kind = stopped.task_kind AND candidate.task_id = stopped.id
@@ -8748,38 +8912,34 @@ export function openJournalStore(
         ORDER BY candidate.updated_at DESC, candidate.id DESC
         LIMIT 1
       ),
-      -- A Repair that stops before publishing any progress inherits the
-      -- canonical comment of its sibling Review for the same revision.
+      -- A Repair that stops before publishing progress inherits the canonical
+      -- status of its sibling Review for the same Revision.
       (
         SELECT candidate.id FROM review_status_commands AS candidate
         JOIN worker_tasks AS sibling ON sibling.id = candidate.task_id
-        WHERE candidate.task_kind = 'adversarial_review' AND candidate.state_tag = 'Published'
+        WHERE stopped.task_kind = 'review_fix'
+          AND candidate.task_kind = 'adversarial_review'
+          AND candidate.state_tag = 'Published'
           AND sibling.subject_id = stopped.subject_id
           AND candidate.revision_id = stopped.revision_id
         ORDER BY candidate.updated_at DESC, candidate.id DESC
         LIMIT 1
       )
     )
-    -- PENDING and WAITING end one Agent Task, but GitHub still owes the pull
-    -- request a final answer. A close or merge ends that remote state too.
-    WHERE stopped.state_tag IN ('Completed', 'Failed', 'ActionRequired', 'Superseded')
+    LEFT JOIN review_closure_resolutions AS closure
+      ON closure.subject_id = subjects.id AND closure.revision_id = current_revisions.id
+    WHERE stopped.task_rank = 1
       AND (
-        published.phase != 'terminal'
+        (
+          json_extract(current_revisions.payload, '$.state') = 'open'
+          AND owned.phase != 'terminal'
+          AND owned.expected_head_sha = json_extract(task_revisions.payload, '$.headSha')
+          AND json_extract(current_revisions.payload, '$.headSha') = json_extract(task_revisions.payload, '$.headSha')
+        )
         OR (
           json_extract(current_revisions.payload, '$.state') = 'closed'
-          AND (
-            instr(published.body, '### 🤖 PENDING') > 0
-            OR instr(published.body, '### 🤖 WAITING') > 0
-          )
+          AND closure.revision_id IS NULL
         )
-      )
-      AND published.expected_head_sha = json_extract(revisions.payload, '$.headSha')
-      -- A closed pull request takes no more work, so its last Task still owns
-      -- the canonical comment however far the head moved first. An open one
-      -- hands the comment to the Task queued for its current head instead.
-      AND (
-        json_extract(current_revisions.payload, '$.headSha') = json_extract(revisions.payload, '$.headSha')
-        OR json_extract(current_revisions.payload, '$.state') = 'closed'
       )
       AND repositories.enabled = 1
       AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
@@ -8799,16 +8959,6 @@ export function openJournalStore(
         WHERE live.subject_id = stopped.subject_id AND live.kind = 'adversarial_review'
           AND live.state_tag IN ('Queued', 'Running')
       )
-      -- READY and BLOCKED are final Review outcomes. PENDING and WAITING are
-      -- terminal Task publications that still need a pull request outcome.
-      AND NOT EXISTS (
-        SELECT 1 FROM review_status_commands AS final
-        WHERE final.phase = 'terminal' AND final.state_tag = 'Published'
-          AND final.revision_id = stopped.revision_id
-          AND final.expected_head_sha = json_extract(revisions.payload, '$.headSha')
-          AND instr(final.body, '### 🤖 PENDING') = 0
-          AND instr(final.body, '### 🤖 WAITING') = 0
-      )
   `).all() as unknown as StoppedReviewRow[]).map(row => ({
     taskId: row.task_id,
     taskKind: row.task_kind,
@@ -8816,6 +8966,9 @@ export function openJournalStore(
     pullRequestNumber: row.github_number,
     revisionId: row.revision_id,
     headSha: row.head_sha,
+    closureRevisionId: row.closure_revision_id,
+    currentHeadSha: row.current_head_sha,
+    currentBaseSha: row.current_base_sha,
     reason: row.reason,
     disposition: row.current_state !== 'closed'
       ? { _tag: 'Stopped' as const }
@@ -8899,6 +9052,73 @@ export function openJournalStore(
       database.exec('ROLLBACK')
       throw error
     }
+  }
+
+  const recordReviewClosure: JournalStore['recordReviewClosure'] = (input) => {
+    const row = database.prepare(`
+      SELECT subjects.id AS subject_id, revisions.payload
+      FROM subjects
+      JOIN repositories ON repositories.id = subjects.repository_id
+      JOIN revisions ON revisions.id = subjects.current_revision_id
+      WHERE repositories.github = ? AND subjects.kind = 'pull_request'
+        AND subjects.github_number = ? AND subjects.current_revision_id = ?
+    `).get(input.repository, input.pullRequestNumber, input.revisionId) as {
+      subject_id: number
+      payload: string
+    } | undefined
+    const pullRequest = row === undefined ? undefined : JSON.parse(row.payload) as GitHubItem
+    if (
+      row === undefined
+      || pullRequest?.kind !== 'pull_request'
+      || pullRequest.state !== 'closed'
+      || pullRequest.headSha !== input.headSha
+      || pullRequest.baseSha !== input.baseSha
+      || (pullRequest.mergedAt === null ? 'Closed' : 'Merged') !== input.disposition._tag
+    ) {
+      return false
+    }
+    const published = input.result._tag === 'Published'
+      ? { body: input.result.body, commentId: input.result.commentId, url: input.result.url }
+      : { body: null, commentId: null, url: null }
+    const inserted = database.prepare(`
+      INSERT OR IGNORE INTO review_closure_resolutions (
+        subject_id, revision_id, head_sha, base_sha, disposition_tag, result_tag,
+        body, github_comment_id, github_url, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      row.subject_id,
+      input.revisionId,
+      input.headSha,
+      input.baseSha,
+      input.disposition._tag,
+      input.result._tag,
+      published.body,
+      published.commentId,
+      published.url,
+      input.at,
+    )
+    if (inserted.changes === 1)
+      return true
+    const existing = database.prepare(`
+      SELECT head_sha, base_sha, disposition_tag, result_tag, body, github_comment_id, github_url
+      FROM review_closure_resolutions
+      WHERE subject_id = ? AND revision_id = ?
+    `).get(row.subject_id, input.revisionId) as {
+      head_sha: string
+      base_sha: string
+      disposition_tag: ReviewClosureDisposition['_tag']
+      result_tag: ReviewClosureResult['_tag']
+      body: string | null
+      github_comment_id: number | null
+      github_url: string | null
+    }
+    return existing.head_sha === input.headSha
+      && existing.base_sha === input.baseSha
+      && existing.disposition_tag === input.disposition._tag
+      && existing.result_tag === input.result._tag
+      && existing.body === published.body
+      && existing.github_comment_id === published.commentId
+      && existing.github_url === published.url
   }
 
   const listOpenAgentPullRequests: JournalStore['listOpenAgentPullRequests'] = repository => (database.prepare(`
@@ -9788,6 +10008,7 @@ export function openJournalStore(
     failRoutineRun,
     isIssueWorkApprovalReady,
     listOpenPullRequestNumbers,
+    listUnverifiedClosedPullRequestNumbers,
     listOpenAgentPullRequests,
     listActiveTaskLeases,
     listRunningTaskItems,
@@ -9799,6 +10020,7 @@ export function openJournalStore(
     isQueuedReviewStatus,
     recordDeletedReviewComment,
     recordStoppedReviewStatus,
+    recordReviewClosure,
     approvePullRequest,
     authorizePublication,
     cancelTask,

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -285,6 +285,89 @@ describe('gitHub reconciliation', () => {
     store.close()
   })
 
+  it('rechecks a legacy CLOSED status before trusting its final state', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'legacy-closure-open',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'review',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 REVIEWING',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-agent', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the Review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:03.000Z',
+      evidence: 'Review stopped before a final outcome.',
+    })
+    store.closeMissingItems(repository.github, [], '2026-08-13T01:03:00.000Z')
+    expect(store.recordStoppedReviewStatus({
+      taskId: review.id,
+      taskKind: 'adversarial_review',
+      revisionId: observed.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '<!-- workflow-state: {"_tag":"PullRequestClosed","headSha":"abc123"} -->\n### 🤖 CLOSED',
+      at: '2026-08-13T01:03:01.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })).toBe(true)
+    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({ disposition: { _tag: 'Closed' } })])
+    let exactReads = 0
+
+    await reconcileRepository(repository, {
+      github: {
+        listOpenItems: () => Promise.resolve(ok([])),
+        getPullRequest: () => {
+          exactReads += 1
+          return Promise.resolve(ok({
+            ...pullRequest,
+            state: 'closed',
+            mergedAt: '2026-08-13T01:04:00.000Z',
+            updatedAt: '2026-08-13T01:04:00.000Z',
+          }))
+        },
+      },
+      store,
+      now: () => new Date('2026-08-13T01:05:00.000Z'),
+    })
+
+    expect(exactReads).toBe(1)
+    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({ disposition: { _tag: 'Merged' } })])
+    store.close()
+  })
+
   it('records a pull request from an explicitly allowed GitHub App', async () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping({ writablePullRequestAuthors: ['harlan-zw', 'harlan-github-agent[bot]'] })

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -1,4 +1,4 @@
-import type { StoppedReview } from '../src/store.ts'
+import type { JournalStore, StoppedReview } from '../src/store.ts'
 import { describe, expect, it } from 'vitest'
 import { err, ok } from '../src/result.ts'
 import { publishStoppedReviews, stoppedReviewComment } from '../src/review-stop-sweep.ts'
@@ -8,6 +8,10 @@ const githubStatus = {
   clearAgentLabels: () => Promise.resolve(ok(undefined)),
 }
 
+const reviewClosureStore = {
+  recordReviewClosure: () => true,
+}
+
 const stopped: StoppedReview = {
   taskId: 'review-task',
   taskKind: 'adversarial_review',
@@ -15,6 +19,9 @@ const stopped: StoppedReview = {
   pullRequestNumber: 24,
   revisionId: 'revision-1',
   headSha: 'abc123',
+  closureRevisionId: 'revision-1',
+  currentHeadSha: 'abc123',
+  currentBaseSha: 'base123',
   reason: 'The pull request is not ready for review.',
   disposition: { _tag: 'Stopped' },
   commentId: 42,
@@ -92,6 +99,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => reviews,
         recordStoppedReviewStatus: () => true,
@@ -116,6 +124,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => {
@@ -142,6 +151,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => {
@@ -177,6 +187,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => true,
@@ -191,6 +202,7 @@ describe('publishStoppedReviews', () => {
 
   it('closes the comment on a merged pull request whose head branch GitHub deleted', async () => {
     let body = ''
+    let closure: Parameters<JournalStore['recordReviewClosure']>[0] | undefined
     const { results } = await publishStoppedReviews({
       github: {
         ...githubStatus,
@@ -203,6 +215,10 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        recordReviewClosure: (input) => {
+          closure = input
+          return true
+        },
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [{ ...stopped, disposition: { _tag: 'Merged' } }],
         recordStoppedReviewStatus: () => true,
@@ -211,6 +227,45 @@ describe('publishStoppedReviews', () => {
 
     expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
     expect(body).toContain('### 🤖 MERGED')
+    expect(closure).toEqual(expect.objectContaining({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: 'revision-1',
+      headSha: 'abc123',
+      baseSha: 'base123',
+      disposition: { _tag: 'Merged' },
+      result: expect.objectContaining({ _tag: 'Published', body }),
+    }))
+  })
+
+  it('keeps a missing closed comment eligible when label cleanup fails', async () => {
+    let closures = 0
+    let retired = 0
+    const { results } = await publishStoppedReviews({
+      github: {
+        clearAgentLabels: () => Promise.resolve(err('GitHub did not clear the labels.')),
+        getPullRequestReviewSnapshot: () => Promise.reject(new Error('A merged pull request needs no snapshot.')),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Missing' })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        recordReviewClosure: () => {
+          closures += 1
+          return true
+        },
+        recordDeletedReviewComment: () => {
+          retired += 1
+          return true
+        },
+        listStoppedReviews: () => [{ ...stopped, disposition: { _tag: 'Merged' } }],
+        recordStoppedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([err('harlan-zw/example#24: GitHub did not clear the labels.')])
+    expect(closures).toBe(0)
+    expect(retired).toBe(0)
   })
 
   it('stops on its own budget and leaves the rest for the next pass', async () => {
@@ -237,6 +292,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date(clock),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => backlog,
         recordStoppedReviewStatus: () => true,
@@ -259,6 +315,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped, stopped],
         recordStoppedReviewStatus: () => true,
@@ -282,6 +339,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: (input) => {
           retired.push(input.commentId)
           return true
@@ -310,6 +368,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: (input) => {
           retired.push(input.commentId)
           return true
@@ -337,6 +396,7 @@ describe('publishStoppedReviews', () => {
       now: () => new Date('2026-08-15T04:00:00.000Z'),
       repositories: [repositoryMapping()],
       store: {
+        ...reviewClosureStore,
         recordDeletedReviewComment: () => true,
         listStoppedReviews: () => [stopped],
         recordStoppedReviewStatus: () => true,

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 
 /** Rewinds past the Routine tables, which every version below 38 predates. */
 function dropRoutines(database: DatabaseSync): void {
+  database.exec('DROP TABLE IF EXISTS review_closure_resolutions')
   database.exec('DROP TABLE IF EXISTS restart_requests')
   database.exec('DROP TABLE IF EXISTS agent_feedback')
   database.exec('DROP TABLE IF EXISTS routine_report_commands')
@@ -372,7 +373,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(47)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(48)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1821,7 +1821,8 @@ describe('journal store', () => {
       },
     })
 
-    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
+    const stopped = store.listStoppedReviews()
+    expect(stopped).toEqual([expect.objectContaining({
       taskId: review.id,
       revisionId: observed.revisionId,
       headSha: pullRequest.headSha,
@@ -1836,7 +1837,125 @@ describe('journal store', () => {
       commentId: 42,
       url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
     })).toBe(true)
+    expect(store.recordReviewClosure({
+      repository: stopped[0]!.repository,
+      pullRequestNumber: stopped[0]!.pullRequestNumber,
+      revisionId: stopped[0]!.closureRevisionId,
+      headSha: stopped[0]!.currentHeadSha,
+      baseSha: stopped[0]!.currentBaseSha,
+      disposition: { _tag: 'Merged' },
+      result: {
+        _tag: 'Published',
+        body: '### 🤖 MERGED',
+        commentId: 42,
+        url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+      },
+      at: '2026-08-13T01:04:00.000Z',
+    })).toBe(true)
     expect(store.listStoppedReviews()).toEqual([])
+  })
+
+  it('closes the READY status that replaced a PENDING Review', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const observed = store.recordObservation({
+      externalId: 'pending-review-before-gate-refresh',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request Revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const pendingBody = '### 🤖 PENDING\n\n- **CI gate:** PENDING. Base branch CI is still running.'
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: pendingBody,
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the Review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    const pendingGates = passedReviewGates()
+    pendingGates.ci = { _tag: 'Pending', reason: 'Base branch CI is still running.', evidence: [] }
+    expect(store.recordReviewRun({
+      id: 'pending-review-run',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: review.revisionId,
+      headSha: pullRequest.headSha,
+      provider: 'codex',
+      sessionId: 'pending-review-session',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:01:00.000Z',
+      completedAt: '2026-08-13T01:02:03.000Z',
+      gates: pendingGates,
+      confidence: 93,
+      findings: [],
+    })._tag).toBe('Inserted')
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:04.000Z',
+      evidence: 'pending-review-run',
+    })).toBe(true)
+    expect(store.supersedeReviewRun({
+      id: 'ready-review-run',
+      supersedesReviewRunId: 'pending-review-run',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: review.revisionId,
+      headSha: pullRequest.headSha,
+      provider: 'codex',
+      sessionId: 'pending-review-session',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:01:00.000Z',
+      completedAt: '2026-08-13T01:03:00.000Z',
+      gates: passedReviewGates(),
+      confidence: 93,
+      findings: [],
+      publication: settlementPublication('ready-after-pending'),
+    })._tag).toBe('Inserted')
+    store.recordObservation({
+      externalId: 'ready-review-merged',
+      observedAt: '2026-08-13T01:04:00.000Z',
+      source: 'poll',
+      subject: {
+        ...pullRequest,
+        state: 'closed',
+        mergedAt: '2026-08-13T01:04:00.000Z',
+        updatedAt: '2026-08-13T01:04:00.000Z',
+      },
+    })
+
+    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
+      disposition: { _tag: 'Merged' },
+      publishedBody: '### 🤖 READY',
+    })])
   })
 
   it('keeps a stopped Review eligible when the merge carried a head its Review never saw', () => {
@@ -1907,21 +2026,36 @@ describe('journal store', () => {
       },
     })
 
-    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
-      taskId: review.id,
-      revisionId: observed.revisionId,
-      headSha: pullRequest.headSha,
+    const stopped = store.listStoppedReviews()
+    expect(stopped).toEqual([expect.objectContaining({
+      headSha: 'repaired24',
+      currentHeadSha: 'repaired24',
       commentId: 42,
     })])
     expect(store.recordStoppedReviewStatus({
-      taskId: review.id,
-      taskKind: 'adversarial_review',
-      revisionId: observed.revisionId,
-      expectedHeadSha: pullRequest.headSha,
+      taskId: stopped[0]!.taskId,
+      taskKind: stopped[0]!.taskKind,
+      revisionId: stopped[0]!.revisionId,
+      expectedHeadSha: stopped[0]!.headSha,
       body: '### 🤖 MERGED',
       at: '2026-08-13T01:05:00.000Z',
       commentId: 42,
       url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })).toBe(true)
+    expect(store.recordReviewClosure({
+      repository: stopped[0]!.repository,
+      pullRequestNumber: stopped[0]!.pullRequestNumber,
+      revisionId: stopped[0]!.closureRevisionId,
+      headSha: stopped[0]!.currentHeadSha,
+      baseSha: stopped[0]!.currentBaseSha,
+      disposition: { _tag: 'Merged' },
+      result: {
+        _tag: 'Published',
+        body: '### 🤖 MERGED',
+        commentId: 42,
+        url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+      },
+      at: '2026-08-13T01:05:00.000Z',
     })).toBe(true)
     expect(store.listStoppedReviews()).toEqual([])
   })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Pull request #115 was merged while Repair was running. The service inferred CLOSED, kept the BLOCKED label, and missed READY written by the gate refresh.

Review and gate updates now share one ordered canonical comment state. The service reads the exact pull request before publishing MERGED or CLOSED, then stores comment and label cleanup for restart Recovery.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.