### PR TITLE
feat(agent): bounded Repair rounds with round history

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -201,7 +201,9 @@ Available empty base and head check sets with no declared required checks mean t
 
 If Review recommends Dismissal, queue no Repair. Use this only when the premise is wrong and Repair would replace the pull request intent. Harlan decides whether to Dismiss.
 
-If fresh Review repeats one finding fingerprint after Repair, stop with Action required. Do not attempt a root architecture rewrite.
+If fresh Review of a Repair commit still records a Repair finding, queue the next Repair round. Give that round every earlier round's commit, report, and target findings. Never repeat a rejected approach.
+
+Allow 3 Repair rounds per contributor commit. A contributor push starts a fresh count. When the rounds are spent, stop with Action required and list every round in the canonical comment. Do not attempt a root architecture rewrite.
 
 If Repair returns Action required or exhausts retries, replace its progress comment with `BLOCKED`. Include every stored finding and its exact next action.
 

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -41,6 +41,7 @@ did not cover it.
 | Conflict resolution | `tasks.kind` | Scheduler | One Task kind | conflict resolution |
 | Baseline repair | `tasks.kind` | Scheduler | One Task for one failing default branch commit | Baseline repair |
 | Repair | `tasks.kind` | Scheduler | One Task for the findings of one Review run | repair |
+| Repair round | `repair_reports`, Repair lineage in `publication_commands` | Scheduler | One Repair in a chain of controller Repairs on one pull request | repair round |
 | Context budget | `agent.contextBudget` | Runner | One per agent session | Context budget |
 | Stack | `subjects` base ref, `publication_commands.base_ref` | GitHub | A pull request whose base is another pull request's head | stack |
 | Issue triage | `worker_tasks.kind` | Scheduler | One Task for one issue Revision | issue triage |
@@ -366,6 +367,16 @@ One local GitHub Actions runner that executes workflow jobs.
 A self-hosted runner is independent of Harlan GitHub Agent. Its availability never changes Harlan GitHub Agent status.
 
 Use self-hosted runner. Do not use Agent, worker, executor, box, or build agent.
+
+### Repair round
+
+One Repair in the chain of controller Repairs that produced the current pull request head.
+
+Round 1 is the first Repair after a contributor commit. If the fresh Review of a Repair commit still finds a defect, the next round starts. A later round reads every earlier round's commit, report, and target findings before it changes anything.
+
+A pull request gets 3 rounds per contributor commit. A contributor push ends the chain and starts a fresh count. When the rounds are spent, Repair stops with Action required, and the canonical comment lists every round.
+
+Use Repair round. Do not use attempt, retry, iteration, or loop.
 
 ### Conflict resolution
 

--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -89,7 +89,8 @@ The final Review replaces that route with one outcome label: `ready`, `pending`,
 The canonical comment lists every Review gate and the next action.
 After GitHub merges or closes the pull request, the comment records that state and Agent labels clear.
 
-Every published Repair head SHA gets a fresh Review. A repeated finding stops with Action required.
+Every published Repair head SHA gets a fresh Review. If that Review still finds a defect, the next Repair round starts. It reads every earlier round's commit and report, so it does not repeat a rejected approach.
+A pull request gets 3 Repair rounds per contributor commit. A contributor push starts a fresh count. When the rounds are spent, Repair stops with Action required and the comment lists every round.
 
 If Repair stops, the canonical review comment changes to `BLOCKED`. It lists every finding and next action.
 

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -30,6 +30,7 @@ import { runParsedAgentTurn } from './agent-turn.ts'
 import { APPROVAL_LABELS } from './approval-labels.ts'
 import { currentGitHubChecks } from './github-agent-source.ts'
 import { isIssueTriageState } from './issue-triage.ts'
+import { repairRoundLabel } from './repair-rounds.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
@@ -910,11 +911,14 @@ async function projectReviewRun(
       fence: task.state.fence,
       at: options.now().toISOString(),
     })
