### PR TITLE
feat(pr): attach screenshots to a pull request comment

### DIFF
--- a/docs/plans/harlan-github-agent.md
+++ b/docs/plans/harlan-github-agent.md
@@ -455,7 +455,7 @@ If CI or deployment fails because of the merge, create a minimal repair from the
 
 Direct default branch repair requires repository owner equality, a canonical checkout below `/home/harlan/sites`, a current writer fence, and a normal push.
 
-Use `chore: <specific problem>` for CI repairs. Never force push or bypass protection. Create a repair PR when protection rejects the push.
+Use `chore: <specific problem>`{lang="html"} for CI repairs. Never force push or bypass protection. Create a repair PR when protection rejects the push.
 
 After the matched deployment succeeds, run HTTP and browser smoke checks against configured production paths.
 

--- a/harlan-agent-kit/scripts/pr-asset.sh
+++ b/harlan-agent-kit/scripts/pr-asset.sh
@@ -3,8 +3,12 @@
 #
 # Usage: pr-asset.sh <file> [key]
 #
-# The key defaults to <repo>/<branch>/<basename>. Every upload overwrites the
-# same key, so a rerun on the same branch replaces the image in place.
+# The key defaults to <repo>/<branch>/<basename>, with a content hash before the
+# extension. Different bytes mean a different URL, so a replaced image is never
+# served stale from the edge. Identical bytes reuse the same object.
+#
+# Only curl is required. The service host runs this with no package manager and
+# no wrangler, so the R2 REST API does the upload directly.
 set -euo pipefail
 
 CONFIG="${PR_ASSETS_CONFIG:-$HOME/.config/harlan-agent-kit/pr-assets.env}"
@@ -23,13 +27,14 @@ if [ ! -f "$FILE" ]; then
   exit 2
 fi
 
-if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
-  echo "pr-asset.sh: set CLOUDFLARE_ACCOUNT_ID, or write it to $CONFIG." >&2
+if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ] || [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+  echo "pr-asset.sh: set CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN, or write them to $CONFIG." >&2
   exit 2
 fi
 
 BUCKET="${PR_ASSETS_BUCKET:-harlan-pr-assets}"
 BASE_URL="${PR_ASSETS_BASE_URL:-https://pr.harlanzw.com}"
+API_URL="${PR_ASSETS_API_URL:-https://api.cloudflare.com/client/v4}"
 
 KEY="${2:-}"
 if [ -z "$KEY" ]; then
@@ -48,6 +53,17 @@ fi
 # Slashes separate the key. Everything else stays URL safe.
 KEY="$(printf '%s' "$KEY" | tr -c 'A-Za-z0-9._/-' '-')"
 
+# The zone rewrites Cache-Control on this domain, so a stable key would serve
+# the old image for hours. Address the object by its content instead.
+DIGEST="$(sha256sum "$FILE" | cut -c1-8)"
+KEY_BASE="${KEY%.*}"
+KEY_EXT="${KEY##*.}"
+if [ "$KEY_BASE" = "$KEY" ]; then
+  KEY="${KEY}-${DIGEST}"
+else
+  KEY="${KEY_BASE}-${DIGEST}.${KEY_EXT}"
+fi
+
 case "${FILE##*.}" in
   png) CONTENT_TYPE="image/png" ;;
   jpg | jpeg) CONTENT_TYPE="image/jpeg" ;;
@@ -58,18 +74,23 @@ case "${FILE##*.}" in
   *) CONTENT_TYPE="application/octet-stream" ;;
 esac
 
-if command -v wrangler > /dev/null 2>&1; then
-  WRANGLER=(wrangler)
-else
-  WRANGLER=(pnpm dlx wrangler@4)
-fi
+BODY_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE"' EXIT
 
-# A rerun reuses the key, so the edge must not hold the old image for long.
-CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" "${WRANGLER[@]}" r2 object put \
-  "${BUCKET}/${KEY}" \
-  --file "$FILE" \
-  --content-type "$CONTENT_TYPE" \
-  --cache-control "public, max-age=300" \
-  --remote > /dev/null
+STATUS="$(curl -sS -X PUT \
+  "${API_URL}/accounts/${CLOUDFLARE_ACCOUNT_ID}/r2/buckets/${BUCKET}/objects/${KEY}" \
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+  -H "Content-Type: ${CONTENT_TYPE}" \
+  -H "Cache-Control: public, max-age=300" \
+  --data-binary "@${FILE}" \
+  -o "$BODY_FILE" \
+  -w '%{http_code}')"
+
+if [ "$STATUS" != "200" ]; then
+  echo "pr-asset.sh: upload failed with HTTP ${STATUS}." >&2
+  head -c 500 "$BODY_FILE" >&2
+  echo >&2
+  exit 1
+fi
 
 echo "${BASE_URL}/${KEY}"

