### PR TITLE
fix(agent): stop two retry loops that #123 missed

### DIFF
--- a/packages/harlan-github-agent/src/candidate-issue-controller.ts
+++ b/packages/harlan-github-agent/src/candidate-issue-controller.ts
@@ -129,6 +129,7 @@ export function createCandidateIssueController(options: CandidateIssueController
               fence: command.fence,
               at: options.now().toISOString(),
               reason: existing.error.message,
+              status: existing.error.status,
             })
             results.push(err(`${command.repository}: ${existing.error.message}`))
           }
@@ -163,6 +164,7 @@ export function createCandidateIssueController(options: CandidateIssueController
               fence: command.fence,
               at: options.now().toISOString(),
               reason: created.error.message,
+              status: created.error.status,
             })
             results.push(err(`${command.repository}: ${created.error.message}`))
           }

--- a/packages/harlan-github-agent/src/failure.ts
+++ b/packages/harlan-github-agent/src/failure.ts
@@ -270,6 +270,11 @@ export function classifyFailure(signal: FailureSignal): FailureClass {
     return { _tag: 'Transient', kind: 'agent_provider' }
   if (signal.status === 429 || matches(rateLimitPatterns, message))
     return { _tag: 'Transient', kind: 'rate_limit' }
+  // GitHub answers 410 Gone when the repository switched the feature off, such
+  // as issues on a repository that accepts none. No retry turns it back on, and
+  // the wording is GitHub's to change, so the status decides and not the text.
+  if (signal.status === 410)
+    return { _tag: 'Permanent', kind: 'policy' }
   if (signal.status !== undefined && signal.status >= 500)
     return { _tag: 'Transient', kind: 'github_unavailable' }
   if (matches(githubUnavailablePatterns, message))

--- a/packages/harlan-github-agent/src/running-label-sweep.ts
+++ b/packages/harlan-github-agent/src/running-label-sweep.ts
@@ -7,7 +7,7 @@ import { err, ok } from './result.ts'
 export interface RunningLabelSweepOptions {
   github: Pick<GitHubAgentSource, 'clearRunningLabel' | 'listRunningLabelledItems'>
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listRunningTaskItems'>
+  store: Pick<JournalStore, 'listRunningTaskItems' | 'mayWriteRepository'>
 }
 
 export interface RunningLabelSweepOutcome {
@@ -53,8 +53,13 @@ export async function clearAbandonedRunningLabels(
     return ok({ repository: mapping.github, cleared })
   }
 
+  // A repository the controller may not write to cannot hold a label this
+  // service wrote, so asking about it only reports the quarantine as a failure
+  // on every start. Two quarantined repositories filed that Incident for days.
   const results: Array<Result<RunningLabelSweepOutcome, string>> = []
-  for (const mapping of options.repositories.filter(candidate => candidate.enabled))
+  const writable = options.repositories.filter((candidate: RepositoryMapping) =>
+    candidate.enabled && options.store.mayWriteRepository(candidate.github))
+  for (const mapping of writable)
     results.push(await sweep(mapping))
   return results
 }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -5877,6 +5877,10 @@ export function openJournalStore(
           return
         }
         if (input.subject.kind === 'pull_request') {
+          // Every mutation Task is claimable only on the subject's current
+          // Revision, so one left on an older Revision can never run again. It
+          // still holds the one active Task slot for its kind, which blocked
+          // the next Repair. Two sat Queued for a fortnight before this.
           supersedeTasks(
             database,
             subject.id,
@@ -5884,6 +5888,22 @@ export function openJournalStore(
             'A newer pull request Revision replaced this Repair.',
             revisionId,
             'review_fix',
+          )
+          supersedeTasks(
+            database,
+            subject.id,
+            input.observedAt,
+            'A newer pull request Revision replaced this Baseline repair.',
+            revisionId,
+            'baseline_repair',
+          )
+          supersedeTasks(
+            database,
+            subject.id,
+            input.observedAt,
+            'A newer pull request Revision replaced this conflict resolution.',
+            revisionId,
+            'resolve_conflict',
           )
         }
         if (input.subject.kind === 'pull_request' && requiresPullRequestApproval(database, mapping, input.subject.author)) {

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -645,7 +645,14 @@ export interface JournalStore {
   stageCandidateIssues: (input: { commands: readonly CandidateIssueCommand[], at: string }) => number
   claimNextCandidateIssue: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedCandidateIssueCommand | null
   completeCandidateIssue: (input: { commandId: string, workerId: string, fence: number, at: string, issueNumber: number, url: string }) => boolean
-  failCandidateIssue: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
+  /**
+   * Records one failed attempt at filing a Candidate's issue.
+   *
+   * `Deferred` returns the command to Pending for the next pass. `Failed` is
+   * terminal: GitHub refused in a way no retry changes, or the command spent
+   * its attempts. `Unchanged` means the lease moved on before this call.
+   */
+  failCandidateIssue: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string, status?: number | undefined }) => 'Deferred' | 'Failed' | 'Unchanged'
   /** Requests the run log entry for one run. Answers false when it already exists. */
   stageRoutineReport: (input: { command: RoutineReportCommand, at: string }) => boolean
   claimNextRoutineReport: (workerId: string, now: string, leaseMilliseconds: number, excludedCommandIds?: readonly string[]) => ClaimedRoutineReportCommand | null
@@ -12114,25 +12121,38 @@ export function openJournalStore(
   const failCandidateIssue: JournalStore['failCandidateIssue'] = (input) => {
     database.exec('BEGIN IMMEDIATE')
     try {
-      const changed = database.prepare(`
-        UPDATE candidate_issue_commands
-        SET state_tag = 'Pending', reason = ?, worker_id = NULL, lease_expires_at = NULL, updated_at = ?
+      const row = database.prepare(`
+        SELECT attempts, max_attempts FROM candidate_issue_commands
         WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
-      `).run(input.reason, input.at, input.commandId, input.workerId, input.fence).changes === 1
-      if (changed) {
-        recordDurableCommandEvent(database, {
-          stream: 'candidate_issue',
-          commandId: input.commandId,
-          event: 'Deferred',
-          from: 'Running',
-          to: 'Pending',
-          reason: input.reason,
-          fence: input.fence,
-          at: input.at,
-        })
+      `).get(input.commandId, input.workerId, input.fence) as { attempts: number, max_attempts: number } | undefined
+      if (row === undefined) {
+        database.exec('COMMIT')
+        return 'Unchanged'
       }
+      // This command returned to Pending whatever GitHub answered, and nothing
+      // read the attempts the claim had already counted. A repository with
+      // issues switched off was asked to file the same proposal 282 times. A
+      // refusal no retry can change stops here, and so does a spent budget.
+      const terminal = !mayRetryFailure({ message: input.reason, status: input.status })
+        || row.attempts >= row.max_attempts
+      const state = terminal ? 'Failed' : 'Pending'
+      database.prepare(`
+        UPDATE candidate_issue_commands
+        SET state_tag = ?, reason = ?, worker_id = NULL, lease_expires_at = NULL, updated_at = ?
+        WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
+      `).run(state, input.reason, input.at, input.commandId, input.workerId, input.fence)
+      recordDurableCommandEvent(database, {
+        stream: 'candidate_issue',
+        commandId: input.commandId,
+        event: terminal ? 'Failed' : 'Deferred',
+        from: 'Running',
+        to: state,
+        reason: input.reason,
+        fence: input.fence,
+        at: input.at,
+      })
       database.exec('COMMIT')
-      return changed
+      return terminal ? 'Failed' : 'Deferred'
     }
     catch (error) {
       database.exec('ROLLBACK')

--- a/packages/harlan-github-agent/test/candidate-issue.test.ts
+++ b/packages/harlan-github-agent/test/candidate-issue.test.ts
@@ -323,6 +323,58 @@ describe('filing the issues Candidates propose', () => {
     }
   })
 
+  it('stops asking a repository that answers 410, because issues are switched off there', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store)
+      store.stageCandidateIssues({
+        commands: candidateIssueCommands(store.listCandidates(routine.routineId), routine),
+        at: now().toISOString(),
+      })
+      const refusing = {
+        findOpenIssueByFingerprint: () => Promise.resolve(ok(null)),
+        createComment: async () => ok({ id: 1 }),
+        createIssue: async () => ({
+          _tag: 'Err' as const,
+          error: { repository: 'harlan-zw/example', message: 'Issues has been disabled in this repository.', status: 410 },
+        }),
+      }
+      const controller = createCandidateIssueController({ github: refusing, now, store, workerId: 'controller-1' })
+
+      await controller.publishPending(new AbortController().signal)
+
+      expect(store.claimNextCandidateIssue('controller-2', now().toISOString(), 60_000)).toBeNull()
+    }
+    finally {
+      store.close()
+    }
+  })
+
+  it('stops a proposal that spends its attempts on the same refusal', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store)
+      store.stageCandidateIssues({
+        commands: candidateIssueCommands(store.listCandidates(routine.routineId), routine),
+        at: now().toISOString(),
+      })
+      const refusing = {
+        findOpenIssueByFingerprint: () => Promise.resolve(ok(null)),
+        createComment: async () => ok({ id: 1 }),
+        createIssue: async () => ({ _tag: 'Err' as const, error: { repository: 'harlan-zw/example', message: 'GitHub returned 502.' } }),
+      }
+      const controller = createCandidateIssueController({ github: refusing, now, store, workerId: 'controller-1' })
+      await controller.publishPending(new AbortController().signal)
+      await controller.publishPending(new AbortController().signal)
+      await controller.publishPending(new AbortController().signal)
+
+      expect(store.claimNextCandidateIssue('controller-2', now().toISOString(), 60_000)).toBeNull()
+    }
+    finally {
+      store.close()
+    }
+  })
+
   it('files nothing when the repository has writes turned off', async () => {
     const store = openJournalStore(':memory:')
     try {

--- a/packages/harlan-github-agent/test/running-label-sweep.test.ts
+++ b/packages/harlan-github-agent/test/running-label-sweep.test.ts
@@ -7,6 +7,7 @@ function sweep(options: {
   labelled: number[]
   running: Array<{ repository: string, itemNumber: number }>
   clear?: (itemNumber: number) => ReturnType<typeof ok<void>> | ReturnType<typeof err<string>>
+  mayWrite?: boolean
 }) {
   const cleared: number[] = []
   const run = async () => clearAbandonedRunningLabels({
@@ -20,12 +21,21 @@ function sweep(options: {
       },
     },
     repositories: [repositoryMapping()],
-    store: { listRunningTaskItems: () => options.running },
+    store: { listRunningTaskItems: () => options.running, mayWriteRepository: () => options.mayWrite ?? true },
   }, new AbortController().signal)
   return { cleared, run }
 }
 
 describe('clearAbandonedRunningLabels', () => {
+  it('asks nothing of a repository the controller may not write to', async () => {
+    const { cleared, run } = sweep({ labelled: [24], running: [], mayWrite: false })
+
+    const results = await run()
+
+    expect(results).toEqual([])
+    expect(cleared).toEqual([])
+  })
+
   it('takes the label off an item a dead process left it on', async () => {
     const { cleared, run } = sweep({ labelled: [24, 25], running: [] })
 

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -2313,6 +2313,50 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
+  it('stops a Baseline repair the next pull request Revision left behind', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'stale-baseline-pr',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the review Task.')
+    const queued = store.queueBaselineRepairForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      baseSha: review.pullRequest.baseSha,
+      at: '2026-08-13T01:02:00.000Z',
+    })
+    if (queued._tag === 'Rejected' || queued._tag === 'NotAuthorized')
+      throw new Error(queued.reason)
+    const repair = store.claimNextBaselineRepairTask('baseline-agent', '2026-08-13T01:03:00.000Z', 600_000)
+    if (repair === null)
+      throw new Error('Expected the Baseline repair Task.')
+
+    const moved = store.recordObservation({
+      externalId: 'stale-baseline-pr-moved',
+      observedAt: '2026-08-13T01:04:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        mergeState: 'clean',
+        headSha: 'moved-head-commit',
+        updatedAt: '2026-08-13T01:04:00.000Z',
+      }),
+    })
+    if (moved._tag !== 'Inserted')
+      throw new Error('Expected the head move to create a new Revision.')
+
+    expect(store.getDashboardSnapshot('2026-08-13T01:05:00.000Z').tasks.find(task => task.id === repair.id)?.state).toEqual({
+      _tag: 'Superseded',
+      reason: 'A newer pull request Revision replaced this Baseline repair.',
+    })
+  })
+
   it('lists the open pull requests this service opened, so a new one can stack on them', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

These two commits were pushed to the #123 branch after it had already merged, so they never landed. Rebased onto current main unchanged. My mistake, and the reason the two faults below are still live on hogwild right now.

**`unhead.unjs.io` has issues switched off, and the controller has asked it to file the same routine proposal 282 times.** `failCandidateIssue` returned the command to `Pending` whatever GitHub answered, and never read the `attempts` the claim had already counted. The row carried `attempts` and `max_attempts` all along. GitHub answers 410 Gone for a repository feature that is off, so the classifier reads the status rather than the sentence.

**Two `baseline_repair` Tasks on nuxtseo.com have sat `Queued` for a fortnight**, one on a pull request that closed on 17 Aug. A Task on a stale Revision can never be claimed, because the claim requires the subject's current Revision, but it still holds the one active Task slot for its kind and blocks the next Repair there. Only `review_fix` was being retired when a new Revision landed.

The startup Running label sweep also asked two quarantined repositories about labels it may not write, and filed the quarantine as a failure on every start. Both errors were in the log again after this afternoon's restart. It skips them now.

Note this does not clear the two Tasks already stuck: the retirement fires when a new Revision lands, and #274 is closed so none ever will. That is two rows to move to `Superseded` by hand, which I would rather you decide on than do to the live journal unasked.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).