### PR TITLE
fix(agent): publish Review findings before Repair

### DIFF
--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -898,16 +898,11 @@ async function projectReviewRun(
       fence: task.state.fence,
       at: options.now().toISOString(),
     })
-    if (queued._tag === 'Queued') {
-      const reported = await reportReviewProgress(options, task, 'review', { percent: 95, label: 'Repair queued' }, signal)
-      if (reported._tag === 'Err')
-        return reported
-      await stampAgentLabel(options, task, 'BLOCKED', signal)
-      return ok({ evidence: run.id, resolution: { _tag: 'Reviewed', reviewRunId: run.id } })
+    if (queued._tag !== 'Queued') {
+      findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0
+        ? { ...finding, nextAction: queued.reason }
+        : finding)
     }
-    findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0
-      ? { ...finding, nextAction: queued.reason }
-      : finding)
   }
   else if (repairable && !recommendsDismissal && preflight._tag === 'ActionRequired') {
     findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -7263,6 +7263,16 @@ export function openJournalStore(
                 AND pull_request_approvals.kind = 'fixes'
             )
           )
+          -- Repair waits until the terminal Review status reaches GitHub.
+          AND (
+            tasks.kind != 'review_fix'
+            OR NOT EXISTS (
+              SELECT 1 FROM review_status_commands
+              WHERE review_status_commands.revision_id = tasks.revision_id
+                AND review_status_commands.phase = 'terminal'
+                AND review_status_commands.state_tag IN ('Pending', 'Running')
+            )
+          )
           -- The throttle asks how much automated work already waits on Harlan,
           -- so it counts only pull requests the controller opened. Counting
           -- everybody's held every issue Task queued for a day behind thirty
@@ -10951,6 +10961,14 @@ export function openJournalStore(
         WHERE final.phase = 'terminal' AND final.state_tag = 'Published'
           AND final.revision_id = candidates.revision_id
           AND final.expected_head_sha = json_extract(revisions.payload, '$.headSha')
+      )
+      -- A pending terminal status owns the comment until Publication finishes.
+      AND NOT EXISTS (
+        SELECT 1 FROM review_status_commands AS finalizing
+        WHERE finalizing.phase = 'terminal'
+          AND finalizing.state_tag IN ('Pending', 'Running')
+          AND finalizing.revision_id = candidates.revision_id
+          AND finalizing.expected_head_sha = json_extract(revisions.payload, '$.headSha')
       )
   `).all() as unknown as QueuedReviewStatusRow[]).map(row => ({
     taskId: row.task_id,

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -345,6 +345,7 @@ describe('subject Workers', () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     let attempt: RecordReviewRunInput | undefined
     let queued = false
+    let terminal = ''
     let worktreeVerified = false
     const worker = createReviewWorker({
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
@@ -408,7 +409,11 @@ describe('subject Workers', () => {
         updateAgentProgress: () => true,
       },
       status: {
-        publish: () => Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+        publish: (_task, phase, body) => {
+          if (phase === 'terminal')
+            terminal = body
+          return Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' }))
+        },
       },
       triageStatus: { publish: () => Promise.reject(new Error('Unexpected issue triage.')) },
       workspaces: {
@@ -445,6 +450,8 @@ describe('subject Workers', () => {
       }),
     })])
     expect(queued).toBe(true)
+    expect(terminal).toContain('### 🤖 BLOCKED')
+    expect(terminal).toContain('The parser drops data.')
     expect(worktreeVerified).toBe(true)
   })
 

--- a/packages/harlan-github-agent/test/review-repair-claim.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-claim.test.ts
@@ -82,6 +82,58 @@ function recordOpenFinding(
 }
 
 describe('review Repair queue', () => {
+  it('starts Repair after the terminal Review status reaches GitHub', () => {
+    const store = createStore()
+    const { review, revisionId } = runningReview(store, 'fix/publish-review-first')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
+    const queued = store.queueReviewFixTaskForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:04.000Z',
+    })
+    if (queued._tag !== 'Queued')
+      throw new Error(queued.reason)
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:05.000Z',
+      revisionId,
+      expectedHeadSha: review.pullRequest.headSha,
+      body: '### 🤖 BLOCKED\n\nUnsafe parser input.',
+      desiredOutcome: 'BLOCKED',
+      reviewRunId: `review-run-${revisionId}`,
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    expect(store.completeReviewTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:00:06.000Z',
+      evidence: `review-run-${revisionId}`,
+      resolution: { _tag: 'Reviewed', reviewRunId: `review-run-${revisionId}` },
+    })).toBe(true)
+
+    expect(store.listQueuedReviewStatuses()).toEqual([])
+    expect(store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:07.000Z', 60_000)).toBeNull()
+    const status = store.claimNextTerminalReviewStatus('status-agent', '2026-08-13T01:00:08.000Z', 60_000)
+    if (status === null)
+      throw new Error('Expected the terminal Review status.')
+    expect(store.completeReviewStatus({
+      commandId: status.id,
+      workerId: status.workerId,
+      fence: status.fence,
+      at: '2026-08-13T01:00:09.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })).toBe(true)
+    expect(store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:10.000Z', 60_000)?.kind).toBe('review_fix')
+  })
+
   it('queues exact findings for a separate Repair Agent', () => {
     const store = createStore()
     const { review, revisionId } = runningReview(store, 'fix/broken-thing')

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -489,7 +489,8 @@ describe('review resilience', () => {
 
     expect(result._tag).toBe('Ok')
     expect(test.queued).toBe(1)
-    expect(test.comments.at(-1)).toContain('REVIEWING · 95% · Repair queued')
+    expect(test.comments.at(-1)).toContain('### 🤖 BLOCKED')
+    expect(test.comments.at(-1)).toContain('Malformed input crosses the parser boundary.')
   })
 
   it('keeps a stable finding identity when its code moves', async () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Review findings could disappear behind a generic queue comment before Repair began. A stalled Repair then left no visible diagnosis.

The terminal BLOCKED result now includes the findings. Repair waits while that status reaches GitHub, and queue updates cannot replace it during publication.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