--- a/harlan-agent-kit/scripts/pr-asset.sh
+++ b/harlan-agent-kit/scripts/pr-asset.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Upload one file to the PR asset bucket and print its public URL.
+#
+# Usage: pr-asset.sh <file> [key]
+#
+# The key defaults to <repo>/<branch>/<basename>. Every upload overwrites the
+# same key, so a rerun on the same branch replaces the image in place.
+set -euo pipefail
+
+CONFIG="${PR_ASSETS_CONFIG:-$HOME/.config/harlan-agent-kit/pr-assets.env}"
+if [ -f "$CONFIG" ]; then
+  # shellcheck disable=SC1090
+  . "$CONFIG"
+fi
+
+FILE="${1:-}"
+if [ -z "$FILE" ]; then
+  echo "pr-asset.sh: pass the file to upload." >&2
+  exit 2
+fi
+if [ ! -f "$FILE" ]; then
+  echo "pr-asset.sh: no file at $FILE." >&2
+  exit 2
+fi
+
+if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+  echo "pr-asset.sh: set CLOUDFLARE_ACCOUNT_ID, or write it to $CONFIG." >&2
+  exit 2
+fi
+
+BUCKET="${PR_ASSETS_BUCKET:-harlan-pr-assets}"
+BASE_URL="${PR_ASSETS_BASE_URL:-https://pr.harlanzw.com}"
+
+KEY="${2:-}"
+if [ -z "$KEY" ]; then
+  # The remote name, so every worktree of one repository shares a prefix.
+  REPO="$(basename -s .git "$(git remote get-url origin 2>/dev/null)" 2>/dev/null || true)"
+  if [ -z "$REPO" ]; then
+    REPO="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+  fi
+  # Empty on a detached HEAD, where the commit identifies the upload instead.
+  BRANCH="$(git branch --show-current 2>/dev/null || true)"
+  if [ -z "$BRANCH" ]; then
+    BRANCH="$(git rev-parse --short HEAD 2>/dev/null || echo detached)"
+  fi
+  KEY="${REPO}/${BRANCH}/$(basename "$FILE")"
+fi
+# Slashes separate the key. Everything else stays URL safe.
+KEY="$(printf '%s' "$KEY" | tr -c 'A-Za-z0-9._/-' '-')"
+
+case "${FILE##*.}" in
+  png) CONTENT_TYPE="image/png" ;;
+  jpg | jpeg) CONTENT_TYPE="image/jpeg" ;;
+  gif) CONTENT_TYPE="image/gif" ;;
+  webp) CONTENT_TYPE="image/webp" ;;
+  svg) CONTENT_TYPE="image/svg+xml" ;;
+  mp4) CONTENT_TYPE="video/mp4" ;;
+  *) CONTENT_TYPE="application/octet-stream" ;;
+esac
+
+if command -v wrangler > /dev/null 2>&1; then
+  WRANGLER=(wrangler)
+else
+  WRANGLER=(pnpm dlx wrangler@4)
+fi
+
+# A rerun reuses the key, so the edge must not hold the old image for long.
+CLOUDFLARE_ACCOUNT_ID="$CLOUDFLARE_ACCOUNT_ID" "${WRANGLER[@]}" r2 object put \
+  "${BUCKET}/${KEY}" \
+  --file "$FILE" \
+  --content-type "$CONTENT_TYPE" \
+  --cache-control "public, max-age=300" \
+  --remote > /dev/null
+
+echo "${BASE_URL}/${KEY}"

--- a/harlan-agent-kit/scripts/pr-asset.test.sh
+++ b/harlan-agent-kit/scripts/pr-asset.test.sh
@@ -7,20 +7,23 @@ asset_script="$script_dir/pr-asset.sh"
 test_root=$(mktemp -d)
 trap 'rm -rf "$test_root"' EXIT
 
