### PR TITLE
fix(agent): say when a Reserve is holding every queued Task

### DIFF
--- a/packages/harlan-github-agent/src/capacity.ts
+++ b/packages/harlan-github-agent/src/capacity.ts
@@ -43,7 +43,50 @@ export function resolveAgentStartState(input: {
   const selected = input.agentSelection.order.map(provider => capacities.get(provider))
   if (selected.some(entry => entry !== undefined && hasSpendableCapacity(entry.capacity, entry.reservePercent)))
     return { _tag: 'Available' }
+  // A Reserve a person can lower outranks a provider that would not answer.
+  // One unreadable provider used to name the whole state CapacityUnavailable,
+  // which reads as a broken provider API. The truth was that the other
+  // provider had published its usage and only its own Reserve stopped it.
+  if (selected.some(entry => entry !== undefined && entry.capacity._tag === 'Available'))
+    return { _tag: 'ReserveReached' }
   if (selected.some(entry => entry === undefined || entry.capacity._tag === 'Unavailable'))
     return { _tag: 'CapacityUnavailable' }
   return { _tag: 'ReserveReached' }
+}
+
+/**
+ * Why no Agent may start, in one line, or null while one may.
+ *
+ * A Reserve that stops every claim is a designed answer and it was silent.
+ * Twenty seven Tasks waited seven hours behind one, with no log line and no
+ * Incident, and the only place that said so was the Dashboard.
+ */
+export function agentStartBlockedReason(input: {
+  startState: AgentStartState
+  queuedTasks: number
+  agentSelection: AgentSelection
+  providerCapacities: readonly ProviderCapacityStatus[]
+}): string | null {
+  if (input.startState._tag !== 'ReserveReached' && input.startState._tag !== 'CapacityUnavailable')
+    return null
+  if (input.queuedTasks === 0)
+    return null
+  const order = new Set<AgentProviderName>(input.agentSelection._tag === 'Automatic'
+    ? input.agentSelection.order
+    : [])
+  const detail = input.providerCapacities
+    .filter(entry => order.has(entry.provider))
+    .map((entry) => {
+      if (entry.capacity._tag === 'Unavailable')
+        // The provider's own reason may end in a stop. One sentence, one stop.
+        return `${entry.provider} did not report a limit: ${entry.capacity.reason.replace(/\.+$/, '')}`
+      if (entry.capacity._tag === 'Unpublished')
+        return `${entry.provider} publishes no limit`
+      return `${entry.provider} used ${entry.capacity.usedPercent.toFixed(1)}% and reserves ${entry.reservePercent}%, resetting ${entry.capacity.resetsAt}`
+    })
+  const tasks = input.queuedTasks === 1 ? '1 queued Task' : `${input.queuedTasks} queued Tasks`
+  const head = input.startState._tag === 'ReserveReached'
+    ? `Every Agent provider reached its Reserve, so ${tasks} cannot start.`
+    : `No Agent provider reported spendable capacity, so ${tasks} cannot start.`
+  return detail.length === 0 ? head : `${head} ${detail.join('. ')}.`
 }

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -21,7 +21,7 @@ import { createApprovalController } from './approval-controller.ts'
 import { createAutoMergeController } from './auto-merge-controller.ts'
 import { createBaselineRepairWorker } from './baseline-repair-worker.ts'
 import { createCandidateIssueController } from './candidate-issue-controller.ts'
-import { resolveAgentStartState } from './capacity.ts'
+import { agentStartBlockedReason, resolveAgentStartState } from './capacity.ts'
 import { createCodexProvider } from './codex-provider.ts'
 import { validateRepositoryMappings } from './config.ts'
 import { createConflictWorker } from './conflict-worker.ts'
@@ -905,9 +905,22 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         }
       })
       recordPassIncidents('review_rerun', reruns.flatMap(result => result._tag === 'Err' ? [result.error] : []))
+      const snapshot = store.getDashboardSnapshot(now().toISOString())
+      // A Reserve or an unreadable provider stops every claim by design, and
+      // said so nowhere outside the Dashboard. Twenty seven Tasks waited seven
+      // hours behind one with no log line and no Incident to read.
+      const blocked = agentStartBlockedReason({
+        startState: resolveAgentStartState(snapshot),
+        queuedTasks: snapshot.tasks.filter(task => task.state._tag === 'Queued').length,
+        agentSelection: snapshot.agentSelection,
+        providerCapacities: snapshot.providerCapacities,
+      })
+      if (blocked !== null)
+        options.logger.info(blocked)
+      recordPassIncidents('agent_capacity', blocked === null ? [] : [blocked])
       const statusSync = await guarded(
         'Pull request status sync',
-        () => pullRequestStatuses.sync(store.getDashboardSnapshot(now().toISOString()), signal),
+        () => pullRequestStatuses.sync(snapshot, signal),
         { checked: 0, errors: [] },
       )
       statusSync.errors.forEach((error) => {

--- a/packages/harlan-github-agent/test/provider-capacity.test.ts
+++ b/packages/harlan-github-agent/test/provider-capacity.test.ts
@@ -2,7 +2,7 @@ import type { AgentProviderName } from '../src/agent-provider.ts'
 import type { ProviderCapacity } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
 import { createAgentRuntimeSource, parseAgentSelection, resolveAgentSelection } from '../src/agent-profile.ts'
-import { resolveAgentStartState } from '../src/capacity.ts'
+import { agentStartBlockedReason, resolveAgentStartState } from '../src/capacity.ts'
 import {
   chooseAgentProvider,
   createProviderCapacitySource,
@@ -151,6 +151,27 @@ describe('resolving Agent start state', () => {
     })).toEqual({ _tag: 'ReserveReached' })
   })
 
