### PR TITLE
fix(agent): exclude forks from repository discovery

### DIFF
--- a/packages/harlan-github-agent/src/github-user-access.ts
+++ b/packages/harlan-github-agent/src/github-user-access.ts
@@ -48,7 +48,7 @@ export function createGitHubUserAccess(options: GitHubUserAccessOptions = {}): G
         'api',
         `repos/${owner}/${repo}`,
         '--jq',
-        '{github: .full_name, defaultBranch: .default_branch, archived: .archived, topics: .topics, owner: {login: .owner.login, type: .owner.type}}',
+        '{github: .full_name, defaultBranch: .default_branch, archived: .archived, fork: .fork, topics: .topics, owner: {login: .owner.login, type: .owner.type}}',
       ])
         .then((output) => {
           const repository = JSON.parse(output) as Omit<InstalledRepository, 'authentication'>

--- a/packages/harlan-github-agent/src/repository-discovery.ts
+++ b/packages/harlan-github-agent/src/repository-discovery.ts
@@ -10,6 +10,7 @@ export interface InstalledRepository {
   github: string
   defaultBranch: string
   archived: boolean
+  fork: boolean
   topics: string[]
   /** How the controller reached this repository: the App, or Harlan's own token. */
   authentication: RepositoryAuthentication
@@ -84,10 +85,13 @@ export async function discoverGitHubAppRepositories(options: GitHubAppRepository
       continue
     if (!isAllowedRepository(repository.full_name, options.allowedOwners))
       continue
+    if (repository.fork)
+      continue
     repositories.push({
       github: repository.full_name,
       defaultBranch: repository.default_branch,
       archived: repository.archived,
+      fork: false,
       topics: repository.topics ?? [],
       authentication: 'app',
       owner: { login: repository.owner.login, type: ownerType },
@@ -168,7 +172,7 @@ export async function discoverUserRepositories(options: UserRepositoryDiscoveryO
       // An unreadable repository is one Harlan cannot reach either, so it stays untracked.
       return undefined
     })))
-  return repositories.flatMap(repository => repository === undefined || repository.archived ? [] : [repository])
+  return repositories.flatMap(repository => repository === undefined || repository.archived || repository.fork ? [] : [repository])
 }
 
 /**
@@ -185,6 +189,7 @@ export function installedWithoutCheckout(
   const checkoutByRepository = new Set(checkouts.map(checkout => checkout.github.toLowerCase()))
   return repositories
     .filter(repository => !repository.archived
+      && !repository.fork
       && isAllowedRepository(repository.github, allowedOwners)
       && !checkoutByRepository.has(repository.github.toLowerCase()))
     .map(repository => repository.github)
@@ -201,6 +206,8 @@ export function buildRepositoryMappings(
   const overrideByRepository = new Map(overrides.map(mapping => [mapping.github.toLowerCase(), mapping]))
 
   return repositories.flatMap((repository) => {
+    if (repository.fork)
+      return []
     if (!isAllowedRepository(repository.github, allowedOwners))
       return []
     const checkout = checkoutByRepository.get(repository.github.toLowerCase())

--- a/packages/harlan-github-agent/test/repository-discovery.test.ts
+++ b/packages/harlan-github-agent/test/repository-discovery.test.ts
@@ -14,10 +14,10 @@ afterEach(() => temporaryDirectories.splice(0).forEach(path => rmSync(path, { re
 
 describe('installedWithoutCheckout', () => {
   const installed = [
-    { github: 'harlan-zw/example', defaultBranch: 'main', archived: false, topics: [], authentication: 'app' as const, owner: { login: 'harlan-zw', type: 'User' as const } },
-    { github: 'harlan-zw/unlighthouse.dev', defaultBranch: 'main', archived: false, topics: [], authentication: 'app' as const, owner: { login: 'harlan-zw', type: 'User' as const } },
-    { github: 'harlan-zw/retired', defaultBranch: 'main', archived: true, topics: [], authentication: 'app' as const, owner: { login: 'harlan-zw', type: 'User' as const } },
-    { github: 'someone-else/tool', defaultBranch: 'main', archived: false, topics: [], authentication: 'app' as const, owner: { login: 'someone-else', type: 'User' as const } },
+    { github: 'harlan-zw/example', defaultBranch: 'main', archived: false, fork: false, topics: [], authentication: 'app' as const, owner: { login: 'harlan-zw', type: 'User' as const } },
+    { github: 'harlan-zw/unlighthouse.dev', defaultBranch: 'main', archived: false, fork: false, topics: [], authentication: 'app' as const, owner: { login: 'harlan-zw', type: 'User' as const } },
+    { github: 'harlan-zw/retired', defaultBranch: 'main', archived: true, fork: false, topics: [], authentication: 'app' as const, owner: { login: 'harlan-zw', type: 'User' as const } },
+    { github: 'someone-else/tool', defaultBranch: 'main', archived: false, fork: false, topics: [], authentication: 'app' as const, owner: { login: 'someone-else', type: 'User' as const } },
   ]
 
   it('names every granted repository that no agent can see', () => {
@@ -62,6 +62,7 @@ describe('repository discovery', () => {
         github: 'harlan-zw/example',
         defaultBranch: 'main',
         archived: false,
+        fork: false,
         topics: [],
         authentication: 'app' as const,
         owner: { login: 'harlan-zw', type: 'User' },
@@ -70,6 +71,7 @@ describe('repository discovery', () => {
         github: 'skilld-dev/shared',
         defaultBranch: 'main',
         archived: false,
+        fork: false,
         topics: ['harlan-agent-issues', 'harlan-agent-conflicts'],
         authentication: 'app' as const,
         owner: { login: 'skilld-dev', type: 'Organization' },
@@ -78,6 +80,7 @@ describe('repository discovery', () => {
         github: 'harlan-zw/remote-only',
         defaultBranch: 'main',
         archived: false,
+        fork: false,
         topics: [],
         authentication: 'app' as const,
         owner: { login: 'harlan-zw', type: 'User' },
@@ -100,6 +103,20 @@ describe('repository discovery', () => {
     expect(mappings[0]?.writablePullRequestAuthors).toEqual(['harlan-zw', 'harlan-github-agent[bot]'])
   })
 
+  it('does not map a fork', () => {
+    const mappings = buildRepositoryMappings([{
+      github: 'harlan-zw/skills',
+      defaultBranch: 'main',
+      archived: false,
+      fork: true,
+      topics: [],
+      authentication: 'app' as const,
+      owner: { login: 'harlan-zw', type: 'User' },
+    }], [{ github: 'harlan-zw/skills', checkout: '/home/harlan/pkg/skills' }], [], ['harlan-zw'])
+
+    expect(mappings).toEqual([])
+  })
+
   it('admits one repository without admitting its owner', () => {
     const allowed = ['harlan-zw', 'nuxt/scripts']
 
@@ -118,6 +135,7 @@ describe('repository discovery', () => {
       github: `nuxt/${name}`,
       defaultBranch: 'main',
       archived: false,
+      fork: false,
       topics: [],
       authentication: 'user',
       owner: { login: 'nuxt', type: 'Organization' },
@@ -141,6 +159,7 @@ describe('repository discovery', () => {
       github: 'nuxt/scripts',
       defaultBranch: 'main',
       archived: false,
+      fork: false,
       topics: [],
       authentication: 'user' as const,
       owner: { login: 'nuxt', type: 'Organization' },
@@ -164,6 +183,7 @@ describe('repository discovery', () => {
       github: 'harlan-zw/example',
       defaultBranch: 'main',
       archived: false,
+      fork: false,
       topics: [],
       authentication: 'app' as const,
       owner: { login: 'harlan-zw', type: 'User' },
@@ -181,6 +201,7 @@ describe('repository discovery', () => {
       github: 'harlan-zw/example',
       defaultBranch: 'main',
       archived: true,
+      fork: false,
       topics: [],
       authentication: 'app' as const,
       owner: { login: 'harlan-zw', type: 'User' },
@@ -194,6 +215,7 @@ describe('repository discovery', () => {
       github: 'harlan-zw/example',
       defaultBranch: 'main',
       archived: false,
+      fork: false,
       topics: [],
       authentication: 'app' as const,
       owner: { login: 'harlan-zw', type: 'User' },

--- a/packages/harlan-github-agent/test/user-token-repositories.test.ts
+++ b/packages/harlan-github-agent/test/user-token-repositories.test.ts
@@ -9,16 +9,18 @@ const installed: InstalledRepository = {
   github: 'harlan-zw/example',
   defaultBranch: 'main',
   archived: false,
+  fork: false,
   topics: [],
   authentication: 'app',
   owner: { login: 'harlan-zw', type: 'User' },
 }
 
-function organizationRepository(github: string, archived = false) {
+function organizationRepository(github: string, archived = false, fork = false) {
   return {
     github,
     defaultBranch: 'main',
     archived,
+    fork,
     topics: [],
     owner: { login: github.split('/')[0] as string, type: 'Organization' as const },
   }
@@ -88,6 +90,15 @@ describe('discoverUserRepositories', () => {
       checkouts,
       installed: [],
       readRepository: github => Promise.resolve(organizationRepository(github, true)),
+    })).toEqual([])
+  })
+
+  it('leaves out a fork', async () => {
+    expect(await discoverUserRepositories({
+      allowedOwners: ['nuxt-modules'],
+      checkouts,
+      installed: [],
+      readRepository: github => Promise.resolve(organizationRepository(github, false, true)),
     })).toEqual([])
   })
 
@@ -183,6 +194,7 @@ describe('createGitHubUserAccess', () => {
           github: 'nuxt-modules/sitemap',
           defaultBranch: 'main',
           archived: false,
+          fork: false,
           topics: [],
           owner: { login: 'nuxt-modules', type: 'Organization' },
         }))
@@ -192,6 +204,7 @@ describe('createGitHubUserAccess', () => {
     expect(await access.readRepository('nuxt-modules/sitemap')).toEqual(expect.objectContaining({
       github: 'nuxt-modules/sitemap',
       defaultBranch: 'main',
+      fork: false,
     }))
     expect(commands[0]?.slice(0, 2)).toEqual(['api', 'repos/nuxt-modules/sitemap'])
   })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Personal forks became owned Repository mappings when the App and a trusted checkout exposed them.

Discovery now reads GitHub's fork field and drops forks before any Repository mapping.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.