-# A stub wrangler records its arguments instead of reaching Cloudflare.
+# A stub curl records its arguments instead of reaching Cloudflare.
 mkdir -p "$test_root/bin"
-cat > "$test_root/bin/wrangler" << 'STUB'
+cat > "$test_root/bin/curl" << 'STUB'
 #!/usr/bin/env bash
-printf '%s\n' "$@" > "$WRANGLER_ARGS_FILE"
+printf '%s\n' "$@" > "$CURL_ARGS_FILE"
+printf '%s' "${CURL_STATUS:-200}"
 STUB
-chmod +x "$test_root/bin/wrangler"
+chmod +x "$test_root/bin/curl"
 export PATH="$test_root/bin:$PATH"
-export WRANGLER_ARGS_FILE="$test_root/wrangler-args"
+export CURL_ARGS_FILE="$test_root/curl-args"
 
 cat > "$test_root/pr-assets.env" << 'ENV'
 CLOUDFLARE_ACCOUNT_ID=account-under-test
+CLOUDFLARE_API_TOKEN=token-under-test
 PR_ASSETS_BUCKET=bucket-under-test
 PR_ASSETS_BASE_URL=https://assets.example.com
+PR_ASSETS_API_URL=https://api.example.com/client/v4
 ENV
 export PR_ASSETS_CONFIG="$test_root/pr-assets.env"
 
@@ -43,46 +46,81 @@ if bash "$asset_script" "$test_root/absent.png" > /dev/null 2>&1; then
   exit 1
 fi
 
-if PR_ASSETS_CONFIG="$test_root/absent.env" CLOUDFLARE_ACCOUNT_ID= \
+if PR_ASSETS_CONFIG="$test_root/absent.env" CLOUDFLARE_ACCOUNT_ID= CLOUDFLARE_API_TOKEN= \
   bash "$asset_script" "$repo/after.png" > /dev/null 2>&1; then
   echo 'a missing account id was accepted' >&2
   exit 1
 fi
 
+if PR_ASSETS_CONFIG="$test_root/absent.env" CLOUDFLARE_ACCOUNT_ID=account-under-test CLOUDFLARE_API_TOKEN= \
+  bash "$asset_script" "$repo/after.png" > /dev/null 2>&1; then
+  echo 'a missing api token was accepted' >&2
+  exit 1
+fi
+
+digest=$(sha256sum "$repo/after.png" | cut -c1-8)
+if [[ "$digest" != 'd75bbc90' ]]; then
+  echo "the fixture content changed, update the expected digest: $digest" >&2
+  exit 1
+fi
+
 url=$(cd "$repo" && bash "$asset_script" after.png)
-if [[ "$url" != 'https://assets.example.com/nuxt-seo/fix/og-image/after.png' ]]; then
+if [[ "$url" != "https://assets.example.com/nuxt-seo/fix/og-image/after-$digest.png" ]]; then
   echo "default key came back wrong: $url" >&2
   exit 1
 fi
 
-args=$(tr '\n' ' ' < "$WRANGLER_ARGS_FILE")
-if [[ "$args" != *'bucket-under-test/nuxt-seo/fix/og-image/after.png'* ]]; then
-  echo "wrangler received the wrong object path: $args" >&2
+# Same bytes, same URL, so an unchanged screenshot does not churn the comment.
+again=$(cd "$repo" && bash "$asset_script" after.png)
+if [[ "$again" != "$url" ]]; then
+  echo "identical content produced two URLs: $url then $again" >&2
   exit 1
 fi
-if [[ "$args" != *'--content-type image/png'* ]]; then
-  echo "wrangler received the wrong content type: $args" >&2
+
+# Changed bytes must never reuse a URL the edge already cached.
+echo changed > "$repo/after.png"
+changed=$(cd "$repo" && bash "$asset_script" after.png)
+if [[ "$changed" == "$url" ]]; then
+  echo "changed content reused the cached URL: $changed" >&2
   exit 1
 fi
-if [[ "$args" != *'--remote'* ]]; then
-  echo 'the upload did not target the remote bucket' >&2
+echo shot > "$repo/after.png"
+# Restore the canonical upload, so the recorded request is the one asserted below.
+url=$(cd "$repo" && bash "$asset_script" after.png)
+
+args=$(tr '\n' ' ' < "$CURL_ARGS_FILE")
+if [[ "$args" != *"https://api.example.com/client/v4/accounts/account-under-test/r2/buckets/bucket-under-test/objects/nuxt-seo/fix/og-image/after-$digest.png"* ]]; then
+  echo "curl received the wrong object URL: $args" >&2
   exit 1
 fi
