### PR TITLE
fix(triage): stop the Running label invalidating issue triage

### DIFF
--- a/packages/harlan-github-agent/src/issue-triage-comment-controller.ts
+++ b/packages/harlan-github-agent/src/issue-triage-comment-controller.ts
@@ -29,7 +29,6 @@ export function createIssueTriageCommentController(options: IssueTriageCommentCo
         fence: task.state.fence,
         at,
         revisionId: task.revisionId,
-        expectedUpdatedAt: task.issue.updatedAt,
         body,
       })
       if (staged._tag === 'Rejected')
@@ -49,7 +48,9 @@ export function createIssueTriageCommentController(options: IssueTriageCommentCo
         })
         return current
       }
-      if (current.value.state !== 'open' || current.value.updatedAt !== command.expectedUpdatedAt) {
+      // updatedAt moves every time this service writes its own labels, so only
+      // the issue being closed says the comment no longer belongs.
+      if (current.value.state !== 'open') {
         const reason = 'The issue changed before the triage comment was posted.'
         options.store.deferIssueTriageComment({
           commandId: command.id,

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1,6 +1,6 @@
 import type { AgentActivityLog } from './agent-activity.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
-import type { GitHubAgentSource, GitHubCheck, GitHubChecksSnapshot, PullRequestReviewSnapshot, RequiredChecks } from './github-agent-source.ts'
+import type { GitHubAgentSource, GitHubCheck, GitHubChecksSnapshot, IssueTriageSnapshot, PullRequestReviewSnapshot, RequiredChecks } from './github-agent-source.ts'
 import type { IssueTriageCommentController } from './issue-triage-comment-controller.ts'
 import type { IssueTriageResult } from './issue-triage.ts'
 import type { PullRequestTriageAgent, PullRequestTriageResult } from './pull-request-triage.ts'
@@ -12,6 +12,7 @@ import type {
   ClaimedAdversarialReviewTask,
   ClaimedAgentTask,
   ClaimedIssueTriageTask,
+  GitHubIssueItem,
   GitHubPullRequestItem,
   RepositoryMapping,
   ReviewFinding,
@@ -1293,13 +1294,28 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
   }
 }
 
+/**
+ * Whether the issue moved under a claimed triage Task.
+ *
+ * `updatedAt` answers labels, and the Running label this service writes at
+ * claim time moves it, so a timestamp can never say whether the work changed.
+ * State and title are Revision content, and the stage gate pins the Revision
+ * itself, so that is all this check needs to repeat.
+ */
+export function issueMovedUnderTriage(
+  issue: Pick<GitHubIssueItem, 'title'>,
+  snapshot: Pick<IssueTriageSnapshot, 'state' | 'title'>,
+): boolean {
+  return snapshot.state !== 'open' || snapshot.title !== issue.title
+}
+
 export function createIssueTriageWorker(options: ItemAgentOptions): IssueTriageWorker {
   return {
     async run(task, signal) {
       const snapshot = await options.github.getIssueTriageSnapshot(task.repositoryMapping, task.issueNumber, signal)
       if (snapshot._tag === 'Err')
         return snapshot
-      if (snapshot.value.state !== 'open' || snapshot.value.updatedAt !== task.issue.updatedAt)
+      if (issueMovedUnderTriage(task.issue, snapshot.value))
         return err('The issue changed before triage started.')
       const workspace = await options.workspaces.prepareIssue(
         task,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -885,7 +885,6 @@ export interface JournalStore {
     fence: number
     at: string
     revisionId: string
-    expectedUpdatedAt: string
     body: string
   }) => { _tag: 'Staged' | 'Duplicate', commandId: string } | { _tag: 'Rejected', reason: string }
   stagePublication: (input: {
@@ -4216,6 +4215,20 @@ const verifiedPullRequestClosureMigration = `
   PRAGMA user_version = 49;
 `
 
+/**
+ * Drops the expected updated at column from issue triage comments.
+ *
+ * The column compared GitHub's `updatedAt` at publish time, but the Running
+ * label the service itself writes bumps `updatedAt` on every claim. A comment
+ * staged under one label state could never publish under the next, so it
+ * waited forever. The Revision identity already answers whether the issue
+ * changed, and it excludes `updatedAt` on purpose.
+ */
+const issueTriageCommentContentMigration = `
+  ALTER TABLE issue_triage_comment_commands DROP COLUMN expected_updated_at;
+  PRAGMA user_version = 50;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -4241,7 +4254,7 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
-  if (version === 49)
+  if (version === 50)
     return
   const existing = database.prepare(`
     SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
@@ -4438,6 +4451,10 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 48) {
     applyMigration(database, verifiedPullRequestClosureMigration)
+    version = 49
+  }
+  if (version === 49) {
+    applyMigration(database, issueTriageCommentContentMigration)
     return
   }
   throw new Error(`Unsupported database schema version: ${version}.`)
@@ -6991,7 +7008,6 @@ export function openJournalStore(
           AND worker_tasks.state_tag = 'Running' AND worker_tasks.worker_id = ?
           AND worker_tasks.fence = ? AND worker_tasks.lease_expires_at > ?
           AND worker_tasks.revision_id = ? AND subjects.current_revision_id = ?
-          AND json_extract(revisions.payload, '$.updatedAt') = ?
           AND repositories.enabled = 1
           AND json_extract(repositories.policy_json, '$.issueWork') = 1
       `).get(
@@ -7001,7 +7017,6 @@ export function openJournalStore(
         input.at,
         input.revisionId,
         input.revisionId,
-        input.expectedUpdatedAt,
       )
       if (authorized === undefined) {
         database.exec('COMMIT')
@@ -7019,15 +7034,14 @@ export function openJournalStore(
       }
       database.prepare(`
         INSERT INTO issue_triage_comment_commands (
-          id, task_id, task_fence, revision_id, expected_updated_at, body, body_sha256,
+          id, task_id, task_fence, revision_id, body, body_sha256,
           state_tag, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, 'Pending', ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, 'Pending', ?, ?)
       `).run(
         commandId,
         input.taskId,
         input.fence,
         input.revisionId,
-        input.expectedUpdatedAt,
         input.body,
         bodySha256,
         input.at,
@@ -7058,7 +7072,6 @@ export function openJournalStore(
           repositories.github AS repository,
           subjects.github_number,
           issue_triage_comment_commands.revision_id,
-          issue_triage_comment_commands.expected_updated_at,
           issue_triage_comment_commands.body,
           issue_triage_comment_commands.outcome_unknown,
           COALESCE(issue_triage_comment_commands.github_comment_id, (
@@ -7090,7 +7103,6 @@ export function openJournalStore(
         repository: string
         github_number: number
         revision_id: string
-        expected_updated_at: string
         body: string
         outcome_unknown: number
         github_comment_id: number | null
@@ -7117,7 +7129,6 @@ export function openJournalStore(
         repository: row.repository,
         issueNumber: row.github_number,
         revisionId: row.revision_id,
-        expectedUpdatedAt: row.expected_updated_at,
         body: row.body,
         outcomeUnknown: row.outcome_unknown === 1,
         commentId: row.github_comment_id,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -759,7 +759,6 @@ export interface IssueTriageCommentCommand {
   repository: string
   issueNumber: number
   revisionId: string
-  expectedUpdatedAt: string
   body: string
   outcomeUnknown: boolean
   commentId: number | null

--- a/packages/harlan-github-agent/test/issue-triage-comment-controller.test.ts
+++ b/packages/harlan-github-agent/test/issue-triage-comment-controller.test.ts
@@ -1,8 +1,77 @@
+import type { IssueTriageSnapshot } from '../src/github-agent-source.ts'
 import type { ClaimedIssueTriageTask } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
 import { createIssueTriageCommentController } from '../src/issue-triage-comment-controller.ts'
-import { ok } from '../src/result.ts'
+import { err, ok } from '../src/result.ts'
 import { issueItem, repositoryMapping } from './fixtures.ts'
+
+function triageTask(): ClaimedIssueTriageTask {
+  const repository = repositoryMapping()
+  const issue = issueItem()
+  return {
+    id: 'triage-task',
+    kind: 'issue_triage',
+    repository: repository.github,
+    issueNumber: issue.number,
+    revisionId: 'revision-1',
+    state: { _tag: 'Running', workerId: 'triage-worker', fence: 2, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+    updatedAt: issue.updatedAt,
+    repositoryMapping: repository,
+    issue,
+  }
+}
+
+const readyResult = {
+  _tag: 'READY_TO_SPEC',
+  difficulty: 4,
+  impact: 4,
+  hasReproduction: true,
+  needsCodebaseReview: true,
+  summary: 'The goal is clear, but the API shape is undecided.',
+  nextAction: 'Write a technical specification.',
+} as const
+
+function controllerWithSnapshot(snapshot: IssueTriageSnapshot) {
+  const deferred: string[] = []
+  const published: number[] = []
+  const task = triageTask()
+  const controller = createIssueTriageCommentController({
+    github: {
+      getIssueTriageSnapshot: () => Promise.resolve(ok(snapshot)),
+      stampAgentLabel: () => Promise.resolve(ok(undefined)),
+      upsertIssueTriageComment: (_repository, _number, _commentId, _body) => {
+        published.push(1)
+        return Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/issues/12#issuecomment-42' }))
+      },
+    },
+    leaseMilliseconds: 60_000,
+    now: () => new Date('2026-08-13T01:00:00.000Z'),
+    store: {
+      stageIssueTriageComment: () => ({ _tag: 'Staged', commandId: 'triage-comment' }),
+      claimIssueTriageComment: () => ({
+        id: 'triage-comment',
+        taskId: task.id,
+        repository: task.repository,
+        issueNumber: task.issueNumber,
+        revisionId: task.revisionId,
+        body: 'body',
+        outcomeUnknown: false,
+        commentId: null,
+        workerId: 'comment-worker',
+        fence: 1,
+        leaseExpiresAt: '2026-08-13T02:00:00.000Z',
+        repositoryMapping: task.repositoryMapping,
+      }),
+      completeIssueTriageComment: () => true,
+      deferIssueTriageComment: (input) => {
+        deferred.push(input.reason)
+        return true
+      },
+    },
+    workerId: 'comment-worker',
+  })
+  return { controller, deferred, published, task }
+}
 
 describe('issue triage publication', () => {
   it('publishes one matching comment and routing label', async () => {
@@ -53,7 +122,6 @@ describe('issue triage publication', () => {
           repository: repository.github,
           issueNumber: issue.number,
           revisionId: task.revisionId,
-          expectedUpdatedAt: issue.updatedAt,
           body: stagedBody,
           outcomeUnknown: false,
           commentId: null,
@@ -81,5 +149,39 @@ describe('issue triage publication', () => {
     expect(result).toEqual(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/issues/12#issuecomment-42' }))
     expect(stamped).toEqual(['READY_TO_SPEC'])
     expect(body).toContain('- **Route:** Ready to spec')
+  })
+
+  it('publishes after the Running label moved updatedAt', async () => {
+    // The service's own Running label write bumps updatedAt, so a snapshot
+    // never answers the timestamp the claim observed. Publication must not
+    // wait for a timestamp that can never return.
+    const { controller, deferred, published, task } = controllerWithSnapshot({
+      body: 'Reproduction',
+      comments: [],
+      state: 'open',
+      title: 'Broken thing',
+      updatedAt: '2026-08-13T01:01:30.000Z',
+    })
+
+    const result = await controller.publish(task, readyResult, new AbortController().signal)
+
+    expect(result).toEqual(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/issues/12#issuecomment-42' }))
+    expect(published).toHaveLength(1)
+    expect(deferred).toEqual([])
+  })
+
+  it('defers when the issue closed before publication', async () => {
+    const { controller, deferred, task } = controllerWithSnapshot({
+      body: 'Reproduction',
+      comments: [],
+      state: 'closed',
+      title: 'Broken thing',
+      updatedAt: '2026-08-13T01:01:30.000Z',
+    })
+
+    const result = await controller.publish(task, readyResult, new AbortController().signal)
+
+    expect(result).toEqual(err('The issue changed before the triage comment was posted.'))
+    expect(deferred).toEqual(['The issue changed before the triage comment was posted.'])
   })
 })

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -2,7 +2,7 @@ import type { RecordReviewRunInput } from '../src/types.ts'
 import type { ProviderCapture } from './fixtures.ts'
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
-import { createIssueTriageWorker, createReviewWorker, reviewSnapshotDigest } from '../src/item-agent.ts'
+import { createIssueTriageWorker, createReviewWorker, issueMovedUnderTriage, reviewSnapshotDigest } from '../src/item-agent.ts'
 import { ok } from '../src/result.ts'
 import { agentRuntime, issueItem, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
@@ -1015,7 +1015,9 @@ describe('subject Workers', () => {
         clearRunningLabel: () => Promise.reject(new Error('Unexpected Running label clear.')),
         listRunningLabelledItems: () => Promise.reject(new Error('Unexpected Running label read.')),
         stampAgentLabel: () => Promise.resolve(ok(undefined)),
-        getIssueTriageSnapshot: () => Promise.resolve(ok({ body: 'Reproduction', comments: [], state: 'open', title: issue.title, updatedAt: issue.updatedAt })),
+        // A later updatedAt than the Task observed: the Running label write
+        // moves it, and triage must still run.
+        getIssueTriageSnapshot: () => Promise.resolve(ok({ body: 'Reproduction', comments: [], state: 'open', title: issue.title, updatedAt: '2026-08-13T01:01:30.000Z' })),
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
         getPullRequestReviewSnapshot: () => Promise.reject(new Error('Unexpected pull request request.')),
@@ -1078,5 +1080,18 @@ describe('subject Workers', () => {
       summary: 'The parser drops valid input.',
       nextAction: 'Write a regression test and repair the parser.',
     })
+  })
+})
+
+describe('issue triage snapshot guard', () => {
+  const issue = { title: 'Broken thing' }
+
+  it('keeps triage running when only the Running label moved updatedAt', () => {
+    expect(issueMovedUnderTriage(issue, { state: 'open', title: 'Broken thing' })).toBe(false)
+  })
+
+  it('stops triage when the issue closed or the title changed', () => {
+    expect(issueMovedUnderTriage(issue, { state: 'closed', title: 'Broken thing' })).toBe(true)
+    expect(issueMovedUnderTriage(issue, { state: 'open', title: 'Renamed by a person' })).toBe(true)
   })
 })

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -36,6 +36,12 @@ function dropSelectionMode(database: DatabaseSync): void {
   database.exec('DROP TABLE item_dismissals')
   database.exec('ALTER TABLE repositories DROP COLUMN writes_enabled')
   dropRoutines(database)
+  restoreExpectedUpdatedAt(database)
+}
+
+/** Rewinds the triage comment table to version 49, which still stored the expected updated at. */
+function restoreExpectedUpdatedAt(database: DatabaseSync): void {
+  database.exec(`ALTER TABLE issue_triage_comment_commands ADD COLUMN expected_updated_at TEXT NOT NULL DEFAULT ''`)
 }
 
 /**
@@ -219,6 +225,7 @@ function journalAtVersion30(path: string): void {
     'a'.repeat(64),
   )
   dropRoutines(database)
+  restoreExpectedUpdatedAt(database)
   database.exec('PRAGMA user_version = 30')
   database.close()
 }
@@ -336,6 +343,7 @@ describe('pull request closure verification migration', () => {
 
     const oldJournal = new DatabaseSync(path)
     oldJournal.exec('DROP TABLE pull_request_closure_verifications; PRAGMA user_version = 48;')
+    restoreExpectedUpdatedAt(oldJournal)
     oldJournal.close()
 
     const migrated = openJournalStore(path, true, CODEX_AGENT_PROFILE)
@@ -386,6 +394,7 @@ describe('installation permission recovery migration', () => {
 
     const oldJournal = new DatabaseSync(path)
     dropRoutines(oldJournal)
+    restoreExpectedUpdatedAt(oldJournal)
     oldJournal.exec('PRAGMA user_version = 32')
     oldJournal.close()
 
@@ -439,6 +448,7 @@ describe('provider session recovery migration', () => {
 
     const oldJournal = new DatabaseSync(path)
     dropRoutines(oldJournal)
+    restoreExpectedUpdatedAt(oldJournal)
     oldJournal.exec('PRAGMA user_version = 34')
     oldJournal.close()
 
@@ -471,7 +481,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(49)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(50)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -1031,7 +1031,6 @@ describe('journal store', () => {
       fence: task.state.fence,
       at: '2026-08-13T01:02:00.000Z',
       revisionId: observed.revisionId,
-      expectedUpdatedAt: task.issue.updatedAt,
       body: '<!-- harlan-agent-kit:issue-triage -->\nTriage result.',
     })
     if (staged._tag === 'Rejected')
@@ -1090,7 +1089,6 @@ describe('journal store', () => {
       fence: task.state.fence,
       at: '2026-08-13T01:02:00.000Z',
       revisionId: observed.revisionId,
-      expectedUpdatedAt: task.issue.updatedAt,
       body: '<!-- harlan-agent-kit:issue-triage -->\nTriage result.',
     })
     expect(staged).toEqual({ _tag: 'Staged', commandId: expect.any(String) })
@@ -1101,7 +1099,6 @@ describe('journal store', () => {
       repository: 'harlan-zw/example',
       issueNumber: 12,
       revisionId: observed.revisionId,
-      expectedUpdatedAt: task.issue.updatedAt,
       commentId: null,
       body: '<!-- harlan-agent-kit:issue-triage -->\nTriage result.',
     }))
@@ -1140,13 +1137,47 @@ describe('journal store', () => {
       fence: rerun.state.fence,
       at: '2026-08-13T02:02:00.000Z',
       revisionId: changed.revisionId,
-      expectedUpdatedAt: rerun.issue.updatedAt,
       body: '<!-- harlan-agent-kit:issue-triage -->\nUpdated triage result.',
     })
     if (restaged._tag === 'Rejected')
       throw new Error(restaged.reason)
     expect(store.claimIssueTriageComment(restaged.commandId, 'comment-controller', '2026-08-13T02:02:01.000Z', 600_000))
       .toEqual(expect.objectContaining({ commentId: 42 }))
+  })
+
+  it('stages a triage comment after the Running label moved updatedAt', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'label-bumped-issue',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: issueItem(),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new issue Revision.')
+    const task = store.claimNextIssueTriageTask('issue-worker', '2026-08-13T01:01:00.000Z', 600_000)
+    if (task === null)
+      throw new Error('Expected an issue triage Task.')
+
+    // The Running label write bumps GitHub's updatedAt without changing any
+    // Revision content, and the next observation carries the new timestamp.
+    store.recordObservation({
+      externalId: 'label-bumped-issue-again',
+      observedAt: '2026-08-13T01:01:30.000Z',
+      source: 'poll',
+      subject: issueItem({ updatedAt: '2026-08-13T01:01:30.000Z' }),
+    })
+
+    const staged = store.stageIssueTriageComment({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:10:00.000Z',
+      revisionId: observed.revisionId,
+      body: '<!-- harlan-agent-kit:issue-triage -->\nTriage result.',
+    })
+    expect(staged).toEqual({ _tag: 'Staged', commandId: expect.any(String) })
   })
 
   it('queues trusted author Issue work only after Ready to implement triage', () => {


### PR DESCRIPTION
## Problem

Candidate issues opened by propose-mode Routines were never picked up. On skilld.dev, issues #98/#99 burned all three triage attempts in 11 minutes and landed permanently Failed. The same gate also strands triage comments in Pending forever (44 on hogwild).

## Root cause

Three issue-triage gates compared GitHub's raw `updatedAt`:
- worker guard (`item-agent.ts`)
- stage authorization (`store.ts`)
- publish check (`issue-triage-comment-controller.ts`)

But the service's own `harlan-agent-running` label write bumps `updatedAt` on every claim, and settle bumps it again. Every first claim rejected itself. PR reviews already compare `headSha` instead; issue triage needed the same treatment.

## Change

- Worker guard compares state and title (Revision content), extracted as `issueMovedUnderTriage`
- Stage authorization pins the Revision only; the `payload.updatedAt` clause is gone
- Publish check requires the issue be open, nothing else
- Migration 50 drops `expected_updated_at`; rewind fixtures restore it

## Verification

- 1044 tests pass, typecheck clean, service tests pass
- Regression tests: triage runs after a label bump, staging survives a re-observed updatedAt, publication does not wait on a timestamp that can never return

> The Harlan Agent Kit opened this pull request automatically. It is not Harlan's own report.