### PR TITLE
fix: verify exact issue state before publishing

### DIFF
--- a/packages/harlan-github-agent/src/github.ts
+++ b/packages/harlan-github-agent/src/github.ts
@@ -2,7 +2,7 @@ import type { Octokit } from 'octokit'
 import type { AutoMergeMethod } from './auto-merge.ts'
 import type { GitHubTokenProvider } from './github-auth.ts'
 import type { Result } from './result.ts'
-import type { GitHubItem, GitHubPullRequestItem, RepositoryMapping, RoutineName } from './types.ts'
+import type { GitHubIssueItem, GitHubItem, GitHubPullRequestItem, RepositoryMapping, RoutineName } from './types.ts'
 import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { approvalLabels } from './approval-labels.ts'
@@ -34,6 +34,7 @@ export interface GitHubReviewRerunRequest {
 export interface GitHubSource {
   isBranchProtected: (repository: RepositoryMapping, branch: string, signal?: AbortSignal) => Promise<Result<boolean, GitHubReadError>>
   hasOpenPullRequestForBranch: (repository: RepositoryMapping, headRef: string, signal?: AbortSignal) => Promise<Result<boolean, GitHubReadError>>
+  getIssue: (repository: RepositoryMapping, number: number, signal?: AbortSignal) => Promise<Result<GitHubIssueItem, GitHubReadError>>
   getPullRequest: (repository: RepositoryMapping, number: number, signal?: AbortSignal) => Promise<Result<GitHubPullRequestItem, GitHubReadError>>
   listOpenItems: (repository: RepositoryMapping, signal?: AbortSignal) => Promise<Result<GitHubItem[], GitHubReadError>>
   listReviewRerunRequests: (repository: RepositoryMapping, signal?: AbortSignal) => Promise<Result<GitHubReviewRerunRequest[], GitHubReadError>>
@@ -124,6 +125,9 @@ function labelNames(labels: Array<string | { name?: string }>): string[] {
   return labels.flatMap(label => typeof label === 'string' ? [label] : label.name === undefined ? [] : [label.name])
 }
 
+type GitHubIssue = Awaited<ReturnType<Octokit['rest']['issues']['get']>>['data']
+type GitHubIssueComment = Awaited<ReturnType<Octokit['rest']['issues']['listComments']>>['data'][number]
+
 function issueContentDigest(input: {
   body: string
   comments: readonly { id: number, author: string, body: string, updatedAt: string }[]
@@ -136,6 +140,47 @@ function issueContentDigest(input: {
     comments: [...input.comments].sort((left, right) => left.id - right.id),
     labels: [...input.labels].map(label => label.toLowerCase()).sort(),
   })).digest('hex')
+}
+
+function issueItem(
+  repository: RepositoryMapping,
+  issue: GitHubIssue,
+  comments: GitHubIssueComment[],
+  labels: string[],
+  routineFiled: boolean,
+  routineTracking: boolean,
+  actorLogin: string,
+): GitHubIssueItem {
+  const controllerLogin = actorLogin.toLowerCase()
+  return {
+    kind: 'issue',
+    approvalLabels: approvalLabels(labels),
+    contentDigest: issueContentDigest({
+      title: issue.title,
+      body: issue.body ?? '',
+      comments: comments.flatMap(comment =>
+        comment.user?.login === undefined || comment.body === undefined || comment.body === null
+        || (comment.user.login.toLowerCase() === controllerLogin && comment.body.includes(AUTOMATED_ISSUE_TRIAGE_MARKER))
+          ? []
+          : [{
+              id: comment.id,
+              author: comment.user.login,
+              body: comment.body,
+              updatedAt: comment.updated_at,
+            }]),
+      labels: labels.filter(label => !label.toLowerCase().startsWith('harlan-agent-')),
+    }),
+    repository: repository.github,
+    number: issue.number,
+    state: issue.state === 'closed' ? 'closed' : 'open',
+    title: issue.title,
+    author: issue.user?.login ?? 'ghost',
+    url: issue.html_url,
+    createdAt: issue.created_at,
+    updatedAt: issue.updated_at,
+    routineFiled,
+    routineTracking,
+  }
 }
 
 function pullRequestItem(
@@ -301,6 +346,35 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
           })
         })
     },