-if [[ "$args" != *'--cache-control public, max-age=300'* ]]; then
+if [[ "$args" != *'Authorization: Bearer token-under-test'* ]]; then
+  echo 'the upload was not authenticated' >&2
+  exit 1
+fi
+if [[ "$args" != *'Content-Type: image/png'* ]]; then
+  echo "curl received the wrong content type: $args" >&2
+  exit 1
+fi
+if [[ "$args" != *'Cache-Control: public, max-age=300'* ]]; then
   echo "a replaced image could stay cached at the edge: $args" >&2
   exit 1
 fi
 
 url=$(cd "$repo" && bash "$asset_script" after.png 'my repo/a branch?/shot one.png')
-if [[ "$url" != 'https://assets.example.com/my-repo/a-branch-/shot-one.png' ]]; then
+if [[ "$url" != "https://assets.example.com/my-repo/a-branch-/shot-one-$digest.png" ]]; then
   echo "an explicit key was not made URL safe: $url" >&2
   exit 1
 fi
 
 sha=$(git -C "$repo" rev-parse --short HEAD)
 url=$(cd "$repo" && git checkout -q --detach && bash "$asset_script" after.png)
-if [[ "$url" != "https://assets.example.com/nuxt-seo/$sha/after.png" ]]; then
+if [[ "$url" != "https://assets.example.com/nuxt-seo/$sha/after-$digest.png" ]]; then
   echo "a detached HEAD did not fall back to the commit: $url" >&2
+  exit 1
+fi
+
+if CURL_STATUS=403 bash -c "cd '$repo' && bash '$asset_script' after.png" > /dev/null 2>&1; then
+  echo 'a rejected upload still printed a URL' >&2
   exit 1
 fi
 

--- a/harlan-agent-kit/scripts/pr-asset.test.sh
+++ b/harlan-agent-kit/scripts/pr-asset.test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+asset_script="$script_dir/pr-asset.sh"
+test_root=$(mktemp -d)
+trap 'rm -rf "$test_root"' EXIT
+
+# A stub wrangler records its arguments instead of reaching Cloudflare.
+mkdir -p "$test_root/bin"
+cat > "$test_root/bin/wrangler" << 'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$WRANGLER_ARGS_FILE"
+STUB
+chmod +x "$test_root/bin/wrangler"
+export PATH="$test_root/bin:$PATH"
+export WRANGLER_ARGS_FILE="$test_root/wrangler-args"
+
+cat > "$test_root/pr-assets.env" << 'ENV'
+CLOUDFLARE_ACCOUNT_ID=account-under-test
+PR_ASSETS_BUCKET=bucket-under-test
+PR_ASSETS_BASE_URL=https://assets.example.com
+ENV
+export PR_ASSETS_CONFIG="$test_root/pr-assets.env"
+
+repo="$test_root/repo"
+git init -q "$repo"
+git -C "$repo" remote add origin https://github.com/harlan-zw/nuxt-seo.git
+git -C "$repo" config user.email test@example.com
+git -C "$repo" config user.name Test
+git -C "$repo" commit -q --allow-empty -m seed
+git -C "$repo" checkout -qb fix/og-image
+echo shot > "$repo/after.png"
+
+if bash "$asset_script" > /dev/null 2>&1; then
+  echo 'a missing file argument was accepted' >&2
+  exit 1
+fi
+
+if bash "$asset_script" "$test_root/absent.png" > /dev/null 2>&1; then
+  echo 'a file that does not exist was accepted' >&2
+  exit 1
+fi
+
+if PR_ASSETS_CONFIG="$test_root/absent.env" CLOUDFLARE_ACCOUNT_ID= \
+  bash "$asset_script" "$repo/after.png" > /dev/null 2>&1; then
+  echo 'a missing account id was accepted' >&2
+  exit 1
+fi
+
+url=$(cd "$repo" && bash "$asset_script" after.png)
+if [[ "$url" != 'https://assets.example.com/nuxt-seo/fix/og-image/after.png' ]]; then
+  echo "default key came back wrong: $url" >&2
+  exit 1
+fi
+
+args=$(tr '\n' ' ' < "$WRANGLER_ARGS_FILE")
+if [[ "$args" != *'bucket-under-test/nuxt-seo/fix/og-image/after.png'* ]]; then
+  echo "wrangler received the wrong object path: $args" >&2
+  exit 1
+fi
+if [[ "$args" != *'--content-type image/png'* ]]; then
+  echo "wrangler received the wrong content type: $args" >&2
+  exit 1
+fi
+if [[ "$args" != *'--remote'* ]]; then
+  echo 'the upload did not target the remote bucket' >&2
+  exit 1
+fi
+if [[ "$args" != *'--cache-control public, max-age=300'* ]]; then
+  echo "a replaced image could stay cached at the edge: $args" >&2
+  exit 1
+fi
+
+url=$(cd "$repo" && bash "$asset_script" after.png 'my repo/a branch?/shot one.png')
+if [[ "$url" != 'https://assets.example.com/my-repo/a-branch-/shot-one.png' ]]; then
+  echo "an explicit key was not made URL safe: $url" >&2
+  exit 1
+fi
+
+sha=$(git -C "$repo" rev-parse --short HEAD)
+url=$(cd "$repo" && git checkout -q --detach && bash "$asset_script" after.png)
+if [[ "$url" != "https://assets.example.com/nuxt-seo/$sha/after.png" ]]; then
+  echo "a detached HEAD did not fall back to the commit: $url" >&2
+  exit 1
+fi
+
+echo 'pr-asset.sh ok'