-    if (queued._tag !== 'Queued') {
-      findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0
-        ? { ...finding, nextAction: queued.reason }
-        : finding)
-    }
+    findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0
+      ? {
+          ...finding,
+          nextAction: queued._tag === 'Queued'
+            ? `Repair ${repairRoundLabel(queued.rounds)} starts. ${finding.nextAction}`
+            : queued.reason,
+        }
+      : finding)
   }
   else if (repairable && !recommendsDismissal && preflight._tag === 'ActionRequired') {
     findings = findings.map((finding, index) => finding._tag === 'Open' && index === 0

--- a/packages/harlan-github-agent/src/repair-rounds.ts
+++ b/packages/harlan-github-agent/src/repair-rounds.ts
@@ -1,0 +1,70 @@
+import type { RepairRound } from './types.ts'
+import { cleanLine } from './text.ts'
+
+/**
+ * How many consecutive controller Repairs one pull request head may carry.
+ *
+ * A Repair whose commit still fails Review used to stop the workflow after one
+ * round. One round is too few: the second Repair Agent reads what the first one
+ * tried and why Review rejected it, so it can choose a different fix. A cap
+ * keeps the chain finite. A contributor commit ends the chain and starts a
+ * fresh count.
+ */
+export const REPAIR_ROUND_LIMIT = 3
+
+export type RepairRoundPlan
+  = | { _tag: 'Allowed', number: number }
+    | { _tag: 'Exhausted', reason: string }
+
+export function repairRoundLabel(rounds: { number: number, limit: number }): string {
+  return `round ${rounds.number} of ${rounds.limit}`
+}
+
+function shortSha(sha: string): string {
+  return sha.slice(0, 7)
+}
+
+function roundLine(round: RepairRound): string {
+  const report = round.summary === null ? 'no Repair report' : cleanLine(round.summary)
+  return `Round ${round.number} (\`${shortSha(round.commitSha)}\`): ${report}`
+}
+
+/**
+ * Decides whether one more Repair may start on a head produced by prior rounds.
+ *
+ * Pure: the store reads the lineage, this function only judges it.
+ */
+export function planRepairRound(prior: RepairRound[], limit: number = REPAIR_ROUND_LIMIT): RepairRoundPlan {
+  const number = prior.length + 1
+  if (number <= limit)
+    return { _tag: 'Allowed', number }
+  const history = prior.map(roundLine).join(' ')
+  return {
+    _tag: 'Exhausted',
+    reason: `Repair used ${prior.length} of ${limit} rounds and the finding remains. ${history} A person decides the next step.`,
+  }
+}
+
+/**
+ * The history one Repair Agent reads before it starts a later round.
+ *
+ * It names every prior commit, what that Repair reported, and what it targeted,
+ * so the Agent can rule out an approach that Review already rejected.
+ */
+export function repairRoundHistory(rounds: { number: number, limit: number, prior: RepairRound[] }): string {
+  if (rounds.prior.length === 0)
+    return ''
+  const lines = rounds.prior.map(round => [
+    `Round ${round.number} published commit ${round.commitSha}.`,
+    `It targeted: ${round.findings.map(cleanLine).join(' | ')}`,
+    `Its Repair Agent reported: ${round.summary === null ? 'no report' : cleanLine(round.summary)}`,
+    ...(round.checks.length === 0 ? [] : [`It ran: ${round.checks.map(cleanLine).join('; ')}`]),
+  ].join('\n'))
+  return `
+This is Repair ${repairRoundLabel(rounds)}. Earlier rounds on this pull request already published commits, and a fresh Review still found the defects below.
+${lines.join('\n\n')}
+
+Read each earlier commit with git show before you change anything.
+Treat every earlier approach as rejected. Choose a different fix that answers the current proof.
+Do not revert an earlier round unless its change caused the current finding.`
+}

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -8,6 +8,7 @@ import type { AgentProgress, ClaimedReviewFixTask, MutationWorkerOutcome, Reposi
 import type { ReviewFixWorktreeManager } from './worktree.ts'
 import { createHash } from 'node:crypto'
 import { runParsedAgentTurn } from './agent-turn.ts'
+import { repairRoundHistory } from './repair-rounds.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
@@ -47,7 +48,7 @@ export interface ReviewFixWorkerOptions {
   onProgressPublishFailure?: (task: ClaimedReviewFixTask, reason: string) => void
   runtime: AgentRuntimeSource
   status: Pick<ReviewStatusController, 'publishRepair'>
-  store: Pick<JournalStore, 'getReviewFixFindings' | 'getWorkerSession' | 'requestReviewRerun' | 'saveWorkerSession' | 'updateAgentProgress'>
+  store: Pick<JournalStore, 'getReviewFixFindings' | 'getWorkerSession' | 'recordRepairReport' | 'requestReviewRerun' | 'saveWorkerSession' | 'updateAgentProgress'>
   validateMapping: (mapping: RepositoryMapping) => Promise<Result<RepositoryMapping, string>>
   worktrees: ReviewFixWorktreeManager
 }
@@ -97,6 +98,7 @@ Work as a fresh local Agent session inside this prepared Git worktree.
 Read repository AGENTS.md and trusted contributor instructions.
 Apply the unit-tests skill before every bug or validation fix.
 Treat the findings below as the complete Repair scope.
+${repairRoundHistory(task.rounds)}
 For each finding, write the named failing regression test first. Confirm it fails for the stated reason.
 Fix every finding. Run focused checks that cover every changed behavior.
 For a visual finding, read the pull request image and reproduce the defect at the shown viewport.
@@ -232,6 +234,18 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
         })
       }
 
+      // The report outlives this Task. A later Repair round reads it to avoid
+      // repeating an approach Review already rejected.
+      const reported = options.store.recordRepairReport({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: options.now().toISOString(),
+        summary: turn.value.value.summary,
+        checks: turn.value.value.checks,
+      })
+      if (!reported)
+        return err('The Repair report lost its fenced lease before the commit was verified.')
       const verified = await options.worktrees.verify(task, prepared.value, signal)
       if (verified._tag === 'Err')
         return verified

--- a/packages/harlan-github-agent/src/review-status-controller.ts
+++ b/packages/harlan-github-agent/src/review-status-controller.ts
@@ -3,6 +3,7 @@ import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedAdversarialReviewTask, ClaimedReviewFixTask, ClaimedReviewStatusCommand, ReviewDesiredOutcome, ReviewStatusTaskPhase } from './types.ts'
 import { formatPhaseDuration } from './agent-progress.ts'
+import { repairRoundLabel } from './repair-rounds.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
 import { updatedAtLabel } from './text.ts'
@@ -134,7 +135,7 @@ export async function publishClaimedReviewStatus(
     : err('GitHub accepted the review comment, but the local review changed. Refresh before retrying.')
 }
 
