### PR TITLE
fix(agent): stop the capacity stall reporting a fleet that is working

### DIFF
--- a/packages/harlan-github-agent/src/capacity.ts
+++ b/packages/harlan-github-agent/src/capacity.ts
@@ -64,12 +64,19 @@ export function resolveAgentStartState(input: {
 export function agentStartBlockedReason(input: {
   startState: AgentStartState
   queuedTasks: number
+  runningTasks: number
   agentSelection: AgentSelection
   providerCapacities: readonly ProviderCapacityStatus[]
 }): string | null {
   if (input.startState._tag !== 'ReserveReached' && input.startState._tag !== 'CapacityUnavailable')
     return null
   if (input.queuedTasks === 0)
+    return null
+  // A capacity reading can miss a provider or fail for one pass, and that read
+  // alone named the whole fleet blocked while six Agents were working. An Agent
+  // holding a Task is proof that claims are not blocked, whatever one reading
+  // of a provider limit says.
+  if (input.runningTasks > 0)
     return null
   const order = new Set<AgentProviderName>(input.agentSelection._tag === 'Automatic'
     ? input.agentSelection.order

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -912,6 +912,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       const blocked = agentStartBlockedReason({
         startState: resolveAgentStartState(snapshot),
         queuedTasks: snapshot.tasks.filter(task => task.state._tag === 'Queued').length,
+        runningTasks: snapshot.tasks.filter(task => task.state._tag === 'Running' || task.state._tag === 'Publishing').length,
         agentSelection: snapshot.agentSelection,
         providerCapacities: snapshot.providerCapacities,
       })

--- a/packages/harlan-github-agent/test/provider-capacity.test.ts
+++ b/packages/harlan-github-agent/test/provider-capacity.test.ts
@@ -201,6 +201,7 @@ describe('naming why no Agent may start', () => {
     expect(agentStartBlockedReason({
       startState: { _tag: 'Available' },
       queuedTasks: 27,
+      runningTasks: 0,
       agentSelection: selection,
       providerCapacities: [reserved, unreadable],
     })).toBeNull()
@@ -210,6 +211,7 @@ describe('naming why no Agent may start', () => {
     expect(agentStartBlockedReason({
       startState: { _tag: 'ReserveReached' },
       queuedTasks: 0,
+      runningTasks: 0,
       agentSelection: selection,
       providerCapacities: [reserved, unreadable],
     })).toBeNull()
@@ -219,15 +221,29 @@ describe('naming why no Agent may start', () => {
     expect(agentStartBlockedReason({
       startState: { _tag: 'ReserveReached' },
       queuedTasks: 27,
+      runningTasks: 0,
       agentSelection: selection,
       providerCapacities: [reserved, unreadable],
     })).toBe('Every Agent provider reached its Reserve, so 27 queued Tasks cannot start. opencode used 50.4% and reserves 25%, resetting 2026-09-04T14:33:32.989Z. codex did not report a limit: Codex refused to report its rate limits.')
+  })
+
+  it('says nothing while an Agent holds a Task, because a stall means nothing runs', () => {
+    // One capacity reading missed a provider and named the whole fleet blocked
+    // while six Agents were working. A held Task disproves the reading.
+    expect(agentStartBlockedReason({
+      startState: { _tag: 'CapacityUnavailable' },
+      queuedTasks: 14,
+      runningTasks: 6,
+      agentSelection: selection,
+      providerCapacities: [reserved, unreadable],
+    })).toBeNull()
   })
 
   it('reads one waiting Task as one Task', () => {
     const reason = agentStartBlockedReason({
       startState: { _tag: 'CapacityUnavailable' },
       queuedTasks: 1,
+      runningTasks: 0,
       agentSelection: selection,
       providerCapacities: [unreadable],
     })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

The Incident I added in #130 is crying wolf. It fired at 01:12, 01:15 and 01:17 with "No Agent provider reported spendable capacity, so 14 queued Tasks cannot start", while six Agents were holding Tasks and `agentStart` read `Available` when asked directly. opencode was at 51.8% against a 25% Reserve the whole time, so nothing was blocked at all.

A capacity reading that misses a provider, or fails for one pass, resolves to `CapacityUnavailable`, and that one reading was enough to name the whole fleet stopped. An Incident that fires while the thing it describes is demonstrably working is worse than no Incident, which is the same complaint I opened #130 to fix.

An Agent holding a Task is proof that claims are not blocked. The reason stays silent while anything runs.

I chose the running count over hardening the capacity read because the read is allowed to fail: it talks to a provider API on every pass. The question the Incident answers is "is the fleet stopped", and the journal already knows that without asking anybody.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).