### PR TITLE
fix(agent): keep Routine runs visible across spec moves and outages

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -325,6 +325,9 @@ function restoreRecoveryBudget(database: DatabaseSync, github: string, at: strin
   return restored
 }
 
+/** How long a refused Candidate issue waits before the controller asks GitHub again. */
+const CANDIDATE_ISSUE_RETRY_MILLISECONDS = 24 * 60 * 60_000
+
 interface RecoveryCandidateRow {
   id: string
   fence: number
@@ -5131,6 +5134,20 @@ const writeQuarantineIncidentMigration = `
   PRAGMA user_version = 59;
 `
 
+/**
+ * Gives Routine runs the same recovery budget Tasks have.
+ *
+ * Six of seven check-ins failed one morning because the Agent provider was
+ * unreachable for half an hour. Each spent its three attempts inside that
+ * window and stayed Failed for the day. Recovery requeues them at capped
+ * backoff until the provider answers or the next instant supersedes them.
+ */
+const routineRecoveryMigration = `
+  ALTER TABLE routine_runs ADD COLUMN recovery_attempts INTEGER NOT NULL DEFAULT 0;
+
+  PRAGMA user_version = 60;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -5391,9 +5408,17 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 58) {
     applyMigration(database, writeQuarantineIncidentMigration)
+    version = 59
+  }
+  if (version === 59) {
+    // A journal rewound for replay already carries the column, and SQLite has
+    // no ADD COLUMN IF NOT EXISTS.
+    const columns = (database.prepare('PRAGMA table_info(routine_runs)').all() as unknown as Array<{ name: string }>)
+      .map(column => column.name)
+    applyMigration(database, columns.includes('recovery_attempts') ? 'PRAGMA user_version = 60;' : routineRecoveryMigration)
     return
   }
-  if (version === 59)
+  if (version === 60)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -8000,6 +8025,25 @@ export function openJournalStore(
           -- requeue here would skip that and work against the old approval.
           AND NOT (tasks.kind = 'issue_work' AND tasks.reason = 'The issue changed before work started.')
       `).all() as unknown as RecoveryCandidateRow[]).filter(row => isRecoverable(row, at))
+      // Only the newest run of a Routine recovers. Once the next instant has
+      // its own run, yesterday's failure is history, not work.
+      const routineRows = (database.prepare(`
+        SELECT routine_runs.id, routine_runs.fence, routine_runs.reason,
+          routine_runs.recovery_attempts, routine_runs.updated_at,
+          routines.repository, 0 AS github_number
+        FROM routine_runs
+        JOIN routines ON routines.id = routine_runs.routine_id
+        JOIN repositories ON repositories.github = routines.repository
+        WHERE routine_runs.state_tag = 'Failed'
+          AND routines.enabled = 1
+          AND routines.retired_at IS NULL
+          AND repositories.enabled = 1
+          AND NOT EXISTS (
+            SELECT 1 FROM routine_runs AS newer
+            WHERE newer.routine_id = routine_runs.routine_id
+              AND newer.scheduled_for > routine_runs.scheduled_for
+          )
+      `).all() as unknown as RecoveryCandidateRow[]).filter(row => isRecoverable(row, at))
       const issueScopeRows = database.prepare(`
         SELECT tasks.id AS task_id, tasks.fence AS task_fence,
           worker_tasks.id AS triage_id, worker_tasks.fence AS triage_fence
@@ -8037,6 +8081,13 @@ export function openJournalStore(
           lease_expires_at = NULL, updated_at = ?
         WHERE id = ? AND state_tag = 'Failed'
       `)