--- a/harlan-agent-kit/skills/nuxt-frontend-design/references/components/feedback.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/references/components/feedback.md
@@ -52,11 +52,15 @@ const open = ref(false)
 </script>
 
 <template>
-  <UButton @click="open = true">Open Settings</UButton>
+  <UButton @click="open = true">
+    Open Settings
+  </UButton>
 
   <UModal v-model:open="open">
     <template #header>
-      <h3 class="text-lg font-semibold">Settings</h3>
+      <h3 class="text-lg font-semibold">
+        Settings
+      </h3>
     </template>
 
     <div class="p-6">
@@ -65,8 +69,12 @@ const open = ref(false)
 
     <template #footer>
       <div class="flex justify-end gap-3">
-        <UButton variant="outline" @click="open = false">Cancel</UButton>
-        <UButton @click="save">Save</UButton>
+        <UButton variant="outline" @click="open = false">
+          Cancel
+        </UButton>
+        <UButton @click="save">
+          Save
+        </UButton>
       </div>
     </template>
   </UModal>
@@ -110,7 +118,8 @@ const open = ref(false)
   [
     { label: 'Delete', icon: 'i-lucide-trash-2', color: 'error' }
   ]
-]">
+]"
+>
   <UButton icon="i-lucide-ellipsis-vertical" variant="ghost" />
 </UDropdownMenu>
 ```

--- a/harlan-agent-kit/skills/nuxt-frontend-design/references/components/forms.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/references/components/forms.md
@@ -34,7 +34,7 @@ async function onSubmit() {
 </script>
 
 <template>
-  <UForm :schema="schema" :state="state" @submit="onSubmit" class="space-y-4">
+  <UForm :schema="schema" :state="state" class="space-y-4" @submit="onSubmit">
     <UFormField label="Name" name="name">
       <UInput v-model="state.name" placeholder="Jane Doe" />
     </UFormField>
@@ -47,7 +47,9 @@ async function onSubmit() {
       <USelect v-model="state.role" :items="['admin', 'user', 'viewer']" />
     </UFormField>
 
-    <UButton type="submit" :loading="loading">Create User</UButton>
+    <UButton type="submit" :loading="loading">
+      Create User
+    </UButton>
   </UForm>
 </template>
 ```

--- a/harlan-agent-kit/skills/nuxt-frontend-design/references/components/navigation.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/references/components/navigation.md
@@ -11,7 +11,8 @@ Sidebar, breadcrumbs, command palette, and header patterns for Nuxt UI.
   { label: 'Docs', to: '/docs' },
   { label: 'Pricing', to: '/pricing' },
   { label: 'Blog', to: '/blog' }
-]">
+]"
+>
   <template #logo>
     <span class="font-display text-xl font-bold">AppName</span>
   </template>
