### PR TITLE
fix(github-agent): require verified pull request closures

### DIFF
--- a/packages/harlan-github-agent/src/reconcile.ts
+++ b/packages/harlan-github-agent/src/reconcile.ts
@@ -91,6 +91,26 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     dependencies.store.recordPollFailure(repository.github, observedAt, message)
     return err({ repository: repository.github, message })
   }
+  const finalWrites = writes.slice(eligibleItems.length)
+  const closureVerificationFailed = finalPullRequests.some((pullRequest, index) => {
+    const write = finalWrites[index]
+    if (pullRequest.state !== 'closed' || write === undefined || write._tag === 'Stale' || write._tag === 'Conflict')
+      return false
+    return !dependencies.store.recordVerifiedPullRequestClosure({
+      repository: repository.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: write.revisionId,
+      headSha: pullRequest.headSha,
+      baseSha: pullRequest.baseSha,
+      disposition: pullRequest.mergedAt === null ? { _tag: 'Closed' } : { _tag: 'Merged' },
+      at: observedAt,
+    })
+  })
+  if (closureVerificationFailed) {
+    const message = 'The final pull request state could not be saved.'
+    dependencies.store.recordPollFailure(repository.github, observedAt, message)
+    return err({ repository: repository.github, message })
+  }
 
   if (dependencies.approvals !== undefined) {
     const approvals = await Promise.all(eligibleItems.map((subject, index) => {

--- a/packages/harlan-github-agent/src/reconcile.ts
+++ b/packages/harlan-github-agent/src/reconcile.ts
@@ -79,19 +79,24 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
   }
   const finalPullRequests = finalPullRequestReads.flatMap(read => read._tag === 'Ok' ? [read.value] : [])
   const observedItems = [...eligibleItems, ...finalPullRequests]
-  const writes = observedItems.map(subject => dependencies.store.recordObservation({
+  const eligibleWrites = eligibleItems.map(subject => dependencies.store.recordObservation({
     externalId: observationId(repository.github, subject),
     observedAt,
     source: 'poll',
     subject,
   }))
+  const finalWrites = finalPullRequests.map(subject => dependencies.store.recordExactPullRequestObservation({
+    externalId: observationId(repository.github, subject),
+    observedAt,
+    subject,
+  }))
+  const writes = [...eligibleWrites, ...finalWrites]
   const conflict = writes.find(write => write._tag === 'Conflict')
   if (conflict?._tag === 'Conflict') {
     const message = `GitHub state hash collision: ${conflict.existingRevisionId} and ${conflict.receivedRevisionId}.`
     dependencies.store.recordPollFailure(repository.github, observedAt, message)
     return err({ repository: repository.github, message })
   }
-  const finalWrites = writes.slice(eligibleItems.length)
   const closureVerificationFailed = finalPullRequests.some((pullRequest, index) => {
     const write = finalWrites[index]
     if (pullRequest.state !== 'closed' || write === undefined || write._tag === 'Stale' || write._tag === 'Conflict')
@@ -137,7 +142,12 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
   }
 
   const missingPullRequests = new Set(missingPullRequestNumbers)
-  const closed = finalPullRequests.filter(pullRequest => missingPullRequests.has(pullRequest.number) && pullRequest.state === 'closed').length + dependencies.store.closeMissingItems(
+  const closed = finalPullRequests.filter((pullRequest, index) => {
+    const write = finalWrites[index]
+    return missingPullRequests.has(pullRequest.number)
+      && pullRequest.state === 'closed'
+      && (write?._tag === 'Inserted' || write?._tag === 'Duplicate')
+  }).length + dependencies.store.closeMissingItems(
     repository.github,
     observedItems.map(subject => ({ kind: subject.kind, number: subject.number })),
     observedAt,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -669,6 +669,16 @@ export interface JournalStore {
   listOpenPullRequestNumbers: (github: string) => number[]
   /** Old inferred closures need one exact read before GitHub becomes final truth. */
   listUnverifiedClosedPullRequestNumbers: (github: string, limit?: number) => number[]
+  /** Records one exact closed pull request read from GitHub. */
+  recordVerifiedPullRequestClosure: (input: {
+    repository: string
+    pullRequestNumber: number
+    revisionId: string
+    headSha: string
+    baseSha: string
+    disposition: ReviewClosureDisposition
+    at: string
+  }) => boolean
   closeMissingItems: (github: string, seen: Array<{ kind: GitHubItem['kind'], number: number }>, observedAt: string) => number
   completeTask: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
   completeWorkerTask: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string }) => boolean
@@ -4178,6 +4188,24 @@ const reviewClosureMigration = `
   PRAGMA user_version = 48;
 `
 
+/** Proves GitHub, rather than an omitted open-list row, supplied a closure. */
+const verifiedPullRequestClosureMigration = `
+  CREATE TABLE pull_request_closure_verifications (
+    subject_id INTEGER NOT NULL REFERENCES subjects(id),
+    revision_id TEXT NOT NULL,
+    head_sha TEXT NOT NULL,
+    base_sha TEXT NOT NULL,
+    disposition_tag TEXT NOT NULL CHECK (disposition_tag IN ('Merged', 'Closed')),
+    verified_at TEXT NOT NULL,
+    PRIMARY KEY (subject_id, revision_id),
+    FOREIGN KEY (revision_id, subject_id) REFERENCES revisions(id, subject_id)
+  );
+
+  CREATE INDEX pull_request_closure_verifications_verified
+    ON pull_request_closure_verifications(verified_at);
+  PRAGMA user_version = 49;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -4203,7 +4231,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 48)
+  if (version === 49)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -4396,6 +4424,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 47) {
     applyMigration(database, reviewClosureMigration)
+    version = 48
+  }
+  if (version === 48) {
+    applyMigration(database, verifiedPullRequestClosureMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -5246,8 +5278,8 @@ export function openJournalStore(
         AND subjects.kind = 'pull_request'
         AND json_extract(revisions.payload, '$.state') = 'closed'
         AND NOT EXISTS (
-          SELECT 1 FROM review_closure_resolutions AS closure
-          WHERE closure.subject_id = subjects.id AND closure.revision_id = revisions.id
+          SELECT 1 FROM pull_request_closure_verifications AS verification
+          WHERE verification.subject_id = subjects.id AND verification.revision_id = revisions.id
         )
         AND (
           EXISTS (
@@ -8928,6 +8960,8 @@ export function openJournalStore(
     )
     LEFT JOIN review_closure_resolutions AS closure
       ON closure.subject_id = subjects.id AND closure.revision_id = current_revisions.id
+    LEFT JOIN pull_request_closure_verifications AS verification
+      ON verification.subject_id = subjects.id AND verification.revision_id = current_revisions.id
     WHERE stopped.task_rank = 1
       AND (
         (
@@ -8938,6 +8972,7 @@ export function openJournalStore(
         )
         OR (
           json_extract(current_revisions.payload, '$.state') = 'closed'
+          AND verification.revision_id IS NOT NULL
           AND closure.revision_id IS NULL
         )
       )
@@ -9054,7 +9089,7 @@ export function openJournalStore(
     }
   }
 
-  const recordReviewClosure: JournalStore['recordReviewClosure'] = (input) => {
+  const recordVerifiedPullRequestClosure: JournalStore['recordVerifiedPullRequestClosure'] = (input) => {
     const row = database.prepare(`
       SELECT subjects.id AS subject_id, revisions.payload
       FROM subjects
@@ -9063,6 +9098,56 @@ export function openJournalStore(
       WHERE repositories.github = ? AND subjects.kind = 'pull_request'
         AND subjects.github_number = ? AND subjects.current_revision_id = ?
     `).get(input.repository, input.pullRequestNumber, input.revisionId) as {
+      subject_id: number
+      payload: string
+    } | undefined
+    const pullRequest = row === undefined ? undefined : JSON.parse(row.payload) as GitHubItem
+    if (
+      row === undefined
+      || pullRequest?.kind !== 'pull_request'
+      || pullRequest.state !== 'closed'
+      || pullRequest.headSha !== input.headSha
+      || pullRequest.baseSha !== input.baseSha
+      || (pullRequest.mergedAt === null ? 'Closed' : 'Merged') !== input.disposition._tag
+    ) {
+      return false
+    }
+    database.prepare(`
+      INSERT INTO pull_request_closure_verifications (
+        subject_id, revision_id, head_sha, base_sha, disposition_tag, verified_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT (subject_id, revision_id) DO UPDATE SET verified_at = excluded.verified_at
+    `).run(
+      row.subject_id,
+      input.revisionId,
+      input.headSha,
+      input.baseSha,
+      input.disposition._tag,
+      input.at,
+    )
+    return true
+  }
+
+  const recordReviewClosure: JournalStore['recordReviewClosure'] = (input) => {
+    const row = database.prepare(`
+      SELECT subjects.id AS subject_id, revisions.payload
+      FROM subjects
+      JOIN repositories ON repositories.id = subjects.repository_id
+      JOIN revisions ON revisions.id = subjects.current_revision_id
+      JOIN pull_request_closure_verifications AS verification
+        ON verification.subject_id = subjects.id AND verification.revision_id = revisions.id
+        AND verification.head_sha = ? AND verification.base_sha = ?
+        AND verification.disposition_tag = ?
+      WHERE repositories.github = ? AND subjects.kind = 'pull_request'
+        AND subjects.github_number = ? AND subjects.current_revision_id = ?
+    `).get(
+      input.headSha,
+      input.baseSha,
+      input.disposition._tag,
+      input.repository,
+      input.pullRequestNumber,
+      input.revisionId,
+    ) as {
       subject_id: number
       payload: string
     } | undefined
@@ -10009,6 +10094,7 @@ export function openJournalStore(
     isIssueWorkApprovalReady,
     listOpenPullRequestNumbers,
     listUnverifiedClosedPullRequestNumbers,
+    recordVerifiedPullRequestClosure,
     listOpenAgentPullRequests,
     listActiveTaskLeases,
     listRunningTaskItems,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -669,6 +669,12 @@ export interface JournalStore {
   listOpenPullRequestNumbers: (github: string) => number[]
   /** Old inferred closures need one exact read before GitHub becomes final truth. */
   listUnverifiedClosedPullRequestNumbers: (github: string, limit?: number) => number[]
+  /** Records one exact pull request read without trusting a local closure timestamp. */
+  recordExactPullRequestObservation: (input: {
+    externalId: string
+    observedAt: string
+    subject: GitHubPullRequestItem
+  }) => RecordObservationResult
   /** Records one exact closed pull request read from GitHub. */
   recordVerifiedPullRequestClosure: (input: {
     repository: string
@@ -2248,6 +2254,10 @@ function canonicalPayload(subject: GitHubItem): string {
 
 function digest(value: string): string {
   return createHash('sha256').update(value).digest('hex')
+}
+
+function inferredClosureObservationId(subject: Pick<GitHubItem, 'repository' | 'kind' | 'number'>, observedAt: string): string {
+  return digest(`poll-closure:${subject.repository}:${subject.kind}:${subject.number}:${observedAt}`)
 }
 
 function issueTriageState(evidence: string | null): IssueTriageState | undefined {
@@ -4935,7 +4945,10 @@ export function openJournalStore(
     }
   }
 
-  const recordObservation: JournalStore['recordObservation'] = (input) => {
+  const writeObservation = (
+    input: Parameters<JournalStore['recordObservation']>[0],
+    exactPullRequest: boolean,
+  ): RecordObservationResult => {
     const payload = canonicalPayload(input.subject)
     const revisionId = revisionIdFor(input.subject)
     database.exec('BEGIN IMMEDIATE')
@@ -5036,15 +5049,40 @@ export function openJournalStore(
         )
         planIssueTriage(database, input.subject, subject.id, revisionId, input.observedAt, mapping)
       }
+      const isStaleAgainstCurrent = (current: GitHubItem, currentRevisionId: string): boolean => {
+        const older = input.subject.updatedAt < current.updatedAt
+        const weakerAtSameVersion = input.subject.updatedAt === current.updatedAt
+          && input.source === 'webhook'
+          && subject.current_source === 'poll'
+        if (!older && !weakerAtSameVersion)
+          return false
+        if (
+          !exactPullRequest
+          || input.subject.kind !== 'pull_request'
+          || current.kind !== 'pull_request'
+          || current.state !== 'closed'
+          || subject.current_source !== 'poll'
+          || input.subject.headSha !== current.headSha
+          || input.subject.baseSha !== current.baseSha
+        ) {
+          return true
+        }
+        const inferredClosure = database.prepare(`
+          SELECT 1 FROM observations
+          WHERE subject_id = ? AND revision_id = ? AND external_id = ?
+        `).get(subject.id, currentRevisionId, inferredClosureObservationId(current, current.updatedAt)) !== undefined
+        if (!inferredClosure)
+          return true
+        return database.prepare(`
+          SELECT 1 FROM pull_request_closure_verifications
+          WHERE subject_id = ? AND revision_id = ?
+        `).get(subject.id, currentRevisionId) !== undefined
+      }
 
       if (external !== undefined) {
         if (subject.current_payload !== null && subject.current_revision_id !== null) {
           const current = JSON.parse(subject.current_payload) as GitHubItem
-          const older = input.subject.updatedAt < current.updatedAt
-          const weakerAtSameVersion = input.subject.updatedAt === current.updatedAt
-            && input.source === 'webhook'
-            && subject.current_source === 'poll'
-          if (older || weakerAtSameVersion) {
+          if (isStaleAgainstCurrent(current, subject.current_revision_id)) {
             database.exec('COMMIT')
             return { _tag: 'Stale', revisionId, currentRevisionId: subject.current_revision_id }
           }
@@ -5069,11 +5107,7 @@ export function openJournalStore(
 
       if (subject.current_payload !== null && subject.current_revision_id !== null) {
         const current = JSON.parse(subject.current_payload) as GitHubItem
-        const older = input.subject.updatedAt < current.updatedAt
-        const weakerAtSameVersion = input.subject.updatedAt === current.updatedAt
-          && input.source === 'webhook'
-          && subject.current_source === 'poll'
-        if (older || weakerAtSameVersion) {
+        if (isStaleAgainstCurrent(current, subject.current_revision_id)) {
           database.exec('COMMIT')
           return { _tag: 'Stale', revisionId, currentRevisionId: subject.current_revision_id }
         }
@@ -5096,6 +5130,13 @@ export function openJournalStore(
       throw error
     }
   }
+
+  const recordObservation: JournalStore['recordObservation'] = input => writeObservation(input, false)
+
+  const recordExactPullRequestObservation: JournalStore['recordExactPullRequestObservation'] = input => writeObservation({
+    ...input,
+    source: 'poll',
+  }, true)
 
   const storedApprovalState = (input: {
     subjectId: number
@@ -5382,7 +5423,7 @@ export function openJournalStore(
             priorAutomatedReview: { _tag: 'None' },
           }
       recordObservation({
-        externalId: digest(`poll-closure:${github}:${subject.kind}:${subject.number}:${observedAt}`),
+        externalId: inferredClosureObservationId(subject, observedAt),
         observedAt,
         source: 'poll',
         subject,
@@ -10094,6 +10135,7 @@ export function openJournalStore(
     isIssueWorkApprovalReady,
     listOpenPullRequestNumbers,
     listUnverifiedClosedPullRequestNumbers,
+    recordExactPullRequestObservation,
     recordVerifiedPullRequestClosure,
     listOpenAgentPullRequests,
     listActiveTaskLeases,

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -354,8 +354,8 @@ describe('gitHub reconciliation', () => {
           return Promise.resolve(ok({
             ...pullRequest,
             state: 'closed',
-            mergedAt: '2026-08-13T01:04:00.000Z',
-            updatedAt: '2026-08-13T01:04:00.000Z',
+            mergedAt: '2026-08-13T01:02:30.000Z',
+            updatedAt: '2026-08-13T01:02:30.000Z',
           }))
         },
       },
@@ -365,6 +365,51 @@ describe('gitHub reconciliation', () => {
 
     expect(exactReads).toBe(1)
     expect(store.listStoppedReviews()).toEqual([expect.objectContaining({ disposition: { _tag: 'Merged' } })])
+    store.close()
+  })
+
+  it('keeps a newer open head when a delayed exact closure returns', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    const pullRequest = pullRequestItem({ updatedAt: '2026-08-13T01:00:00.000Z' })
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'open-before-delayed-closure',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+
+    const result = await reconcileRepository(repository, {
+      github: {
+        listOpenItems: () => Promise.resolve(ok([])),
+        getPullRequest: () => {
+          store.recordObservation({
+            externalId: 'new-head-before-delayed-closure',
+            observedAt: '2026-08-13T04:00:00.000Z',
+            source: 'webhook',
+            subject: {
+              ...pullRequest,
+              headSha: 'new-head',
+              updatedAt: '2026-08-13T04:00:00.000Z',
+            },
+          })
+          return Promise.resolve(ok({
+            ...pullRequest,
+            state: 'closed',
+            updatedAt: '2026-08-13T01:30:00.000Z',
+          }))
+        },
+      },
+      store,
+      now: () => new Date('2026-08-13T05:00:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: { repository: repository.github, subjects: 0, inserted: 0, duplicates: 0, stale: 0, closed: 0 },
+    })
+    expect(store.listOpenPullRequestNumbers(repository.github)).toEqual([pullRequest.number])
     store.close()
   })
 

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -343,7 +343,7 @@ describe('gitHub reconciliation', () => {
       commentId: 42,
       url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
     })).toBe(true)
-    expect(store.listStoppedReviews()).toEqual([expect.objectContaining({ disposition: { _tag: 'Closed' } })])
+    expect(store.listStoppedReviews()).toEqual([])
     let exactReads = 0
 
     await reconcileRepository(repository, {

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -19,6 +19,7 @@ afterEach(() => {
 
 /** Rewinds past the Routine tables, which every version below 38 predates. */
 function dropRoutines(database: DatabaseSync): void {
+  database.exec('DROP TABLE IF EXISTS pull_request_closure_verifications')
   database.exec('DROP TABLE IF EXISTS review_closure_resolutions')
   database.exec('DROP TABLE IF EXISTS restart_requests')
   database.exec('DROP TABLE IF EXISTS agent_feedback')
@@ -250,6 +251,103 @@ describe('review usage migration', () => {
   })
 })
 
+describe('pull request closure verification migration', () => {
+  it('rechecks closure resolutions written before exact verification existed', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    const repository = repositoryMapping()
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.syncRepositories([repository], '2026-08-18T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'review-before-legacy-closure',
+      observedAt: '2026-08-18T00:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the open pull request Revision.')
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-18T00:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-18T00:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: '### 🤖 READY',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-agent', '2026-08-18T00:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the Review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-18T00:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-18T00:02:03.000Z',
+      evidence: 'Review finished.',
+    })
+    const merged = store.recordObservation({
+      externalId: 'legacy-closure-resolution',
+      observedAt: '2026-08-18T00:03:00.000Z',
+      source: 'poll',
+      subject: {
+        ...pullRequest,
+        state: 'closed',
+        mergedAt: '2026-08-18T00:03:00.000Z',
+        updatedAt: '2026-08-18T00:03:00.000Z',
+      },
+    })
+    if (merged._tag !== 'Inserted')
+      throw new Error('Expected the merged pull request Revision.')
+    expect(store.recordVerifiedPullRequestClosure({
+      repository: repository.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: merged.revisionId,
+      headSha: pullRequest.headSha,
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Merged' },
+      at: '2026-08-18T00:03:00.000Z',
+    })).toBe(true)
+    expect(store.recordReviewClosure({
+      repository: repository.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: merged.revisionId,
+      headSha: pullRequest.headSha,
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Merged' },
+      result: { _tag: 'Superseded' },
+      at: '2026-08-18T00:04:00.000Z',
+    })).toBe(true)
+    store.close()
+
+    const oldJournal = new DatabaseSync(path)
+    oldJournal.exec('DROP TABLE pull_request_closure_verifications; PRAGMA user_version = 48;')
+    oldJournal.close()
+
+    const migrated = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    try {
+      expect(migrated.listUnverifiedClosedPullRequestNumbers(repository.github)).toEqual([pullRequest.number])
+    }
+    finally {
+      migrated.close()
+    }
+  })
+})
+
 describe('installation permission recovery migration', () => {
   it('gives Tasks blocked by the old Workflow permission request one bounded recovery', () => {
     const path = join(directory, 'state.sqlite')
@@ -373,7 +471,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(48)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(49)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1809,7 +1809,7 @@ describe('journal store', () => {
     })).toBe(true)
     expect(store.listStoppedReviews()).toEqual([])
 
-    store.recordObservation({
+    const merged = store.recordObservation({
       externalId: 'review-merged',
       observedAt: '2026-08-13T01:03:00.000Z',
       source: 'poll',
@@ -1820,6 +1820,17 @@ describe('journal store', () => {
         updatedAt: '2026-08-13T01:03:00.000Z',
       },
     })
+    if (merged._tag !== 'Inserted')
+      throw new Error('Expected the merged pull request Revision.')
+    expect(store.recordVerifiedPullRequestClosure({
+      repository: pullRequest.repository,
+      pullRequestNumber: pullRequest.number,
+      revisionId: merged.revisionId,
+      headSha: pullRequest.headSha,
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Merged' },
+      at: '2026-08-13T01:03:00.000Z',
+    })).toBe(true)
 
     const stopped = store.listStoppedReviews()
     expect(stopped).toEqual([expect.objectContaining({
@@ -1940,7 +1951,7 @@ describe('journal store', () => {
       findings: [],
       publication: settlementPublication('ready-after-pending'),
     })._tag).toBe('Inserted')
-    store.recordObservation({
+    const merged = store.recordObservation({
       externalId: 'ready-review-merged',
       observedAt: '2026-08-13T01:04:00.000Z',
       source: 'poll',
@@ -1951,6 +1962,17 @@ describe('journal store', () => {
         updatedAt: '2026-08-13T01:04:00.000Z',
       },
     })
+    if (merged._tag !== 'Inserted')
+      throw new Error('Expected the merged pull request Revision.')
+    expect(store.recordVerifiedPullRequestClosure({
+      repository: pullRequest.repository,
+      pullRequestNumber: pullRequest.number,
+      revisionId: merged.revisionId,
+      headSha: pullRequest.headSha,
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Merged' },
+      at: '2026-08-13T01:04:00.000Z',
+    })).toBe(true)
 
     expect(store.listStoppedReviews()).toEqual([expect.objectContaining({
       disposition: { _tag: 'Merged' },
@@ -2013,7 +2035,7 @@ describe('journal store', () => {
       source: 'poll',
       subject: { ...pullRequest, headSha: 'repaired24', updatedAt: '2026-08-13T01:03:00.000Z' },
     })
-    store.recordObservation({
+    const merged = store.recordObservation({
       externalId: 'repaired-merged',
       observedAt: '2026-08-13T01:04:00.000Z',
       source: 'poll',
@@ -2025,6 +2047,17 @@ describe('journal store', () => {
         updatedAt: '2026-08-13T01:04:00.000Z',
       },
     })
+    if (merged._tag !== 'Inserted')
+      throw new Error('Expected the repaired merged pull request Revision.')
+    expect(store.recordVerifiedPullRequestClosure({
+      repository: pullRequest.repository,
+      pullRequestNumber: pullRequest.number,
+      revisionId: merged.revisionId,
+      headSha: 'repaired24',
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Merged' },
+      at: '2026-08-13T01:04:00.000Z',
+    })).toBe(true)
 
     const stopped = store.listStoppedReviews()
     expect(stopped).toEqual([expect.objectContaining({

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -2818,6 +2818,113 @@ describe('journal store', () => {
     expect(store.getDashboardSnapshot('2026-08-13T03:00:00.000Z').items[0]?.title).toBe('New title')
   })
 
+  it('restores an exact open pull request over its inferred closure', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ updatedAt: '2026-08-13T01:00:00.000Z' })
+    const open = store.recordObservation({
+      externalId: 'open-before-inferred-closure',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    if (open._tag !== 'Inserted')
+      throw new Error('Expected the open pull request Revision.')
+    store.closeMissingItems(pullRequest.repository, [], '2026-08-13T02:00:00.000Z')
+
+    const exact = store.recordExactPullRequestObservation({
+      externalId: 'exact-open-after-inferred-closure',
+      observedAt: '2026-08-13T03:00:00.000Z',
+      subject: pullRequest,
+    })
+
+    expect(exact).toEqual({ _tag: 'Duplicate', revisionId: open.revisionId })
+    expect(store.listOpenPullRequestNumbers(pullRequest.repository)).toEqual([pullRequest.number])
+  })
+
+  it.each([
+    {
+      name: 'a newer open head from a poll',
+      source: 'poll' as const,
+      subject: pullRequestItem({ headSha: 'new-head', updatedAt: '2026-08-13T04:00:00.000Z' }),
+    },
+    {
+      name: 'a newer closed Revision from a webhook',
+      source: 'webhook' as const,
+      subject: pullRequestItem({ state: 'closed', title: 'Closed on GitHub', updatedAt: '2026-08-13T04:00:00.000Z' }),
+    },
+  ])('keeps $name ahead of a delayed exact read', ({ source, subject }) => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ updatedAt: '2026-08-13T01:00:00.000Z' })
+    store.recordObservation({
+      externalId: 'open-before-delayed-exact-read',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    store.closeMissingItems(pullRequest.repository, [], '2026-08-13T02:00:00.000Z')
+    store.recordObservation({
+      externalId: `newer-before-delayed-exact-read-${source}`,
+      observedAt: '2026-08-13T04:00:00.000Z',
+      source,
+      subject,
+    })
+
+    const exact = store.recordExactPullRequestObservation({
+      externalId: `delayed-exact-read-${source}`,
+      observedAt: '2026-08-13T05:00:00.000Z',
+      subject: {
+        ...pullRequest,
+        state: 'closed',
+        updatedAt: '2026-08-13T01:30:00.000Z',
+      },
+    })
+
+    expect(exact._tag).toBe('Stale')
+  })
+
+  it('keeps a verified closure ahead of an older exact read', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ updatedAt: '2026-08-13T01:00:00.000Z' })
+    store.recordObservation({
+      externalId: 'open-before-verified-closure',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    store.closeMissingItems(pullRequest.repository, [], '2026-08-13T02:00:00.000Z')
+    const closed = store.recordExactPullRequestObservation({
+      externalId: 'exact-verified-closure',
+      observedAt: '2026-08-13T03:00:00.000Z',
+      subject: {
+        ...pullRequest,
+        state: 'closed',
+        updatedAt: '2026-08-13T01:30:00.000Z',
+      },
+    })
+    if (closed._tag !== 'Inserted')
+      throw new Error('Expected the exact closed pull request Revision.')
+    expect(store.recordVerifiedPullRequestClosure({
+      repository: pullRequest.repository,
+      pullRequestNumber: pullRequest.number,
+      revisionId: closed.revisionId,
+      headSha: pullRequest.headSha,
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Closed' },
+      at: '2026-08-13T03:00:00.000Z',
+    })).toBe(true)
+
+    const exact = store.recordExactPullRequestObservation({
+      externalId: 'older-exact-after-verified-closure',
+      observedAt: '2026-08-13T04:00:00.000Z',
+      subject: pullRequest,
+    })
+
+    expect(exact._tag).toBe('Stale')
+  })
+
   it('supersedes conflict work when the pull request becomes clean', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The #116 smoke queued 234 legacy Review comments for closure before checking their inferred CLOSED state against GitHub. Hogwild stopped after two bounded passes.

Closure publication now requires a durable exact GitHub read. Existing cleanup rows get checked again, so a wrong CLOSED result can still recover to MERGED.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.