### PR TITLE
fix(agent): unblock automated PR repairs

### DIFF
--- a/packages/harlan-github-agent/src/repository-discovery.ts
+++ b/packages/harlan-github-agent/src/repository-discovery.ts
@@ -106,7 +106,7 @@ function defaultMapping(repository: InstalledRepository, checkout: string): Repo
     ownership,
     defaultBranch: repository.defaultBranch,
     writablePullRequestAuthors: ['harlan-zw', AGENT_ACTOR_LOGIN],
-    writablePullRequestHeadPrefixes: ['fix/', 'feat/', 'chore/', 'docs/', 'refactor/', 'perf/', 'test/'],
+    writablePullRequestHeadPrefixes: ['fix/', 'feat/', 'chore/', 'docs/', 'refactor/', 'perf/', 'test/', 'ci/'],
     issueWork: ownership === 'owned',
     maxOpenPullRequests: null,
     pullRequestReview: true,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -8536,10 +8536,15 @@ export function openJournalStore(
         bodySha256,
         input.reconciliationId ?? '',
       ].join(':'))
-      const existing = database.prepare('SELECT 1 FROM review_status_commands WHERE id = ?').get(commandId)
+      const existing = database.prepare(`
+        SELECT id FROM review_status_commands
+        WHERE task_kind = 'adversarial_review'
+          AND task_id = ? AND task_fence = ?
+          AND phase = 'terminal' AND body_sha256 = ?
+      `).get(row.task_id, row.task_fence, bodySha256) as { id: string } | undefined
       if (existing !== undefined) {
         database.exec('COMMIT')
-        return { _tag: 'Duplicate', commandId }
+        return { _tag: 'Duplicate', commandId: existing.id }
       }
       database.prepare(`
         INSERT INTO review_status_commands (

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -8537,14 +8537,43 @@ export function openJournalStore(
         input.reconciliationId ?? '',
       ].join(':'))
       const existing = database.prepare(`
-        SELECT id FROM review_status_commands
+        SELECT id, state_tag, fence FROM review_status_commands
         WHERE task_kind = 'adversarial_review'
           AND task_id = ? AND task_fence = ?
           AND phase = 'terminal' AND body_sha256 = ?
-      `).get(row.task_id, row.task_fence, bodySha256) as { id: string } | undefined
-      if (existing !== undefined) {
+      `).get(row.task_id, row.task_fence, bodySha256) as {
+        id: string
+        state_tag: 'Pending' | 'Running' | 'Published' | 'Superseded'
+        fence: number
+      } | undefined
+      if (existing !== undefined && (existing.state_tag === 'Pending' || existing.state_tag === 'Running')) {
         database.exec('COMMIT')
         return { _tag: 'Duplicate', commandId: existing.id }
+      }
+      if (existing !== undefined) {
+        // The identical body already went through Publication, so this restage
+        // means GitHub lost the comment. Requeue the same command, keeping its
+        // comment id, so the publisher repairs the existing comment.
+        const reason = existing.state_tag === 'Published'
+          ? 'The published gate comment needs repair.'
+          : 'The superseded gate status was requeued for Publication.'
+        database.prepare(`
+          UPDATE review_status_commands
+          SET state_tag = 'Pending', outcome_unknown = 1, reason = ?, worker_id = NULL,
+            lease_expires_at = NULL, revision_id = ?, expected_head_sha = ?, updated_at = ?
+          WHERE id = ? AND state_tag = ? AND fence = ?
+        `).run(reason, input.revisionId, input.expectedHeadSha, input.at, existing.id, existing.state_tag, existing.fence)
+        recordReviewStatusEvent(database, {
+          commandId: existing.id,
+          event: 'DriftReconciliationStaged',
+          from: existing.state_tag,
+          to: 'Pending',
+          reason,
+          fence: existing.fence,
+          at: input.at,
+        })
+        database.exec('COMMIT')
+        return { _tag: 'Staged', commandId: existing.id }
       }
       database.prepare(`
         INSERT INTO review_status_commands (

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -8899,11 +8899,20 @@ export function openJournalStore(
         `).get(input.commandId) as { review_run_id: string | null, body: string }
         if (command.review_run_id !== null) {
           const publicationResult = { _tag: 'Published' as const, githubCommentId: input.commentId, url: input.url }
+          // A drift repair republishes the same command id, so the row already
+          // exists and must move to the replacement comment. Keeping the stale
+          // comment id here would requeue the command on every sweep pass and
+          // create a duplicate gate comment each time.
           database.prepare(`
-            INSERT OR IGNORE INTO review_publications (
+            INSERT INTO review_publications (
               id, review_run_id, body, body_sha256, created_at, result_tag,
               github_comment_id, github_url, reason, content_digest
             ) VALUES (?, ?, ?, ?, ?, 'Published', ?, ?, NULL, ?)
+            ON CONFLICT (id) DO UPDATE SET
+              created_at = excluded.created_at,
+              github_comment_id = excluded.github_comment_id,
+              github_url = excluded.github_url,
+              content_digest = excluded.content_digest
           `).run(
             input.commandId,
             command.review_run_id,

--- a/packages/harlan-github-agent/test/repository-discovery.test.ts
+++ b/packages/harlan-github-agent/test/repository-discovery.test.ts
@@ -5,7 +5,8 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { buildRepositoryMappings, discoverLocalCheckouts, installedWithoutCheckout, isAllowedRepository } from '../src/repository-discovery.ts'
-import { repositoryMapping } from './fixtures.ts'
+import { canRepairPullRequestHead } from '../src/repository-policy.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
 const temporaryDirectories: string[] = []
 
@@ -186,5 +187,20 @@ describe('repository discovery', () => {
     }], [{ github: 'harlan-zw/example', checkout: '/home/harlan/pkg/example' }], [], ['harlan-zw'])
 
     expect(mappings[0]?.enabled).toBe(false)
+  })
+
+  it('lets the controller repair a CI branch without explicit policy', () => {
+    const mappings = buildRepositoryMappings([{
+      github: 'harlan-zw/example',
+      defaultBranch: 'main',
+      archived: false,
+      topics: [],
+      authentication: 'app' as const,
+      owner: { login: 'harlan-zw', type: 'User' },
+    }], [{ github: 'harlan-zw/example', checkout: '/home/harlan/pkg/example' }], [], ['harlan-zw'])
+
+    expect(canRepairPullRequestHead(mappings[0]!, pullRequestItem({
+      headRef: 'ci/self-hosted-runners',
+    }))).toBe(true)
   })
 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -5174,6 +5174,58 @@ describe('journal store', () => {
     expect(store.listReviewGateRefreshes()).toHaveLength(1)
   })
 
