### PR TITLE
fix(agent): show runner scheduler capacity

### DIFF
--- a/packages/harlan-github-agent/dashboard/app/pages/index.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/index.vue
@@ -45,6 +45,7 @@ import {
 import {
   formatHogwildHost,
   formatHogwildLoad,
+  formatHogwildRunnerCapacity,
   formatHogwildServiceMetrics,
   formatHogwildTemperature,
 } from '../utils/hogwild-status.ts'
@@ -394,6 +395,14 @@ useHead({
               </dt>
               <dd class="break-words font-mono text-xs text-muted">
                 {{ formatHogwildHost(hogwildStatus.host) }}
+              </dd>
+            </div>
+            <div class="grid gap-1 py-2 sm:grid-cols-[9rem_minmax(0,1fr)] sm:items-baseline sm:gap-4">
+              <dt class="field-label">
+                Self-hosted runners
+              </dt>
+              <dd class="break-words font-mono text-xs text-muted">
+                {{ formatHogwildRunnerCapacity(hogwildStatus.runners) }}
               </dd>
             </div>
           </dl>

--- a/packages/harlan-github-agent/dashboard/app/utils/hogwild-status.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/hogwild-status.ts
@@ -11,6 +11,27 @@ export type HogwildServiceState
     | { _tag: 'Inactive' }
     | { _tag: 'Unavailable' }
 
+export type HogwildRunnerStatus
+  = | { _tag: 'Unavailable' }
+    | {
+      _tag: 'Available'
+      budgets: {
+        cpu: number
+        memoryBytes: number
+        memoryHeadroomBytes: number
+      }
+      pools: Array<{
+        cpuPerRunner: number
+        live: number
+        maximum: number
+        memoryLimitBytes: number
+        memoryReservationBytes: number
+        queue: { _tag: 'Available', jobs: number } | { _tag: 'Unavailable' }
+        running: number
+      }>
+      updatedAt: number
+    }
+
 export interface HogwildStatus {
   host: {
     cpu: string
@@ -19,6 +40,7 @@ export interface HogwildStatus {
     operatingSystem: string
   }
   load: [number, number, number]
+  runners: HogwildRunnerStatus
   services: Array<{
     name: 'AdGuard Home' | 'Cloudflare Tunnel' | 'GitHub runner' | 'Jellyfin'
     state: HogwildServiceState
@@ -175,6 +197,32 @@ export function formatHogwildHost(host: HogwildStatus['host']): string {
   return `${host.cpu} · ${host.logicalCores} logical cores · ${host.operatingSystem} ${host.kernel}`
 }
 
+export function formatHogwildRunnerCapacity(status: HogwildRunnerStatus): string {
+  if (status._tag === 'Unavailable')
+    return 'Unavailable'
+
+  const running = sum(status.pools, pool => pool.running)
+  const queued = status.pools.every(pool => pool.queue._tag === 'Available')
+    ? String(sum(status.pools, pool => pool.queue._tag === 'Available' ? pool.queue.jobs : 0))
+    : 'Unavailable'
+  const live = sum(status.pools, pool => pool.live)
+  const maximum = sum(status.pools, pool => pool.maximum)
+  const cpuReserved = sum(status.pools, pool => pool.live * pool.cpuPerRunner)
+  const memoryReserved = sum(status.pools, pool => pool.live * pool.memoryReservationBytes)
+  const largestHardLimit = Math.max(0, ...status.pools.map(pool => pool.memoryLimitBytes))
+
+  return `${running} running · ${queued} queued · ${live} / ${maximum} live · ${cpuReserved} / ${status.budgets.cpu} CPU reserved · ${formatGibibytes(memoryReserved)} / ${formatGibibytes(status.budgets.memoryBytes)} memory reserved · ${formatGibibytes(largestHardLimit)} largest hard limit · keeps ${formatGibibytes(status.budgets.memoryHeadroomBytes)} available`
+}
+
+function formatGibibytes(bytes: number): string {
+  const gibibytes = bytes / 1024 ** 3
+  return `${Number.isInteger(gibibytes) ? gibibytes : gibibytes.toFixed(1)} GiB`
+}
+
+function sum<Value>(values: Value[], select: (value: Value) => number): number {
+  return values.reduce((total, value) => total + select(value), 0)
+}
+
 function formatDuration(seconds: number): string {
   if (seconds >= 86_400)
     return `${Math.floor(seconds / 86_400)}d ${Math.floor(seconds % 86_400 / 3_600)}h`
@@ -197,17 +245,94 @@ function parseJson(input: string): { _tag: 'Ok', value: unknown } | { _tag: 'Err
 function parseStatus(value: Record<string, unknown>): HogwildStatus | undefined {
   const host = parseHost(value.host)
   const load = parseLoad(value.load)
+  const runners = parseRunners(value.runners)
   const services = parseServices(value.services)
   const temperatures = parseTemperatures(value.temperatures)
   const updatedAt = count(value.updatedAt)
   if (host === undefined
     || load === undefined
+    || runners === undefined
     || services === undefined
     || temperatures === undefined
     || updatedAt === undefined) {
     return undefined
   }
-  return { host, load, services, temperatures, updatedAt }
+  return { host, load, runners, services, temperatures, updatedAt }
+}
+
+function parseRunners(value: unknown): HogwildRunnerStatus | undefined {
+  if (!isRecord(value))
+    return undefined
+  if (value._tag === 'Unavailable')
+    return { _tag: 'Unavailable' }
+  if (value._tag !== 'Available' || !isRecord(value.budgets) || !Array.isArray(value.pools))
+    return undefined
+  const cpu = count(value.budgets.cpu)
+  const memoryBytes = count(value.budgets.memoryBytes)
+  const memoryHeadroomBytes = count(value.budgets.memoryHeadroomBytes)
+  const updatedAt = count(value.updatedAt)
+  if (cpu === undefined
+    || memoryBytes === undefined
+    || memoryHeadroomBytes === undefined
+    || updatedAt === undefined) {
+    return undefined
+  }
+  const pools = value.pools.map(parseRunnerPool)
+  if (pools.includes(undefined))
+    return undefined
+  return {
+    _tag: 'Available',
+    budgets: {
+      cpu,
+      memoryBytes,
+      memoryHeadroomBytes,
+    },
+    pools: pools as Extract<HogwildRunnerStatus, { _tag: 'Available' }>['pools'],
+    updatedAt,
+  }
+}
+
+function parseRunnerPool(value: unknown): Extract<HogwildRunnerStatus, { _tag: 'Available' }>['pools'][number] | undefined {
+  if (!isRecord(value))
+    return undefined
+  const cpuPerRunner = count(value.cpuPerRunner)
+  const live = count(value.live)
+  const maximum = count(value.maximum)
+  const memoryLimitBytes = count(value.memoryLimitBytes)
+  const memoryReservationBytes = count(value.memoryReservationBytes)
+  const running = count(value.running)
+  if (cpuPerRunner === undefined
+    || live === undefined
+    || maximum === undefined
+    || memoryLimitBytes === undefined
+    || memoryReservationBytes === undefined
+    || memoryReservationBytes > memoryLimitBytes
+    || running === undefined) {
+    return undefined
+  }
+  const queue = parseRunnerQueue(value.queue)
+  return queue === undefined
+    ? undefined
+    : {
+        cpuPerRunner,
+        live,
+        maximum,
+        memoryLimitBytes,
+        memoryReservationBytes,
+        queue,
+        running,
+      }
+}
+
+function parseRunnerQueue(value: unknown): Extract<HogwildRunnerStatus, { _tag: 'Available' }>['pools'][number]['queue'] | undefined {
+  if (!isRecord(value))
+    return undefined
+  if (value._tag === 'Unavailable')
+    return { _tag: 'Unavailable' }
+  const jobs = count(value.jobs)
+  return value._tag === 'Available' && jobs !== undefined
+    ? { _tag: 'Available', jobs }
+    : undefined
 }
 
 function parseHost(value: unknown): HogwildStatus['host'] | undefined {

--- a/packages/harlan-github-agent/test/hogwild-status.test.ts
+++ b/packages/harlan-github-agent/test/hogwild-status.test.ts
@@ -5,6 +5,7 @@ import {
   emptyHogwildHistory,
   formatHogwildHost,
   formatHogwildLoad,
+  formatHogwildRunnerCapacity,
   formatHogwildServiceMetrics,
   formatHogwildTemperature,
   formatHogwildTemperatures,
@@ -21,6 +22,24 @@ const details: HogwildStatus = {
     operatingSystem: 'Linux',
   },
   load: [0.2, 0.4, 1.02],
+  runners: {
+    _tag: 'Available',
+    budgets: {
+      cpu: 20,
+      memoryBytes: 24 * 1024 ** 3,
+      memoryHeadroomBytes: 6 * 1024 ** 3,
+    },
+    pools: [{
+      cpuPerRunner: 8,
+      live: 2,
+      maximum: 4,
+      memoryLimitBytes: 9 * 1024 ** 3,
+      memoryReservationBytes: 5 * 1024 ** 3,
+      queue: { _tag: 'Available', jobs: 1 },
+      running: 2,
+    }],
+    updatedAt: 1_787_899_378_238,
+  },
   services: [
     {
       name: 'Jellyfin',
@@ -102,6 +121,7 @@ describe('hogwild status boundary', () => {
     expect(formatHogwildTemperatures(details.temperatures)).toBe('CPU 41.0°C · Storage 54.9°C')
     expect(formatHogwildLoad(details.load)).toBe('0.20 · 0.40 · 1.02')
     expect(formatHogwildHost(details.host)).toBe('Intel(R) Core(TM) Ultra 9 285HX · 24 logical cores · Linux 7.0.0-30-generic')
+    expect(formatHogwildRunnerCapacity(details.runners)).toBe('2 running · 1 queued · 2 / 4 live · 16 / 20 CPU reserved · 10 GiB / 24 GiB memory reserved · 9 GiB largest hard limit · keeps 6 GiB available')
   })
 
   it('appends each live poll once and keeps a bounded recent window', () => {


### PR DESCRIPTION
### ❓ Type of change\n\n- [ ] 📖 Documentation\n- [x] 🐞 Bug fix\n- [ ] 👌 Enhancement\n- [ ] ✨ New feature\n- [ ] 🧹 Chore\n- [ ] ⚠️ Breaking change\n\n### 📚 Description\n\nThe System pane showed host load but ignored the runner capacity in Hogwild's private status. It now shows runner counts, CPU and memory reservations, the largest hard limit, and memory kept available.\n\n> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.