### PR TITLE
fix(agent): clear legacy Review Publication Incidents

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -5077,6 +5077,17 @@ const reviewGateProjectionMigration = `
   PRAGMA user_version = 56;
 `
 
+/** Clears Publication Incidents that existed before they belonged to a repository. */
+const repositoryScopedReviewStatusIncidentMigration = `
+  UPDATE incidents
+  SET resolved_at = last_seen_at
+  WHERE resolved_at IS NULL
+    AND scope_tag = 'Service'
+    AND operation = 'review_status_publication';
+
+  PRAGMA user_version = 57;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -5325,9 +5336,13 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 55) {
     applyForeignKeyMigration(database, reviewGateProjectionMigration)
+    version = 56
+  }
+  if (version === 56) {
+    applyMigration(database, repositoryScopedReviewStatusIncidentMigration)
     return
   }
-  if (version === 56)
+  if (version === 57)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -492,6 +492,47 @@ describe('provider session recovery migration', () => {
   })
 })
 
+describe('review status Incident recovery migration', () => {
+  it('clears only Service Incidents that predate repository-scoped Publication recovery', () => {
+    const path = join(directory, 'state.sqlite')
+    const store = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    store.recordIncident({
+      scope: { _tag: 'Service' },
+      kind: 'unknown',
+      severity: 'error',
+      operation: 'review_status_publication',
+      message: 'GitHub did not stamp the harlan-agent-ready label.',
+      recovery: { _tag: 'ActionRequired' },
+      at: '2026-08-31T14:18:11.426Z',
+    })
+    store.recordIncident({
+      scope: { _tag: 'Service' },
+      kind: 'network',
+      severity: 'warning',
+      operation: 'review_rerun',
+      message: 'GitHub timed out.',
+      recovery: { _tag: 'Retrying', attempt: 1, nextAttemptAt: '2026-08-31T14:19:11.426Z' },
+      at: '2026-08-31T14:18:11.426Z',
+    })
+    store.close()
+
+    const oldJournal = new DatabaseSync(path)
+    oldJournal.exec('PRAGMA user_version = 56')
+    oldJournal.close()
+
+    const migrated = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    try {
+      expect(migrated.listIncidents()).toMatchObject([{
+        operation: 'review_rerun',
+        message: 'GitHub timed out.',
+      }])
+    }
+    finally {
+      migrated.close()
+    }
+  })
+})
+
 describe('gitHub vocabulary migration', () => {
   it('carries a version 22 journal across without losing a row', () => {
     const path = join(directory, 'state.sqlite')
@@ -509,7 +550,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(56)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(57)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two label failures stayed in the System pane after later Publications succeeded. They predate repository-scoped recovery, so the journal migration closes those legacy Service Incidents.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.