@@ -27,7 +28,8 @@ Sidebar, breadcrumbs, command palette, and header patterns for Nuxt UI.
 ```vue
 <UHeader :ui="{
   root: 'sticky top-0 z-50 backdrop-blur-lg bg-default/80 border-b border-default'
-}" />
+}"
+/>
 ```
 
 ---
@@ -53,7 +55,8 @@ Sidebar, breadcrumbs, command palette, and header patterns for Nuxt UI.
   { label: 'Home', to: '/' },
   { label: 'Projects', to: '/projects' },
   { label: 'My Project' }
-]" />
+]"
+/>
 ```
 
 ---
@@ -89,7 +92,8 @@ For custom command palette:
   { label: 'Overview', slot: 'overview', icon: 'i-lucide-layout-grid' },
   { label: 'Analytics', slot: 'analytics', icon: 'i-lucide-bar-chart-3' },
   { label: 'Settings', slot: 'settings', icon: 'i-lucide-settings' }
-]">
+]"
+>
   <template #overview>...</template>
   <template #analytics>...</template>
   <template #settings>...</template>

--- a/harlan-agent-kit/skills/nuxt-frontend-design/references/pages/landing.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/references/pages/landing.md
@@ -41,7 +41,9 @@ Components:
 <template>
   <div>
     <LandingHero>
-      <template #visual><HeroVisual /></template>
+      <template #visual>
+        <HeroVisual />
+      </template>
     </LandingHero>
     <TrustBar :logos="logos" />
     <FeaturesGrid :features="features" />

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -261,6 +261,27 @@ EOF
 
 Keep it to the checks a reviewer would otherwise have to repeat. Prose lines, not ticked boxes.
 
+### Screenshots
+
+A visible change earns a picture, in that same comment. GitHub only accepts a pasted image through the web UI, so upload the file first and embed the URL it prints:
+
+```bash
+"${CLAUDE_SKILL_DIR}/../../scripts/pr-asset.sh" .playwright/after.png
+# https://pr.harlanzw.com/<repo>/<branch>/after.png
+```
+
+The key is `<repo>/<branch>/<filename>`, so a rerun on the same branch replaces the image and the comment keeps working. The edge caches it for 5 minutes, so a replaced image can take that long to show. `~/.config/harlan-agent-kit/pr-assets.env` holds the bucket and its public host. Without that file the script exits 2 and says what is missing; post the comment without the image rather than blocking the PR.
+
+Take the picture before you need it: [nuxt-frontend-review](../nuxt-frontend-review/SKILL.md) already captures the running page. Two images beat one, labelled `Before` and `After`:
+
+```markdown
+| Before | After |
+| --- | --- |
+| ![before](https://pr.harlanzw.com/nuxt-seo/fix-og-image/before.png) | ![after](https://pr.harlanzw.com/nuxt-seo/fix-og-image/after.png) |
+```
+
+Only for a change someone can see: a page, a component, a CLI frame, a rendered email. Never a screenshot of passing tests or a green terminal.
+
 ## Step 6: Monitor CI & Review Comments
 
 After creating or updating a PR, enter a **fix loop** -- keep watching until CI is green and all review comments are addressed.

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -267,22 +267,22 @@ A visible change earns a picture, in that same comment. GitHub only accepts a pa
 
 ```bash
 "${CLAUDE_SKILL_DIR}/../../scripts/pr-asset.sh" .playwright/after.png
-# https://pr.harlanzw.com/<repo>/<branch>/after.png
+# https://pr.harlanzw.com/<repo>/<branch>/after-9f2c1a04.png
 ```
 
-The key is `<repo>/<branch>/<filename>`, so a rerun on the same branch replaces the image and the comment keeps working. The edge caches it for 5 minutes, so a replaced image can take that long to show. `~/.config/harlan-agent-kit/pr-assets.env` holds the bucket and its public host. Without that file the script exits 2 and says what is missing; post the comment without the image rather than blocking the PR.
+The URL carries a hash of the file, so a changed screenshot is a new URL and the edge can never serve the old one. Re-upload after every change and put the new URL in the comment. `~/.config/harlan-agent-kit/pr-assets.env` holds the account, the token, and the public host. Without it the script exits 2 and says what is missing; post the comment without the image rather than blocking the PR.
 
 Take the picture before you need it: [nuxt-frontend-review](../nuxt-frontend-review/SKILL.md) already captures the running page. Two images beat one, labelled `Before` and `After`:
 
 ```markdown
 | Before | After |
 | --- | --- |
-| ![before](https://pr.harlanzw.com/nuxt-seo/fix-og-image/before.png) | ![after](https://pr.harlanzw.com/nuxt-seo/fix-og-image/after.png) |
+| ![before](https://pr.harlanzw.com/nuxt-seo/fix-og-image/before-3d81be77.png) | ![after](https://pr.harlanzw.com/nuxt-seo/fix-og-image/after-9f2c1a04.png) |
 ```
 
 Only for a change someone can see: a page, a component, a CLI frame, a rendered email. Never a screenshot of passing tests or a green terminal.
 
-The bucket expires objects after 90 days, so a picture on a very old pull request goes blank. Nothing to clean up by hand, and [close-off](../close-off/SKILL.md) leaves the bucket alone: a merged pull request stays readable while anyone is still likely to open it.
+The bucket expires objects after 90 days, so a picture on a very old pull request goes blank. That is also what clears the superseded uploads. Nothing to clean up by hand, and [close-off](../close-off/SKILL.md) leaves the bucket alone: a merged pull request stays readable while anyone is still likely to open it.
 
 ## Step 6: Monitor CI & Review Comments
 

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -282,6 +282,8 @@ Take the picture before you need it: [nuxt-frontend-review](../nuxt-frontend-rev
 
 Only for a change someone can see: a page, a component, a CLI frame, a rendered email. Never a screenshot of passing tests or a green terminal.
 
+The bucket expires objects after 90 days, so a picture on a very old pull request goes blank. Nothing to clean up by hand, and [close-off](../close-off/SKILL.md) leaves the bucket alone: a merged pull request stays readable while anyone is still likely to open it.
+
 ## Step 6: Monitor CI & Review Comments
 
 After creating or updating a PR, enter a **fix loop** -- keep watching until CI is green and all review comments are addressed.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "service:hogwild:update": "bash scripts/hogwild-service.sh update",
     "test:service": "bash scripts/service.test.sh && bash scripts/hogwild-service.test.sh",
     "test:worktree-claim": "bash harlan-agent-kit/scripts/worktree-claim.test.sh",
+    "test:pr-asset": "bash harlan-agent-kit/scripts/pr-asset.test.sh",
     "test:pr-skill-only": "bash harlan-agent-kit/hooks/pr-skill-only.test.sh",
     "test:wt-only": "bash harlan-agent-kit/hooks/wt-only.test.sh",
     "test:sentry-checkin": "python3 -m unittest discover -s harlan-agent-kit/skills/sentry-checkin/scripts -p 'test_*.py'",


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

I have never once seen a screenshot on one of my PRs, and I finally worked out why: nothing in the kit can produce one. `nuxt-frontend-review` takes them for its own report, then they die there. GitHub has no image upload API either, pasting into the web UI is the only supported path, so an agent could not attach one even if it had the file.

So the images go to R2 now (`pr.harlanzw.com`), and `pr-asset.sh` prints the public URL to embed. Account, token and host come from `~/.config/harlan-agent-kit/pr-assets.env`, outside any repo, so this works from every checkout. No config means exit 2 and a message, not a broken PR.

Two things I got wrong on the first pass and fixed here.

**wrangler was the wrong dependency.** The service host has node and corepack, no npm, no pnpm, no wrangler, and no Cloudflare login. Uploads go through the R2 REST API with plain `curl`, which every host already has.

**Stable keys cannot promise freshness.** I set `Cache-Control: public, max-age=300` on upload and the zone served it back as `max-age=14400` anyway, on a key that had never been fetched before:

```
$ curl -sI https://pr.harlanzw.com/probe/fresh-1788276363.png
cache-control: public, max-age=14400
```

So the URL now carries the first 8 hex of the file's sha256. Different bytes, different URL, and the edge can never hand a reviewer last week's screenshot. Identical bytes reuse the object, so nothing churns when a rerun produces the same image. Superseded uploads age out on the 90 day lifecycle rule that is already on the bucket.

Still open: `pr.harlanzw.com` needs a scoped API token in the env file, and the service host needs that file before it can post an image. Not done in this PR.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).