+      const retryRoutineRun = database.prepare(`
+        UPDATE routine_runs
+        SET state_tag = 'Queued', reason = NULL, attempts = 0, worker_id = NULL,
+          recovery_attempts = recovery_attempts + 1,
+          lease_expires_at = NULL, progress_percent = 0, progress_label = 'Starting', updated_at = ?
+        WHERE id = ? AND state_tag = 'Failed'
+      `)
       const awaitFreshTriage = database.prepare(`
         UPDATE tasks
         SET state_tag = 'Superseded', reason = ?,
@@ -8071,6 +8122,20 @@ export function openJournalStore(
         retried += 1
         recordTransition(database, {
           taskId: row.id,
+          from: 'Failed',
+          to: 'Queued',
+          reason: 'A recoverable controller failure was repaired.',
+          fence: row.fence,
+          at,
+        })
+      })
+      routineRows.forEach((row) => {
+        if (retryRoutineRun.run(at, row.id).changes !== 1)
+          return
+        retried += 1
+        recordRoutineRunEvent(database, {
+          runId: row.id,
+          event: 'Retrying',
           from: 'Failed',
           to: 'Queued',
           reason: 'A recoverable controller failure was repaired.',
@@ -11657,7 +11722,18 @@ export function openJournalStore(
     updatedAt: row.updated_at,
   })
 
-  /** Reconciles active definitions while preserving every historical Run. */
+  /**
+   * Reconciles active definitions while preserving every historical Run.
+   *
+   * A schedule change or a re-enable moves `last_run_at` to now, so the new
+   * schedule never fires for an instant that passed under the old one.
+   * Retiring and reviving a Routine leaves `last_run_at` and `enabled` alone,
+   * because a revival is not a re-enable and must not reset it. The spec moved
+   * to `.github/routines.yml` one afternoon, every Routine was retired and
+   * revived on the same pass, and the reset made that morning's run, which had
+   * never opened, read as already answered. Nothing reported it. With the
+   * instant kept, the planner records it as Skipped and the run log says so.
+   */
   const syncRoutines: JournalStore['syncRoutines'] = (input) => {
     const upsert = database.prepare(`
       INSERT INTO routines (id, repository, name, crons, time_zone, mode, enabled, spec_sha, last_run_at, retired_at, updated_at)
@@ -11667,7 +11743,6 @@ export function openJournalStore(
           WHEN routines.crons != excluded.crons
             OR routines.time_zone != excluded.time_zone
             OR routines.enabled != excluded.enabled
-            OR routines.retired_at IS NOT NULL
           THEN excluded.updated_at
           ELSE routines.last_run_at
         END,
@@ -11698,11 +11773,11 @@ export function openJournalStore(
       })
       database.prepare(`
         UPDATE routines
-        SET enabled = 0, retired_at = ?, last_run_at = ?, updated_at = ?
+        SET retired_at = ?, updated_at = ?
         WHERE repository = ?
           ${declared.length === 0 ? '' : `AND id NOT IN (${placeholders})`}
           AND retired_at IS NULL
-      `).run(input.at, input.at, input.at, input.repository, ...declared)
+      `).run(input.at, input.at, input.repository, ...declared)
 
       const superseded = database.prepare(`
         SELECT routine_runs.id, routine_runs.fence
@@ -11762,6 +11837,7 @@ export function openJournalStore(
     progress_percent: number
     progress_label: string
     usage: string
+    recovery_attempts: number
     created_at: string
     updated_at: string
   }
@@ -12210,7 +12286,21 @@ export function openJournalStore(
     }
   }
 
