### PR TITLE
feat(agent): add control API client and CLI

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -69,6 +69,19 @@ pnpm --filter harlan-github-agent exec node --experimental-strip-types src/cli.t
 
 Use `https://harlan-github-agent.localhost/`. Inspect `/health` first, then `/api/state`.
 
+Prefer the Control API CLI for agent-readable monitoring and durable service controls.
+It reads the URL and password from the configuration file by default.
+
+```bash
+harlan-github-agent control status --config /absolute/path/to/harlan-github-agent.yml
+harlan-github-agent control tasks --config /absolute/path/to/harlan-github-agent.yml
+harlan-github-agent control incidents --config /absolute/path/to/harlan-github-agent.yml
+harlan-github-agent control events --limit 50 --config /absolute/path/to/harlan-github-agent.yml
+```
+
+Use `pause`, `resume`, `restart`, `update`, or `cancel --task TASK_ID` for the matching durable control.
+Every command prints one JSON value. A tagged JSON error exits with status 1.
+
 Workers run as normal local agent sessions inside disposable Git worktrees. They inherit Harlan's global agent context, installed skills, environment, provider login, and authenticated `gh` client.
 
 `agent.provider` names the Agent provider the service starts with. It defaults to `codex`.

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -27,6 +27,7 @@ did not cover it.
 | Lease holder | `tasks.worker_id` | Scheduler | One per Running Task | none |
 | Queue | derived dashboard state | Controller | Orders active Tasks and actionable Items | queue |
 | Stats | derived from Journal records | Dashboard | N completed records per date range | Stats |
+| Control API | authenticated HTTP routes | Controller | One per service, used by the dashboard and CLI | Control API |
 | Pause | `agent_control` | Controller | Stops new agent Tasks from starting | Pause |
 | Restart request | `restart_requests` | Controller | N per service, one active | Restart after current work |
 | Service update | `origin/main`, `restart_requests.operation_tag` | Controller | One check, optional Restart request | Update available; Update after current work |
@@ -259,6 +260,14 @@ The dashboard view of completed work and its useful outcomes for one date range.
 Stats derives facts from the Journal. It never replaces the records that support them.
 
 Use Stats for the page and route. Do not use analytics, insights, value score, or impact score.
+
+### Control API
+
+The authenticated HTTP interface for reading service state and requesting durable controls.
+
+The dashboard and `harlan-github-agent control` use the same routes. A Control API request never edits the Journal directly.
+
+Use Control API. Do not use dashboard API, admin API, management API, or runner API.
 
 ### Pause
 

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -113,6 +113,43 @@ Register the dashboard with `./bin/install-portless-alias`.
 
 Open `https://harlan-github-agent.localhost/`. Use `agent` as the dashboard username.
 
+## Control API and CLI
+
+The dashboard and CLI use the same authenticated Control API.
+Every CLI command prints one JSON value.
+Expected failures print one tagged JSON error and exit with status 1.
+
+Use the configuration file on the service host:
+
+```bash
+harlan-github-agent control status --config /absolute/path/to/harlan-github-agent.yml
+harlan-github-agent control tasks --config /absolute/path/to/harlan-github-agent.yml
+harlan-github-agent control incidents --config /absolute/path/to/harlan-github-agent.yml
+harlan-github-agent control events --limit 50 --config /absolute/path/to/harlan-github-agent.yml
+```
+
+Target another instance with its URL and password file:
+
+```bash
+harlan-github-agent control pause --url https://harlan-github-agent.localhost --password-file /absolute/path/to/dashboard-password
+harlan-github-agent control resume --url https://harlan-github-agent.localhost --password-file /absolute/path/to/dashboard-password
+harlan-github-agent control restart --url https://harlan-github-agent.localhost --password-file /absolute/path/to/dashboard-password
+harlan-github-agent control update --url https://harlan-github-agent.localhost --password-file /absolute/path/to/dashboard-password
+harlan-github-agent control cancel --task TASK_ID --url https://harlan-github-agent.localhost --password-file /absolute/path/to/dashboard-password
+```
+
+The package exports the typed Control API client:
+
+```ts
+import { createControlClient } from 'harlan-github-agent'
+
+const client = createControlClient({
+  authentication: { _tag: 'Basic', password },
+  baseUrl: 'https://harlan-github-agent.localhost',
+  fetch,
+})
+```
+
 ## Webhooks
 
 Set `webhook.enabled` to start a second listener on its own port. It carries one route, `POST /webhook`, and nothing else. Keep the dashboard port on loopback: it can pause agents, approve pull requests, cancel tasks, and eject sessions, so it must never be exposed.

--- a/packages/harlan-github-agent/src/app.ts
+++ b/packages/harlan-github-agent/src/app.ts
@@ -354,8 +354,8 @@ export function createAgentApp(options: AgentAppOptions): H3 {
       // Validation below reports malformed JSON as a bad request.
       return undefined
     }) as { source?: unknown } | undefined
-    if (body?.source !== 'dashboard')
-      throw createError({ status: 400, statusText: 'Bad Request', message: 'Update source must be dashboard.' })
+    if (body?.source !== 'dashboard' && body?.source !== 'helper')
+      throw createError({ status: 400, statusText: 'Bad Request', message: 'Update source must be dashboard or helper.' })
     const update = options.store.getDashboardSnapshot(options.now().toISOString()).serviceUpdate
     if (update._tag !== 'Available')
       throw createError({ status: 409, statusText: 'Conflict', message: 'No service update is available.' })

--- a/packages/harlan-github-agent/src/cli-leading-options.ts
+++ b/packages/harlan-github-agent/src/cli-leading-options.ts
@@ -1,19 +1,19 @@
 /**
- * Move options from before the subcommand name to the end of the arguments.
+ * Move options from before a subcommand name to the end of the arguments.
  *
  * citty parses the whole argument list once per command level, so an option
- * before the subcommand name binds to the root command. The control
- * subcommand then read its default configuration file instead of the requested
- * one, and the parent command still started the whole agent service.
+ * before the subcommand name binds to the root command. The subcommand then
+ * read its default configuration file instead of the requested one, and for
+ * `control` the parent command still started the whole agent service.
  *
  * Options with a separate value only swallow the next argument when the option
  * name declares a value. Returns the original arguments unchanged when the
- * first positional argument is not the subcommand.
+ * first positional argument is not one of the subcommands.
  */
 export function forwardLeadingOptions(
   rawArgs: readonly string[],
   valueOptionNames: readonly string[],
-  subCommandName: string,
+  subCommandNames: readonly string[],
 ): string[] {
   const leading: string[] = []
   let index = 0
@@ -31,7 +31,7 @@ export function forwardLeadingOptions(
     argument = rawArgs[index]
   }
   const firstPositional = rawArgs[index]
-  if (leading.length === 0 || firstPositional !== subCommandName)
+  if (leading.length === 0 || firstPositional === undefined || !subCommandNames.includes(firstPositional))
     return [...rawArgs]
   return [...rawArgs.slice(index), ...leading]
 }

--- a/packages/harlan-github-agent/src/cli-leading-options.ts
+++ b/packages/harlan-github-agent/src/cli-leading-options.ts
@@ -1,0 +1,37 @@
+/**
+ * Move options from before the subcommand name to the end of the arguments.
+ *
+ * citty parses the whole argument list once per command level, so an option
+ * before the subcommand name binds to the root command. The control
+ * subcommand then read its default configuration file instead of the requested
+ * one, and the parent command still started the whole agent service.
+ *
+ * Options with a separate value only swallow the next argument when the option
+ * name declares a value. Returns the original arguments unchanged when the
+ * first positional argument is not the subcommand.
+ */
+export function forwardLeadingOptions(
+  rawArgs: readonly string[],
+  valueOptionNames: readonly string[],
+  subCommandName: string,
+): string[] {
+  const leading: string[] = []
+  let index = 0
+  let argument = rawArgs[index]
+  while (argument !== undefined && argument.startsWith('-') && argument !== '--') {
+    leading.push(argument)
+    const nextArgument = rawArgs[index + 1]
+    if (!argument.includes('=') && valueOptionNames.includes(argument) && nextArgument !== undefined && !nextArgument.startsWith('-')) {
+      leading.push(nextArgument)
+      index += 2
+    }
+    else {
+      index += 1
+    }
+    argument = rawArgs[index]
+  }
+  const firstPositional = rawArgs[index]
+  if (leading.length === 0 || firstPositional !== subCommandName)
+    return [...rawArgs]
+  return [...rawArgs.slice(index), ...leading]
+}

--- a/packages/harlan-github-agent/src/cli-subcommand.ts
+++ b/packages/harlan-github-agent/src/cli-subcommand.ts
@@ -5,10 +5,52 @@
  * to know it has nothing left to do. Without this, `sweep-worktrees` also
  * started the whole service and tried to bind the dashboard port.
  *
