### PR TITLE
fix(check): report lint instead of rewriting the repository

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -37,7 +37,7 @@ skipped=()
 if should_skip eslint; then
   skipped+=("eslint")
 elif [ -f "node_modules/.bin/eslint" ]; then
-  run_check eslint ./node_modules/.bin/eslint . --fix
+  run_check eslint ./node_modules/.bin/eslint .
 else
   skipped+=("eslint")
 fi

--- a/bin/check
+++ b/bin/check
@@ -138,6 +138,19 @@ for label in "${labels[@]}"; do
   fi
 done
 
+# Most lint failures are mechanical. Name the command that clears them, so the
+# next step is not a hand edit the fixer would have done anyway.
+if [ -f "$tmpdir/eslint.fail" ] && grep -q 'potentially fixable' "$tmpdir/eslint.log" 2>/dev/null; then
+  echo "Some lint problems are fixable."
+  echo "To fix the files this task changed, run:"
+  echo "  ./node_modules/.bin/eslint --fix \$(git diff --name-only HEAD)"
+  if has_script lint:fix; then
+    echo "To fix the whole repository, run \`pnpm lint:fix\`. Only do that on purpose."
+  fi
+  echo "Never hand edit a file this task does not own."
+  echo ""
+fi
+
 [ ${#skipped[@]} -gt 0 ] && echo "SKIPPED: ${skipped[*]}"
 
 if [ -n "$errors" ]; then


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

`check` ran `eslint . --fix` across the whole repository, so a command that reads as read only wrote to five files I had never opened while I was working on something unrelated. `pre-commit-push.sh` calls `check`, which means those edits were one `git add -A` away from riding along in a commit under a message that had nothing to do with them.

Worse, it did that on a passing run. Every one of those five files held warnings, not errors, so eslint exited 0, `check` printed `All checks passed`, and the working tree had changed anyway.

The autofix path is already covered twice over: the `eslint` PostToolUse hook fixes each file as it is edited, and `pnpm lint:fix` fixes the repository when I ask it to.

Second commit is the part I actually care about. A failure now says what to run:

```
Some lint problems are fixable.
To fix the files this task changed, run:
  ./node_modules/.bin/eslint --fix $(git diff --name-only HEAD)
To fix the whole repository, run `pnpm lint:fix`. Only do that on purpose.
Never hand edit a file this task does not own.
```

Without that, an agent that hits a lint failure hand edits its way to green, which is slower and touches files it has no business touching. The scoped command is the default on purpose, since the repo wide one is how the mess above happened.

Expect this to surface lint that `check` used to swallow.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).