+  /**
+   * Requests one issue per Candidate.
+   *
+   * A command that GitHub refused for good stays Failed, but only for a day. A
+   * repository with Issues switched off refused seven proposals, and switching
+   * Issues on filed none of them, because nothing ever asked again. One try a
+   * day keeps a broken repository quiet and lets a repaired one catch up on its
+   * own. Each retry still reports its refusal as an Incident.
+   */
   const stageCandidateIssues: JournalStore['stageCandidateIssues'] = (input) => {
+    const revive = database.prepare(`
+      UPDATE candidate_issue_commands
+      SET state_tag = 'Pending', reason = NULL, attempts = 0, updated_at = ?
+      WHERE candidate_id = ? AND state_tag = 'Failed' AND updated_at <= ?
+    `)
     const statement = database.prepare(`
       INSERT INTO candidate_issue_commands (
         id, candidate_id, repository, routine_name, title, body, state_tag, created_at, updated_at
@@ -12218,10 +12308,24 @@ export function openJournalStore(
       VALUES (?, ?, ?, ?, ?, ?, 'Pending', ?, ?)
       ON CONFLICT (candidate_id) DO NOTHING
     `)
+    const revivableBefore = new Date(Date.parse(input.at) - CANDIDATE_ISSUE_RETRY_MILLISECONDS).toISOString()
     let staged = 0
     database.exec('BEGIN IMMEDIATE')
     try {
       input.commands.forEach((command) => {
+        if (revive.run(input.at, command.candidateId, revivableBefore).changes === 1) {
+          staged += 1
+          recordDurableCommandEvent(database, {
+            stream: 'candidate_issue',
+            commandId: command.id,
+            event: 'Revived',
+            from: 'Failed',
+            to: 'Pending',
+            reason: 'A day passed since GitHub refused this proposal, so it is asked again.',
+            at: input.at,
+          })
+          return
+        }
         const inserted = statement.run(
           command.id,
           command.candidateId,

--- a/packages/harlan-github-agent/test/candidate-issue.test.ts
+++ b/packages/harlan-github-agent/test/candidate-issue.test.ts
@@ -350,6 +350,38 @@ describe('filing the issues Candidates propose', () => {
     }
   })
 
+  it('asks again a day later, so a repository that switches Issues on gets its proposals', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store)
+      const commands = candidateIssueCommands(store.listCandidates(routine.routineId), routine)
+      store.stageCandidateIssues({ commands, at: now().toISOString() })
+      const refusing = {
+        findOpenIssueByFingerprint: () => Promise.resolve(ok(null)),
+        createComment: async () => ok({ id: 1 }),
+        createIssue: async () => ({
+          _tag: 'Err' as const,
+          error: { repository: 'harlan-zw/example', message: 'Issues has been disabled in this repository.', status: 410 },
+        }),
+      }
+      await createCandidateIssueController({ github: refusing, now, store, workerId: 'controller-1' })
+        .publishPending(new AbortController().signal)
+
+      expect(store.stageCandidateIssues({ commands, at: '2026-08-27T20:00:00.000Z' })).toBe(0)
+      expect(store.claimNextCandidateIssue('controller-2', '2026-08-27T20:00:00.000Z', 60_000)).toBeNull()
+
+      expect(store.stageCandidateIssues({ commands, at: '2026-08-28T07:10:00.000Z' })).toBe(1)
+      const calls: Array<{ title: string, labels?: readonly string[] }> = []
+      await createCandidateIssueController({ github: publisher(calls), now: () => new Date('2026-08-28T07:10:00.000Z'), store, workerId: 'controller-3' })
+        .publishPending(new AbortController().signal)
+
+      expect(calls.map(call => call.title)).toEqual(['pr-triage: This helper is never called.'])
+    }
+    finally {
+      store.close()
+    }
+  })
+
   it('stops a proposal that spends its attempts on the same refusal', async () => {
     const store = openJournalStore(':memory:')
     try {

--- a/packages/harlan-github-agent/test/routine-controller.test.ts
+++ b/packages/harlan-github-agent/test/routine-controller.test.ts
@@ -297,3 +297,40 @@ routines:
     }
   })
 })
+
+const sydneySpec = 'version: 1\nroutines:\n  - name: sentry-checkin\n    on:\n      schedule:\n        - cron: "0 5 * * *"\n    timezone: Australia/Sydney\n    mode: propose\n    enabled: true\n'
+
+describe('moving a Routine spec', () => {
+  it('keeps the last run across retire and revive, so a missed instant is still reported', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      await syncRepositoryRoutines(repositoryMapping(), {
+        github: githubReturning(ok({ _tag: 'Present', specSha: 'abc123', text: sydneySpec })),
+        now: at('2026-08-30T18:00:00.000Z'),
+        store,
+      })
+      const onTime = planRoutineRuns({ now: at('2026-08-30T19:00:30.000Z'), store })
+      expect(onTime.opened.map(run => run.scheduledFor)).toEqual(['2026-08-30T19:00:00.000Z'])
+
+      // The next morning passes with no pass planning it. That afternoon the
+      // spec file moves, so one sync retires the Routine and the next revives it.
+      await syncRepositoryRoutines(repositoryMapping(), {
+        github: githubReturning(ok({ _tag: 'Absent', specSha: 'def456' })),
+        now: at('2026-09-01T04:21:49.000Z'),
+        store,
+      })
+      await syncRepositoryRoutines(repositoryMapping(), {
+        github: githubReturning(ok({ _tag: 'Present', specSha: 'def456', text: sydneySpec })),
+        now: at('2026-09-01T04:21:50.000Z'),
+        store,
+      })
+
+      const afterMove = planRoutineRuns({ now: at('2026-09-01T04:25:00.000Z'), store })
+      expect(afterMove.opened).toEqual([])
+      expect(afterMove.skipped.map(run => run.scheduledFor)).toEqual(['2026-08-31T19:00:00.000Z'])
+    }
+    finally {
+      store.close()
+    }
+  })
+})

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -628,7 +628,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(59)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(60)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4708,6 +4708,69 @@ describe('journal store', () => {
       .toContain('RestartRecovered')
   })
 
