### PR TITLE
fix(agent): retire a review comment another actor owns

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -165,10 +165,21 @@ export interface PublishedReviewStatus {
  * `Missing` means a person deleted the comment, so there is nothing to correct.
  * `Changed` means somebody wrote it after the caller last read it.
  */
+/**
+ * Why a stored comment id names a comment this service must never edit.
+ *
+ * Neither reason changes on a later pass, so a caller retires the publication
+ * that holds the id instead of asking GitHub the same question every pass.
+ */
+export type ForeignReviewCommentReason
+  = | 'The stored automated review comment belongs to another pull request.'
+    | 'The stored automated review comment belongs to another GitHub actor.'
+
 export type EditedReviewStatus
   = | { _tag: 'Edited', commentId: number, url: string }
     | { _tag: 'Changed' }
     | { _tag: 'Missing' }
+    | { _tag: 'Foreign', reason: ForeignReviewCommentReason }
 
 export interface GitHubAgentSource {
   consumeApprovalLabel: (repository: RepositoryMapping, subjectKind: 'issue' | 'pull_request', itemNumber: number, label: string, signal: AbortSignal) => Promise<Result<void, string>>
@@ -727,7 +738,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
       return octokit.value.rest.issues.getComment({ owner, repo, comment_id: commentId, ...requestOptions })
         .then(async (existing) => {
           if (existing.data.issue_url !== undefined && !existing.data.issue_url.endsWith(`/${pullRequestNumber}`))
-            return err('The stored automated review comment belongs to another pull request.')
+            return ok({ _tag: 'Foreign' as const, reason: 'The stored automated review comment belongs to another pull request.' as const })
           const legacyActor = options.legacyActor
           const existingHead = automatedReviewHead(existing.data.body ?? '')?.toLowerCase()
           const expectedHead = automatedReviewHead(expectedBody)?.toLowerCase()
@@ -741,7 +752,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
             && existingHead === expectedHead
             && existingHead === nextHead
           if (existing.data.user?.login.toLowerCase() !== actor && !legacyOwned)
-            return err('The stored automated review comment belongs to another GitHub actor.')
+            return ok({ _tag: 'Foreign' as const, reason: 'The stored automated review comment belongs to another GitHub actor.' as const })
           if (existing.data.body === body && existing.data.html_url !== undefined)
             return ok({ _tag: 'Edited' as const, commentId: existing.data.id, url: existing.data.html_url })
           if (existing.data.body !== expectedBody)

--- a/packages/harlan-github-agent/src/queue-position-sweep.ts
+++ b/packages/harlan-github-agent/src/queue-position-sweep.ts
@@ -63,6 +63,7 @@ export type QueuePositionOutcome
   = | { _tag: 'Published', repository: string, pullRequestNumber: number, queue: ReviewQueueState }
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
+    | { _tag: 'Retired', repository: string, pullRequestNumber: number, reason: string }
 
 /**
  * Tells a waiting pull request where its Task sits in the Queue.
@@ -132,6 +133,20 @@ export async function publishQueuePositions(
         reason: 'A person deleted the comment.',
       })
       return ok({ _tag: 'CommentGone', repository: status.repository, pullRequestNumber: status.pullRequestNumber })
+    }
+    if (edited.value._tag === 'Foreign') {
+      // The stored id names a comment another actor or pull request owns, and
+      // that never changes. One pull request asked GitHub 173 times in an
+      // afternoon. Retiring the publication ends it, and the next Review opens
+      // its own comment.
+      options.store.recordDeletedReviewComment({
+        taskKind: status.taskKind,
+        taskId: status.taskId,
+        commentId: status.commentId,
+        at,
+        reason: edited.value.reason,
+      })
+      return ok({ _tag: 'Retired', repository: status.repository, pullRequestNumber: status.pullRequestNumber, reason: edited.value.reason })
     }
     if (edited.value._tag === 'Changed')
       return ok({ _tag: 'Superseded', repository: status.repository, pullRequestNumber: status.pullRequestNumber })

--- a/packages/harlan-github-agent/src/review-gate-sweep.ts
+++ b/packages/harlan-github-agent/src/review-gate-sweep.ts
@@ -2,6 +2,7 @@ import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
 import type { JournalStore, ReviewGateRefresh } from './store.ts'
 import type { RepositoryMapping, ReviewOutcomeName } from './types.ts'
+import { createHash } from 'node:crypto'
 import { refreshControllerGates, reviewOutcome, terminalComment } from './item-agent.ts'
 import { err, ok } from './result.ts'
 
@@ -9,12 +10,13 @@ export type ReviewGateRefreshOutcome
   = | { _tag: 'PublicationQueued', repository: string, pullRequestNumber: number, outcome: ReviewOutcomeName }
     | { _tag: 'Unchanged', repository: string, pullRequestNumber: number, outcome: ReviewOutcomeName, reason: string }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
+    | { _tag: 'Retired', repository: string, pullRequestNumber: number, reason: string }
 
 export interface ReviewGateSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot' | 'stampAgentLabel'>
   now: () => Date
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'stageReviewGateStatus'>
+  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'recordReviewPublication' | 'stageReviewGateStatus'>
 }
 
 /**
@@ -58,6 +60,23 @@ export async function refreshReviewGates(
       )
       if (confirmed._tag === 'Err')
         return err(`${review.repository}#${review.pullRequestNumber}: ${confirmed.error}`)
+      if (confirmed.value._tag === 'Foreign') {
+        // The stored id names a comment another actor or pull request owns.
+        // Staging a fresh status would send the publish loop back to the same
+        // id every pass. A failed Publication with the reason takes this
+        // Review out of the refresh list, and the next Review opens its own.
+        const at = options.now().toISOString()
+        const recorded = options.store.recordReviewPublication({
+          id: createHash('sha256').update(`${review.reviewRunId}:foreign:${review.commentId}`).digest('hex'),
+          reviewRunId: review.reviewRunId,
+          body: review.publishedBody,
+          at,
+          result: { _tag: 'Failed', reason: confirmed.value.reason },
+        })
+        if (recorded._tag === 'Rejected')
+          return err(`${review.repository}#${review.pullRequestNumber}: ${confirmed.value.reason} The refusal could not be recorded.`)
+        return ok({ _tag: 'Retired', repository: review.repository, pullRequestNumber: review.pullRequestNumber, reason: confirmed.value.reason })
+      }
       if (confirmed.value._tag !== 'Edited') {
         const at = options.now().toISOString()
         const staged = options.store.stageReviewGateStatus({

--- a/packages/harlan-github-agent/src/review-stop-sweep.ts
+++ b/packages/harlan-github-agent/src/review-stop-sweep.ts
@@ -10,6 +10,7 @@ export type StoppedReviewOutcome
   = | { _tag: 'Published', repository: string, pullRequestNumber: number }
     | { _tag: 'CommentGone', repository: string, pullRequestNumber: number }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
+    | { _tag: 'Retired', repository: string, pullRequestNumber: number, reason: string }
 
 export type { StoppedReviewDisposition }
 
@@ -168,7 +169,12 @@ export async function publishStoppedReviews(
       })
       return ok({ _tag: 'CommentGone', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
     }
-    if (edited.value._tag === 'Changed') {
+    // Changed: another Task now owns the comment. Foreign: the stored id names
+    // a comment another actor or pull request owns, which no pass can change.
+    // Both end this publication; the closure still records that the pull
+    // request left, so the row stops asking.
+    if (edited.value._tag === 'Changed' || edited.value._tag === 'Foreign') {
+      const foreign = edited.value._tag === 'Foreign' ? edited.value.reason : null
       if (closure !== null) {
         const labels = await options.github.clearAgentLabels(mapping, review.pullRequestNumber, signal)
         if (labels._tag === 'Err')
@@ -191,9 +197,11 @@ export async function publishStoppedReviews(
         taskId: review.taskId,
         commentId: review.commentId,
         at,
-        reason: 'Another Task replaced the canonical comment.',
+        reason: foreign ?? 'Another Task replaced the canonical comment.',
       })
-      return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
+      return ok(foreign === null
+        ? { _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber }
+        : { _tag: 'Retired', repository: review.repository, pullRequestNumber: review.pullRequestNumber, reason: foreign })
     }
     const labels = await options.github.clearAgentLabels(mapping, review.pullRequestNumber, signal)
     if (labels._tag === 'Err')

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -944,7 +944,9 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
               ? `${result.value.repository}#${result.value.pullRequestNumber}: the stopped review comment was deleted, so nothing was written.`
               : result.value._tag === 'Superseded'
                 ? `${result.value.repository}#${result.value.pullRequestNumber}: another writer took the comment, so it was left alone.`
-                : `${result.value.repository}#${result.value.pullRequestNumber}: closed the stopped review comment.`)
+                : result.value._tag === 'Retired'
+                  ? `${result.value.repository}#${result.value.pullRequestNumber}: ${result.value.reason} The publication retired.`
+                  : `${result.value.repository}#${result.value.pullRequestNumber}: closed the stopped review comment.`)
           }
           else {
             options.logger.error(`Stopped review comment: ${result.error}`)
@@ -981,9 +983,11 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
               ? `${result.value.repository}#${result.value.pullRequestNumber}: the automated comment was deleted, so nothing was written.`
               : result.value._tag === 'Superseded'
                 ? `${result.value.repository}#${result.value.pullRequestNumber}: an agent claimed the Task, so the Queue position comment was left to it.`
-                : result.value.queue._tag === 'Paused'
-                  ? `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads that the repository is paused.`
-                  : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.queue.position} of ${result.value.queue.total}.`)
+                : result.value._tag === 'Retired'
+                  ? `${result.value.repository}#${result.value.pullRequestNumber}: ${result.value.reason} The publication retired.`
+                  : result.value.queue._tag === 'Paused'
+                    ? `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads that the repository is paused.`
+                    : `${result.value.repository}#${result.value.pullRequestNumber}: the comment now reads Queue position ${result.value.queue.position} of ${result.value.queue.total}.`)
           }
           else {
             options.logger.error(`Queue position comment: ${result.error}`)

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -965,6 +965,8 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
               options.logger.info(`${result.value.repository}#${result.value.pullRequestNumber}: queued the ${result.value.outcome} Review status.`)
             else if (result.value._tag === 'Superseded')
               options.logger.info(`${result.value.repository}#${result.value.pullRequestNumber}: the head commit moved, so the prior Review was left alone.`)
+            else if (result.value._tag === 'Retired')
+              options.logger.info(`${result.value.repository}#${result.value.pullRequestNumber}: ${result.value.reason} The Review left the refresh list.`)
           }
           else {
             options.logger.error(`Waiting review: ${result.error}`)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -1,5 +1,6 @@
 import type { AgentProviderName, AgentTokenUsage } from './agent-provider.ts'
 import type { TransientKind } from './failure.ts'
+import type { ForeignReviewCommentReason } from './github-agent-source.ts'
 import type { IssueTriageState } from './issue-triage.ts'
 import type { RecordPullRequestTriageRunInput, RecordPullRequestTriageRunResult, StatsFact, StatsRange, StatsSnapshot, StatsTaskKind } from './stats.ts'
 import type {
@@ -861,7 +862,7 @@ export interface JournalStore {
     taskId: string
     commentId: number
     at: string
-    reason: 'A person deleted the comment.' | 'Another Task replaced the canonical comment.'
+    reason: 'A person deleted the comment.' | 'Another Task replaced the canonical comment.' | ForeignReviewCommentReason
   }) => boolean
   recordStoppedReviewStatus: (input: {
     taskId: string

--- a/packages/harlan-github-agent/test/edit-review-status.test.ts
+++ b/packages/harlan-github-agent/test/edit-review-status.test.ts
@@ -85,4 +85,21 @@ describe('editReviewStatus compare and swap', () => {
     const result = await source().editReviewStatus(repositoryMapping(), 24, 5, publishedBody, 'updated body', new AbortController().signal)
     expect(result).toEqual(ok({ _tag: 'Changed' }))
   })
+
+  it('reports Foreign without writing when another actor owns the comment', async () => {
+    hoisted.state.remoteBody = publishedBody
+    hoisted.state.writes = 0
+    hoisted.octokit.rest.issues.getComment = () => Promise.resolve({
+      data: {
+        id: 5,
+        html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-5',
+        issue_url: 'https://github.com/harlan-zw/example/issues/24',
+        user: { login: 'someone-else' },
+        body: publishedBody,
+      },
+    })
+    const result = await source().editReviewStatus(repositoryMapping(), 24, 5, publishedBody, 'updated body', new AbortController().signal)
+    expect(hoisted.state.writes).toBe(0)
+    expect(result).toEqual(ok({ _tag: 'Foreign', reason: 'The stored automated review comment belongs to another GitHub actor.' }))
+  })
 })

--- a/packages/harlan-github-agent/test/queue-position-sweep.test.ts
+++ b/packages/harlan-github-agent/test/queue-position-sweep.test.ts
@@ -291,6 +291,37 @@ describe('publishQueuePositions', () => {
     expect(recorded).toBe(0)
     expect(retired).toEqual([42])
   })
+
+  it('retires the publication once the comment belongs to another actor', async () => {
+    const retired: Array<{ commentId: number, reason: string }> = []
+    let recorded = 0
+    const reason = 'The stored automated review comment belongs to another GitHub actor.' as const
+    const results = await publishQueuePositions({
+      github: {
+        clearAgentLabels: () => Promise.resolve(ok(undefined)),
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Foreign', reason })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        recordDeletedReviewComment: (input) => {
+          retired.push({ commentId: input.commentId, reason: input.reason })
+          return true
+        },
+        listQueuedReviewStatuses: () => [queuedRepair()],
+        isQueuedReviewStatus: () => true,
+        recordQueuedReviewStatus: () => {
+          recorded += 1
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Retired', repository: 'harlan-zw/example', pullRequestNumber: 24, reason })])
+    expect(recorded).toBe(0)
+    expect(retired).toEqual([{ commentId: 42, reason }])
+  })
   it('leaves the comment alone once the head commit moves', async () => {
     let writes = 0
     const results = await publishQueuePositions({

--- a/packages/harlan-github-agent/test/review-gate-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-gate-sweep.test.ts
@@ -77,6 +77,7 @@ function snapshot(baseChecks: GitHubCheck[], headChecks: GitHubCheck[] = [check(
 
 interface Recorded {
   edited?: { commentId: number, expectedBody: string, body: string }
+  failed: Array<{ reviewRunId: string, reason: string }>
   staged: Array<{ reviewRunId: string, outcome: string, ci: string, reconciliationId?: string, body: string }>
   stamped: string[]
 }
@@ -86,7 +87,7 @@ function harness(options: {
   live?: ReturnType<typeof snapshot>
   edit?: () => Promise<any>
 }) {
-  const recorded: Recorded = { staged: [], stamped: [] }
+  const recorded: Recorded = { failed: [], staged: [], stamped: [] }
   const run = async () => refreshReviewGates({
     github: {
       getPullRequestReviewSnapshot: () => Promise.resolve(options.live ?? snapshot([check()])),
@@ -107,6 +108,11 @@ function harness(options: {
     repositories: [repositoryMapping()],
     store: {
       listReviewGateRefreshes: () => [options.review ?? gateRefresh()],
+      recordReviewPublication: (input) => {
+        if (input.result._tag === 'Failed')
+          recorded.failed.push({ reviewRunId: input.reviewRunId, reason: input.result.reason })
+        return { _tag: 'Inserted', publicationId: input.id }
+      },
       stageReviewGateStatus: (input) => {
         recorded.staged.push({
           reviewRunId: input.reviewRunId,
@@ -263,6 +269,27 @@ describe('refreshReviewGates', () => {
     })])
     expect(recorded.stamped).toEqual([])
     expect(recorded.staged[0]?.reconciliationId).toContain('Missing:42:')
+  })
+
+  it('retires the Review instead of staging a status when another actor owns the comment', async () => {
+    const live = snapshot([check({ status: 'in_progress', conclusion: null })])
+    if (live._tag !== 'Ok')
+      throw new Error('Expected a Review snapshot.')
+    const reason = 'The stored automated review comment belongs to another GitHub actor.' as const
+    const { recorded, run } = harness({
+      live,
+      review: gateRefresh({
+        gates: refreshControllerGates(pendingControllerGates(), live.value, repositoryMapping()).gates,
+      }),
+      edit: () => Promise.resolve(ok({ _tag: 'Foreign', reason })),
+    })
+
+    const results = await run()
+
+    expect(results).toEqual([ok({ _tag: 'Retired', repository: 'harlan-zw/example', pullRequestNumber: 24, reason })])
+    expect(recorded.staged).toEqual([])
+    expect(recorded.stamped).toEqual([])
+    expect(recorded.failed).toEqual([{ reviewRunId: 'run-1', reason }])
   })
 })
 

--- a/packages/harlan-github-agent/test/review-stop-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-stop-sweep.test.ts
@@ -140,6 +140,37 @@ describe('publishStoppedReviews', () => {
     expect(recorded).toBe(1)
   })
 
+  it('retires the publication once the comment belongs to another actor', async () => {
+    const retired: Array<{ commentId: number, reason: string }> = []
+    let recorded = 0
+    const reason = 'The stored automated review comment belongs to another GitHub actor.' as const
+    const { results } = await publishStoppedReviews({
+      github: {
+        ...githubStatus,
+        getPullRequestReviewSnapshot: () => Promise.resolve(snapshot()),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Foreign', reason })),
+      },
+      now: () => new Date('2026-08-15T04:00:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        ...reviewClosureStore,
+        recordDeletedReviewComment: (input) => {
+          retired.push({ commentId: input.commentId, reason: input.reason })
+          return true
+        },
+        listStoppedReviews: () => [stopped],
+        recordStoppedReviewStatus: () => {
+          recorded += 1
+          return true
+        },
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Retired', repository: 'harlan-zw/example', pullRequestNumber: 24, reason })])
+    expect(recorded).toBe(0)
+    expect(retired).toEqual([{ commentId: 42, reason }])
+  })
+
   it('does not finish while stale Agent labels remain', async () => {
     let recorded = 0
     const { results } = await publishStoppedReviews({

--- a/packages/harlan-github-agent/test/upsert-review-status.test.ts
+++ b/packages/harlan-github-agent/test/upsert-review-status.test.ts
@@ -81,7 +81,7 @@ describe('review status actor handoff', () => {
 
     const result = await source.editReviewStatus(repositoryMapping(), 24, 5, 'Human review comment', newBody, new AbortController().signal)
 
-    expect(result).toEqual({ _tag: 'Err', error: 'The stored automated review comment belongs to another GitHub actor.' })
+    expect(result).toEqual(ok({ _tag: 'Foreign', reason: 'The stored automated review comment belongs to another GitHub actor.' }))
     expect(userUpdate).not.toHaveBeenCalled()
     expect(appUpdate).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Two comment sweeps had no memory of a refusal. When the stored comment id turned out to belong to another actor or another pull request, the edit came back as an error string, the pass recorded an Incident, and the next pass asked GitHub the exact same question. On Hogwild `nuxtseo.com#725` produced that Incident 173 times between 07:16 and 13:58 UTC on 1 September, and `gscdump.com#181` and `nuxtseo.com#705` did the same.

The edit now reports a foreign comment as a typed outcome, and both sweeps retire the publication with that reason, the way they already retire a deleted comment.

Open question: the review gate sweep sees the same outcome and stages a fresh publication, which then fails on the same foreign id through the command retry budget. I left that path alone because it does stop on its own, but it could retire too.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01L2sAKNhhmQvKYZnQZ2YLms