### PR TITLE
fix(agent): let expired work release restart

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -907,7 +907,7 @@ export interface JournalStore {
   completeRestart: (at: string) => RestartRequest | null
   requireRestartAction: (input: { id: string, at: string, reason: string }) => RestartRequest | null
   prepareForRestart: (at: string) => boolean
-  isSafeToRestart: () => boolean
+  isSafeToRestart: (at?: string) => boolean
   pauseAgents: (at: string) => StoredAgentControl
   setRepositoryPaused: (github: string, paused: boolean) => boolean
   /** True when a person has trusted the controller to write to this repository. */
@@ -10029,22 +10029,46 @@ export function openJournalStore(
     return getAgentControl()
   }
 
-  const isSafeToRestart: JournalStore['isSafeToRestart'] = () => {
+  const isSafeToRestart: JournalStore['isSafeToRestart'] = (at = '') => {
     const row = database.prepare(`
       SELECT (
-        EXISTS (SELECT 1 FROM tasks WHERE state_tag IN ('Running', 'Publishing'))
-        OR EXISTS (SELECT 1 FROM worker_tasks WHERE state_tag = 'Running')
-        OR EXISTS (SELECT 1 FROM routine_runs WHERE state_tag = 'Running')
-        OR EXISTS (SELECT 1 FROM publication_commands WHERE state_tag IN ('Pending', 'Running'))
+        EXISTS (
+          SELECT 1 FROM tasks
+          WHERE state_tag = 'Publishing'
+            OR (state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?))
+        )
+        OR EXISTS (
+          SELECT 1 FROM worker_tasks
+          WHERE state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?)
+        )
+        OR EXISTS (
+          SELECT 1 FROM routine_runs
+          WHERE state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?)
+        )
+        OR EXISTS (
+          SELECT 1 FROM publication_commands
+          WHERE state_tag = 'Pending'
+            OR (state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?))
+        )
         OR EXISTS (
           SELECT 1 FROM review_status_commands
-          WHERE state_tag = 'Running' OR (state_tag = 'Pending' AND phase = 'terminal')
+          WHERE (state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?))
+            OR (state_tag = 'Pending' AND phase = 'terminal')
         )
-        OR EXISTS (SELECT 1 FROM issue_triage_comment_commands WHERE state_tag = 'Running')
-        OR EXISTS (SELECT 1 FROM candidate_issue_commands WHERE state_tag = 'Running')
-        OR EXISTS (SELECT 1 FROM routine_report_commands WHERE state_tag = 'Running')
+        OR EXISTS (
+          SELECT 1 FROM issue_triage_comment_commands
+          WHERE state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?)
+        )
+        OR EXISTS (
+          SELECT 1 FROM candidate_issue_commands
+          WHERE state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?)
+        )
+        OR EXISTS (
+          SELECT 1 FROM routine_report_commands
+          WHERE state_tag = 'Running' AND (lease_expires_at IS NULL OR lease_expires_at > ?)
+        )
       ) AS busy
-    `).get() as { busy: number }
+    `).get(at, at, at, at, at, at, at, at) as { busy: number }
     return row.busy === 0
   }
 
@@ -10097,7 +10121,7 @@ export function openJournalStore(
       database.exec('ROLLBACK')
       throw error
     }
-    return isSafeToRestart()
+    return isSafeToRestart(at)
   }
 
   const listWorkflowEvents: JournalStore['listWorkflowEvents'] = (input = {}) => {

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -516,6 +516,24 @@ describe('journal store', () => {
     })
   })
 
+  it('allows restart after a dead Task lease expires', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'restart-expired-task',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem(),
+    })
+    expect(store.claimNextConflictTask('conflict-1', '2026-08-13T01:01:00.000Z', 60_000)).not.toBeNull()
+
+    expect(store.prepareForRestart('2026-08-13T01:01:59.999Z')).toBe(false)
+    expect(store.prepareForRestart('2026-08-13T01:02:00.000Z')).toBe(true)
+
+    expect(store.recoverInterruptedAgentTasks('2026-08-13T01:02:01.000Z')).toBe(1)
+    expect(store.claimNextConflictTask('conflict-2', '2026-08-13T01:02:02.000Z', 60_000)?.state.fence).toBe(2)
+  })
+
   it('keeps restart unsafe until a pending terminal Review Publication finishes', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A dead Agent lease could stay Running after its process died. Restart then waited for recovery that only runs after restart.

Restart safety now waits for live leases. The next process recovers expired work.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.