### PR TITLE
fix(agent): clear expired review updates before restart

### DIFF
--- a/packages/harlan-github-agent/src/restart-request.ts
+++ b/packages/harlan-github-agent/src/restart-request.ts
@@ -4,7 +4,7 @@ import type { RestartRequest } from './types.ts'
 const DEFAULT_INTERVAL_MILLISECONDS = 2_000
 const DEFAULT_MAXIMUM_WAIT_MILLISECONDS = 50 * 60_000
 
-type RestartStore = Pick<JournalStore, 'beginRestart' | 'getRestartRequest' | 'isSafeToRestart' | 'requireRestartAction'>
+type RestartStore = Pick<JournalStore, 'beginRestart' | 'getRestartRequest' | 'prepareForRestart' | 'requireRestartAction'>
 
 export interface RestartController {
   start: () => void
@@ -47,7 +47,7 @@ export function createRestartController(options: {
       return
     }
 
-    if (!options.store.isSafeToRestart())
+    if (!options.store.prepareForRestart(at))
       return
     const restarting = options.store.beginRestart({ id: request.id, processId: options.processId, at })
     if (restarting?._tag === 'Restarting')

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -897,6 +897,7 @@ export interface JournalStore {
   beginRestart: (input: { id: string, processId: string, at: string }) => RestartRequest | null
   completeRestart: (at: string) => RestartRequest | null
   requireRestartAction: (input: { id: string, at: string, reason: string }) => RestartRequest | null
+  prepareForRestart: (at: string) => boolean
   isSafeToRestart: () => boolean
   pauseAgents: (at: string) => StoredAgentControl
   setRepositoryPaused: (github: string, paused: boolean) => boolean
@@ -9957,6 +9958,58 @@ export function openJournalStore(
     return row.busy === 0
   }
 
+  const prepareForRestart: JournalStore['prepareForRestart'] = (at) => {
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      const terminalRows = database.prepare(`
+        SELECT id, fence FROM review_status_commands
+        WHERE state_tag = 'Running' AND phase = 'terminal' AND lease_expires_at <= ?
+      `).all(at) as unknown as Array<{ id: string, fence: number }>
+      const progressRows = database.prepare(`
+        SELECT id, fence FROM review_status_commands
+        WHERE state_tag = 'Running' AND phase != 'terminal' AND lease_expires_at <= ?
+      `).all(at) as unknown as Array<{ id: string, fence: number }>
+      database.prepare(`
+        UPDATE review_status_commands
+        SET state_tag = 'Pending', outcome_unknown = 1,
+          reason = 'The automated review did not finish before the Restart request.',
+          worker_id = NULL, lease_expires_at = NULL, updated_at = ?
+        WHERE state_tag = 'Running' AND phase = 'terminal' AND lease_expires_at <= ?
+      `).run(at, at)
+      terminalRows.forEach(row => recordReviewStatusEvent(database, {
+        commandId: row.id,
+        event: 'LeaseRecovered',
+        from: 'Running',
+        to: 'Pending',
+        reason: 'The automated review did not finish before the Restart request.',
+        fence: row.fence,
+        at,
+      }))
+      database.prepare(`
+        UPDATE review_status_commands
+        SET state_tag = 'Superseded',
+          reason = 'The automated review did not finish before the Restart request.',
+          worker_id = NULL, lease_expires_at = NULL, updated_at = ?
+        WHERE state_tag = 'Running' AND phase != 'terminal' AND lease_expires_at <= ?
+      `).run(at, at)
+      progressRows.forEach(row => recordReviewStatusEvent(database, {
+        commandId: row.id,
+        event: 'RestartSuperseded',
+        from: 'Running',
+        to: 'Superseded',
+        reason: 'The automated review did not finish before the Restart request.',
+        fence: row.fence,
+        at,
+      }))
+      database.exec('COMMIT')
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+    return isSafeToRestart()
+  }
+
   const listWorkflowEvents: JournalStore['listWorkflowEvents'] = (input = {}) => {
     const limit = Math.max(1, Math.min(1_000, input.limit ?? 200))
     const rows = input.stream === undefined
@@ -12612,6 +12665,7 @@ export function openJournalStore(
     beginRestart,
     completeRestart,
     requireRestartAction,
+    prepareForRestart,
     isSafeToRestart,
     dismissItem,
     restoreItem,

--- a/packages/harlan-github-agent/test/restart-request.test.ts
+++ b/packages/harlan-github-agent/test/restart-request.test.ts
@@ -155,7 +155,7 @@ describe('restart request', () => {
       maximumWaitMilliseconds: 50 * 60_000,
       store: {
         getRestartRequest: () => request,
-        isSafeToRestart: () => safe,
+        prepareForRestart: () => safe,
         beginRestart(input) {
           request = {
             _tag: 'Restarting',
@@ -205,7 +205,7 @@ describe('restart request', () => {
       maximumWaitMilliseconds: 50 * 60_000,
       store: {
         getRestartRequest: () => request,
-        isSafeToRestart: () => false,
+        prepareForRestart: () => false,
         beginRestart: () => null,
         requireRestartAction(input) {
           request = {

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -344,6 +344,53 @@ describe('journal store', () => {
     })
   })
 
+  it('supersedes an expired progress Publication before restart', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'restart-expired-progress-status',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request.')
+    const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:01:00.000Z', 60_000)
+    if (task === null)
+      throw new Error('Expected a Review Task.')
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:01:01.000Z',
+      revisionId: observed.revisionId,
+      expectedHeadSha: task.pullRequest.headSha,
+      phase: 'review',
+      body: '<!-- harlan-agent-kit:pr-triage -->\nReview in progress.',
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    expect(store.claimReviewStatus(staged.commandId, 'publisher-1', '2026-08-13T01:01:02.000Z', 60_000)).not.toBeNull()
+    store.completeWorkerTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:01:03.000Z',
+      evidence: 'review-1',
+    })
+
+    expect(store.prepareForRestart('2026-08-13T01:02:01.000Z')).toBe(false)
+    expect(store.prepareForRestart('2026-08-13T01:02:02.000Z')).toBe(true)
+    expect(store.listWorkflowEvents({ stream: 'review_status', limit: 1 })[0]).toMatchObject({
+      entityId: staged.commandId,
+      event: 'RestartSuperseded',
+      from: 'Running',
+      to: 'Superseded',
+      reason: 'The automated review did not finish before the Restart request.',
+    })
+  })
+
   it('keeps restart unsafe until a pending terminal Review Publication finishes', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

An expired automated review update delayed Restart requests for 50 minutes after all work finished. The service now clears expired progress updates and retries final updates before restart.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.