- * Only the first argument counts. A subcommand name that arrives later belongs
- * to an option, such as a configuration path.
+ * citty dispatches on the first positional argument, so an option before the
+ * subcommand name must not hide it. A name that arrives as an option value,
+ * such as a configuration path, is not a subcommand. That needs the value
+ * flags of the command, so pass its argument definitions.
  */
-export function invokesSubCommand(rawArgs: readonly string[], names: readonly string[]): boolean {
-  const first = rawArgs[0]
-  return first !== undefined && names.includes(first)
+interface ArgumentDefinition {
+  type?: 'string' | 'boolean' | 'enum' | 'positional'
+  alias?: string | readonly string[]
+}
+
+interface ArgumentDefinitions {
+  readonly [key: string]: ArgumentDefinition
+}
+
+function camelCase(value: string): string {
+  return value.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())
+}
+
+function flagTakesValue(flag: string, definitions: ArgumentDefinitions): boolean {
+  const name = flag.replace(/^-{1,2}/, '')
+  for (const [key, definition] of Object.entries(definitions)) {
+    if (definition.type !== 'string' && definition.type !== 'enum')
+      continue
+    if (key === name || camelCase(key) === camelCase(name))
+      return true
+    const aliases = definition.alias === undefined ? [] : Array.isArray(definition.alias) ? definition.alias : [definition.alias]
+    if (aliases.includes(name))
+      return true
+  }
+  return false
+}
+
+export function invokesSubCommand(rawArgs: readonly string[], names: readonly string[], definitions: ArgumentDefinitions): boolean {
+  for (let index = 0; index < rawArgs.length; index++) {
+    const argument = rawArgs[index]
+    if (argument === undefined)
+      return false
+    if (argument === '--')
+      return false
+    if (argument.startsWith('-')) {
+      const value = rawArgs[index + 1]
+      if (!argument.includes('=') && value !== undefined && flagTakesValue(argument, definitions))
+        index += 1
+      continue
+    }
+    return names.includes(argument)
+  }
+  return false
 }

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -417,8 +417,10 @@ const command = defineCommand({
 })
 
 type ControlCliInvocation
-  = | { _tag: 'Run' }
+  = | { _tag: 'Run', rawArgs: string[] }
     | { _tag: 'Fail', error: ControlCommandError }