+  it('deduplicates a reconciled gate status with the same published body', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'gate-status-deduplication',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    finishReviewTask(store, '2026-08-13T01:00:30.000Z')
+    const gates = passedReviewGates()
+    store.recordReviewRun({
+      id: 'gate-status-review',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      headSha: 'abc123',
+      provider: 'codex',
+      sessionId: 'session-1',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:01:00.000Z',
+      completedAt: '2026-08-13T01:02:00.000Z',
+      gates,
+      confidence: 96,
+      findings: [],
+    })
+    const input = {
+      reviewRunId: 'gate-status-review',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      expectedHeadSha: 'abc123',
+      gates,
+      body: '### 🤖 READY',
+      desiredOutcome: 'READY' as const,
+      at: '2026-08-13T01:03:00.000Z',
+    }
+    const staged = store.stageReviewGateStatus(input)
+    if (staged._tag !== 'Staged')
+      throw new Error(`Expected a staged gate status, not ${staged._tag}.`)
+
+    expect(store.stageReviewGateStatus({
+      ...input,
+      reconciliationId: 'github-comment-drifted',
+      at: '2026-08-13T01:04:00.000Z',
+    })).toEqual({ _tag: 'Duplicate', commandId: staged.commandId })
+  })
+
   it('records comment publication failures for later analysis', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -5226,6 +5226,77 @@ describe('journal store', () => {
     })).toEqual({ _tag: 'Duplicate', commandId: staged.commandId })
   })
 