+    getIssue: async (repository, number, signal) => {
+      const { owner, repo } = repositoryParts(repository.github)
+      const octokit = await client(repository.github, signal)
+      if (octokit._tag === 'Err')
+        return octokit
+      const request = signal === undefined ? {} : { request: { signal } }
+      return Promise.all([
+        octokit.value.rest.issues.get({ owner, repo, issue_number: number, ...request }),
+        octokit.value.paginate(octokit.value.rest.issues.listComments, { owner, repo, issue_number: number, per_page: 100, ...request }),
+      ]).then(([response, comments]) => {
+        const labels = labelNames(response.data.labels)
+        return ok(issueItem(
+          repository,
+          response.data,
+          comments,
+          labels,
+          hasRoutineIssueLabel(labels),
+          isRoutineTrackingIssue({ repository: repository.github, title: response.data.title, body: response.data.body, labels }),
+          options.actorLogin(repository),
+        ))
+      }).catch((error: unknown): Result<GitHubIssueItem, GitHubReadError> => {
+        const status = errorStatus(error)
+        return err({
+          repository: repository.github,
+          message: error instanceof Error ? error.message : 'GitHub request failed.',
+          ...(status === undefined ? {} : { status }),
+        })
+      })
+    },
     getPullRequest: async (repository, number, signal) => {
       const { owner, repo } = repositoryParts(repository.github)
       const octokit = await client(repository.github, signal)
@@ -395,7 +469,6 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
             return [{ issue, labels, routineFiled, routineTracking }]
           })
         const issues: GitHubItem[] = await mapConcurrent(eligibleIssueRows, 4, async ({ issue, labels, routineFiled, routineTracking }) => {
-          const controllerLogin = options.actorLogin(repository).toLowerCase()
           const comments = await octokit.value.paginate(octokit.value.rest.issues.listComments, {
             owner,
             repo,
@@ -403,36 +476,7 @@ export function createGitHubSource(options: GitHubSourceOptions): GitHubSource {
             per_page: 100,
             ...requestOptions,
           })
-          const contentDigest = issueContentDigest({
-            title: issue.title,
-            body: issue.body ?? '',
-            comments: comments.flatMap(comment =>
-              comment.user?.login === undefined || comment.body === undefined || comment.body === null
-              || (comment.user.login.toLowerCase() === controllerLogin && comment.body.includes(AUTOMATED_ISSUE_TRIAGE_MARKER))
-                ? []
-                : [{
-                    id: comment.id,
-                    author: comment.user.login,
-                    body: comment.body,
-                    updatedAt: comment.updated_at,
-                  }]),
-            labels: labels.filter(label => !label.toLowerCase().startsWith('harlan-agent-')),
-          })
-          return {
-            kind: 'issue',
-            approvalLabels: approvalLabels(labels),
-            contentDigest,
-            repository: repository.github,
-            number: issue.number,
-            state: issue.state === 'closed' ? 'closed' : 'open',
-            title: issue.title,
-            author: issue.user?.login ?? 'ghost',
-            url: issue.html_url,
-            createdAt: issue.created_at,
-            updatedAt: issue.updated_at,
-            routineFiled,
-            routineTracking,
-          }
+          return issueItem(repository, issue, comments, labels, routineFiled, routineTracking, options.actorLogin(repository))
         })
 
         const eligiblePullRows = pullRows.filter(pull => isEligibleGitHubSubjectAuthor({

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -363,7 +363,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       const frozen = await options.github.getIssueTriageSnapshot(validated.value, task.issueNumber, signal)
       if (frozen._tag === 'Err')
         return frozen
-      if (frozen.value.state !== 'open' || frozen.value.updatedAt !== snapshot.value.updatedAt)
+      if (issueSnapshotDigest({ ...frozen.value, baseSha: prepared.value.defaultBranchSha }) !== scopeDigest)
         return err('The issue changed before the controller committed the fix.')
 
       const committed = await options.worktrees.commit(task, stacked.value.workspace, stacked.value.patch, response.commitMessage, signal)

--- a/packages/harlan-github-agent/src/reconcile.ts
+++ b/packages/harlan-github-agent/src/reconcile.ts
@@ -25,7 +25,7 @@ export interface ReconciliationError {
 export interface ReconciliationDependencies {
   approvals?: ApprovalController
   autoMerge?: AutoMergeController
-  github: Pick<GitHubSource, 'getPullRequest' | 'listOpenItems'>
+  github: Pick<GitHubSource, 'getIssue' | 'getPullRequest' | 'listOpenItems'>
   store: JournalStore
   now: () => Date
   signal?: AbortSignal
@@ -63,34 +63,46 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
       ? { kind: 'issue', routineFiled: subject.routineFiled }
       : { kind: 'pull_request', allowedAuthors: repository.writablePullRequestAuthors },
   ))
+  const seenIssues = new Set(eligibleItems.flatMap(subject => subject.kind === 'issue' ? [subject.number] : []))
+  const missingIssueNumbers = dependencies.store.listOpenIssueNumbers(repository.github)
+    .filter(number => !seenIssues.has(number))
   const seenPullRequests = new Set(eligibleItems.flatMap(subject => subject.kind === 'pull_request' ? [subject.number] : []))
   const missingPullRequestNumbers = dependencies.store.listOpenPullRequestNumbers(repository.github)
     .filter(number => !seenPullRequests.has(number))
   const unverifiedClosedPullRequestNumbers = dependencies.store.listUnverifiedClosedPullRequestNumbers(repository.github)
     .filter(number => !seenPullRequests.has(number))
   const finalPullRequestNumbers = [...new Set([...missingPullRequestNumbers, ...unverifiedClosedPullRequestNumbers])]
-  const finalPullRequestReads = await Promise.all(finalPullRequestNumbers.map(number =>
-    dependencies.github.getPullRequest(repository, number, dependencies.signal)))
-  const failedFinalRead = finalPullRequestReads.find(read => read._tag === 'Err')
+  const [finalIssueReads, finalPullRequestReads] = await Promise.all([
+    Promise.all(missingIssueNumbers.map(number => dependencies.github.getIssue(repository, number, dependencies.signal))),
+    Promise.all(finalPullRequestNumbers.map(number => dependencies.github.getPullRequest(repository, number, dependencies.signal))),
+  ])
+  const failedFinalRead = [...finalIssueReads, ...finalPullRequestReads].find(read => read._tag === 'Err')
   if (failedFinalRead?._tag === 'Err') {
     if (dependencies.signal?.aborted !== true)
       dependencies.store.recordPollFailure(repository.github, observedAt, failedFinalRead.error.message, failedFinalRead.error.status)
     return err({ repository: repository.github, message: failedFinalRead.error.message })
   }
+  const finalIssues = finalIssueReads.flatMap(read => read._tag === 'Ok' ? [read.value] : [])
   const finalPullRequests = finalPullRequestReads.flatMap(read => read._tag === 'Ok' ? [read.value] : [])
-  const observedItems = [...eligibleItems, ...finalPullRequests]
+  const observedItems = [...eligibleItems, ...finalIssues, ...finalPullRequests]
   const eligibleWrites = eligibleItems.map(subject => dependencies.store.recordObservation({
     externalId: observationId(repository.github, subject),
     observedAt,
     source: 'poll',
     subject,
   }))
-  const finalWrites = finalPullRequests.map(subject => dependencies.store.recordExactPullRequestObservation({
+  const finalIssueWrites = finalIssues.map(subject => dependencies.store.recordObservation({
+    externalId: observationId(repository.github, subject),
+    observedAt,
+    source: 'poll',
+    subject,
+  }))
+  const finalPullRequestWrites = finalPullRequests.map(subject => dependencies.store.recordExactPullRequestObservation({
     externalId: observationId(repository.github, subject),
     observedAt,
     subject,
   }))
-  const writes = [...eligibleWrites, ...finalWrites]
+  const writes = [...eligibleWrites, ...finalIssueWrites, ...finalPullRequestWrites]
   const conflict = writes.find(write => write._tag === 'Conflict')
   if (conflict?._tag === 'Conflict') {
     const message = `GitHub state hash collision: ${conflict.existingRevisionId} and ${conflict.receivedRevisionId}.`
@@ -98,7 +110,7 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     return err({ repository: repository.github, message })
   }
   const closureVerificationFailed = finalPullRequests.some((pullRequest, index) => {
-    const write = finalWrites[index]
+    const write = finalPullRequestWrites[index]
     if (pullRequest.state !== 'closed' || write === undefined || write._tag === 'Stale' || write._tag === 'Conflict')
       return false
     return !dependencies.store.recordVerifiedPullRequestClosure({
@@ -141,9 +153,15 @@ export async function reconcileRepository(repository: RepositoryMapping, depende
     )))
   }
 
+  const missingIssues = new Set(missingIssueNumbers)
   const missingPullRequests = new Set(missingPullRequestNumbers)
-  const closed = finalPullRequests.filter((pullRequest, index) => {
-    const write = finalWrites[index]
+  const closed = finalIssues.filter((issue, index) => {
+    const write = finalIssueWrites[index]
+    return missingIssues.has(issue.number)
+      && issue.state === 'closed'
+      && (write?._tag === 'Inserted' || write?._tag === 'Duplicate')
+  }).length + finalPullRequests.filter((pullRequest, index) => {
+    const write = finalPullRequestWrites[index]
     return missingPullRequests.has(pullRequest.number)
       && pullRequest.state === 'closed'
       && (write?._tag === 'Inserted' || write?._tag === 'Duplicate')

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -686,6 +686,8 @@ export interface JournalStore {
   updateRoutineRunProgress: (input: { taskId: string, workerId: string, fence: number, progress: AgentProgress, at: string }) => boolean
   completeRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, evidence: string, usage?: AgentTokenUsage }) => boolean
   failRoutineRun: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
+  /** Issues absent from the next open snapshot need one exact final GitHub read. */
+  listOpenIssueNumbers: (github: string) => number[]
   /** Pull requests absent from the next open snapshot need one exact final GitHub read. */
   listOpenPullRequestNumbers: (github: string) => number[]
   /** Old inferred closures need one exact read before GitHub becomes final truth. */
@@ -6241,16 +6243,19 @@ export function openJournalStore(
       AND json_extract(revisions.payload, '$.state') = 'open'
   `).get(repository, pullRequestNumber, revisionId, revisionId, kind) !== undefined
 
-  const listOpenPullRequestNumbers: JournalStore['listOpenPullRequestNumbers'] = github => (database.prepare(`
+  const listOpenItemNumbers = (github: string, kind: GitHubItem['kind']): number[] => (database.prepare(`
     SELECT subjects.github_number
     FROM subjects
     JOIN repositories ON repositories.id = subjects.repository_id
     JOIN revisions ON revisions.id = subjects.current_revision_id
     WHERE repositories.github = ?
-      AND subjects.kind = 'pull_request'
+      AND subjects.kind = ?
       AND json_extract(revisions.payload, '$.state') = 'open'
     ORDER BY subjects.github_number
-  `).all(github) as unknown as Array<{ github_number: number }>).map(row => row.github_number)
+  `).all(github, kind) as unknown as Array<{ github_number: number }>).map(row => row.github_number)
+
+  const listOpenIssueNumbers: JournalStore['listOpenIssueNumbers'] = github => listOpenItemNumbers(github, 'issue')
+  const listOpenPullRequestNumbers: JournalStore['listOpenPullRequestNumbers'] = github => listOpenItemNumbers(github, 'pull_request')
 
   const listUnverifiedClosedPullRequestNumbers: JournalStore['listUnverifiedClosedPullRequestNumbers'] = (github, limit = 5) => {
     const safeLimit = Math.max(0, Math.min(20, Math.trunc(limit)))
@@ -12589,6 +12594,7 @@ export function openJournalStore(
     completeRoutineRun,
     failRoutineRun,
     isIssueWorkApprovalReady,
+    listOpenIssueNumbers,
     listOpenPullRequestNumbers,
     listUnverifiedClosedPullRequestNumbers,
     recordExactPullRequestObservation,

--- a/packages/harlan-github-agent/test/github.test.ts
+++ b/packages/harlan-github-agent/test/github.test.ts
@@ -197,6 +197,48 @@ describe('gitHub subjects', () => {
     expect(changedByHuman.contentDigest).not.toBe(initialIssue.contentDigest)
   })
 
+  it('reads one exact issue with the same semantic state as the open list', async () => {
+    const listComments = () => undefined
+    const issue = {
+      number: 12,
+      state: 'open',
+      title: 'Broken thing',
+      body: 'Please fix it.',
+      user: { login: 'harlan-github-agent[bot]', type: 'Bot' },
+      html_url: 'https://github.com/harlan-zw/example/issues/12',
+      created_at: '2026-08-01T00:00:00.000Z',
+      updated_at: '2026-08-13T00:00:00.000Z',
+      labels: [{ name: 'routine:sentry-checkin' }, { name: 'harlan-agent-running' }],
+    }
+    const client = {
+      paginate: (method: unknown) => Promise.resolve(method === listComments
+        ? [{ id: 1, body: 'Human detail.', updated_at: '2026-08-13T00:01:00.000Z', user: { login: 'harlan-zw' } }]
+        : []),
+      rest: {
+        issues: {
+          get: () => Promise.resolve({ data: issue }),
+          listComments,
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      issueCutoff: '2026-07-01',
+      tokens: {
+        getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T02:00:00.000Z' })),
+        invalidate: () => undefined,
+      },
+    })
+
+    expect(await source.getIssue(repositoryMapping(), 12)).toEqual(ok(expect.objectContaining({
+      number: 12,
+      state: 'open',
+      routineFiled: true,
+      contentDigest: expect.stringMatching(/^[a-f\d]{64}$/),
+    })))
+  })
+
   it('uses one fixed inclusive issue cutoff', () => {
     expect(isIssueAtOrAfterCutoff('2026-07-13T23:59:59.999Z', '2026-07-14')).toBe(false)
     expect(isIssueAtOrAfterCutoff('2026-07-14T00:00:00.000Z', '2026-07-14')).toBe(true)

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -66,6 +66,7 @@ describe('issue work worker', () => {
     const repository = repositoryMapping({ authentication: 'user', ownership: 'maintained', conflictResolution: false })
     const issue = issueItem()
     const capture: ProviderCapture = { requests: [] }
+    let snapshotReads = 0
     const worker = createIssueWorkWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
         outcome: 'implemented',
@@ -84,7 +85,16 @@ Fixed the parser.
 Closes #12.`,
       }), capture)),
       github: {
-        getIssueTriageSnapshot: () => Promise.resolve(ok({ body: 'Reproduction', comments: [], state: 'open', title: issue.title, updatedAt: '2026-08-13T01:00:00.000Z' })),
+        getIssueTriageSnapshot: () => {
+          snapshotReads += 1
+          return Promise.resolve(ok({
+            body: 'Reproduction',
+            comments: [],
+            state: 'open',
+            title: issue.title,
+            updatedAt: snapshotReads === 1 ? '2026-08-13T01:00:00.000Z' : '2026-08-13T01:05:00.000Z',
+          }))
+        },
         getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Found', body: '### Description\n\n### Linked Issues' })),
         listPullRequestFiles: () => Promise.resolve(ok([])),
       },
@@ -125,6 +135,7 @@ Closes #12.`,
       sessionId: 'triage-session',
       workspace: '/tmp/issue-work',
     })])
+    expect(snapshotReads).toBe(2)
     expect(result).toEqual(ok({
       _tag: 'Publish',
       usage: { _tag: 'Unavailable' },
@@ -145,6 +156,64 @@ Closes #12.`,
       }),
     })))
     expect(JSON.stringify(result)).not.toContain('[Codex]')
+  })
+
+  it('rejects issue work when a human comment changes its meaning', async () => {
+    const repository = repositoryMapping()
+    const issue = issueItem()
+    const snapshots = [
+      { body: 'Reproduction', comments: [], state: 'open' as const, title: issue.title, updatedAt: '2026-08-13T01:00:00.000Z' },
+      { body: 'Reproduction', comments: ['Use a different fix.'], state: 'open' as const, title: issue.title, updatedAt: '2026-08-13T01:05:00.000Z' },
+    ]
+    let snapshotReads = 0
+    let committed = false
+    const worker = createIssueWorkWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        outcome: 'implemented',
+        summary: 'Fixed the parser.',
+        checks: ['pnpm test'],
+        commitMessage: 'fix(parser): preserve valid input',
+        pullRequestTitle: 'fix: broken thing',
+        pullRequestBody: '### Description\n\nFixed the parser.\n\n### Linked Issues\n\nCloses #12.',
+      }))),
+      github: {
+        getIssueTriageSnapshot: () => Promise.resolve(ok(snapshots[Math.min(snapshotReads++, 1)]!)),
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Found', body: '### Description\n\n### Linked Issues' })),
+        listPullRequestFiles: () => Promise.resolve(ok([])),
+      },
+      now: () => new Date('2026-08-13T01:06:00.000Z'),
+      store: {
+        getWorkerSession: () => 'triage-session',
+        listOpenAgentPullRequests: () => [],
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: () => Promise.resolve(ok(repository)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/issue-work', headSha: 'base-sha', baseSha: 'base-sha', defaultBranchSha: 'base-sha' })),
+        verify: () => Promise.resolve(ok({ digest: 'patch-digest', changedFiles: 2, changedPaths: ['src/parser.ts', 'test/parser.test.ts'] })),
+        restack: () => Promise.reject(new Error('Issue work must not restack without a stack base.')),
+        commit: () => {
+          committed = true
+          return Promise.resolve(ok({ commitSha: 'commit-sha', baseSha: 'base-sha', artifactRef: 'artifact-ref', digest: 'patch-digest', changedFiles: 2 }))
+        },
+      },
+    })
+
+    const result = await worker.run({
+      id: 'issue-work-task',
+      kind: 'issue_work',
+      repository: repository.github,
+      issueNumber: issue.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T01:10:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: repository,
+      issue,
+    }, new AbortController().signal)
+
+    expect(result).toEqual({ _tag: 'Err', error: 'The issue changed before the controller committed the fix.' })
+    expect(committed).toBe(false)
   })
 
   it('publishes the patch with safe metadata when Agent output is malformed', async () => {

--- a/packages/harlan-github-agent/test/reconcile.test.ts
+++ b/packages/harlan-github-agent/test/reconcile.test.ts
@@ -6,7 +6,8 @@ import { AGENT_ACTOR_LOGIN } from '../src/review-comment.ts'
 import { openJournalStore } from '../src/store.ts'
 import { issueItem, pullRequestItem, repositoryMapping } from './fixtures.ts'
 
-const noPullRequestRead = {
+const noFinalRead = {
+  getIssue: () => Promise.reject(new Error('No issue should need a final read.')),
   getPullRequest: () => Promise.reject(new Error('No pull request should need a final read.')),
 }
 
@@ -17,7 +18,7 @@ describe('gitHub reconciliation', () => {
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([issueItem({ author: 'github-actions[bot]' })])) },
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([issueItem({ author: 'github-actions[bot]' })])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -58,7 +59,11 @@ describe('gitHub reconciliation', () => {
     expect(store.listIncidents()).toHaveLength(1)
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([botIssue])) },
+      github: {
+        ...noFinalRead,
+        getIssue: () => Promise.resolve(ok({ ...botIssue, state: 'closed' as const })),
+        listOpenItems: () => Promise.resolve(ok([botIssue])),
+      },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -72,13 +77,84 @@ describe('gitHub reconciliation', () => {
     store.close()
   })
 
+  it('keeps an issue open when its exact GitHub read says it is open', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    const issue = issueItem({ author: 'harlan-zw' })
+    let exactReads = 0
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'issue-before-missing-list-result',
+      observedAt: '2026-08-13T00:01:00.000Z',
+      source: 'poll',
+      subject: issue,
+    })
+
+    const result = await reconcileRepository(repository, {
+      github: {
+        ...noFinalRead,
+        getIssue: () => {
+          exactReads += 1
+          return Promise.resolve(ok(issue))
+        },
+        listOpenItems: () => Promise.resolve(ok([])),
+      },
+      store,
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: { repository: repository.github, subjects: 0, inserted: 0, duplicates: 0, stale: 0, closed: 0 },
+    })
+    expect(exactReads).toBe(1)
+    expect(store.getDashboardSnapshot('2026-08-13T01:00:00.000Z').items)
+      .toEqual([expect.objectContaining({ kind: 'issue', number: issue.number, state: 'open' })])
+    store.close()
+  })
+
+  it('keeps an issue open when its exact GitHub read fails', async () => {
+    const store = openJournalStore(':memory:')
+    const repository = repositoryMapping()
+    const issue = issueItem({ author: 'harlan-zw' })
+    store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'issue-before-read-failure',
+      observedAt: '2026-08-13T00:01:00.000Z',
+      source: 'poll',
+      subject: issue,
+    })
+
+    const result = await reconcileRepository(repository, {
+      github: {
+        ...noFinalRead,
+        getIssue: () => Promise.resolve(err({
+          repository: repository.github,
+          message: 'GitHub did not return the issue.',
+          status: 503,
+        })),
+        listOpenItems: () => Promise.resolve(ok([])),
+      },
+      store,
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+    })
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      error: { repository: repository.github, message: 'GitHub did not return the issue.' },
+    })
+    expect(store.getDashboardSnapshot('2026-08-13T01:00:00.000Z').items)
+      .toEqual([expect.objectContaining({ kind: 'issue', number: issue.number, state: 'open' })])
+    store.close()
+  })
+
   it('keeps a Routine candidate issue eligible for Issue triage', async () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([
         issueItem({ number: 41, author: AGENT_ACTOR_LOGIN, routineFiled: true, url: 'https://github.com/harlan-zw/example/issues/41' }),
       ])) },
       store,