+  it('requeues a Routine run that failed while the Agent provider was unreachable', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const [routine] = store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'sentry-checkin', crons: ['0 9 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+      at: '2026-08-13T00:01:00.000Z',
+    })
+    if (routine === undefined)
+      throw new Error('Expected a stored Routine.')
+    store.openRoutineRun({ routineId: routine.id, scheduledFor: '2026-08-13T09:00:00.000Z', specSha: routine.specSha, at: '2026-08-13T09:00:01.000Z' })
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextRoutineRun('routine-1', `2026-08-13T09:0${attempt}:00.000Z`, 60_000)
+      if (task === null)
+        throw new Error('Expected a queued Routine run.')
+      expect(store.failRoutineRun({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-13T09:0${attempt}:30.000Z`,
+        reason: 'The opencode session failed: Internal network failure, please try again later.',
+      })).toBe(attempt < 3 ? 'Retrying' : 'Failed')
+    }
+    expect(store.claimNextRoutineRun('routine-2', '2026-08-13T09:04:00.000Z', 60_000)).toBeNull()
+
+    expect(store.retryRecoverableWorkerFailures('2026-08-13T09:05:00.000Z')).toBe(1)
+    expect(store.claimNextRoutineRun('routine-3', '2026-08-13T09:06:00.000Z', 60_000)).toMatchObject({
+      attempts: 1,
+      state: { fence: 4 },
+    })
+  })
+
+  it('leaves a failed Routine run alone once a newer instant has its own run', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const [routine] = store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'sentry-checkin', crons: ['0 9 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+      at: '2026-08-13T00:01:00.000Z',
+    })
+    if (routine === undefined)
+      throw new Error('Expected a stored Routine.')
+    store.openRoutineRun({ routineId: routine.id, scheduledFor: '2026-08-13T09:00:00.000Z', specSha: routine.specSha, at: '2026-08-13T09:00:01.000Z' })
+    for (const attempt of [1, 2, 3]) {
+      const task = store.claimNextRoutineRun('routine-1', `2026-08-13T09:0${attempt}:00.000Z`, 60_000)
+      if (task === null)
+        throw new Error('Expected a queued Routine run.')
+      store.failRoutineRun({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: `2026-08-13T09:0${attempt}:30.000Z`,
+        reason: 'The opencode session failed: Internal network failure, please try again later.',
+      })
+    }
+    store.openRoutineRun({ routineId: routine.id, scheduledFor: '2026-08-14T09:00:00.000Z', specSha: routine.specSha, at: '2026-08-14T09:00:01.000Z' })
+
+    expect(store.retryRecoverableWorkerFailures('2026-08-14T09:00:02.000Z')).toBe(0)
+    expect(store.claimNextRoutineRun('routine-2', '2026-08-14T09:00:03.000Z', 60_000)?.scheduledFor).toBe('2026-08-14T09:00:00.000Z')
+  })
+
   it('requeues a task that an earlier shutdown recorded as aborted', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Three faults from the last week of `sentry-checkin` runs on Hogwild.

On 1 September no check-in ran and nothing said so. That morning's poll pass was still aborting on the review gate defect #124 fixed, so the 05:00 instant never opened. In the afternoon the spec moved to `.github/routines.yml`, which retired and revived every Routine on one pass, and the revival stamped `last_run_at` with the current time. The missed instant then read as already answered. Retire and revive now leave `last_run_at` and `enabled` alone, so the planner records the instant as Skipped and the run log says it.

`unhead.unjs.io` had Issues disabled, so seven proposals failed for good and switching Issues on (done today) would never have filed them. A Failed Candidate issue is asked again once a day.

On 31 August the GLM endpoint was down for half an hour. Six runs spent their three attempts inside that window and stayed Failed for the day. Failed Routine runs join the same recovery pass Tasks use, at the same capped backoff, until the next instant has its own run.

Migration adds `recovery_attempts` to `routine_runs` (v60). Deploy with `pnpm service:hogwild:update`; the DB backup and pause it needs are in the deployment notes.

Open question: a cron or timezone change still resets `last_run_at` to now, so a changed schedule never catches up on an instant from the same day. I left that as is. Say if you would rather see those as Skipped too.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