### PR TITLE
feat(agent): say what a queued Review is answering

### DIFF
--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -1,6 +1,6 @@
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
-import type { JournalStore, QueuedReviewStatus, ReviewQueueState } from './store.ts'
+import type { JournalStore, QueuedReviewHistory, QueuedReviewStatus, ReviewQueueState } from './store.ts'
 import type { RepositoryMapping } from './types.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
@@ -8,6 +8,26 @@ import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.t
 const workLabel: Record<QueuedReviewStatus['taskKind'], string> = {
   adversarial_review: 'Review',
   review_fix: 'Repair',
+}
+
+/**
+ * What ran before this Task, in one sentence, or nothing on a first Review.
+ *
+ * A Review of the controller's own Repair used to read as a bare QUEUED
+ * comment. Nothing said a Review had already run, found defects, and pushed a
+ * fix, so the pull request looked untouched while the Queue worked through it.
+ */
+export function queuedReviewHistoryLine(history: QueuedReviewHistory): string | null {
+  if (history._tag === 'FirstReview')
+    return null
+  const defects = history.findings === 1 ? '1 defect' : `${history.findings} defects`
+  const outcome = history.priorOutcome.toLowerCase()
+  const prior = history.findings === 0
+    ? `The last Review of \`${history.priorHeadSha.slice(0, 12)}\` answered ${outcome}.`
+    : `The last Review of \`${history.priorHeadSha.slice(0, 12)}\` answered ${outcome} on ${defects}.`
+  return history._tag === 'AfterRepair'
+    ? `${prior} A Repair pushed this commit, so this Review answers the Repair.`
+    : `${prior} A new commit replaced it, so this Review answers the new commit.`
 }
 
 /**
@@ -22,12 +42,13 @@ export function queuePositionComment(status: QueuedReviewStatus): string {
   const next = status.queue._tag === 'Paused'
     ? `${work} starts when this repository resumes.`
     : `${work} starts when an Agent is free.`
+  const history = queuedReviewHistoryLine(status.history)
   return `${AUTOMATED_REVIEW_MARKER}
 <!-- reviewed-sha: ${status.headSha} -->
 ### 🤖 ${heading}
 
 ${automatedDisclosure({ kind: 'review', notes: ['The Dashboard shows the exact Queue position.'] })}
-
+${history === null ? '' : `\n${history}\n`}
 Next: ${next}`
 }
 

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -480,6 +480,10 @@ interface QueuedReviewStatusRow {
   total: number | null
   github_comment_id: number
   published_body: string
+  prior_head_sha: string | null
+  prior_outcome: string | null
+  prior_findings: number | null
+  head_from_repair: number
 }
 
 /**
@@ -510,6 +514,22 @@ export type ReviewVerdictState
   = | { _tag: 'Answered' }
     | { _tag: 'Unanswered' }
 
+/**
+ * What already happened on this pull request, for a Task that has not started.
+ *
+ * A Review of the controller's own Repair looked exactly like a first Review:
+ * a bare QUEUED comment, no defect count, no sign that anything had run. A
+ * reader could not tell whether the Queue was making progress at all.
+ */
+export type QueuedReviewHistory
+  = | { _tag: 'FirstReview' }
+    | {
+      _tag: 'AfterRepair' | 'AfterPush'
+      priorHeadSha: string
+      priorOutcome: string
+      findings: number
+    }
+
 export interface QueuedReviewStatus {
   taskId: string
   taskKind: 'adversarial_review' | 'review_fix'
@@ -519,6 +539,8 @@ export interface QueuedReviewStatus {
   headSha: string
   queue: ReviewQueueState
   verdict: ReviewVerdictState
+  /** The Review that answered the previous head, and how this head arrived. */
+  history: QueuedReviewHistory
   commentId: number
   /** What the canonical comment holds now, so an unchanged position writes nothing. */
   publishedBody: string
@@ -10692,7 +10714,21 @@ export function openJournalStore(
         WHERE candidates.paused = 0 AND peer.task_kind = candidates.task_kind
       ) AS total,
       COALESCE(published.github_comment_id, prompt.github_comment_id) AS github_comment_id,
-      COALESCE(published.body, prompt.body) AS published_body
+      COALESCE(published.body, prompt.body) AS published_body,
+      -- The newest Review that answered an earlier head of this pull request.
+      prior_run.head_sha AS prior_head_sha,
+      prior_run.outcome_tag AS prior_outcome,
+      prior_run.finding_count AS prior_findings,
+      -- A head the controller pushed itself. It is the difference between
+      -- waiting on somebody's new commit and waiting on our own Repair.
+      EXISTS (
+        SELECT 1 FROM publication_commands
+        JOIN tasks AS repair ON repair.id = publication_commands.task_id
+        WHERE repair.subject_id = candidates.subject_id
+          AND repair.kind = 'review_fix'
+          AND publication_commands.state_tag = 'Published'
+          AND publication_commands.commit_sha = json_extract(revisions.payload, '$.headSha')
+      ) AS head_from_repair
     FROM candidates
     JOIN subjects ON subjects.id = candidates.subject_id
     JOIN repositories ON repositories.id = subjects.repository_id
@@ -10700,6 +10736,15 @@ export function openJournalStore(
     -- The Approval prompt is the canonical comment until a Task publishes one.
     LEFT JOIN approval_prompt_comments AS prompt
       ON prompt.subject_id = candidates.subject_id AND prompt.revision_id = candidates.revision_id
+    LEFT JOIN (
+      SELECT subject_id, revision_id, head_sha, outcome_tag,
+        json_array_length(findings) AS finding_count, completed_at,
+        ROW_NUMBER() OVER (PARTITION BY subject_id ORDER BY completed_at DESC, id DESC) AS run_rank
+      FROM review_runs
+    ) AS prior_run
+      ON prior_run.subject_id = candidates.subject_id
+      AND prior_run.run_rank = 1
+      AND prior_run.revision_id != candidates.revision_id
     LEFT JOIN review_status_commands AS published ON published.id = COALESCE(
       (
         SELECT candidate.id FROM review_status_commands AS candidate
@@ -10748,6 +10793,14 @@ export function openJournalStore(
       ? { _tag: 'Paused' as const }
       : { _tag: 'Waiting' as const, position: row.position, total: row.total },
     verdict: row.answered === 1 ? { _tag: 'Answered' as const } : { _tag: 'Unanswered' as const },
+    history: row.prior_head_sha === null || row.prior_outcome === null
+      ? { _tag: 'FirstReview' as const }
+      : {
+          _tag: row.head_from_repair === 1 ? 'AfterRepair' as const : 'AfterPush' as const,
+          priorHeadSha: row.prior_head_sha,
+          priorOutcome: row.prior_outcome,
+          findings: row.prior_findings ?? 0,
+        },
     commentId: row.github_comment_id,
     publishedBody: row.published_body,
   }))

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -1,6 +1,6 @@
 import type { QueuedReviewStatus } from '../src/store.ts'
 import { describe, expect, it } from 'vitest'
-import { publishQueuePositions, queuePositionComment } from '../src/queue-position-sweep.ts'
+import { publishQueuePositions, queuedReviewHistoryLine, queuePositionComment } from '../src/queue-position-sweep.ts'
 import { err, ok } from '../src/result.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
@@ -14,6 +14,7 @@ function queuedRepair(overrides: Partial<QueuedReviewStatus> = {}): QueuedReview
     headSha: 'abc123',
     queue: { _tag: 'Waiting', position: 3, total: 7 },
     verdict: { _tag: 'Answered' },
+    history: { _tag: 'FirstReview' },
     commentId: 42,
     publishedBody: '### 🤖 REVIEWING · Repair queued',
     ...overrides,
@@ -32,6 +33,55 @@ function snapshot(overrides: Parameters<typeof pullRequestItem>[0] = {}) {
     reviews: [],
   })
 }
+
+describe('the queued review history line', () => {
+  it('says nothing before any Review has run', () => {
+    expect(queuedReviewHistoryLine({ _tag: 'FirstReview' })).toBeNull()
+  })
+
+  it('names the Repair when the controller pushed the commit under review', () => {
+    const line = queuedReviewHistoryLine({
+      _tag: 'AfterRepair',
+      priorHeadSha: 'eb2933b2d12adbdc25a9600668450b395bc55ff8',
+      priorOutcome: 'Blocked',
+      findings: 4,
+    })
+
+    expect(line).toBe('The last Review of `eb2933b2d12a` answered blocked on 4 defects. A Repair pushed this commit, so this Review answers the Repair.')
+  })
+
+  it('names a new commit when somebody else pushed it', () => {
+    const line = queuedReviewHistoryLine({
+      _tag: 'AfterPush',
+      priorHeadSha: 'eb2933b2d12adbdc25a9600668450b395bc55ff8',
+      priorOutcome: 'Blocked',
+      findings: 1,
+    })
+
+    expect(line).toBe('The last Review of `eb2933b2d12a` answered blocked on 1 defect. A new commit replaced it, so this Review answers the new commit.')
+  })
+
+  it('leaves the defect count out when the prior Review found none', () => {
+    const line = queuedReviewHistoryLine({
+      _tag: 'AfterPush',
+      priorHeadSha: 'eb2933b2d12adbdc25a9600668450b395bc55ff8',
+      priorOutcome: 'Ready',
+      findings: 0,
+    })
+
+    expect(line).toBe('The last Review of `eb2933b2d12a` answered ready. A new commit replaced it, so this Review answers the new commit.')
+  })
+
+  it('puts the history into the comment a waiting pull request carries', () => {
+    const body = queuePositionComment(queuedRepair({
+      taskKind: 'adversarial_review',
+      history: { _tag: 'AfterRepair', priorHeadSha: 'eb2933b2d12adbdc25a9600668450b395bc55ff8', priorOutcome: 'Blocked', findings: 4 },
+    }))
+
+    expect(body).toContain('A Repair pushed this commit, so this Review answers the Repair.')
+    expect(body).toContain('Next: Review starts when an Agent is free.')
+  })
+})
 
 describe('queuePositionComment', () => {
   it('keeps exact position in the Dashboard', () => {

--- a/packages/harlan-github-agent/test/queue-position.test.ts
+++ b/packages/harlan-github-agent/test/queue-position.test.ts
@@ -132,6 +132,76 @@ describe('listQueuedReviewStatuses', () => {
     ])
   })
 
+  it('names the Repair a queued Review is answering, so a re-review is not a bare QUEUED', () => {
+    const store = createStore()
+    queuedRepair(store, 30, '2026-08-13T01:00:00.000Z')
+    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (repair === null)
+      throw new Error('Expected the Repair Task.')
+    const repairCommit = 'd'.repeat(40)
+    const stagedPublication = store.stagePublication({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      publication: {
+        _tag: 'UpdatePullRequest',
+        taskKind: 'review_fix',
+        baseRef: 'main',
+        pullRequestNumber: repair.pullRequestNumber,
+        commitSha: repairCommit,
+        baseSha: repair.pullRequest.baseSha,
+        expectedHeadSha: repair.pullRequest.headSha,
+        headRef: repair.pullRequest.headRef,
+        artifactRef: 'refs/harlan-github-agent/publications/queued-history',
+        patchDigest: 'repair-patch',
+        changedFiles: 1,
+      },
+    })
+    if (stagedPublication._tag !== 'Staged')
+      throw new Error(`stagePublication: ${JSON.stringify(stagedPublication)}`)
+    const publication = store.claimNextPublication('publisher', '2026-08-13T01:03:00.000Z', 60_000)
+    if (publication === null)
+      throw new Error('Expected the Repair Publication.')
+    expect(store.completePublication({
+      commandId: publication.id,
+      workerId: publication.workerId,
+      fence: publication.fence,
+      at: '2026-08-13T01:04:00.000Z',
+      evidence: 'Published Repair commit.',
+    })).toBe(true)
+
+    // The Repair push becomes the next head, which queues a fresh Review.
+    const repaired = store.recordObservation({
+      externalId: 'queued-history-repaired-head',
+      observedAt: '2026-08-13T01:05:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({
+        number: 30,
+        headRef: 'fix/thing-30',
+        headSha: repairCommit,
+        mergeState: 'clean',
+        url: 'https://github.com/harlan-zw/example/pull/30',
+        updatedAt: '2026-08-13T01:05:00.000Z',
+      }),
+    })
+    if (repaired._tag !== 'Inserted')
+      throw new Error('Expected the Repair push to create a new Revision.')
+
+    expect(store.listQueuedReviewStatuses()).toEqual([
+      expect.objectContaining({
+        pullRequestNumber: 30,
+        taskKind: 'adversarial_review',
+        history: {
+          _tag: 'AfterRepair',
+          priorHeadSha: 'head30',
+          priorOutcome: 'Blocked',
+          findings: 1,
+        },
+      }),
+    ])
+  })
+
   it('agrees with the claim, so position 1 is the Task the next agent takes', () => {
     const store = createStore()
     queuedRepair(store, 24, '2026-08-13T01:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

harlan-zw/nuxt-seo-utils#141 has been sitting on this comment:

```
### 🤖 QUEUED

> ... The Dashboard shows the exact Queue position.

Next: Review starts when an Agent is free.
```

Reading that, you cannot tell whether anything has happened. What actually happened is that a Review answered `eb2933b2`, found 4 defects and blocked it, a Repair pushed `c606721c`, and the queued Review is there to answer the Repair. All of it invisible.

The Queue status carries that history now, so the same comment reads:

```
The last Review of `eb2933b2d12a` answered blocked on 4 defects. A Repair pushed this commit, so this Review answers the Repair.
```

It distinguishes a head the controller pushed itself from somebody else's commit, because "waiting to check my own fix" and "waiting to check your new commit" are different things to a reader. A first Review adds no line at all.

I did not touch the Queue position: exact position still belongs to the Dashboard, so a Queue movement still writes nothing to GitHub. The history only changes when a Revision does.

Open question I did not resolve: the prior outcome renders as the raw tag lowercased, so it reads "answered blocked". That is fine for `Blocked` and `Ready`, and slightly odd for `Pending`. Worth a proper mapping if a Review can queue behind a pending verdict, which I do not think it can.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).