### PR TITLE
fix(agent): let a repository incident be resolved by that repository

### DIFF
--- a/packages/harlan-github-agent/src/review-status-scheduler.ts
+++ b/packages/harlan-github-agent/src/review-status-scheduler.ts
@@ -15,6 +15,14 @@ export interface ReviewStatusSchedulerOptions {
   now: () => Date
   onError: (error: unknown) => void
   onFailure: (repository: string, pullRequestNumber: number, reason: string) => void
+  /**
+   * One terminal comment that reached GitHub.
+   *
+   * A failure here raises an Incident, and without a success signal that
+   * Incident had no way back out of the System pane. One stayed open for a day
+   * after the defect behind it was fixed.
+   */
+  onPublished: (repository: string, pullRequestNumber: number) => void
   store: Pick<JournalStore, 'claimNextTerminalReviewStatus' | 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt'>
   workerId: string
 }
@@ -37,8 +45,12 @@ export function createReviewStatusScheduler(options: ReviewStatusSchedulerOption
 
     controller = new AbortController()
     const published = await publishClaimedReviewStatus(options, command, true, controller.signal)
-    if (published._tag === 'Err' && !controller.signal.aborted)
-      options.onFailure(command.repository, command.pullRequestNumber, published.error)
+    if (published._tag === 'Err') {
+      if (!controller.signal.aborted)
+        options.onFailure(command.repository, command.pullRequestNumber, published.error)
+      return
+    }
+    options.onPublished(command.repository, command.pullRequestNumber)
   }
 
   function runNow(): Promise<void> {

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -7,7 +7,7 @@ import type { GitHubUserAccess } from './github-user-access.ts'
 import type { Result } from './result.ts'
 import type { RoutineSyncOutcome } from './routine-controller.ts'
 import type { JournalStore } from './store.ts'
-import type { ClaimedAgentTask, DashboardSnapshot, RepositoryMapping, ServiceTrigger, ValidatedAgentConfig } from './types.ts'
+import type { ClaimedAgentTask, DashboardSnapshot, IncidentScope, RepositoryMapping, ServiceTrigger, ValidatedAgentConfig } from './types.ts'
 import { randomUUID } from 'node:crypto'
 import { dirname, join } from 'node:path'
 import { createAgentActivityLog } from './agent-activity.ts'
@@ -113,15 +113,24 @@ export function dashboardSnapshotForTriggers(
     : { ...snapshot, routines: [], routineRuns: [] }
 }
 
+/**
+ * Records one Incident the controller raised outside a poll pass.
+ *
+ * The scope decides who can clear it later. An Incident about one repository
+ * takes that repository's scope, so the next success there resolves it. A
+ * Service-scoped one about a single repository has no way back out of the
+ * System pane, and two sat there for a day after their defect was fixed.
+ */
 function recordServiceIncident(
   store: Pick<JournalStore, 'recordIncident'>,
   at: string,
   operation: string,
   message: string,
+  scope: IncidentScope = { _tag: 'Service' },
 ): void {
   const failure = classifyFailure({ message })
   store.recordIncident({
-    scope: { _tag: 'Service' },
+    scope,
     kind: failure.kind,
     severity: failure._tag === 'Transient' ? 'warning' : 'error',
     operation,
@@ -536,14 +545,16 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         report: (event) => {
           if (event._tag === 'AutoMergeEnabled') {
             options.logger.info(`${event.repository}#${event.pullRequestNumber}: GitHub auto-merge is enabled. GitHub merges it when its checks pass.`)
+            store.resolveIncidents({ _tag: 'Repository', repository: event.repository }, now().toISOString(), 'auto_merge')
             return
           }
           if (event._tag === 'Merged') {
             options.logger.info(`${event.repository}#${event.pullRequestNumber}: merged ${event.sha.slice(0, 12)}, because GitHub had nothing left to wait for.`)
+            store.resolveIncidents({ _tag: 'Repository', repository: event.repository }, now().toISOString(), 'auto_merge')
             return
           }
           options.logger.error(`${event.repository}#${event.pullRequestNumber}: GitHub refused auto-merge: ${event.reason}`)
-          recordServiceIncident(store, now().toISOString(), 'auto_merge', event.reason)
+          recordServiceIncident(store, now().toISOString(), 'auto_merge', event.reason, { _tag: 'Repository', repository: event.repository })
         },
         store,
       }),
@@ -643,7 +654,13 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onError: error => options.logger.error(error),
         onFailure: (repository, pullRequestNumber, reason) => {
           options.logger.error(`${repository}#${pullRequestNumber}: terminal Review Publication failed: ${reason}`)
-          recordServiceIncident(store, now().toISOString(), 'review_status_publication', reason)
+          recordServiceIncident(store, now().toISOString(), 'review_status_publication', reason, { _tag: 'Repository', repository })
+        },
+        // A repository that publishes again is publishing, so its earlier
+        // refusal is over. Another pull request still failing there raises its
+        // own Incident on its next attempt, seconds later.
+        onPublished: (repository) => {
+          store.resolveIncidents({ _tag: 'Repository', repository }, now().toISOString(), 'review_status_publication')
         },
         store,
         workerId: randomUUID(),

--- a/packages/harlan-github-agent/test/incidents.test.ts
+++ b/packages/harlan-github-agent/test/incidents.test.ts
@@ -41,6 +41,40 @@ describe('incident log', () => {
     })
   })
 
