### PR TITLE
feat(agent): let the configuration set how many Agents run at once

### DIFF
--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -205,7 +205,7 @@ function isDashboardOrigin(value: string): boolean {
 function agentSettings(source: UnknownRecord, issues: ConfigIssue[]): AgentConfig['agent'] | undefined {
   const agent = source.agent
   if (agent === undefined)
-    return { provider: 'codex', reservePercent: DEFAULT_RESERVE_PERCENT, order: DEFAULT_PROVIDER_ORDER }
+    return { provider: 'codex', reservePercent: DEFAULT_RESERVE_PERCENT, order: DEFAULT_PROVIDER_ORDER, maximumActiveAgents: null }
   if (!isRecord(agent)) {
     issues.push({ path: '$.agent', message: 'Expected an object.' })
     return undefined
@@ -228,9 +228,20 @@ function agentSettings(source: UnknownRecord, issues: ConfigIssue[]): AgentConfi
   if (order === undefined)
     issues.push({ path: '$.agent.order', message: 'Expected each Agent provider once, in preference order.' })
 
-  if (provider === undefined || reserve === undefined || order === undefined)
+  // Absent keeps the Agent provider's own default, so an existing file changes
+  // nothing. The ceiling is a guard against a typo, not a measured limit.
+  const activeValue = agent.maximum_active_agents
+  const maximumActiveAgents = activeValue === undefined
+    ? null
+    : typeof activeValue === 'number' && Number.isInteger(activeValue) && activeValue >= 1 && activeValue <= 16
+      ? activeValue
+      : undefined
+  if (maximumActiveAgents === undefined)
+    issues.push({ path: '$.agent.maximum_active_agents', message: 'Expected a whole number from 1 to 16.' })
+
+  if (provider === undefined || reserve === undefined || order === undefined || maximumActiveAgents === undefined)
     return undefined
-  return { provider, reservePercent: reserve, order }
+  return { provider, reservePercent: reserve, order, maximumActiveAgents }
 }
 
 /** The webhook listener is off unless the configuration turns it on. */

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -258,7 +258,14 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     options.logger.info(`${unmapped.length} granted repositories have no local checkout under a trusted root, so no agent can see them${names}. Clone one to include it.`)
   }
 
-  const configuredProfile = agentProfile(config.agent.provider)
+  // The configuration decides how many Agents run, and the provider profile
+  // decides everything else about them. One permit pool serves every Task kind,
+  // so this number is the whole service's throughput.
+  const providerProfile = agentProfile(config.agent.provider)
+  const configuredProfile = {
+    ...providerProfile,
+    maximumActiveAgents: config.agent.maximumActiveAgents ?? providerProfile.maximumActiveAgents,
+  }
   const store = openJournalStore(config.storage.path, config.mutationsEnabled, configuredProfile, config.maxOpenPullRequests)
   const processId = randomUUID()
   const restartController = createRestartController({

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -73,6 +73,16 @@ export interface AgentConfig {
     reservePercent: Record<AgentProviderName, number>
     /** Agent providers automatic selection walks, in preference order. */
     order: readonly AgentProviderName[]
+    /**
+     * How many Agents may hold a Task at once, or null to keep the provider's
+     * own default.
+     *
+     * One pool serves every Task kind, so this number is the whole service's
+     * throughput. Four left eleven Reviews and eighteen Issue work Tasks
+     * waiting on a 24 core host at 6GB of an 18GB cap. Raise it against memory,
+     * not against core count: each Agent runs a whole coding session.
+     */
+    maximumActiveAgents: number | null
   }
   github: {
     appId: number

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -49,6 +49,42 @@ describe('configuration boundary', () => {
     expect(parsed._tag === 'Ok' && parsed.value.server.allowedOrigin).toBe('https://harlan-github-agent.localhost')
   })
 
+  it('keeps the Agent provider default when the file names no agent count', () => {
+    const parsed = parseConfigText(configText)
+
+    expect(parsed._tag === 'Ok' && parsed.value.agent.maximumActiveAgents).toBeNull()
+  })
+
+  it('reads how many Agents may hold a Task at once', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  maximum_active_agents: 6
+`)
+
+    expect(parsed._tag === 'Ok' && parsed.value.agent.maximumActiveAgents).toBe(6)
+  })
+
+  it('refuses an agent count that would spend the whole host', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  maximum_active_agents: 40
+`)
+
+    expect(parsed._tag === 'Err' && parsed.error.map(issue => issue.path)).toContain('$.agent.maximum_active_agents')
+  })
+
+  it('refuses an agent count below one, which would start nothing', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  maximum_active_agents: 0
+`)
+
+    expect(parsed._tag === 'Err' && parsed.error.map(issue => issue.path)).toContain('$.agent.maximum_active_agents')
+  })
+
   it('accepts an HTTPS Tailscale dashboard origin', () => {
     const parsed = parseConfigText(configText.replace(
       'https://harlan-github-agent.localhost',


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

Hogwild has been sitting at 11 queued Reviews and 18 queued Issue work Tasks behind 4 Agents for the last hour, at 6GB of an 18GB cap and load 3.9 on 24 cores. There is clearly room to run more, and no way to say so: `maximumActiveAgents: 4` lives in each provider profile in `agent-profile.ts` and is exposed in no configuration key, so the only way to change throughput was to edit source and redeploy.

```yaml
agent:
  provider: opencode
  maximum_active_agents: 6
```

Absent keeps the provider's own default, so an existing file behaves exactly as before. The 1 to 16 range is a guard against a typo, not a measured limit.

I have deliberately not raised the number here. One permit pool serves every Task kind, so this is the whole service's throughput, and the binding constraint is memory rather than cores: each Agent is a full coding session, and the service peaked at 14GB against an 18GB cap yesterday under a heavier mix. That wants measuring at 6 before going further, which I would rather do against the live host than guess at in a diff.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).