+  it('requeues a Published gate status when its GitHub comment drifted', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'gate-status-drift-repair',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    finishReviewTask(store, '2026-08-13T01:00:30.000Z')
+    const gates = passedReviewGates()
+    store.recordReviewRun({
+      id: 'gate-status-drift-review',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      headSha: 'abc123',
+      provider: 'codex',
+      sessionId: 'session-1',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:01:00.000Z',
+      completedAt: '2026-08-13T01:02:00.000Z',
+      gates,
+      confidence: 96,
+      findings: [],
+    })
+    const input = {
+      reviewRunId: 'gate-status-drift-review',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      expectedHeadSha: 'abc123',
+      gates,
+      body: '### 🤖 READY',
+      desiredOutcome: 'READY' as const,
+      at: '2026-08-13T01:03:00.000Z',
+    }
+    const staged = store.stageReviewGateStatus(input)
+    if (staged._tag !== 'Staged')
+      throw new Error(`Expected a staged gate status, not ${staged._tag}.`)
+    const published = store.claimReviewStatus(staged.commandId, 'publisher-1', '2026-08-13T01:03:10.000Z', 60_000)
+    if (published === null)
+      throw new Error('Expected the first publication claim.')
+    expect(store.completeReviewStatus({
+      commandId: published.id,
+      workerId: published.workerId,
+      fence: published.fence,
+      at: '2026-08-13T01:03:20.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })).toBe(true)
+
+    // The sweep restaged the identical body after GitHub lost the comment.
+    expect(store.stageReviewGateStatus({
+      ...input,
+      reconciliationId: 'github-comment-deleted:42:2026-08-13T01:05:00.000Z',
+      at: '2026-08-13T01:05:00.000Z',
+    })).toEqual({ _tag: 'Staged', commandId: staged.commandId })
+
+    expect(store.claimReviewStatus(staged.commandId, 'publisher-2', '2026-08-13T01:05:10.000Z', 60_000))
+      .toEqual(expect.objectContaining({
+        id: staged.commandId,
+        outcomeUnknown: true,
+        commentId: 42,
+      }))
+  })
+
   it('records comment publication failures for later analysis', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -5289,12 +5289,31 @@ describe('journal store', () => {
       at: '2026-08-13T01:05:00.000Z',
     })).toEqual({ _tag: 'Staged', commandId: staged.commandId })
 
-    expect(store.claimReviewStatus(staged.commandId, 'publisher-2', '2026-08-13T01:05:10.000Z', 60_000))
-      .toEqual(expect.objectContaining({
-        id: staged.commandId,
-        outcomeUnknown: true,
-        commentId: 42,
-      }))
+    const repaired = store.claimReviewStatus(staged.commandId, 'publisher-2', '2026-08-13T01:05:10.000Z', 60_000)
+    expect(repaired).toEqual(expect.objectContaining({
+      id: staged.commandId,
+      outcomeUnknown: true,
+      commentId: 42,
+    }))
+    if (repaired === null)
+      throw new Error('Expected the drift repair claim.')
+
+    expect(store.completeReviewStatus({
+      commandId: repaired.id,
+      workerId: repaired.workerId,
+      fence: repaired.fence,
+      at: '2026-08-13T01:05:20.000Z',
+      commentId: 43,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-43',
+    })).toBe(true)
+
+    // The repair published a replacement comment. The next sweep pass must
+    // target the replacement, or every pass requeues the command and creates
+    // another duplicate gate comment forever.
+    expect(store.listReviewGateRefreshes()).toEqual([expect.objectContaining({
+      reviewRunId: 'gate-status-drift-review',
+      commentId: 43,
+    })])
   })
 
   it('records comment publication failures for later analysis', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two controller paths blocked repairs. Discovered repositories rejected `ci/` branches. Replayed gate updates also hit a unique constraint and aborted the poll. Allow the branch prefix and treat identical gate updates as duplicates.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