@@ -125,7 +201,7 @@ describe('gitHub reconciliation', () => {
     expect(store.listIncidents()).toHaveLength(1)
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([
         { ...trackingIssue, routineTracking: true },
       ])) },
       store,
@@ -148,7 +224,7 @@ describe('gitHub reconciliation', () => {
     expect(store.countOpenPullRequests()).toBe(0)
 
     const github = {
-      ...noPullRequestRead,
+      ...noFinalRead,
       listOpenItems: () => Promise.resolve(ok([
         pullRequestItem({ number: 24, controllerOwned: true }),
         pullRequestItem({ number: 25, controllerOwned: true }),
@@ -164,6 +240,8 @@ describe('gitHub reconciliation', () => {
     // A pull request that disappears from the open list closes, so it stops counting.
     await reconcileRepository(repository, {
       github: {
+        ...noFinalRead,
+        getIssue: () => Promise.resolve(ok(issueItem({ number: 12, author: 'harlan-zw' }))),
         getPullRequest: () => Promise.resolve(ok({
           ...pullRequestItem({ number: 25, controllerOwned: true }),
           state: 'closed' as const,
@@ -234,6 +312,7 @@ describe('gitHub reconciliation', () => {
 
     const result = await reconcileRepository(repository, {
       github: {
+        ...noFinalRead,
         listOpenItems: () => Promise.resolve(ok([])),
         getPullRequest: () => Promise.resolve(ok({
           ...pullRequest,
@@ -270,6 +349,7 @@ describe('gitHub reconciliation', () => {
 
     const result = await reconcileRepository(repository, {
       github: {
+        ...noFinalRead,
         listOpenItems: () => Promise.resolve(ok([])),
         getPullRequest: () => Promise.resolve(err({
           repository: repository.github,
@@ -354,6 +434,7 @@ describe('gitHub reconciliation', () => {
 
     await reconcileRepository(repository, {
       github: {
+        ...noFinalRead,
         listOpenItems: () => Promise.resolve(ok([])),
         getPullRequest: () => {
           exactReads += 1
@@ -388,6 +469,7 @@ describe('gitHub reconciliation', () => {
 
     const result = await reconcileRepository(repository, {
       github: {
+        ...noFinalRead,
         listOpenItems: () => Promise.resolve(ok([])),
         getPullRequest: () => {
           store.recordObservation({
@@ -425,7 +507,7 @@ describe('gitHub reconciliation', () => {
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([pullRequestItem({ author: 'harlan-github-agent[bot]' })])) },
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([pullRequestItem({ author: 'harlan-github-agent[bot]' })])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -441,7 +523,7 @@ describe('gitHub reconciliation', () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
-    const github = { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([issueItem()])) }
+    const github = { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([issueItem()])) }
     const now = () => new Date('2026-08-13T01:00:00.000Z')
 
     const first = await reconcileRepository(repository, { github, store, now })
@@ -473,7 +555,7 @@ describe('gitHub reconciliation', () => {
           return Promise.resolve(ok(undefined))
         },
       },
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([issue])) },
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([issue])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })
@@ -487,7 +569,7 @@ describe('gitHub reconciliation', () => {
     const store = openJournalStore(':memory:')
     const repository = repositoryMapping()
     store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
-    const github = { ...noPullRequestRead, listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'Rate limited' })) }
+    const github = { ...noFinalRead, listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'Rate limited' })) }
     const now = () => new Date('2026-08-13T01:00:00.000Z')
 
     const result = await reconcileRepository(repository, { github, store, now })
@@ -505,7 +587,7 @@ describe('gitHub reconciliation', () => {
     controller.abort()
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'This operation was aborted' })) },
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(err({ repository: repository.github, message: 'This operation was aborted' })) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
       signal: controller.signal,
@@ -533,7 +615,7 @@ describe('gitHub reconciliation', () => {
     })
 
     const result = await reconcileRepository(repository, {
-      github: { ...noPullRequestRead, listOpenItems: () => Promise.resolve(ok([incoming])) },
+      github: { ...noFinalRead, listOpenItems: () => Promise.resolve(ok([incoming])) },
       store,
       now: () => new Date('2026-08-13T01:00:00.000Z'),
     })


### PR DESCRIPTION
## Summary

Fix routine issue work that stopped before opening pull requests.
Ignore controller timestamp changes while preserving semantic change checks.
Confirm missing issues with an exact GitHub read before closing local state.

## Verification

- `pnpm --filter harlan-github-agent test:run`
- `pnpm --filter harlan-github-agent lint`
- `pnpm --filter harlan-github-agent typecheck`
- `pnpm --filter harlan-github-agent build`