+
+const controlValueOptionFlags = ['--config', '-c', '--url', '--password-file']
 
 function hasTaskArgument(rawArgs: readonly string[]): boolean {
   return rawArgs.some((argument, index) => {
@@ -430,28 +432,47 @@ function hasTaskArgument(rawArgs: readonly string[]): boolean {
 
 function parseControlCliInvocation(rawArgs: readonly string[]): ControlCliInvocation {
   if (rawArgs[0] !== 'control' || rawArgs.some(argument => argument === '--help' || argument === '-h'))
-    return { _tag: 'Run' }
+    return { _tag: 'Run', rawArgs: [...rawArgs] }
 
-  const commandName = rawArgs[1]
   const subCommands = controlCommand.subCommands
-  if (commandName === undefined || typeof subCommands !== 'object' || subCommands === null || !Object.hasOwn(subCommands, commandName)) {
+  if (typeof subCommands !== 'object' || subCommands === null)
+    return { _tag: 'Run', rawArgs: [...rawArgs] }
+
+  // citty dispatches on the first positional argument, so connection options
+  // between `control` and the nested command name must not hide the name.
+  // Skip value-taking option tokens, then forward those options to the end,
+  // where the subcommand parses them.
+  const leading: string[] = []
+  let index = 1
+  let argument = rawArgs[index]
+  while (argument !== undefined && argument.startsWith('-') && argument !== '--') {
+    const nextArgument = rawArgs[index + 1]
+    const takesValue = !argument.includes('=') && controlValueOptionFlags.includes(argument)
+      && nextArgument !== undefined && !nextArgument.startsWith('-')
+    leading.push(...takesValue ? [argument, nextArgument] : [argument])
+    index += takesValue ? 2 : 1
+    argument = rawArgs[index]
+  }
+  const commandName = rawArgs[index]
+  if (commandName === undefined || !Object.hasOwn(subCommands, commandName)) {
     return {
       _tag: 'Fail',
       error: { _tag: 'UnknownControlCommand', message: 'Select a valid control command.' },
     }
   }
 
-  if ((commandName === 'activity' || commandName === 'cancel') && !hasTaskArgument(rawArgs.slice(2))) {
+  const nestedRawArgs = leading.length === 0
+    ? [...rawArgs]
+    : ['control', ...rawArgs.slice(index), ...leading]
+  if ((commandName === 'activity' || commandName === 'cancel') && !hasTaskArgument(nestedRawArgs.slice(2))) {
     return {
       _tag: 'Fail',
       error: { _tag: 'MissingTaskId', message: 'Set --task to one Task ID.' },
     }
   }
 
-  return { _tag: 'Run' }
+  return { _tag: 'Run', rawArgs: nestedRawArgs }
 }
-
-const controlValueOptionFlags = ['--config', '-c', '--url', '--password-file']
 
 const cliArguments = process.argv.slice(2)
 // A leading `--config` binds to the root command in citty, so forward the
@@ -463,5 +484,5 @@ if (controlCliInvocation._tag === 'Fail') {
   process.exitCode = 1
 }
 else {
-  void runMain(command, { rawArgs: normalizedCliArguments })
+  void runMain(command, { rawArgs: controlCliInvocation.rawArgs })
 }

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -346,6 +346,8 @@ const rootArguments = {
   config: configArgument,
 }
 
+const rootSubCommandNames = ['combine-service-state', 'sweep-worktrees', 'control']
+
 const command = defineCommand({
   meta: {
     name: 'harlan-github-agent',
@@ -362,7 +364,7 @@ const command = defineCommand({
     // citty runs this after it ran the subcommand, so stop before the service
     // starts and binds the dashboard port. citty dispatches on the first
     // positional argument, so look there, even when options precede the name.
-    if (invokesSubCommand(rawArgs, ['combine-service-state', 'sweep-worktrees', 'control'], rootArguments))
+    if (invokesSubCommand(rawArgs, rootSubCommandNames, rootArguments))
       return
     const configPath = resolve(args.config)
     const parsed = await loadConfig(configPath)
@@ -476,8 +478,8 @@ function parseControlCliInvocation(rawArgs: readonly string[]): ControlCliInvoca
 
 const cliArguments = process.argv.slice(2)
 // A leading `--config` binds to the root command in citty, so forward the
-// control connection options to the end, where the subcommand parses them.
-const normalizedCliArguments = forwardLeadingOptions(cliArguments, controlValueOptionFlags, 'control')
+// connection options behind every subcommand name, where they parse them.
+const normalizedCliArguments = forwardLeadingOptions(cliArguments, controlValueOptionFlags, rootSubCommandNames)
 const controlCliInvocation = parseControlCliInvocation(normalizedCliArguments)
 if (controlCliInvocation._tag === 'Fail') {
   writeJson(controlCliInvocation.error, process.stderr)

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -11,6 +11,7 @@ import { createControlClient } from './control-client.ts'
 import { loadDashboardPassword } from './dashboard-password.ts'
 import { loadGitIdentity } from './git-identity.ts'
 import { discoverLocalCheckouts } from './repository-discovery.ts'
+import { err } from './result.ts'
 import { combineServiceState } from './service-state.ts'
 import { createGitServiceUpdateSource } from './service-update.ts'
 import { startAgentService } from './service.ts'
@@ -55,6 +56,7 @@ type ControlCommandError
   = | { _tag: 'ConfigurationFailure', message: string }
     | { _tag: 'InvalidTaskId', message: string }
     | { _tag: 'InvalidEventLimit', message: string }
+    | { _tag: 'InvalidStream', message: string }
     | { _tag: 'InvalidBaseUrl', message: string }
 
 const workflowEventStreams = [
@@ -76,7 +78,9 @@ async function loadControlClient(args: ControlConnectionArguments): Promise<Resu
   const configPath = resolve(args.config)
   let baseUrl = args.url
   if (baseUrl === undefined) {
-    const configuration = await loadConfig(configPath)
+    const configuration = await loadConfig(configPath).catch((error: unknown) =>
+      err([{ path: '$', message: error instanceof Error ? error.message : 'The configuration file could not be read.' }]),
+    )
     if (configuration._tag === 'Err') {
       return {
         _tag: 'Err',
@@ -90,7 +94,9 @@ async function loadControlClient(args: ControlConnectionArguments): Promise<Resu
   }
 
   const passwordPath = resolve(args['password-file'] ?? join(dirname(configPath), 'dashboard-password'))
-  const password = await loadDashboardPassword(passwordPath)
+  const password = await loadDashboardPassword(passwordPath).catch((error: unknown) =>
+    err(error instanceof Error ? error.message : 'The dashboard password file could not be read.'),
+  )
   if (password._tag === 'Err')
     return { _tag: 'Err' as const, error: { _tag: 'ConfigurationFailure' as const, message: password.error } }
 
@@ -182,9 +188,8 @@ const controlCommand = defineCommand({
       args: {
         ...controlConnectionArguments,
         stream: {
-          type: 'enum',
-          description: 'One workflow event stream.',
-          options: [...workflowEventStreams],
+          type: 'string',
+          description: `One workflow event stream: ${workflowEventStreams.join(', ')}.`,
         },
         limit: {
           type: 'string',
@@ -193,6 +198,12 @@ const controlCommand = defineCommand({
         },
       },
       async run({ args }) {
+        const stream = workflowEventStreams.find(candidate => candidate === args.stream)
+        if (args.stream !== undefined && stream === undefined) {
+          writeJson({ _tag: 'InvalidStream', message: 'Select a valid workflow event stream.' } satisfies ControlCommandError, process.stderr)
+          process.exitCode = 1
+          return
+        }
         const limit = Number(args.limit)
         if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1_000) {
           writeJson({ _tag: 'InvalidEventLimit', message: 'Set the event limit from 1 to 1000.' } satisfies ControlCommandError, process.stderr)
@@ -201,7 +212,7 @@ const controlCommand = defineCommand({
         }
         await runControl(args as unknown as ControlConnectionArguments, client => client.workflowEvents({
           limit,
-          ...(args.stream === undefined ? {} : { stream: args.stream }),
+          ...(stream === undefined ? {} : { stream }),
         }).then(result => result._tag === 'Err' ? result : { _tag: 'Ok', value: { events: result.value } }))
       },
     }),

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
+import { forwardLeadingOptions } from './cli-leading-options.ts'
 import { invokesSubCommand } from './cli-subcommand.ts'
 import { loadConfig, loadGitHubAppPrivateKey, loadWebhookSecret, validateRepositoryMappings } from './config.ts'
 import { createControlClient } from './control-client.ts'
@@ -341,15 +342,17 @@ const combineState = defineCommand({
   },
 })
 
+const rootArguments = {
+  config: configArgument,
+}
+
 const command = defineCommand({
   meta: {
     name: 'harlan-github-agent',
     version: '0.0.0',
     description: 'Run the local GitHub maintenance control plane.',
   },
-  args: {
-    config: configArgument,
-  },
+  args: rootArguments,
   subCommands: {
     'combine-service-state': combineState,
     'sweep-worktrees': sweepWorktrees,
@@ -357,8 +360,9 @@ const command = defineCommand({
   },
   async run({ args, rawArgs }) {
     // citty runs this after it ran the subcommand, so stop before the service
-    // starts and binds the dashboard port.
-    if (invokesSubCommand(rawArgs, ['combine-service-state', 'sweep-worktrees', 'control']))
+    // starts and binds the dashboard port. citty dispatches on the first
+    // positional argument, so look there, even when options precede the name.
+    if (invokesSubCommand(rawArgs, ['combine-service-state', 'sweep-worktrees', 'control'], rootArguments))
       return
     const configPath = resolve(args.config)
     const parsed = await loadConfig(configPath)
@@ -447,11 +451,17 @@ function parseControlCliInvocation(rawArgs: readonly string[]): ControlCliInvoca
   return { _tag: 'Run' }
 }
 
-const controlCliInvocation = parseControlCliInvocation(process.argv.slice(2))
+const controlValueOptionFlags = ['--config', '-c', '--url', '--password-file']
+
+const cliArguments = process.argv.slice(2)
+// A leading `--config` binds to the root command in citty, so forward the
+// control connection options to the end, where the subcommand parses them.
+const normalizedCliArguments = forwardLeadingOptions(cliArguments, controlValueOptionFlags, 'control')
+const controlCliInvocation = parseControlCliInvocation(normalizedCliArguments)
 if (controlCliInvocation._tag === 'Fail') {
   writeJson(controlCliInvocation.error, process.stderr)
   process.exitCode = 1
 }
 else {
-  void runMain(command)
+  void runMain(command, { rawArgs: normalizedCliArguments })
 }

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
+import type { ControlClient } from './control-client.ts'
+import type { Result } from './result.ts'
 import { dirname, join, resolve } from 'node:path'
 import process from 'node:process'
 import { defineCommand, runMain } from 'citty'
 import { consola } from 'consola'
 import { invokesSubCommand } from './cli-subcommand.ts'
 import { loadConfig, loadGitHubAppPrivateKey, loadWebhookSecret, validateRepositoryMappings } from './config.ts'
+import { createControlClient } from './control-client.ts'
 import { loadDashboardPassword } from './dashboard-password.ts'
 import { loadGitIdentity } from './git-identity.ts'
 import { discoverLocalCheckouts } from './repository-discovery.ts'
@@ -29,6 +32,202 @@ const configArgument = {
   description: 'Configuration file path.',
   default: 'harlan-github-agent.yml',
 } as const
+
+const controlConnectionArguments = {
+  'config': configArgument,
+  'url': {
+    type: 'string',
+    description: 'Service URL. Defaults to server.allowed_origin in the configuration file.',
+  },
+  'password-file': {
+    type: 'string',
+    description: 'Password file. Defaults to dashboard-password beside the configuration file.',
+  },
+} as const
+
+interface ControlConnectionArguments {
+  'config': string
+  'url': string | undefined
+  'password-file': string | undefined
+}
+
+type ControlCommandError
+  = | { _tag: 'ConfigurationFailure', message: string }
+    | { _tag: 'InvalidTaskId', message: string }
+    | { _tag: 'InvalidEventLimit', message: string }
+    | { _tag: 'InvalidBaseUrl', message: string }
+
+const workflowEventStreams = [
+  'task',
+  'worker_task',
+  'publication',
+  'review_run',
+  'review_gate',
+  'review_resolution',
+  'review_status',
+  'issue_triage_status',
+  'routine_run',
+  'candidate_issue',
+  'routine_report',
+  'provider_circuit',
+] as const
+
+async function loadControlClient(args: ControlConnectionArguments): Promise<Result<ControlClient, ControlCommandError>> {
+  const configPath = resolve(args.config)
+  let baseUrl = args.url
+  if (baseUrl === undefined) {
+    const configuration = await loadConfig(configPath)
+    if (configuration._tag === 'Err') {
+      return {
+        _tag: 'Err',
+        error: {
+          _tag: 'ConfigurationFailure',
+          message: configuration.error.map(issue => `${issue.path}: ${issue.message}`).join('\n'),
+        },
+      }
+    }
+    baseUrl = configuration.value.server.allowedOrigin
+  }
+
+  const passwordPath = resolve(args['password-file'] ?? join(dirname(configPath), 'dashboard-password'))
+  const password = await loadDashboardPassword(passwordPath)
+  if (password._tag === 'Err')
+    return { _tag: 'Err' as const, error: { _tag: 'ConfigurationFailure' as const, message: password.error } }
+
+  return createControlClient({
+    authentication: { _tag: 'Basic', password: password.value },
+    baseUrl,
+    fetch: globalThis.fetch,
+  })
+}
+
+function writeJson(value: unknown, stream: NodeJS.WriteStream): void {
+  stream.write(`${JSON.stringify(value)}\n`)
+}
+
+async function runControl<ErrorValue>(
+  args: ControlConnectionArguments,
+  action: (client: ControlClient) => Promise<Result<unknown, ErrorValue>>,
+): Promise<void> {
+  const client = await loadControlClient(args)
+  if (client._tag === 'Err') {
+    writeJson(client.error, process.stderr)
+    process.exitCode = 1
+    return
+  }
+  const result = await action(client.value)
+  if (result._tag === 'Err') {
+    writeJson(result.error, process.stderr)
+    process.exitCode = 1
+    return
+  }
+  writeJson(result.value, process.stdout)
+}
+
+function taskId(value: string): { _tag: 'Ok', value: string } | { _tag: 'Err', error: ControlCommandError } {
+  return /^[a-f\d]{64}$/.test(value)
+    ? { _tag: 'Ok', value }
+    : { _tag: 'Err', error: { _tag: 'InvalidTaskId', message: 'The Task ID must contain 64 lowercase hexadecimal characters.' } }
+}
+
+function controlTaskCommand(input: { name: 'activity' | 'cancel', description: string }) {
+  return defineCommand({
+    meta: { name: input.name, description: input.description },
+    args: {
+      ...controlConnectionArguments,
+      task: {
+        type: 'string',
+        description: 'Task ID.',
+        required: true,
+      },
+    },
+    async run({ args }) {
+      const parsedTaskId = taskId(args.task)
+      if (parsedTaskId._tag === 'Err') {
+        writeJson(parsedTaskId.error, process.stderr)
+        process.exitCode = 1
+        return
+      }
+      await runControl(args, client => input.name === 'activity'
+        ? client.activity(parsedTaskId.value).then(result => result._tag === 'Err' ? result : { _tag: 'Ok', value: { taskId: parsedTaskId.value, activity: result.value } })
+        : client.cancelTask(parsedTaskId.value))
+    },
+  })
+}
+
+const controlCommand = defineCommand({
+  meta: {
+    name: 'control',
+    description: 'Read and control one running Harlan GitHub Agent service.',
+  },
+  subCommands: {
+    status: defineCommand({
+      meta: { name: 'status', description: 'Read service health and the shared dashboard state.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.status()),
+    }),
+    tasks: defineCommand({
+      meta: { name: 'tasks', description: 'List current Tasks.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.tasks().then(result => result._tag === 'Err' ? result : { _tag: 'Ok', value: { tasks: result.value } })),
+    }),
+    incidents: defineCommand({
+      meta: { name: 'incidents', description: 'List unresolved Incidents.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.incidents().then(result => result._tag === 'Err' ? result : { _tag: 'Ok', value: { incidents: result.value } })),
+    }),
+    activity: controlTaskCommand({ name: 'activity', description: 'Read the redacted activity for one active Task.' }),
+    events: defineCommand({
+      meta: { name: 'events', description: 'List durable workflow events.' },
+      args: {
+        ...controlConnectionArguments,
+        stream: {
+          type: 'enum',
+          description: 'One workflow event stream.',
+          options: [...workflowEventStreams],
+        },
+        limit: {
+          type: 'string',
+          description: 'Maximum events from 1 to 1000.',
+          default: '200',
+        },
+      },
+      async run({ args }) {
+        const limit = Number(args.limit)
+        if (!Number.isSafeInteger(limit) || limit < 1 || limit > 1_000) {
+          writeJson({ _tag: 'InvalidEventLimit', message: 'Set the event limit from 1 to 1000.' } satisfies ControlCommandError, process.stderr)
+          process.exitCode = 1
+          return
+        }
+        await runControl(args as unknown as ControlConnectionArguments, client => client.workflowEvents({
+          limit,
+          ...(args.stream === undefined ? {} : { stream: args.stream }),
+        }).then(result => result._tag === 'Err' ? result : { _tag: 'Ok', value: { events: result.value } }))
+      },
+    }),
+    pause: defineCommand({
+      meta: { name: 'pause', description: 'Pause new agent Tasks.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.pause()),
+    }),
+    resume: defineCommand({
+      meta: { name: 'resume', description: 'Resume new agent Tasks.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.resume()),
+    }),
+    restart: defineCommand({
+      meta: { name: 'restart', description: 'Request Restart after current work.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.restart()),
+    }),
+    update: defineCommand({
+      meta: { name: 'update', description: 'Request Update after current work.' },
+      args: controlConnectionArguments,
+      run: ({ args }) => runControl(args, client => client.update()),
+    }),
+    cancel: controlTaskCommand({ name: 'cancel', description: 'Cancel one active or queued Task.' }),
+  },
+})
 
 const sweepWorktrees = defineCommand({
   meta: {
@@ -141,11 +340,12 @@ const command = defineCommand({
   subCommands: {
     'combine-service-state': combineState,
     'sweep-worktrees': sweepWorktrees,
+    'control': controlCommand,
   },
   async run({ args, rawArgs }) {
     // citty runs this after it ran the subcommand, so stop before the service
     // starts and binds the dashboard port.
-    if (invokesSubCommand(rawArgs, ['combine-service-state', 'sweep-worktrees']))
+    if (invokesSubCommand(rawArgs, ['combine-service-state', 'sweep-worktrees', 'control']))
       return
     const configPath = resolve(args.config)
     const parsed = await loadConfig(configPath)

--- a/packages/harlan-github-agent/src/cli.ts
+++ b/packages/harlan-github-agent/src/cli.ts
@@ -54,6 +54,8 @@ interface ControlConnectionArguments {
 
 type ControlCommandError
   = | { _tag: 'ConfigurationFailure', message: string }
+    | { _tag: 'MissingTaskId', message: string }
+    | { _tag: 'UnknownControlCommand', message: string }
     | { _tag: 'InvalidTaskId', message: string }
     | { _tag: 'InvalidEventLimit', message: string }
     | { _tag: 'InvalidStream', message: string }
@@ -410,4 +412,46 @@ const command = defineCommand({
   },
 })
 
-void runMain(command)
+type ControlCliInvocation
+  = | { _tag: 'Run' }
+    | { _tag: 'Fail', error: ControlCommandError }
+
+function hasTaskArgument(rawArgs: readonly string[]): boolean {
+  return rawArgs.some((argument, index) => {
+    const nextArgument = rawArgs[index + 1]
+    return argument.startsWith('--task=')
+      || (argument === '--task' && nextArgument !== undefined && !nextArgument.startsWith('-'))
+  })
+}
+
+function parseControlCliInvocation(rawArgs: readonly string[]): ControlCliInvocation {
+  if (rawArgs[0] !== 'control' || rawArgs.some(argument => argument === '--help' || argument === '-h'))
+    return { _tag: 'Run' }
+
+  const commandName = rawArgs[1]
+  const subCommands = controlCommand.subCommands
+  if (commandName === undefined || typeof subCommands !== 'object' || subCommands === null || !Object.hasOwn(subCommands, commandName)) {
+    return {
+      _tag: 'Fail',
+      error: { _tag: 'UnknownControlCommand', message: 'Select a valid control command.' },
+    }
+  }
+
+  if ((commandName === 'activity' || commandName === 'cancel') && !hasTaskArgument(rawArgs.slice(2))) {
+    return {
+      _tag: 'Fail',
+      error: { _tag: 'MissingTaskId', message: 'Set --task to one Task ID.' },
+    }
+  }
+
+  return { _tag: 'Run' }
+}
+
+const controlCliInvocation = parseControlCliInvocation(process.argv.slice(2))
+if (controlCliInvocation._tag === 'Fail') {
+  writeJson(controlCliInvocation.error, process.stderr)
+  process.exitCode = 1
+}
+else {
+  void runMain(command)
+}

--- a/packages/harlan-github-agent/src/control-client.ts
+++ b/packages/harlan-github-agent/src/control-client.ts
@@ -203,18 +203,25 @@ export function createControlClient(options: ControlClientOptions): Result<Contr
     if (response._tag === 'Err')
       return response
 
+    const accepted = input.acceptedStatuses ?? [200]
+    if (!accepted.includes(response.value.status)) {
+      // The body is best effort: a non-JSON error body only loses the extracted message, the status is kept.
+      const body = await response.value.json().catch(() => {
+        // Ignorable: the fallback message below already carries the HTTP status.
+        return undefined
+      })
+      return err({
+        _tag: 'HttpFailure',
+        status: response.value.status,
+        message: body === undefined
+          ? `The service returned HTTP ${response.value.status}.`
+          : errorMessage(body, `The service returned HTTP ${response.value.status}.`),
+      })
+    }
     const body = await response.value.json()
       .then(value => ok(value), () => err({ _tag: 'InvalidResponse' as const, message: 'The service returned invalid JSON.' }))
     if (body._tag === 'Err')
       return body
-    const accepted = input.acceptedStatuses ?? [200]
-    if (!accepted.includes(response.value.status)) {
-      return err({
-        _tag: 'HttpFailure',
-        status: response.value.status,
-        message: errorMessage(body.value, `The service returned HTTP ${response.value.status}.`),
-      })
-    }
     const parsed = input.parse(body.value)
     return parsed._tag === 'Ok'
       ? parsed

--- a/packages/harlan-github-agent/src/control-client.ts
+++ b/packages/harlan-github-agent/src/control-client.ts
@@ -1,0 +1,271 @@
+import type { Result } from './result.ts'
+import type { CancelTaskResult } from './store.ts'
+import type {
+  AgentActivityItem,
+  DashboardSnapshot,
+  DashboardTask,
+  Incident,
+  RestartRequest,
+  StoredAgentControl,
+  WorkflowEvent,
+  WorkflowEventStream,
+} from './types.ts'
+import { Buffer } from 'node:buffer'
+import { err, ok } from './result.ts'
+
+export interface ControlHealth {
+  status: 'starting' | 'ready' | 'degraded'
+  mutationsEnabled: boolean
+  repositories: number
+  issues: number
+  pullRequests: number
+  tasks: number
+}
+
+export interface ControlStatus {
+  health: ControlHealth
+  state: DashboardSnapshot
+}
+
+export interface ControlClientConfigurationError {
+  _tag: 'InvalidBaseUrl'
+  message: string
+}
+
+export type ControlApiError
+  = | { _tag: 'NetworkFailure', message: string }
+    | { _tag: 'HttpFailure', status: number, message: string }
+    | { _tag: 'InvalidResponse', message: string }
+
+export type ControlClientError
+  = | ControlApiError
+    | { _tag: 'TaskNotFound', taskId: string }
+
+export interface ControlClientOptions {
+  baseUrl: string
+  authentication: { _tag: 'Basic', password: string }
+  fetch: (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+}
+
+export interface WorkflowEventQuery {
+  stream?: WorkflowEventStream
+  limit?: number
+}
+
+type TaskCancellation = Extract<CancelTaskResult, { _tag: 'Cancelled' | 'AlreadyCancelled' }>
+type Parsed<Value> = Result<Value, string>
+type ResponseParser<Value> = (value: unknown) => Parsed<Value>
+
+export interface ControlClient {
+  health: () => Promise<Result<ControlHealth, ControlApiError>>
+  state: () => Promise<Result<DashboardSnapshot, ControlApiError>>
+  status: () => Promise<Result<ControlStatus, ControlApiError>>
+  tasks: () => Promise<Result<DashboardTask[], ControlApiError>>
+  incidents: () => Promise<Result<Incident[], ControlApiError>>
+  activity: (taskId: string) => Promise<Result<AgentActivityItem[], ControlClientError>>
+  workflowEvents: (query?: WorkflowEventQuery) => Promise<Result<WorkflowEvent[], ControlApiError>>
+  pause: () => Promise<Result<StoredAgentControl, ControlApiError>>
+  resume: () => Promise<Result<StoredAgentControl, ControlApiError>>
+  restart: () => Promise<Result<RestartRequest, ControlApiError>>
+  update: () => Promise<Result<RestartRequest, ControlApiError>>
+  cancelTask: (taskId: string) => Promise<Result<TaskCancellation, ControlApiError>>
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function integer(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function parseHealth(value: unknown): Parsed<ControlHealth> {
+  const input = record(value)
+  if (input === undefined
+    || (input.status !== 'starting' && input.status !== 'ready' && input.status !== 'degraded')
+    || typeof input.mutationsEnabled !== 'boolean'
+    || !integer(input.repositories)
+    || !integer(input.issues)
+    || !integer(input.pullRequests)
+    || !integer(input.tasks)) {
+    return err('The service returned invalid health data.')
+  }
+  return ok(input as unknown as ControlHealth)
+}
+
+function parseState(value: unknown): Parsed<DashboardSnapshot> {
+  const input = record(value)
+  if (input === undefined
+    || typeof input.generatedAt !== 'string'
+    || (input.status !== 'starting' && input.status !== 'ready' && input.status !== 'degraded')
+    || typeof input.mutationsEnabled !== 'boolean'
+    || !Array.isArray(input.agents)
+    || !Array.isArray(input.incidents)
+    || !Array.isArray(input.repositories)
+    || !Array.isArray(input.tasks)) {
+    return err('The service returned invalid state data.')
+  }
+  return ok(input as unknown as DashboardSnapshot)
+}
+
+function parseAgentControl(value: unknown): Parsed<StoredAgentControl> {
+  const input = record(value)
+  if (input?._tag === 'Running')
+    return ok({ _tag: 'Running' })
+  if (input?._tag === 'Paused' && typeof input.pausedAt === 'string')
+    return ok({ _tag: 'Paused', pausedAt: input.pausedAt })
+  return err('The service returned invalid Agent control data.')
+}
+
+function parseRestartRequest(value: unknown): Parsed<RestartRequest> {
+  const input = record(value)
+  const operation = record(input?.operation)
+  const validOperation = operation?._tag === 'Restart'
+    || (operation?._tag === 'Update' && typeof operation.targetCommit === 'string')
+  if (input === undefined
+    || !['Requested', 'Restarting', 'Completed', 'ActionRequired'].includes(String(input._tag))
+    || typeof input.id !== 'string'
+    || (input.source !== 'dashboard' && input.source !== 'tray' && input.source !== 'helper')
+    || !validOperation
+    || typeof input.requestedAt !== 'string') {
+    return err('The service returned an invalid Restart request.')
+  }
+  return ok(input as unknown as RestartRequest)
+}
+
+function parseCancellation(value: unknown): Parsed<TaskCancellation> {
+  const input = record(value)
+  if (input?._tag === 'Cancelled' || input?._tag === 'AlreadyCancelled')
+    return ok({ _tag: input._tag })
+  return err('The service returned an invalid Task cancellation.')
+}
+
+function parseWorkflowEvents(value: unknown): Parsed<WorkflowEvent[]> {
+  const input = record(value)
+  return Array.isArray(input?.events)
+    ? ok(input.events as WorkflowEvent[])
+    : err('The service returned invalid workflow events.')
+}
+
+function errorMessage(value: unknown, fallback: string): string {
+  const input = record(value)
+  if (typeof input?.message === 'string' && input.message.length > 0)
+    return input.message
+  if (typeof input?.statusMessage === 'string' && input.statusMessage.length > 0)
+    return input.statusMessage
+  return fallback
+}
+
+function caughtMessage(value: unknown): string {
+  return value instanceof Error && value.message.length > 0
+    ? value.message
+    : 'The service could not be reached.'
+}
+
+function parseBaseUrl(value: string): Result<URL, ControlClientConfigurationError> {
+  if (!URL.canParse(value))
+    return err({ _tag: 'InvalidBaseUrl', message: 'Enter a valid service URL.' })
+  const url = new URL(value)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:')
+    return err({ _tag: 'InvalidBaseUrl', message: 'The service URL must use HTTP or HTTPS.' })
+  if (url.username.length > 0 || url.password.length > 0 || url.search.length > 0 || url.hash.length > 0)
+    return err({ _tag: 'InvalidBaseUrl', message: 'The service URL must not contain credentials, a query, or a fragment.' })
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}/`
+  return ok(url)
+}
+
+export function createControlClient(options: ControlClientOptions): Result<ControlClient, ControlClientConfigurationError> {
+  const parsedBaseUrl = parseBaseUrl(options.baseUrl)
+  if (parsedBaseUrl._tag === 'Err')
+    return parsedBaseUrl
+  const baseUrl = parsedBaseUrl.value
+  const authorization = `Basic ${Buffer.from(`agent:${options.authentication.password}`).toString('base64')}`
+
+  async function request<Value>(input: {
+    method: 'GET' | 'POST'
+    path: string
+    parse: ResponseParser<Value>
+    body?: unknown
+    acceptedStatuses?: readonly number[]
+  }): Promise<Result<Value, ControlApiError>> {
+    const headers = new Headers({ authorization, accept: 'application/json' })
+    if (input.method === 'POST') {
+      headers.set('content-type', 'application/json')
+      headers.set('origin', baseUrl.origin)
+    }
+    const response = await options.fetch(new URL(input.path, baseUrl), {
+      method: input.method,
+      headers,
+      ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
+    }).then(value => ok(value), reason => err({ _tag: 'NetworkFailure' as const, message: caughtMessage(reason) }))
+    if (response._tag === 'Err')
+      return response
+
+    const body = await response.value.json()
+      .then(value => ok(value), () => err({ _tag: 'InvalidResponse' as const, message: 'The service returned invalid JSON.' }))
+    if (body._tag === 'Err')
+      return body
+    const accepted = input.acceptedStatuses ?? [200]
+    if (!accepted.includes(response.value.status)) {
+      return err({
+        _tag: 'HttpFailure',
+        status: response.value.status,
+        message: errorMessage(body.value, `The service returned HTTP ${response.value.status}.`),
+      })
+    }
+    const parsed = input.parse(body.value)
+    return parsed._tag === 'Ok'
+      ? parsed
+      : err({ _tag: 'InvalidResponse', message: parsed.error })
+  }
+
+  const health = () => request({ method: 'GET', path: 'health', parse: parseHealth, acceptedStatuses: [200, 503] })
+  const state = () => request({ method: 'GET', path: 'api/state', parse: parseState })
+
+  return ok({
+    health,
+    state,
+    async status() {
+      const healthResult = await health()
+      if (healthResult._tag === 'Err')
+        return healthResult
+      const stateResult = await state()
+      return stateResult._tag === 'Err'
+        ? stateResult
+        : ok({ health: healthResult.value, state: stateResult.value })
+    },
+    async tasks() {
+      const result = await state()
+      return result._tag === 'Err' ? result : ok(result.value.tasks)
+    },
+    async incidents() {
+      const result = await state()
+      return result._tag === 'Err' ? result : ok(result.value.incidents)
+    },
+    async activity(taskId) {
+      const result = await state()
+      if (result._tag === 'Err')
+        return result
+      const agent = result.value.agents.find(candidate => candidate._tag === 'ActiveAgent' && candidate.id === taskId)
+      return agent?._tag === 'ActiveAgent'
+        ? ok(agent.activity)
+        : err({ _tag: 'TaskNotFound', taskId })
+    },
+    workflowEvents(query = {}) {
+      const search = new URLSearchParams()
+      if (query.stream !== undefined)
+        search.set('stream', query.stream)
+      if (query.limit !== undefined)
+        search.set('limit', String(query.limit))
+      const suffix = search.size === 0 ? '' : `?${search.toString()}`
+      return request({ method: 'GET', path: `api/workflow-events${suffix}`, parse: parseWorkflowEvents })
+    },
+    pause: () => request({ method: 'POST', path: 'api/agents/pause', parse: parseAgentControl }),
+    resume: () => request({ method: 'POST', path: 'api/agents/resume', parse: parseAgentControl }),
+    restart: () => request({ method: 'POST', path: 'api/service/restart', body: { source: 'helper' }, parse: parseRestartRequest, acceptedStatuses: [202] }),
+    update: () => request({ method: 'POST', path: 'api/service/update', body: { source: 'helper' }, parse: parseRestartRequest, acceptedStatuses: [202] }),
+    cancelTask: taskId => request({ method: 'POST', path: 'api/tasks/cancel', body: { taskId }, parse: parseCancellation }),
+  })
+}

--- a/packages/harlan-github-agent/src/index.ts
+++ b/packages/harlan-github-agent/src/index.ts
@@ -13,6 +13,8 @@ export { candidateIssueBody, candidateIssueCommands, createCandidateIssueControl
 export { createCodexProvider } from './codex-provider.ts'
 export { loadConfig, loadGitHubAppPrivateKey, loadWebhookSecret, normalizeGitHubRemote, parseConfigText, validateRepositoryMappings } from './config.ts'
 export { createConflictWorker } from './conflict-worker.ts'
+export { createControlClient } from './control-client.ts'
+export type { ControlApiError, ControlClient, ControlClientConfigurationError, ControlClientError, ControlClientOptions, ControlHealth, ControlStatus, WorkflowEventQuery } from './control-client.ts'
 export { createExternalWatchController, mergeExternalWatchSnapshot } from './external-watch.ts'
 export { createGitHubAgentSource } from './github-agent-source.ts'
 export { createGitHubAppTokenProvider, createRepositoryTokenProvider } from './github-auth.ts'

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -361,6 +361,49 @@ describe('dashboard HTTP app', () => {
     })])
   })
 
+  it('pins the available commit in a CLI Update request', async () => {
+    const latestCommit = 'b'.repeat(40)
+    const requests: unknown[] = []
+    const app = createAgentApp({
+      allowedOrigin,
+      dashboardPassword,
+      dashboardRoot,
+      now,
+      store: {
+        ...agentControls,
+        approveIssueWork: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }),
+        approvePullRequest: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }),
+        cancelTask: () => ({ _tag: 'Rejected', reason: { _tag: 'TaskNotFound' } }),
+        getDashboardSnapshot: () => dashboardSnapshot({
+          serviceUpdate: {
+            _tag: 'Available',
+            deployedCommit: 'a'.repeat(40),
+            latestCommit,
+            checkedAt: now().toISOString(),
+          },
+        }),
+        listReviewRuns: () => [],
+        requestRestart(input) {
+          requests.push(input)
+          return { _tag: 'Requested', id: input.id, source: input.source, operation: input.operation, requestedAt: input.at }
+        },
+        requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'ItemNotFound' } }),
+      },
+    })
+
+    const response = await app.request(`http://${allowedHost}/api/service/update`, {
+      method: 'POST',
+      headers: { 'authorization': authorization, 'host': allowedHost, 'origin': allowedOrigin, 'content-type': 'application/json' },
+      body: JSON.stringify({ source: 'helper' }),
+    })
+
+    expect(response.status).toBe(202)
+    expect(requests).toEqual([expect.objectContaining({
+      source: 'helper',
+      operation: { _tag: 'Update', targetCommit: latestCommit },
+    })])
+  })
+
   it('reports read-only health', async () => {
     const response = await createApp().request(`http://${allowedHost}/health`, { headers: { authorization, host: allowedHost } })
 

--- a/packages/harlan-github-agent/test/cli-leading-options.test.ts
+++ b/packages/harlan-github-agent/test/cli-leading-options.test.ts
@@ -2,40 +2,51 @@ import { describe, expect, it } from 'vitest'
 import { forwardLeadingOptions } from '../src/cli-leading-options.ts'
 
 const valueOptions = ['--config', '-c', '--url', '--password-file']
+const subCommands = ['combine-service-state', 'sweep-worktrees', 'control']
 
 describe('forwardLeadingOptions', () => {
   it('moves a leading --config with its value behind the control subcommand', () => {
-    expect(forwardLeadingOptions(['--config', 'a.yml', 'control', 'status'], valueOptions, 'control'))
+    expect(forwardLeadingOptions(['--config', 'a.yml', 'control', 'status'], valueOptions, subCommands))
       .toEqual(['control', 'status', '--config', 'a.yml'])
   })
 
   it('moves every leading connection option, including attached values and aliases', () => {
-    expect(forwardLeadingOptions(['-c', 'a.yml', '--url=http://x', 'control', 'tasks'], valueOptions, 'control'))
+    expect(forwardLeadingOptions(['-c', 'a.yml', '--url=http://x', 'control', 'tasks'], valueOptions, subCommands))
       .toEqual(['control', 'tasks', '-c', 'a.yml', '--url=http://x'])
   })
 
   it('leaves arguments alone when the subcommand is already first', () => {
-    expect(forwardLeadingOptions(['control', 'status', '--config', 'a.yml'], valueOptions, 'control'))
+    expect(forwardLeadingOptions(['control', 'status', '--config', 'a.yml'], valueOptions, subCommands))
       .toEqual(['control', 'status', '--config', 'a.yml'])
   })
 
-  it('leaves arguments alone when the first positional is another subcommand', () => {
-    expect(forwardLeadingOptions(['--config', 'a.yml', 'sweep-worktrees'], valueOptions, 'control'))
-      .toEqual(['--config', 'a.yml', 'sweep-worktrees'])
+  it('moves a leading --config behind sweep-worktrees', () => {
+    expect(forwardLeadingOptions(['--config', 'a.yml', 'sweep-worktrees', '--dry-run'], valueOptions, subCommands))
+      .toEqual(['sweep-worktrees', '--dry-run', '--config', 'a.yml'])
+  })
+
+  it('moves a leading --config behind combine-service-state', () => {
+    expect(forwardLeadingOptions(['-c', 'a.yml', 'combine-service-state', 'g.json', 'r.json'], valueOptions, subCommands))
+      .toEqual(['combine-service-state', 'g.json', 'r.json', '-c', 'a.yml'])
+  })
+
+  it('leaves arguments alone when the first positional is not a known subcommand', () => {
+    expect(forwardLeadingOptions(['--config', 'a.yml', 'unknown'], valueOptions, subCommands))
+      .toEqual(['--config', 'a.yml', 'unknown'])
   })
 
   it('leaves arguments alone when no subcommand follows the options', () => {
-    expect(forwardLeadingOptions(['--config', 'a.yml'], valueOptions, 'control'))
+    expect(forwardLeadingOptions(['--config', 'a.yml'], valueOptions, subCommands))
       .toEqual(['--config', 'a.yml'])
   })
 
   it('forwards an unknown leading option without swallowing the subcommand', () => {
-    expect(forwardLeadingOptions(['--nope', 'control', 'status'], valueOptions, 'control'))
+    expect(forwardLeadingOptions(['--nope', 'control', 'status'], valueOptions, subCommands))
       .toEqual(['control', 'status', '--nope'])
   })
 
   it('stops at the end-of-options marker', () => {
-    expect(forwardLeadingOptions(['--', '--config', 'control'], valueOptions, 'control'))
+    expect(forwardLeadingOptions(['--', '--config', 'control'], valueOptions, subCommands))
       .toEqual(['--', '--config', 'control'])
   })
 })

--- a/packages/harlan-github-agent/test/cli-leading-options.test.ts
+++ b/packages/harlan-github-agent/test/cli-leading-options.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { forwardLeadingOptions } from '../src/cli-leading-options.ts'
+
+const valueOptions = ['--config', '-c', '--url', '--password-file']
+
+describe('forwardLeadingOptions', () => {
+  it('moves a leading --config with its value behind the control subcommand', () => {
+    expect(forwardLeadingOptions(['--config', 'a.yml', 'control', 'status'], valueOptions, 'control'))
+      .toEqual(['control', 'status', '--config', 'a.yml'])
+  })
+
+  it('moves every leading connection option, including attached values and aliases', () => {
+    expect(forwardLeadingOptions(['-c', 'a.yml', '--url=http://x', 'control', 'tasks'], valueOptions, 'control'))
+      .toEqual(['control', 'tasks', '-c', 'a.yml', '--url=http://x'])
+  })
+
+  it('leaves arguments alone when the subcommand is already first', () => {
+    expect(forwardLeadingOptions(['control', 'status', '--config', 'a.yml'], valueOptions, 'control'))
+      .toEqual(['control', 'status', '--config', 'a.yml'])
+  })
+
+  it('leaves arguments alone when the first positional is another subcommand', () => {
+    expect(forwardLeadingOptions(['--config', 'a.yml', 'sweep-worktrees'], valueOptions, 'control'))
+      .toEqual(['--config', 'a.yml', 'sweep-worktrees'])
+  })
+
+  it('leaves arguments alone when no subcommand follows the options', () => {
+    expect(forwardLeadingOptions(['--config', 'a.yml'], valueOptions, 'control'))
+      .toEqual(['--config', 'a.yml'])
+  })
+
+  it('forwards an unknown leading option without swallowing the subcommand', () => {
+    expect(forwardLeadingOptions(['--nope', 'control', 'status'], valueOptions, 'control'))
+      .toEqual(['control', 'status', '--nope'])
+  })
+
+  it('stops at the end-of-options marker', () => {
+    expect(forwardLeadingOptions(['--', '--config', 'control'], valueOptions, 'control'))
+      .toEqual(['--', '--config', 'control'])
+  })
+})

--- a/packages/harlan-github-agent/test/cli-subcommand.test.ts
+++ b/packages/harlan-github-agent/test/cli-subcommand.test.ts
@@ -1,22 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import { invokesSubCommand } from '../src/cli-subcommand.ts'
 
+const rootArguments = { config: { type: 'string', alias: 'c' } } as const
+
 describe('invokesSubCommand', () => {
   it('reports the sweep subcommand, so the service does not also start', () => {
     // citty runs the parent command after a subcommand, so the parent must know
     // it has nothing to do. Otherwise a sweep binds the dashboard port too.
-    expect(invokesSubCommand(['sweep-worktrees', '--dry-run'], ['sweep-worktrees'])).toBe(true)
+    expect(invokesSubCommand(['sweep-worktrees', '--dry-run'], ['sweep-worktrees'], rootArguments)).toBe(true)
+  })
+
+  it('reports the subcommand when connection options precede it', () => {
+    expect(invokesSubCommand(['--config', 'agent.yml', 'control', 'status'], ['control'], rootArguments)).toBe(true)
+  })
+
+  it('reports the subcommand behind an unknown option', () => {
+    expect(invokesSubCommand(['--nope', 'control', 'status'], ['control'], rootArguments)).toBe(true)
   })
 
   it('reports no subcommand when the service starts normally', () => {
-    expect(invokesSubCommand(['--config', '/etc/agent.yml'], ['sweep-worktrees'])).toBe(false)
+    expect(invokesSubCommand(['--config', '/etc/agent.yml'], ['sweep-worktrees'], rootArguments)).toBe(false)
   })
 
   it('reports no subcommand for an empty invocation', () => {
-    expect(invokesSubCommand([], ['sweep-worktrees'])).toBe(false)
+    expect(invokesSubCommand([], ['sweep-worktrees'], rootArguments)).toBe(false)
   })
 
   it('ignores a subcommand name that arrives as an option value', () => {
-    expect(invokesSubCommand(['--config', 'sweep-worktrees'], ['sweep-worktrees'])).toBe(false)
+    expect(invokesSubCommand(['--config', 'sweep-worktrees'], ['sweep-worktrees'], rootArguments)).toBe(false)
+  })
+
+  it('ignores a subcommand name behind the end-of-options marker', () => {
+    expect(invokesSubCommand(['--', 'control'], ['control'], rootArguments)).toBe(false)
   })
 })

--- a/packages/harlan-github-agent/test/control-cli.test.ts
+++ b/packages/harlan-github-agent/test/control-cli.test.ts
@@ -32,6 +32,22 @@ afterEach(async () => {
 })
 
 describe('harlan GitHub Agent control CLI', () => {
+  it('prints one tagged JSON error and exits 1 when a Task ID is missing', async () => {
+    const run = await runControlCli(['control', 'cancel'])
+
+    expect(run.code).toBe(1)
+    expect(run.stdout).toBe('')
+    expect(JSON.parse(run.stderr)).toEqual({ _tag: 'MissingTaskId', message: 'Set --task to one Task ID.' })
+  })
+
+  it('prints one tagged JSON error and exits 1 when the control command is unknown', async () => {
+    const run = await runControlCli(['control', 'unknown'])
+
+    expect(run.code).toBe(1)
+    expect(run.stdout).toBe('')
+    expect(JSON.parse(run.stderr)).toEqual({ _tag: 'UnknownControlCommand', message: 'Select a valid control command.' })
+  })
+
   it('prints one tagged JSON error and exits 1 when the configuration file is missing', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
     temporaryDirectories.push(directory)

--- a/packages/harlan-github-agent/test/control-cli.test.ts
+++ b/packages/harlan-github-agent/test/control-cli.test.ts
@@ -11,11 +11,61 @@ import { dashboardSnapshot } from './fixtures.ts'
 const executeFile = promisify(execFile)
 const temporaryDirectories: string[] = []
 
+interface CliRun {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+function runControlCli(args: string[]): Promise<CliRun> {
+  return executeFile(process.execPath, ['--experimental-strip-types', 'src/cli.ts', ...args], { cwd: join(import.meta.dirname, '..') })
+    .then(({ stdout, stderr }) => ({ code: 0, stdout, stderr }))
+    .catch((error: NodeJS.ErrnoException & { stdout: string, stderr: string }) => ({
+      code: typeof error.code === 'number' ? error.code : 1,
+      stdout: error.stdout,
+      stderr: error.stderr,
+    }))
+}
+
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, { recursive: true })))
 })
 
 describe('harlan GitHub Agent control CLI', () => {
+  it('prints one tagged JSON error and exits 1 when the configuration file is missing', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
+    temporaryDirectories.push(directory)
+
+    const run = await runControlCli(['control', 'status', '--config', join(directory, 'missing.yml')])
+
+    expect(run.code).toBe(1)
+    expect(JSON.parse(run.stderr)).toEqual({ _tag: 'ConfigurationFailure', message: expect.any(String) })
+  })
+
+  it('prints one tagged JSON error and exits 1 when the password file is missing', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
+    temporaryDirectories.push(directory)
+
+    const run = await runControlCli([
+      'control',
+      'status',
+      '--url',
+      'http://127.0.0.1:9',
+      '--password-file',
+      join(directory, 'missing-dashboard-password'),
+    ])
+
+    expect(run.code).toBe(1)
+    expect(JSON.parse(run.stderr)).toEqual({ _tag: 'ConfigurationFailure', message: expect.any(String) })
+  })
+
+  it('prints one tagged JSON error and exits 1 when the event stream is unknown', async () => {
+    const run = await runControlCli(['control', 'events', '--stream', 'nope', '--url', 'http://127.0.0.1:9'])
+
+    expect(run.code).toBe(1)
+    expect(JSON.parse(run.stderr)).toEqual({ _tag: 'InvalidStream', message: expect.any(String) })
+  })
+
   it('prints machine-readable service status without starting another service', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
     temporaryDirectories.push(directory)

--- a/packages/harlan-github-agent/test/control-cli.test.ts
+++ b/packages/harlan-github-agent/test/control-cli.test.ts
@@ -1,0 +1,58 @@
+import type { AddressInfo } from 'node:net'
+import { execFile } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, describe, expect, it } from 'vitest'
+import { dashboardSnapshot } from './fixtures.ts'
+
+const executeFile = promisify(execFile)
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, { recursive: true })))
+})
+
+describe('harlan GitHub Agent control CLI', () => {
+  it('prints machine-readable service status without starting another service', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
+    temporaryDirectories.push(directory)
+    const passwordFile = join(directory, 'dashboard-password')
+    await writeFile(passwordFile, 'test-password-with-at-least-32-bytes\n', { mode: 0o600 })
+    const snapshot = dashboardSnapshot()
+    const server = createServer((request, response) => {
+      response.setHeader('content-type', 'application/json')
+      if (request.url === '/health') {
+        response.end(JSON.stringify({ status: 'ready', mutationsEnabled: false, repositories: 0, issues: 0, pullRequests: 0, tasks: 0 }))
+        return
+      }
+      if (request.url === '/api/state') {
+        response.end(JSON.stringify(snapshot))
+        return
+      }
+      response.statusCode = 404
+      response.end(JSON.stringify({ message: 'Not found.' }))
+    })
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address() as AddressInfo
+
+    const result = await executeFile(process.execPath, [
+      '--experimental-strip-types',
+      'src/cli.ts',
+      'control',
+      'status',
+      '--url',
+      `http://127.0.0.1:${address.port}`,
+      '--password-file',
+      passwordFile,
+    ], { cwd: join(import.meta.dirname, '..') }).finally(() => new Promise<void>((resolve, reject) => server.close(error => error === undefined ? resolve() : reject(error))))
+
+    expect(JSON.parse(result.stdout)).toEqual({
+      health: { status: 'ready', mutationsEnabled: false, repositories: 0, issues: 0, pullRequests: 0, tasks: 0 },
+      state: snapshot,
+    })
+    expect(result.stderr).toBe('')
+  })
+})

--- a/packages/harlan-github-agent/test/control-cli.test.ts
+++ b/packages/harlan-github-agent/test/control-cli.test.ts
@@ -78,6 +78,18 @@ describe('harlan GitHub Agent control CLI', () => {
     expect(JSON.parse(errorLine ?? '')).toEqual({ _tag: 'ConfigurationFailure', message: expect.stringContaining(configPath) })
   })
 
+  it('loads the requested configuration file when --config precedes sweep-worktrees', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
+    temporaryDirectories.push(directory)
+    const configPath = join(directory, 'requested-missing.yml')
+
+    const run = await runControlCli(['--config', configPath, 'sweep-worktrees', '--dry-run'])
+
+    expect(run.code).toBe(1)
+    expect(run.stderr).toContain(configPath)
+    expect(run.stderr).not.toContain('harlan-github-agent.yml')
+  })
+
   it('prints one tagged JSON error and exits 1 when the configuration file is missing', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
     temporaryDirectories.push(directory)

--- a/packages/harlan-github-agent/test/control-cli.test.ts
+++ b/packages/harlan-github-agent/test/control-cli.test.ts
@@ -48,6 +48,21 @@ describe('harlan GitHub Agent control CLI', () => {
     expect(JSON.parse(run.stderr)).toEqual({ _tag: 'UnknownControlCommand', message: 'Select a valid control command.' })
   })
 
+  it('forwards a leading --config to the control subcommand and exits 1 with one tagged JSON error', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
+    temporaryDirectories.push(directory)
+    const configPath = join(directory, 'missing.yml')
+
+    const run = await runControlCli(['--config', configPath, 'control', 'status'])
+
+    expect(run.code).toBe(1)
+    expect(run.stdout).toBe('')
+    const errorLines = run.stderr.split('\n').filter(line => line.trim() !== '')
+    expect(errorLines).toHaveLength(1)
+    const [errorLine] = errorLines
+    expect(JSON.parse(errorLine ?? '')).toEqual({ _tag: 'ConfigurationFailure', message: expect.stringContaining(configPath) })
+  })
+
   it('prints one tagged JSON error and exits 1 when the configuration file is missing', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
     temporaryDirectories.push(directory)

--- a/packages/harlan-github-agent/test/control-cli.test.ts
+++ b/packages/harlan-github-agent/test/control-cli.test.ts
@@ -63,6 +63,21 @@ describe('harlan GitHub Agent control CLI', () => {
     expect(JSON.parse(errorLine ?? '')).toEqual({ _tag: 'ConfigurationFailure', message: expect.stringContaining(configPath) })
   })
 
+  it('forwards connection options between control and the nested command and exits 1 with one tagged JSON error', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
+    temporaryDirectories.push(directory)
+    const configPath = join(directory, 'missing.yml')
+
+    const run = await runControlCli(['control', '--config', configPath, 'status'])
+
+    expect(run.code).toBe(1)
+    expect(run.stdout).toBe('')
+    const errorLines = run.stderr.split('\n').filter(line => line.trim() !== '')
+    expect(errorLines).toHaveLength(1)
+    const [errorLine] = errorLines
+    expect(JSON.parse(errorLine ?? '')).toEqual({ _tag: 'ConfigurationFailure', message: expect.stringContaining(configPath) })
+  })
+
   it('prints one tagged JSON error and exits 1 when the configuration file is missing', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'harlan-control-cli-'))
     temporaryDirectories.push(directory)

--- a/packages/harlan-github-agent/test/control-client.test.ts
+++ b/packages/harlan-github-agent/test/control-client.test.ts
@@ -85,4 +85,20 @@ describe('harlan GitHub Agent control client', () => {
       error: { _tag: 'HttpFailure', status: 409, message: 'The task already finished.' },
     })
   })
+
+  it('returns an HTTP failure with the status for a non-JSON error body', async () => {
+    const created = clientWith([
+      new Response('<html>Bad Gateway</html>', { status: 502, headers: { 'content-type': 'text/html' } }),
+    ], [])
+
+    expect(created._tag).toBe('Ok')
+    if (created._tag === 'Err')
+      return
+    const result = await created.value.cancelTask('a'.repeat(64))
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      error: { _tag: 'HttpFailure', status: 502, message: 'The service returned HTTP 502.' },
+    })
+  })
 })

--- a/packages/harlan-github-agent/test/control-client.test.ts
+++ b/packages/harlan-github-agent/test/control-client.test.ts
@@ -1,0 +1,88 @@
+import { Buffer } from 'node:buffer'
+import { describe, expect, it } from 'vitest'
+import { createControlClient } from '../src/index.ts'
+import { dashboardSnapshot } from './fixtures.ts'
+
+const baseUrl = 'https://hogwild.example.test'
+const password = 'test-password-with-at-least-32-bytes'
+
+function clientWith(responses: Response[], requests: Request[]) {
+  return createControlClient({
+    authentication: { _tag: 'Basic', password },
+    baseUrl,
+    fetch: async (input, init) => {
+      requests.push(new Request(input, init))
+      const response = responses.shift()
+      if (response === undefined)
+        throw new Error('No response was prepared.')
+      return response
+    },
+  })
+}
+
+describe('harlan GitHub Agent control client', () => {
+  it('reads health before the shared dashboard state', async () => {
+    const requests: Request[] = []
+    const snapshot = dashboardSnapshot()
+    const created = clientWith([
+      Response.json({ status: 'ready', mutationsEnabled: false, repositories: 2, issues: 3, pullRequests: 4, tasks: 5 }),
+      Response.json(snapshot),
+    ], requests)
+
+    expect(created._tag).toBe('Ok')
+    if (created._tag === 'Err')
+      return
+    const result = await created.value.status()
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: {
+        health: { status: 'ready', mutationsEnabled: false, repositories: 2, issues: 3, pullRequests: 4, tasks: 5 },
+        state: snapshot,
+      },
+    })
+    expect(requests.map(request => request.url)).toEqual([
+      `${baseUrl}/health`,
+      `${baseUrl}/api/state`,
+    ])
+    expect(requests[0]?.headers.get('authorization')).toBe(`Basic ${Buffer.from(`agent:${password}`).toString('base64')}`)
+  })
+
+  it('sends one guarded Restart request through the existing control API', async () => {
+    const requests: Request[] = []
+    const accepted = {
+      _tag: 'Requested' as const,
+      id: 'request-1',
+      source: 'helper' as const,
+      operation: { _tag: 'Restart' as const },
+      requestedAt: '2026-09-02T01:00:00.000Z',
+    }
+    const created = clientWith([Response.json(accepted, { status: 202 })], requests)
+
+    expect(created._tag).toBe('Ok')
+    if (created._tag === 'Err')
+      return
+    const result = await created.value.restart()
+
+    expect(result).toEqual({ _tag: 'Ok', value: accepted })
+    expect(requests[0]?.method).toBe('POST')
+    expect(requests[0]?.headers.get('origin')).toBe(baseUrl)
+    await expect(requests[0]?.json()).resolves.toEqual({ source: 'helper' })
+  })
+
+  it('returns an HTTP failure as a value', async () => {
+    const created = clientWith([
+      Response.json({ message: 'The task already finished.' }, { status: 409 }),
+    ], [])
+
+    expect(created._tag).toBe('Ok')
+    if (created._tag === 'Err')
+      return
+    const result = await created.value.cancelTask('a'.repeat(64))
+
+    expect(result).toEqual({
+      _tag: 'Err',
+      error: { _tag: 'HttpFailure', status: 409, message: 'The task already finished.' },
+    })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Agents had to assemble curl requests and know dashboard internals before they could inspect or control a Hogwild service. The package now exports a typed Control API client, plus JSON CLI commands that use the dashboard's durable routes.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.