+  it('blames the Reserve, not the unread provider, when one provider did publish', () => {
+    // One unreadable provider used to name the whole state CapacityUnavailable,
+    // which reads as a broken provider API. The Reserve is the actionable half.
+    expect(resolveAgentStartState({
+      ...input,
+      agentSelection: { _tag: 'Automatic' as const, order: ['opencode', 'codex'] as const },
+      providerCapacities: [
+        {
+          provider: 'opencode',
+          reservePercent: 50,
+          capacity: { _tag: 'Available', usedPercent: 50.36, resetsAt: '2026-09-04T14:33:32.989Z' },
+        },
+        {
+          provider: 'codex',
+          reservePercent: 20,
+          capacity: { _tag: 'Unavailable', reason: 'Codex refused to report its rate limits.' },
+        },
+      ],
+    })).toEqual({ _tag: 'ReserveReached' })
+  })
+
   it('keeps an unread limit distinct from a reached Reserve', () => {
     expect(resolveAgentStartState({
       ...input,
@@ -160,6 +181,58 @@ describe('resolving Agent start state', () => {
         capacity: { _tag: 'Unavailable', reason: 'timed out' },
       }],
     })).toEqual({ _tag: 'CapacityUnavailable' })
+  })
+})
+
+describe('naming why no Agent may start', () => {
+  const selection = { _tag: 'Automatic' as const, order: ['opencode', 'codex'] as const }
+  const reserved = {
+    provider: 'opencode' as const,
+    reservePercent: 25,
+    capacity: { _tag: 'Available' as const, usedPercent: 50.36, resetsAt: '2026-09-04T14:33:32.989Z' },
+  }
+  const unreadable = {
+    provider: 'codex' as const,
+    reservePercent: 20,
+    capacity: { _tag: 'Unavailable' as const, reason: 'Codex refused to report its rate limits.' },
+  }
+
+  it('says nothing while an Agent may start', () => {
+    expect(agentStartBlockedReason({
+      startState: { _tag: 'Available' },
+      queuedTasks: 27,
+      agentSelection: selection,
+      providerCapacities: [reserved, unreadable],
+    })).toBeNull()
+  })
+
+  it('says nothing when no Task is waiting, because nothing is held', () => {
+    expect(agentStartBlockedReason({
+      startState: { _tag: 'ReserveReached' },
+      queuedTasks: 0,
+      agentSelection: selection,
+      providerCapacities: [reserved, unreadable],
+    })).toBeNull()
+  })
+
+  it('names the Reserve, the usage, and the reset a person needs to act', () => {
+    expect(agentStartBlockedReason({
+      startState: { _tag: 'ReserveReached' },
+      queuedTasks: 27,
+      agentSelection: selection,
+      providerCapacities: [reserved, unreadable],
+    })).toBe('Every Agent provider reached its Reserve, so 27 queued Tasks cannot start. opencode used 50.4% and reserves 25%, resetting 2026-09-04T14:33:32.989Z. codex did not report a limit: Codex refused to report its rate limits.')
+  })
+
+  it('reads one waiting Task as one Task', () => {
+    const reason = agentStartBlockedReason({
+      startState: { _tag: 'CapacityUnavailable' },
+      queuedTasks: 1,
+      agentSelection: selection,
+      providerCapacities: [unreadable],
+    })
+
+    expect(reason).toContain('so 1 queued Task cannot start.')
   })
 })
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

The service stopped claiming Tasks at 06:54Z yesterday and ran nothing for seven hours. Twenty seven Tasks sat queued. Nothing in the journal said why, no Incident was raised, and I only found it by reading `agentStart` out of the Dashboard API.

The cause was correct behaviour: opencode had used 50.36% of its window against a 50% Reserve, so unattended work was not allowed to spend further. That is exactly what the Reserve is for. It just needs to say so.

The poll pass names it now, with the usage, the Reserve and the reset instant, and records it under `agent_capacity`. That operation already had a `resolveIncidents` call at startup and nothing anywhere that raised it.

Second thing this fixes: the state was reported as `CapacityUnavailable`, which reads as a broken provider API and sent me looking in the wrong place. It said that because Codex would not report its rate limits at all, and an unreadable provider outranked a reached Reserve. It is the other way round now, since a Reserve is the half a person can act on.

Not addressed here: Codex has been answering `Unavailable` with "Codex refused to report its rate limits" for as long as I have been looking, which means there is no second provider to fall back to when opencode is reserved. That is worth chasing separately.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).