-function repairProgressComment(headSha: string, progress: AgentProgress, at: string): string {
+function repairProgressComment(task: ClaimedReviewFixTask, progress: AgentProgress, at: string): string {
   // Declarative, and about the Repair rather than the reader. These lines read
   // as instructions to whoever opened the pull request when they are imperative,
   // and every other automated comment states what the work does next.
@@ -148,8 +149,8 @@ function repairProgressComment(headSha: string, progress: AgentProgress, at: str
           ? 'Repair fixes the Review findings.'
           : 'Repair creates its Git worktree.'
   return `${AUTOMATED_REVIEW_MARKER}
-<!-- reviewed-sha: ${headSha} -->
-### 🤖 REPAIR · ${progress.percent}% · ${progress.label}${formatPhaseDuration(progress.since, at)}
+<!-- reviewed-sha: ${task.pullRequest.headSha} -->
+### 🤖 REPAIR · ${repairRoundLabel(task.rounds)} · ${progress.percent}% · ${progress.label}${formatPhaseDuration(progress.since, at)}
 
 ${automatedDisclosure({ kind: 'repair update', updatedAt: updatedAtLabel(at) })}
 
@@ -213,7 +214,7 @@ export function createReviewStatusController(options: ReviewStatusControllerOpti
       const published = await publishStatus(
         task,
         { taskKind: 'review_fix', phase: 'repair' },
-        repairProgressComment(task.pullRequest.headSha, progress, options.now().toISOString()),
+        repairProgressComment(task, progress, options.now().toISOString()),
         true,
         signal,
       )

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -60,6 +60,7 @@ import type {
   RecordReviewRunInput,
   RecordReviewRunRejection,
   RecordReviewRunResult,
+  RepairRound,
   RepositoryMapping,
   RepositoryStatus,
   RestartOperation,
@@ -104,6 +105,7 @@ import { AGENT_MODELS, AGENT_PROVIDER_NAMES, CODEX_AGENT_PROFILE, parseAgentSele
 import { classifyFailure, isTransientFailure, MAXIMUM_RECOVERY_ATTEMPTS, mayRetryFailure, nextRecoveryAt, REVIEW_REPAIR_REFUSALS } from './failure.ts'
 import { isRepositoryWriteQuarantineReason } from './github-write-gate.ts'
 import { isIssueTriageState } from './issue-triage.ts'
+import { planRepairRound, REPAIR_ROUND_LIMIT } from './repair-rounds.ts'
 import { canRepairBaseline, canRepairPullRequestHead, canWorkIssues } from './repository-policy.ts'
 import { buildStats } from './stats.ts'
 import { cleanLine } from './text.ts'
@@ -629,6 +631,8 @@ export interface JournalStore {
     fence: number
     at: string
   }) => ReviewFixQueueResult
+  /** Stores one Repair Agent's report under its fenced lease, before its commit is staged. */
+  recordRepairReport: (input: { taskId: string, workerId: string, fence: number, at: string, summary: string, checks: string[] }) => boolean
   queueBaselineRepairForReview: (input: {
     taskId: string
     workerId: string
@@ -3551,7 +3555,7 @@ function planConflictResolution(
  * What the controller may do with the exact findings one Review recorded.
  */
 type ReviewFixPlan
-  = | { _tag: 'Planned', taskId: string }
+  = | { _tag: 'Planned', taskId: string, rounds: { number: number, limit: number } }
     | { _tag: 'Refused', reason: string }
 
 function openReviewFindings(database: DatabaseSync, subjectId: number, revisionId: string): Array<Extract<ReviewFinding, { _tag: 'Open' }>> {
@@ -3566,37 +3570,55 @@ function openReviewFindings(database: DatabaseSync, subjectId: number, revisionI
     : (JSON.parse(row.findings) as ReviewFinding[]).filter((finding): finding is Extract<ReviewFinding, { _tag: 'Open' }> => finding._tag === 'Open')
 }
 
-function findingIdentity(finding: Extract<ReviewFinding, { _tag: 'Open' }>): string {
-  return finding.details?.fingerprint
-    ?? cleanLine(finding.summary).toLocaleLowerCase('en-US')
-}
-
 /**
- * Finds a defect that survived the repair which created the current head SHA.
+ * The chain of controller Repairs that produced the current head SHA, oldest first.
  *
- * Comparing only the direct repair parent avoids treating a later contributor
- * edit as a failed controller repair.
+ * Each published Repair commit names the Revision it repaired. That Revision's
+ * head may itself be a Repair commit. The walk stops at the first head no
+ * Repair published, which is a contributor commit, so a contributor push
+ * always starts a fresh count.
  */
-function repeatedReviewFinding(
-  database: DatabaseSync,
-  subject: GitHubPullRequestItem,
-  subjectId: number,
-  revisionId: string,
-): Extract<ReviewFinding, { _tag: 'Open' }> | undefined {
-  const repaired = database.prepare(`
-    SELECT tasks.revision_id
+function reviewFixRounds(database: DatabaseSync, subjectId: number, headSha: string): RepairRound[] {
+  const repairedBy = database.prepare(`
+    SELECT tasks.id AS task_id, tasks.revision_id, publication_commands.commit_sha,
+      json_extract(revisions.payload, '$.headSha') AS repaired_head_sha,
+      repair_reports.summary, repair_reports.checks
     FROM publication_commands
     JOIN tasks ON tasks.id = publication_commands.task_id
+    JOIN revisions ON revisions.id = tasks.revision_id
+    LEFT JOIN repair_reports ON repair_reports.task_id = tasks.id
     WHERE tasks.subject_id = ? AND tasks.kind = 'review_fix'
       AND publication_commands.state_tag = 'Published'
       AND publication_commands.commit_sha = ?
     ORDER BY publication_commands.published_at DESC, publication_commands.id DESC
     LIMIT 1
-  `).get(subjectId, subject.headSha) as { revision_id: string } | undefined
-  if (repaired === undefined)
-    return undefined
-  const previous = new Set(openReviewFindings(database, subjectId, repaired.revision_id).map(findingIdentity))
-  return openReviewFindings(database, subjectId, revisionId).find(finding => previous.has(findingIdentity(finding)))
+  `)
+  const rounds: RepairRound[] = []
+  const seen = new Set<string>()
+  let commitSha = headSha
+  while (!seen.has(commitSha)) {
+    seen.add(commitSha)
+    const row = repairedBy.get(subjectId, commitSha) as {
+      task_id: string
+      revision_id: string
+      commit_sha: string
+      repaired_head_sha: string | null
+      summary: string | null
+      checks: string | null
+    } | undefined
+    if (row === undefined || row.repaired_head_sha === null)
+      break
+    rounds.unshift({
+      number: 0,
+      revisionId: row.revision_id,
+      commitSha: row.commit_sha,
+      summary: row.summary,
+      checks: row.checks === null ? [] : JSON.parse(row.checks) as string[],
+      findings: openReviewFindings(database, subjectId, row.revision_id).map(finding => finding.summary),
+    })
+    commitSha = row.repaired_head_sha
+  }
+  return rounds.map((round, index) => ({ ...round, number: index + 1 }))
 }
 
 function requeueReviewFix(
@@ -3604,6 +3626,7 @@ function requeueReviewFix(
   existing: { id: string, state_tag: TaskRow['state_tag'], fence: number },
   reason: string,
   observedAt: string,
+  rounds: { number: number, limit: number },
 ): ReviewFixPlan {
   database.prepare(`
     UPDATE tasks
@@ -3620,7 +3643,7 @@ function requeueReviewFix(
     fence: existing.fence,
     at: observedAt,
   })
-  return { _tag: 'Planned', taskId: existing.id }
+  return { _tag: 'Planned', taskId: existing.id, rounds }
 }
 
 /**
@@ -3658,11 +3681,12 @@ function planReviewFix(
   const dismissal = openFindings.find(finding => finding.resolution === 'Dismissal')
   if (dismissal !== undefined)
     return refuse(`Review recommends Dismissal: ${cleanLine(dismissal.summary)}`)
-  const repeated = repeatedReviewFinding(database, subject, subjectId, revisionId)
-  if (repeated !== undefined)
-    return refuse(`A repaired head still has the same Review finding: ${cleanLine(repeated.summary)}`)
   if (openFindings.length === 0)
     return refuse('The Review recorded no open finding to repair.')
+  const round = planRepairRound(reviewFixRounds(database, subjectId, subject.headSha))
+  if (round._tag === 'Exhausted')
+    return refuse(round.reason)
+  const rounds = { number: round.number, limit: REPAIR_ROUND_LIMIT }
 
   database.prepare(`
     INSERT OR IGNORE INTO pull_request_approvals (subject_id, revision_id, kind, approved_at)
@@ -3683,17 +3707,17 @@ function planReviewFix(
       VALUES (?, ?, ?, 'review_fix', 'Queued', NULL, ?)
     `).run(taskId, subjectId, revisionId, observedAt)
     recordTransition(database, { taskId, from: null, to: 'Queued', reason: null, fence: 0, at: observedAt })
-    return { _tag: 'Planned', taskId }
+    return { _tag: 'Planned', taskId, rounds }
   }
   if (existing.cancelled === 1)
     return { _tag: 'Refused', reason: REVIEW_REPAIR_REFUSALS.cancelled }
   if (existing.state_tag === 'Queued')
-    return { _tag: 'Planned', taskId: existing.id }
+    return { _tag: 'Planned', taskId: existing.id, rounds }
   // A newer Review recorded exact findings for this same head commit.
   if (existing.state_tag === 'Superseded')
-    return requeueReviewFix(database, existing, 'The exact pull request head commit is active again.', observedAt)
+    return requeueReviewFix(database, existing, 'The exact pull request head commit is active again.', observedAt, rounds)
   if (existing.state_tag === 'Failed' || existing.state_tag === 'ActionRequired')
-    return requeueReviewFix(database, existing, 'The review made a newer repair for this head commit.', observedAt)
+    return requeueReviewFix(database, existing, 'The review made a newer repair for this head commit.', observedAt, rounds)
   if (existing.state_tag === 'Completed')
     return { _tag: 'Refused', reason: REVIEW_REPAIR_REFUSALS.published }
   return { _tag: 'Refused', reason: REVIEW_REPAIR_REFUSALS.owned }
@@ -5131,6 +5155,18 @@ const writeQuarantineIncidentMigration = `
   PRAGMA user_version = 59;
 `
 
+/** Stores what each Repair Agent reported, so a later Repair round can read it. */
+const repairReportMigration = `
+  CREATE TABLE repair_reports (
+    task_id TEXT PRIMARY KEY REFERENCES tasks(id),
+    summary TEXT NOT NULL,
+    checks TEXT NOT NULL,
+    recorded_at TEXT NOT NULL
+  );
+
+  PRAGMA user_version = 60;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -5391,9 +5427,13 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 58) {
     applyMigration(database, writeQuarantineIncidentMigration)
+    version = 59
+  }
+  if (version === 59) {
+    applyMigration(database, repairReportMigration)
     return
   }
-  if (version === 59)
+  if (version === 60)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -7359,8 +7399,10 @@ export function openJournalStore(
       if (subject.kind !== 'pull_request')
         throw new Error(`Pull request Task ${row.id} crossed the issue claim boundary.`)
       const task = { ...taskBase, kind, pullRequestNumber: row.github_number, pullRequest: subject }
-      if (kind === 'review_fix')
-        return { ...task, kind }
+      if (kind === 'review_fix') {
+        const prior = reviewFixRounds(database, row.subject_id, subject.headSha)
+        return { ...task, kind, rounds: { number: prior.length + 1, limit: REPAIR_ROUND_LIMIT, prior } }
+      }
       if (kind === 'resolve_conflict')
         return { ...task, kind }
       if (kind === 'baseline_repair')
@@ -7428,13 +7470,29 @@ export function openJournalStore(
       const plan = planReviewFix(database, subject, row.subject_id, row.revision_id, input.at, mapping)
       database.exec('COMMIT')
       return plan._tag === 'Planned'
-        ? { _tag: 'Queued', taskId: plan.taskId }
+        ? { _tag: 'Queued', taskId: plan.taskId, rounds: plan.rounds }
         : { _tag: 'ActionRequired', reason: plan.reason }
     }
     catch (error) {
       database.exec('ROLLBACK')
       throw error
     }
+  }
+
+  const recordRepairReport: JournalStore['recordRepairReport'] = (input) => {
+    const owned = database.prepare(`
+      SELECT 1 FROM tasks
+      WHERE id = ? AND kind = 'review_fix' AND state_tag = 'Running'
+        AND worker_id = ? AND fence = ? AND lease_expires_at > ?
+    `).get(input.taskId, input.workerId, input.fence, input.at) !== undefined
+    if (!owned)
+      return false
+    database.prepare(`
+      INSERT INTO repair_reports (task_id, summary, checks, recorded_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT (task_id) DO UPDATE SET summary = excluded.summary, checks = excluded.checks, recorded_at = excluded.recorded_at
+    `).run(input.taskId, input.summary, JSON.stringify(input.checks), input.at)
+    return true
   }
 
   const retireBaselineRepairForReview: JournalStore['retireBaselineRepairForReview'] = (input) => {
@@ -12754,6 +12812,7 @@ export function openJournalStore(
     claimNextIssueWorkTask,
     claimNextReviewFixTask,
     queueReviewFixTaskForReview,
+    recordRepairReport,
     queueBaselineRepairForReview,
     retireBaselineRepairForReview,
     claimNextPublication,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -477,6 +477,7 @@ export interface ClaimedReviewFixTask extends ReviewFixTask {
   state: Extract<TaskState, { _tag: 'Running' }>
   repositoryMapping: RepositoryMapping
   pullRequest: GitHubPullRequestItem
+  rounds: { number: number, limit: number, prior: RepairRound[] }
 }
 
 /**
@@ -488,8 +489,25 @@ export interface ClaimedReviewFixTask extends ReviewFixTask {
  * wording of a reason, decides whether the review runs again.
  */
 export type ReviewFixQueueResult
-  = | { _tag: 'Queued', taskId: string }
+  = | { _tag: 'Queued', taskId: string, rounds: { number: number, limit: number } }
     | { _tag: 'ActionRequired', reason: string }
+
+/**
+ * One earlier controller Repair in the chain that produced the current head.
+ *
+ * Round 1 is the first Repair after a contributor commit. A later round reads
+ * every earlier one, so it never repeats an approach Review already rejected.
+ */
+export interface RepairRound {
+  number: number
+  revisionId: string
+  commitSha: string
+  /** What that round's Repair Agent reported, or null when the report was never stored. */
+  summary: string | null
+  checks: string[]
+  /** Summaries of the findings that round set out to fix. */
+  findings: string[]
+}
 
 export interface BaselineRepairTask {
   id: string

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -395,7 +395,7 @@ describe('subject Workers', () => {
       store: {
         queueReviewFixTaskForReview: () => {
           queued = true
-          return { _tag: 'Queued', taskId: 'repair-task' }
+          return { _tag: 'Queued', taskId: 'repair-task', rounds: { number: 1, limit: 3 } }
         },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,

--- a/packages/harlan-github-agent/test/review-fix-worker.test.ts
+++ b/packages/harlan-github-agent/test/review-fix-worker.test.ts
@@ -20,6 +20,7 @@ describe('review fix Worker', () => {
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: mapping,
       pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
     }
     const findings: ReviewFinding[] = [{
       _tag: 'Open',
@@ -58,6 +59,7 @@ describe('review fix Worker', () => {
       status: { publishRepair: () => Promise.resolve(ok(undefined)) },
       store: {
         getReviewFixFindings: () => findings,
+        recordRepairReport: () => true,
         getWorkerSession: () => 'review-session-must-not-resume',
         requestReviewRerun: () => { throw new Error('A successful Repair must not queue another Review.') },
         saveWorkerSession: () => undefined,
@@ -95,6 +97,101 @@ describe('review fix Worker', () => {
     expect(capture.requests[0]?.prompt).toContain('Download images only from GitHub-hosted media URLs')
   })
 
+  it('hands a later round the earlier rounds and stores its own report', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const mapping = repositoryMapping({ ownership: 'maintained' })
+    const task: ClaimedReviewFixTask = {
+      id: 'repair-task-2',
+      kind: 'review_fix',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-2',
+      state: { _tag: 'Running', workerId: 'repair-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+      rounds: {
+        number: 2,
+        limit: 3,
+        prior: [{
+          number: 1,
+          revisionId: 'revision-1',
+          commitSha: 'a'.repeat(40),
+          summary: 'Widened the parser guard.',
+          checks: ['pnpm vitest run test/parser.test.ts'],
+          findings: ['The parser drops buffered bytes.'],
+        }],
+      },
+    }
+    const findings: ReviewFinding[] = [{
+      _tag: 'Open',
+      summary: 'The parser drops buffered bytes.',
+      nextAction: 'Preserve all buffered bytes.',
+      details: {
+        fingerprint: 'f'.repeat(64),
+        location: { path: 'src/parser.ts', line: 42 },
+        proof: 'A split UTF-8 sequence still loses its first byte after the widened guard.',
+        regressionTest: 'Split one UTF-8 sequence across two chunks and assert the original string.',
+      },
+    }]
+    const capture: ProviderCapture = { requests: [] }
+    const reports: Array<{ summary: string, checks: string[] }> = []
+
+    const result = await createReviewFixWorker({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        outcome: 'repaired',
+        summary: 'Buffered the partial sequence across chunks.',
+        checks: ['pnpm vitest run test/parser.test.ts'],
+        commitMessage: 'fix(parser): buffer partial sequences',
+      }), capture)),
+      status: { publishRepair: () => Promise.resolve(ok(undefined)) },
+      store: {
+        getReviewFixFindings: () => findings,
+        getWorkerSession: () => null,
+        recordRepairReport: (input) => {
+          reports.push({ summary: input.summary, checks: input.checks })
+          return true
+        },
+        requestReviewRerun: () => { throw new Error('A successful Repair must not queue another Review.') },
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: () => Promise.resolve(ok(mapping)),
+      worktrees: {
+        prepare: () => Promise.resolve(ok({ path: '/tmp/repair-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+        verify: () => Promise.resolve(ok({ digest: 'patch-digest', changedFiles: 2 })),
+        commit: () => Promise.resolve(ok({
+          commitSha: 'repair-commit-2',
+          baseSha: pullRequest.baseSha,
+          artifactRef: 'artifact-ref',
+          digest: 'patch-digest',
+          changedFiles: 2,
+        })),
+      },
+    }).run(task, new AbortController().signal)
+
+    expect(result).toMatchObject({ _tag: 'Ok', value: { _tag: 'Publish' } })
+    const prompt = capture.requests[0]?.prompt ?? ''
+    expect(prompt).toContain('This is Repair round 2 of 3.')
+    expect(prompt).toContain(`Round 1 published commit ${'a'.repeat(40)}.`)
+    expect(prompt).toContain('Its Repair Agent reported: Widened the parser guard.')
+    expect(prompt).toContain('Treat every earlier approach as rejected.')
+    expect(reports).toEqual([{ summary: 'Buffered the partial sequence across chunks.', checks: ['pnpm vitest run test/parser.test.ts'] }])
+  })
+
   it('queues one fresh Review when Repair disproves a finding', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const mapping = repositoryMapping({ ownership: 'maintained' })
@@ -108,6 +205,7 @@ describe('review fix Worker', () => {
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: mapping,
       pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
     }
     const findings: ReviewFinding[] = [{
       _tag: 'Open',
@@ -145,6 +243,7 @@ describe('review fix Worker', () => {
       status: { publishRepair: () => Promise.resolve(ok(undefined)) },
       store: {
         getReviewFixFindings: () => findings,
+        recordRepairReport: () => true,
         getWorkerSession: () => null,
         requestReviewRerun: (input) => {
           reruns.push(input)
@@ -191,6 +290,7 @@ describe('review fix Worker', () => {
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: mapping,
       pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
     }
     const openFinding = (fingerprint: string): ReviewFinding => ({
       _tag: 'Open',
@@ -227,6 +327,7 @@ describe('review fix Worker', () => {
         status: { publishRepair: () => Promise.resolve(ok(undefined)) },
         store: {
           getReviewFixFindings: () => findings,
+          recordRepairReport: () => true,
           getWorkerSession: () => null,
           requestReviewRerun: (input) => {
             reruns.push(input.requestId)
@@ -267,6 +368,7 @@ describe('review fix Worker', () => {
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: mapping,
       pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
     }
     const findings: ReviewFinding[] = [{
       _tag: 'Open',
@@ -303,6 +405,7 @@ describe('review fix Worker', () => {
       status: { publishRepair: () => Promise.resolve(ok(undefined)) },
       store: {
         getReviewFixFindings: () => findings,
+        recordRepairReport: () => true,
         getWorkerSession: () => null,
         requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'DisputeCapReached' } }),
         saveWorkerSession: () => undefined,
@@ -337,6 +440,7 @@ describe('review fix Worker', () => {
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: mapping,
       pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
     }
     const findings: ReviewFinding[] = [{
       _tag: 'Open',
@@ -374,6 +478,7 @@ describe('review fix Worker', () => {
       status: { publishRepair: () => Promise.resolve(ok(undefined)) },
       store: {
         getReviewFixFindings: () => findings,
+        recordRepairReport: () => true,
         getWorkerSession: () => null,
         requestReviewRerun: () => { throw new Error('An invalid result must not queue another Review.') },
         saveWorkerSession: () => undefined,

--- a/packages/harlan-github-agent/test/review-fix-worktree.test.ts
+++ b/packages/harlan-github-agent/test/review-fix-worktree.test.ts
@@ -70,6 +70,7 @@ function fixture(): { remote: string, root: string, task: ClaimedReviewFixTask }
       state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T01:10:00.000Z' },
       repositoryMapping: mapping,
       pullRequest: pullRequestItem({ number: 1, baseSha, headSha, headRef: 'fix/review', mergeState: 'clean' }),
+      rounds: { number: 1, limit: 3, prior: [] },
     },
   }
 }

--- a/packages/harlan-github-agent/test/review-repair-claim.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-claim.test.ts
@@ -562,27 +562,30 @@ describe('review Repair queue', () => {
     })])
   })
 
-  it('stops when a published Repair leaves the same finding', () => {
-    const store = createStore()
-    const { review, revisionId } = runningReview(store, 'fix/repeated-finding')
-    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
-    const queued = store.queueReviewFixTaskForReview({
-      taskId: review.id,
-      workerId: review.state.workerId,
-      fence: review.state.fence,
-      at: '2026-08-13T01:00:04.000Z',
-    })
-    if (queued._tag !== 'Queued')
-      throw new Error(queued.reason)
-    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:05.000Z', 60_000)
+  /**
+   * Runs one full Repair round: claim the Repair, store its report, publish
+   * its commit, observe the new head, and record the fresh Review finding.
+   * Returns the fresh Review Task that now decides whether another round starts.
+   */
+  function publishRepairRound(store: ReturnType<typeof openJournalStore>, headRef: string, round: number) {
+    const at = (second: number) => `2026-08-13T01:0${round}:${String(second).padStart(2, '0')}.000Z`
+    const repair = store.claimNextReviewFixTask(`repair-agent-${round}`, at(5), 60_000)
     if (repair === null)
-      throw new Error('Expected the Repair Task.')
-    const repairCommit = 'd'.repeat(40)
+      throw new Error(`Expected the round ${round} Repair Task.`)
+    expect(store.recordRepairReport({
+      taskId: repair.id,
+      workerId: repair.state.workerId,
+      fence: repair.state.fence,
+      at: at(6),
+      summary: `Round ${round} widened the parser guard.`,
+      checks: ['pnpm vitest run test/parser.test.ts'],
+    })).toBe(true)
+    const repairCommit = String(round).repeat(40)
     expect(store.stagePublication({
       taskId: repair.id,
       workerId: repair.state.workerId,
       fence: repair.state.fence,
-      at: '2026-08-13T01:00:06.000Z',
+      at: at(7),
       publication: {
         _tag: 'UpdatePullRequest',
         taskKind: 'review_fix',
@@ -592,46 +595,87 @@ describe('review Repair queue', () => {
         baseSha: 'base123',
         expectedHeadSha: repair.pullRequest.headSha,
         headRef: repair.pullRequest.headRef,
-        artifactRef: 'refs/harlan-github-agent/publications/repeated-finding',
-        patchDigest: 'repair-patch',
+        artifactRef: `refs/harlan-github-agent/publications/${headRef}-${round}`,
+        patchDigest: `repair-patch-${round}`,
         changedFiles: 2,
       },
     })._tag).toBe('Staged')
-    const publication = store.claimNextPublication('publisher', '2026-08-13T01:00:07.000Z', 60_000)
+    const publication = store.claimNextPublication('publisher', at(8), 60_000)
     if (publication === null)
       throw new Error('Expected the Repair Publication.')
     expect(store.completePublication({
       commandId: publication.id,
       workerId: publication.workerId,
       fence: publication.fence,
-      at: '2026-08-13T01:00:08.000Z',
+      at: at(9),
       evidence: 'Published Repair commit.',
     })).toBe(true)
-
     const repaired = store.recordObservation({
-      externalId: 'repeated-finding-repaired-head',
-      observedAt: '2026-08-13T01:01:00.000Z',
+      externalId: `${headRef}-repaired-${round}`,
+      observedAt: at(10),
       source: 'poll',
-      subject: pullRequestItem({
-        headRef: 'fix/repeated-finding',
-        headSha: repairCommit,
-        mergeState: 'clean',
-        updatedAt: '2026-08-13T01:01:00.000Z',
-      }),
+      subject: pullRequestItem({ headRef, headSha: repairCommit, mergeState: 'clean', updatedAt: at(10) }),
     })
     if (repaired._tag !== 'Inserted')
       throw new Error('Expected a new repaired Revision.')
-    const freshReview = store.claimNextAdversarialReviewTask('fresh-review-agent', '2026-08-13T01:01:01.000Z', 60_000)
+    const freshReview = store.claimNextAdversarialReviewTask(`fresh-review-agent-${round}`, at(11), 60_000)
     if (freshReview === null)
       throw new Error('Expected a fresh Review Task.')
     recordOpenFinding(store, repaired.revisionId, repairCommit)
+    return { repair, freshReview, at: at(12) }
+  }
 
-    expect(store.queueReviewFixTaskForReview({
-      taskId: freshReview.id,
-      workerId: freshReview.state.workerId,
-      fence: freshReview.state.fence,
-      at: '2026-08-13T01:01:02.000Z',
-    })).toEqual({ _tag: 'ActionRequired', reason: 'A repaired head still has the same Review finding: Unsafe parser input.' })
+  function queueRound(store: ReturnType<typeof openJournalStore>, review: { id: string, state: { workerId: string, fence: number } }, at: string) {
+    return store.queueReviewFixTaskForReview({ taskId: review.id, workerId: review.state.workerId, fence: review.state.fence, at })
+  }
+
+  it('starts a second Repair round that reads the first round when the finding survives', () => {
+    const store = createStore()
+    const { review, revisionId } = runningReview(store, 'fix/repeated-finding')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
+    expect(queueRound(store, review, '2026-08-13T01:00:04.000Z')).toMatchObject({ _tag: 'Queued', rounds: { number: 1, limit: 3 } })
+
+    const first = publishRepairRound(store, 'fix/repeated-finding', 1)
+    expect(queueRound(store, first.freshReview, first.at)).toMatchObject({ _tag: 'Queued', rounds: { number: 2, limit: 3 } })
+
+    const second = store.claimNextReviewFixTask('repair-agent-2', '2026-08-13T01:02:00.000Z', 60_000)
+    if (second === null)
+      throw new Error('Expected the round 2 Repair Task.')
+    expect(second.rounds).toEqual({
+      number: 2,
+      limit: 3,
+      prior: [{
+        number: 1,
+        revisionId,
+        commitSha: '1'.repeat(40),
+        summary: 'Round 1 widened the parser guard.',
+        checks: ['pnpm vitest run test/parser.test.ts'],
+        findings: ['Unsafe parser input.'],
+      }],
+    })
+  })
+
+  it('stops with the round history once the round limit is spent', () => {
+    const store = createStore()
+    const { review, revisionId } = runningReview(store, 'fix/exhausted-rounds')
+    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
+    expect(queueRound(store, review, '2026-08-13T01:00:04.000Z')._tag).toBe('Queued')
+
+    const first = publishRepairRound(store, 'fix/exhausted-rounds', 1)
+    expect(queueRound(store, first.freshReview, first.at)).toMatchObject({ _tag: 'Queued', rounds: { number: 2 } })
+    const second = publishRepairRound(store, 'fix/exhausted-rounds', 2)
+    expect(queueRound(store, second.freshReview, second.at)).toMatchObject({ _tag: 'Queued', rounds: { number: 3 } })
+    const third = publishRepairRound(store, 'fix/exhausted-rounds', 3)
+
+    expect(queueRound(store, third.freshReview, third.at)).toEqual({
+      _tag: 'ActionRequired',
+      reason: 'Repair used 3 of 3 rounds and the finding remains. '
+        + 'Round 1 (`1111111`): Round 1 widened the parser guard. '
+        + 'Round 2 (`2222222`): Round 2 widened the parser guard. '
+        + 'Round 3 (`3333333`): Round 3 widened the parser guard. '
+        + 'A person decides the next step.',
+    })
+    expect(store.claimNextReviewFixTask('repair-agent-4', '2026-08-13T01:04:00.000Z', 60_000)).toBeNull()
   })
 
   it('hands a fresh Review the identities its repaired Revision reported', () => {

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -115,7 +115,7 @@ function harness(input: {
     store: {
       queueReviewFixTaskForReview: input.queueRepair ?? (() => {
         repairs.queued += 1
-        return { _tag: 'Queued', taskId: 'repair-task' }
+        return { _tag: 'Queued', taskId: 'repair-task', rounds: { number: 1, limit: 3 } }
       }),
       getRepairedHeadFindings: () => [],
       listReviewRuns: () => input.reviewRuns ?? [],

--- a/packages/harlan-github-agent/test/review-status-controller.test.ts
+++ b/packages/harlan-github-agent/test/review-status-controller.test.ts
@@ -18,6 +18,7 @@ describe('review status controller', () => {
       updatedAt: '2026-08-13T01:00:00.000Z',
       repositoryMapping: repository,
       pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
     }
     let replaced = false
     let body = ''
@@ -83,7 +84,7 @@ describe('review status controller', () => {
     expect(await controller.publishRepair(task, { percent: 35, label: 'Git worktree ready' }, new AbortController().signal)).toEqual(ok(undefined))
 
     expect(read().replaced).toBe(true)
-    expect(read().body).toContain('### 🤖 REPAIR · 35% · Git worktree ready')
+    expect(read().body).toContain('### 🤖 REPAIR · round 1 of 3 · 35% · Git worktree ready')
   })
 
   it('says how long one phase has run, so a slow agent reads as alive', async () => {
@@ -96,7 +97,7 @@ describe('review status controller', () => {
       new AbortController().signal,
     )).toEqual(ok(undefined))
 
-    expect(read().body).toContain('### 🤖 REPAIR · 70% · Editing files for 35 min')
+    expect(read().body).toContain('### 🤖 REPAIR · round 1 of 3 · 70% · Editing files for 35 min')
   })
 
   it('leaves a phase that just started without a duration', async () => {
@@ -108,6 +109,6 @@ describe('review status controller', () => {
       new AbortController().signal,
     )).toEqual(ok(undefined))
 
-    expect(read().body).toContain('### 🤖 REPAIR · 70% · Editing files\n')
+    expect(read().body).toContain('### 🤖 REPAIR · round 1 of 3 · 70% · Editing files\n')
   })
 })

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -37,7 +37,13 @@ function dropReviewResolutionAdditions(database: DatabaseSync): void {
     database.exec('ALTER TABLE review_status_commands DROP COLUMN review_run_id')
 }
 
+/** Rewinds past the Repair report table, which every version below 60 predates. */
+function dropRepairReports(database: DatabaseSync): void {
+  database.exec('DROP TABLE IF EXISTS repair_reports')
+}
+
 function dropRestartOperationAdditions(database: DatabaseSync): void {
+  dropRepairReports(database)
   const columns = database.prepare('PRAGMA table_info(restart_requests)').all() as unknown as Array<{ name: string }>
   if (columns.some(column => column.name === 'target_commit'))
     database.exec('ALTER TABLE restart_requests DROP COLUMN target_commit')
@@ -595,6 +601,7 @@ describe('write quarantine Incident recovery migration', () => {
     store.close()
 
     const oldJournal = new DatabaseSync(path)
+    dropRepairReports(oldJournal)
     oldJournal.exec('PRAGMA user_version = 58')
     oldJournal.close()
 
@@ -628,7 +635,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(59)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(60)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -3181,7 +3181,7 @@ describe('journal store', () => {
       workerId: rerun.state.workerId,
       fence: rerun.state.fence,
       at: '2026-08-13T01:02:03.000Z',
-    })).toEqual({ _tag: 'Queued', taskId: expect.any(String) })
+    })).toEqual({ _tag: 'Queued', taskId: expect.any(String), rounds: { number: 1, limit: 3 } })
   })
 
   it('does not carry Approval to a new Revision', () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

On nuxtseo.com#755 Repair pushed one commit, the fresh Review found the same defect, and the workflow stopped `BLOCKED`. The rule was one round with no memory, so a person had to step in for anything the first Repair Agent misread.

Repair now runs in rounds. A fresh Review that still finds a defect queues the next round, and that round is handed every earlier round's commit, report, and target findings with the instruction to treat them as rejected. A pull request gets 3 rounds per contributor commit; a contributor push starts a fresh count. When the rounds are spent, Repair stops with Action required and the comment lists every round:

```
### 🤖 REPAIR · round 2 of 3 · 35% · Repair worktree ready
```

```
Repair used 3 of 3 rounds and the finding remains. Round 1 (`5b4b20d`): ... A person decides the next step.
```

Schema moves to 60 with a `repair_reports` table. Not yet exercised on Hogwild; a `/harlan-agent rerun` on nuxtseo.com#755 after deploy is the first real round 2.

Open question: 3 is a guess. Happy to make it a per repository policy if two rounds turn out to be the usual number.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01AB4o9K84jwi2g4JJviCnrA