+  it('resolves one repository publication failure without touching another repository', () => {
+    const store = createStore()
+    store.syncRepositories([
+      repositoryMapping(),
+      repositoryMapping({ github: 'harlan-zw/other', checkout: '/home/harlan/sites/other' }),
+    ], '2026-08-18T00:00:00.000Z')
+    const failure = (repository: string, at: string): void => {
+      store.recordIncident({
+        scope: { _tag: 'Repository', repository },
+        kind: 'unknown',
+        severity: 'error',
+        operation: 'review_status_publication',
+        message: 'GitHub did not stamp the harlan-agent-ready label.',
+        recovery: { _tag: 'ActionRequired' },
+        at,
+      })
+    }
+    failure('harlan-zw/example', '2026-08-18T00:01:00.000Z')
+    failure('harlan-zw/other', '2026-08-18T00:01:30.000Z')
+
+    // The success signal for one repository. It answers only for that one, so
+    // the other repository keeps the Incident nobody has fixed yet.
+    const resolved = store.resolveIncidents(
+      { _tag: 'Repository', repository: 'harlan-zw/example' },
+      '2026-08-18T00:02:00.000Z',
+      'review_status_publication',
+    )
+
+    expect(resolved).toBe(1)
+    expect(store.listIncidents().map(incident => incident.scope)).toEqual([
+      { _tag: 'Repository', repository: 'harlan-zw/other' },
+    ])
+  })
+
   it('separates two different failures on the same repository', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-18T00:00:00.000Z')

--- a/packages/harlan-github-agent/test/review-status-scheduler.test.ts
+++ b/packages/harlan-github-agent/test/review-status-scheduler.test.ts
@@ -66,6 +66,7 @@ describe('review status scheduler', () => {
     const test = stagedTerminalStatus()
     const bodies: string[] = []
     const failures: string[] = []
+    const published: string[] = []
     const scheduler = createReviewStatusScheduler({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot(test.pullRequest))),
@@ -80,6 +81,7 @@ describe('review status scheduler', () => {
       now: () => new Date('2026-08-13T01:01:30.000Z'),
       onError: (error) => { throw error },
       onFailure: (_repository, _number, reason) => failures.push(reason),
+      onPublished: (repository, number) => published.push(`${repository}#${number}`),
       store: test.store,
       workerId: 'status-publisher-1',
     })
@@ -88,6 +90,8 @@ describe('review status scheduler', () => {
 
     expect(bodies).toEqual(['<!-- harlan-agent-kit:pr-triage -->\n### 🤖 READY · 96/100'])
     expect(failures).toEqual([])
+    // The success signal an Incident raised here needs to be resolved by.
+    expect(published).toEqual([`harlan-zw/example#${test.pullRequest.number}`])
     expect(test.store.claimNextTerminalReviewStatus('status-publisher-2', '2026-08-13T01:02:00.000Z', 60_000)).toBeNull()
   })
 
@@ -95,6 +99,7 @@ describe('review status scheduler', () => {
     const test = stagedTerminalStatus()
     let writes = 0
     const failures: string[] = []
+    const published: string[] = []
     const scheduler = createReviewStatusScheduler({
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot(test.pullRequest))),
@@ -111,6 +116,7 @@ describe('review status scheduler', () => {
       now: () => new Date('2026-08-13T01:01:30.000Z'),
       onError: (error) => { throw error },
       onFailure: (_repository, _number, reason) => failures.push(reason),
+      onPublished: (repository, number) => published.push(`${repository}#${number}`),
       store: test.store,
       workerId: 'status-publisher-1',
     })
@@ -143,6 +149,7 @@ describe('review status scheduler', () => {
       now: () => new Date('2026-08-13T01:01:30.000Z'),
       onError: (error) => { throw error },
       onFailure: () => undefined,
+      onPublished: () => undefined,
       store: test.store,
       workerId: 'status-publisher-1',
     })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Two `review_status_publication` incidents have been sitting in the System pane since yesterday, one occurrence each, long after #123 fixed the label stamp behind them. They cannot clear: `review_status_publication` is only ever passed to `recordServiceIncident`, never to `resolveIncidents`, unlike everything raised through the pass recorder. `auto_merge` has the same shape.

Both are about a single pull request but were recorded as Service scope with no repository, which is why the System pane showed them with a blank repository column and why nothing could ever answer them. They take the repository's scope now, and the next terminal Review Publication or auto-merge there resolves them.

That is deliberately looser than one incident per pull request: a second pull request still failing in the same repository has its own incident raised again on its next attempt, seconds later, and I would rather a stale row clear early than never. Task scope would be exact, but `onFailure` only carries a repository and a number, and threading a task id through for this felt like more surface than the problem earns. Happy to be argued out of that.

The Review status scheduler had no success signal at all, so it gained one.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).