### PR TITLE
feat(skills): vendor the PR Lens skill and gate it on change size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 # Harness worktrees; wt owns worktrees as repo siblings
 .claude/worktrees/
+
+# PR Lens writes its previews here. They are rebuilt on demand.
+.pr-lens/

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Every Skill lives in [`harlan-agent-kit/skills/`](./harlan-agent-kit/skills).
 | [`pkg-conform`](./harlan-agent-kit/skills/pkg-conform/SKILL.md) | Conform or scaffold a TypeScript package or Nuxt module |
 | [`plan-ceo`](./harlan-agent-kit/skills/plan-ceo/SKILL.md) | Challenge scope and strategy before anyone writes code |
 | [`pr`](./harlan-agent-kit/skills/pr/SKILL.md) | Create or update a pull request from current work |
+| [`pr-lens`](./harlan-agent-kit/skills/pr-lens/SKILL.md) | Draw a change as animated architecture and data-flow diagrams with [PR Lens](https://prlens.dev) |
 | [`pr-triage`](./harlan-agent-kit/skills/pr-triage/SKILL.md) | Repair, rank, and order the owned PR backlog |
 | [`release-notes`](./harlan-agent-kit/skills/release-notes/SKILL.md) | Draft changelogs, release notes, and upgrade guides |
 | [`ripast`](./harlan-agent-kit/skills/ripast/SKILL.md) | Run AST-aware refactors with [Ripast](https://github.com/harlan-zw/ripast) |

--- a/agent-context/context.md
+++ b/agent-context/context.md
@@ -111,6 +111,7 @@ Unsure means no label. Rules: `harlan-agent-kit/references/auto-merge.md`.
 ## Workflow
 
 - Ship the smallest thing that solves it. Add structure when it fails.
+- A pull request that crosses three or more modules, a boundary, or a sequence carries a PR Lens diagram in its description. Smaller ones do not. Read `skills/pr-lens/SKILL.md`.
 - Production error: fix the category, not the instance.
 - Refactors and architecture audits: finish the whole change before stopping (imports updated, old code removed, tests pass).
 

--- a/harlan-agent-kit/skills/pr-lens/LICENSE
+++ b/harlan-agent-kit/skills/pr-lens/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Coldtea AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/harlan-agent-kit/skills/pr-lens/SKILL.md
+++ b/harlan-agent-kit/skills/pr-lens/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: pr-lens
+description: "Draw a code change or part of a codebase as an animated architecture or data-flow diagram. Use when opening or updating a pull request that touches more than one module, when asked to diagram, visualise or explain a change or a system, or when a reviewer needs the blast radius before the diff."
+user_invocable: true
+argument-hint: "[base ref, PR number, or path to diagram]"
+---
+
+# PR Lens
+
+Vendored from [coldteadotai/pr-lens](https://github.com/coldteadotai/pr-lens) `packages/agent-skill` (MIT, see `LICENSE`). Adapted for this kit: `pnpm dlx` replaces `npx`, and the pull request rules below defer to the [pr skill](../pr/SKILL.md).
+
+## When to reach for this without being asked
+
+The [pr skill](../pr/SKILL.md) calls this skill in Step 3 for every non-trivial pull request. Use it on your own when:
+
+- the change touches three or more modules, or crosses a runtime, service, or store boundary
+- a reviewer would need to hold more than one call chain in their head
+- the pull request body needs to explain a sequence, a retirement, or a new path
+
+Skip it for one-file fixes, dependency bumps, formatting, and Markdown-only work. A diagram of a one-line change reads as noise.
+
+Run the CLI from the task worktree. `.pr-lens/` is scratch; never commit it.
+
+PR Lens draws code as visually rich animated diagrams. It can represent diffs, architecture, data flows, and more.
+
+The diff or code is represented as one JSON document (lanes, nodes, edges, ordered flows) and it renders the JSON as an animated SVG
+
+## Operating manual
+
+1. **Read the diff.** When asked to represent a code change: `git diff --find-renames <base>...<head>`. The base is the merge base, not the tip of the base branch.
+
+   If not expressing a code diff, read the code to be visually represented
+
+2. **Write the document** to `.pr-lens/graph.json`, following `references/graph-document.md`. `references/example.graph.json` is valid reference with three lanes, all four delta states, a hero edge, a seven-step flow, a nested drill-down tree. Read it before you write your first one. It is quicker than reading the reference.
+
+3. **Validate, and fix**
+
+   ```bash
+   pnpm dlx @coldtea/pr-lens-cli validate .pr-lens/graph.json
+   ```
+
+   Fix every failure and run it again. Do not render an invalid document; do not "work around" a failure by deleting the element it names.
+
+4. **Render.**
+
+   ```bash
+   pnpm dlx @coldtea/pr-lens-cli render .pr-lens/graph.json --theme dark
+   ```
+
+   Render dark as the default theme unless explicitly requested. The SVGs, the manifest and `drawn.graph.json` land in `.pr-lens/`, which the CLI adds to the repository's .gitignore. Do not commit any of it. These files are rebuilt from the diff whenever anyone wants them again. Each SVG is named after its view, the theme and a content hash; `manifest.json` lists them by lens and view, so read the names from there or from the directory.
+
+   If the user asked for a diagram and nothing more, this is the end of the loop. If working in an environment that supports a visual way to display the image e.g., an in-app browser, an artifact, do so. Otherwise, tell them where the SVGs are and which one is the top view.
+
+5. **Attach, when there is a pull request to attach to.** That means the user asked you to open a PR, asked for a diagram on one that exists, or you are opening a PR as part of changes made. Otherwise skip this step.
+
+   GitHub CLI uploads the diagram with the pull request. Write the body with a Markdown image pointing at the local file, then pass the same path to `--attach`. `gh` rewrites the reference to the uploaded asset and keeps the alt text you wrote:
+
+   ```markdown
+   Moves bulk sending off the per-recipient trigger and onto a batch endpoint.
+
+   ![Architecture after this change: the queue route, the new bulk sender and the retired per-recipient path](.pr-lens/overview-dark-4f9bd6c1.svg)
+   ```
+
+   ```bash
+   gh pr create --title "Batch broadcast sends" --body-file .pr-lens/body.md \
+     --attach .pr-lens/overview-dark-4f9bd6c1.svg
+   ```
+
+   On a pull request that already exists, `gh pr edit <number>` with the same two flags puts the diagram in the description, and `gh pr comment <number>` puts it in a comment. Repeat `--attach` for each diagram the body references.
+
+   gh has three rules:
+   - The reference has to be a Markdown image, `![alt](path)`. An HTML `<img>` or `<picture>` is left as written, and the file is appended at the bottom of the body instead.
+   - The alt text is the caption a reader without images gets. Say what the diagram shows, in one line.
+   - `--attach` arrived in GitHub CLI 2.99. Check with `gh --version` before you write a body around it.
+
+   Attach the views a reviewer needs and leave the rest in `.pr-lens/`: the top architecture view first, then a data flow if the change has a sequence worth following. A body with four diagrams reads worse than one with two, except the four are really needed to understand the change e.g., in the case of a complex feature or refactor.
+
+   When `--attach` is not an option, publish the SVGs somewhere durable and let the CLI compose the comment instead:
+
+   ```bash
+   pnpm dlx @coldtea/pr-lens-cli comment \
+     --graph .pr-lens/drawn.graph.json \
+     --manifest .pr-lens/manifest.json \
+     --asset-base-url https://raw.githubusercontent.com/<owner>/<repo>/<branch>/<dir>
+   ```
+
+   `--graph` takes `drawn.graph.json`, not the document you wrote, because corrections change what the diagrams show and the CLI refuses a document its manifest does not describe. `--asset-base-url` is where you published the SVGs; leave it out and the markdown points at local paths no reader can fetch. The markdown goes to stdout, with each diagram as a `<picture>` pair; posting it is your business.
+
+If you would rather not author the document yourself, `pnpm dlx @coldtea/pr-lens-cli analyze --base <ref>` does steps 1 and 2 by asking a provider — Gemini, OpenAI, or any endpoint speaking `/chat/completions` — with a key of your own. That is the only path here that needs one.
+
+## The pull request body, when there is one
+
+A reviewer should understand the change before reading the diff, so the diagram goes where they look first: the description, not a trailing comment. Open with one sentence on why the change exists, then the architecture diagram, then whatever proves the change works, such as a screenshot of the result or a recording of the interaction. Use one visual per idea. A diagram that needs a paragraph of explanation has a document problem; go back to step 2.
+
+## What makes a document worth reading
+
+- **Include what did not change.** A diagram of only the changed nodes says nothing about blast radius. The unchanged neighbours a change touches are the context; mark them `delta: "unchanged"`.
+- **Lanes are the reader's mental model** (a runtime, a tier, a boundary), not the folder tree.
+- **One hero edge**, two at the outside: the connection the change is really about.
+- **Add a flow only when there is a sequence** worth animating. One good flow beats three thin ones.
+- **Attach file refs**: they become the permalinks a reviewer clicks.
+- **There is no findings lens.** PR Lens is the comprehension layer, not another review bot. There is no field for a bug, a risk or a security note, and a document that invents one is rejected rather than trimmed.
+
+## Choosing architecture views
+
+Treat architecture views as a C4-inspired decision tree, not a checklist. One useful view is enough for a small change. Start with system context when the change affects a user, an external system or a system boundary. Use a container view for the affected applications, services, jobs, data stores and runtimes. Add a component child only when an affected container's internals matter. Do not add code-level views by default.
+
+Every child moves down one level and covers a materially narrower scope. Skip empty, repetitive or speculative levels, and do not infer architecture from folder names alone. Two views should not carry substantially the same nodes and edges. Keep the unchanged direct neighbours that explain blast radius.
+
+Keep data-flow views as separate roots rather than nesting them in the architecture tree. Set `defaultOpen: true` on the highest useful architecture view. Lower levels should normally keep the default, `false`.
+
+## What the validator will catch
+
+Read `references/graph-document.md` before writing. The four failures that account for nearly everything:
+
+| Code                         | What you did                                                         |
+| ---------------------------- | -------------------------------------------------------------------- |
+| `BROKEN_REFERENCE`           | an edge, a flow step or a view names an id you never declared        |
+| `INVALID_DOCUMENT`           | an invented field; the schemas are strict, unknown keys are rejected |
+| `DUPLICATE_ID`               | two nodes, edges or views sharing an id                              |
+| `UNSUPPORTED_SCHEMA_VERSION` | `schemaVersion` is not the contract version installed                |
+
+Four rules cannot be expressed in JSON Schema and are checked only by the parser, so structured output alone does not make a document valid: referential integrity, a line range that ends before it starts, a `self` message whose endpoints disagree, and a patch whose two commits are the same. Always validate.
+
+## Fixing a map instead of writing one
+
+When someone says the diagram is wrong (a node is misnamed, a folder should not be on it, something sits in the wrong lane), do not edit the generated document. It is regenerated on every run. Write the correction into `.github/pr-lens.yml`, which is an overlay applied over fresh inference every time:
+
+```yaml
+schemaVersion: 0.1.0
+map:
+  rename:
+    - match: functions/src/broadcast/sendBroadcastBulk.ts
+      to: Broadcast sender
+  exclude:
+    - '**/*.test.ts'
+  lane:
+    - match: packages/broadcast-lib/**
+      lane: functions
+```
+
+`references/config.md` has the full format and the recipes. Validate it the same way: `pnpm dlx @coldtea/pr-lens-cli validate .github/pr-lens.yml`.
+
+A `match` beginning with `id:` addresses one node exactly; anything else is a path glob matched against a node's file paths. Prefer the glob, because it keeps holding when the next run names the node differently. A lane pin may name a lane the document never declared: the band is created, and takes the id for its label, so give it one a reader would want to see.
+
+`pr-lens render` says so when a correction matched nothing, which is how a config that has drifted, because the file it named moved or was deleted, becomes visible instead of quietly doing nothing.
+
+## What ships with this skill
+
+Everything you need is beside this page. Nothing here asks you to install a package first.
+
+|                                 |                                                                                    |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `references/graph-document.md`  | the document, field by field: enums, limits, and where documents actually go wrong |
+| `references/config.md`          | `.github/pr-lens.yml`, the correction overlay, in full                             |
+| `references/example.graph.json` | one complete document that validates, to read and to copy the shape of             |
+
+The same document ships as `postmark-refactor.graph.json` in `@coldtea/pr-lens-schema`, and the JSON Schema the validator enforces is published at `https://unpkg.com/@coldtea/pr-lens-schema/json-schema/graph-doc.schema.json`. Neither is something you need to fetch to write a document.

--- a/harlan-agent-kit/skills/pr-lens/references/config.md
+++ b/harlan-agent-kit/skills/pr-lens/references/config.md
@@ -1,0 +1,90 @@
+# Correcting the map: `.github/pr-lens.yml`
+
+The generated document is regenerated on every run, so editing it is pointless. Corrections live in `.github/pr-lens.yml`, an overlay applied over fresh inference every time. Inference never writes back into this file, which is why a correction keeps holding as the code moves.
+
+```yaml
+schemaVersion: 0.1.0 # required
+lenses: [architecture, data-flow]
+branding: true
+map:
+  rename:
+    - match: functions/src/broadcast/sendBroadcastBulk.ts
+      to: Broadcast sender
+  exclude:
+    - '**/*.test.ts'
+    - scripts/**
+  lane:
+    - match: packages/broadcast-lib/**
+      lane: functions
+  group:
+    - match: id:build-bulk-payload
+      group: broadcast-lib
+```
+
+Every field except `schemaVersion` is optional, and the file itself is optional. For editor autocomplete, point at the published JSON Schema — no install needed:
+
+```jsonc
+{ "$ref": "https://unpkg.com/@coldtea/pr-lens-schema/json-schema/config.schema.json" }
+```
+
+## Selectors
+
+A `match` beginning with `id:` addresses exactly one node, as in `id:build-bulk-payload`. Anything else is a repository-relative path glob matched against the node's file paths.
+
+**Prefer the glob.** Ids come from inference and may change when the code does; a path correction survives that. Reach for `id:` only when no path distinguishes the node, or when the node has no files at all (an external service, a queue).
+
+## The four corrections
+
+| | What it does |
+| --- | --- |
+| `rename` | replaces the inferred label |
+| `exclude` | drops matching nodes, and the edges and flow steps that hung from them |
+| `lane` | moves matching nodes into a lane, **creating it** when the document declares no such id |
+| `group` | clusters matching nodes under a sub-group inside their lane |
+
+Up to 128 of each. They are about intent rather than structure: there is no way to add a node or draw an edge here, and the one thing a correction can bring into existence is a lane, a band a repository wants that inference did not find. It takes the id for its label, because the id is the only name this file carries, so write `lane: infrastructure` rather than `lane: l3`. If the map is wrong in a way corrections cannot express, the fix belongs in the analysis, not in this file.
+
+## Recipes
+
+**"Stop showing me the test files."**
+```yaml
+map:
+  exclude: ['**/*.test.ts', '**/__tests__/**']
+```
+
+**"That node is called the wrong thing."** Match the file it comes from, not its id:
+```yaml
+map:
+  rename:
+    - match: server/lib/broadcast/createBroadcastSendTask.ts
+      to: Send task
+```
+
+**"These belong in a band of their own."** The lane need not exist yet:
+```yaml
+map:
+  lane:
+    - match: infra/**
+      lane: infrastructure
+```
+
+**"Keep the shared library together."**
+```yaml
+map:
+  group:
+    - match: packages/broadcast-lib/**
+      group: broadcast-lib
+```
+
+**"Only draw the architecture."**
+```yaml
+lenses: [architecture]
+```
+
+## Check it
+
+```bash
+pnpm dlx @coldtea/pr-lens-cli validate .github/pr-lens.yml
+```
+
+`pr-lens render` reports any correction that changed nothing about the document it drew. That is a config that has drifted out of date, usually because the file a selector named has moved or gone. It is not an error and nothing stops, but it is worth fixing: a correction that matches nothing is a correction nobody is getting.

--- a/harlan-agent-kit/skills/pr-lens/references/example.graph.json
+++ b/harlan-agent-kit/skills/pr-lens/references/example.graph.json
@@ -1,0 +1,580 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "graph",
+  "generatedAt": "2026-08-19T18:24:00.000Z",
+  "title": "Batch broadcast sending through Postmark",
+  "summary": "Broadcast delivery moves from one Postmark request per recipient to batched requests of 500, with suppression filtering pulled in front of the send and the payload builder extracted into a shared library.",
+  "lenses": [
+    "architecture",
+    "data-flow"
+  ],
+  "provenance": {
+    "repo": {
+      "owner": "ohansemmanuel",
+      "name": "bestregards",
+      "host": "github.com"
+    },
+    "base": {
+      "sha": "3f5c1ab9d24e7f08c6b1a5d3e9074c2b8a6f1d40",
+      "ref": "main"
+    },
+    "head": {
+      "sha": "b71e0d4c8a92f5361de7c0b4a8f2593d6c1e8a77",
+      "ref": "batch-broadcast-send"
+    },
+    "pullRequest": {
+      "number": 128,
+      "title": "Send broadcasts in batches of 500",
+      "url": "https://github.com/ohansemmanuel/bestregards/pull/128"
+    },
+    "generator": {
+      "name": "pr-lens-examples",
+      "version": "0.1.0"
+    }
+  },
+  "lanes": [
+    {
+      "id": "web",
+      "label": "Next.js",
+      "subtitle": "Vercel",
+      "order": 0
+    },
+    {
+      "id": "functions",
+      "label": "Cloud Functions",
+      "subtitle": "Firebase",
+      "order": 1
+    },
+    {
+      "id": "external",
+      "label": "External",
+      "subtitle": "Postmark",
+      "order": 2
+    }
+  ],
+  "nodes": [
+    {
+      "id": "broadcast-composer",
+      "label": "Broadcast composer",
+      "kind": "ui",
+      "delta": "unchanged",
+      "lane": "web",
+      "subtitle": "app/broadcasts/new",
+      "summary": "Where an author writes a broadcast and hits send. Untouched by this change.",
+      "files": [
+        {
+          "path": "app/broadcasts/new/page.tsx"
+        }
+      ],
+      "badges": []
+    },
+    {
+      "id": "queue-route",
+      "label": "POST /api/broadcasts/queue",
+      "kind": "route",
+      "delta": "modified",
+      "lane": "web",
+      "summary": "Writes the queue document. Now stamps the recipient count and batch size the sender will use instead of leaving batching to the worker.",
+      "files": [
+        {
+          "path": "app/api/broadcasts/queue/route.ts",
+          "startLine": 24,
+          "endLine": 96
+        }
+      ],
+      "badges": [
+        "+38 / -12"
+      ]
+    },
+    {
+      "id": "broadcast-queue",
+      "label": "broadcastQueue",
+      "kind": "datastore",
+      "delta": "modified",
+      "lane": "functions",
+      "subtitle": "Firestore collection",
+      "summary": "Queue documents gained batchSize and suppressedCount fields, and results are now written back per batch rather than per recipient.",
+      "files": [
+        {
+          "path": "functions/src/broadcast/schema.ts",
+          "startLine": 12,
+          "endLine": 48
+        }
+      ],
+      "badges": []
+    },
+    {
+      "id": "send-broadcast-bulk",
+      "label": "sendBroadcastBulk",
+      "kind": "function",
+      "delta": "added",
+      "lane": "functions",
+      "subtitle": "onWrite trigger",
+      "summary": "New trigger handler. Fetches suppressions once, builds batched payloads, and posts them to Postmark in chunks of 500.",
+      "files": [
+        {
+          "path": "functions/src/broadcast/sendBroadcastBulk.ts",
+          "startLine": 1,
+          "endLine": 142
+        }
+      ],
+      "badges": [
+        "new"
+      ]
+    },
+    {
+      "id": "build-bulk-payload",
+      "label": "buildBulkPayload",
+      "kind": "function",
+      "delta": "added",
+      "lane": "functions",
+      "summary": "Turns a broadcast and its recipient slice into a Postmark batch request body.",
+      "files": [
+        {
+          "path": "packages/broadcast-lib/src/buildBulkPayload.ts",
+          "startLine": 1,
+          "endLine": 74
+        }
+      ],
+      "badges": []
+    },
+    {
+      "id": "get-suppressed-emails",
+      "label": "getSuppressedEmails",
+      "kind": "function",
+      "delta": "added",
+      "lane": "functions",
+      "summary": "Pulls the Postmark suppression dump once per broadcast so suppressed addresses are filtered before any batch is sent.",
+      "files": [
+        {
+          "path": "packages/broadcast-lib/src/getSuppressedEmails.ts",
+          "startLine": 1,
+          "endLine": 58
+        }
+      ],
+      "badges": []
+    },
+    {
+      "id": "broadcast-lib",
+      "label": "broadcast-lib",
+      "kind": "package",
+      "delta": "added",
+      "lane": "functions",
+      "subtitle": "packages/broadcast-lib",
+      "summary": "New shared package so the queue route and the sender agree on payload shape and batch size.",
+      "files": [
+        {
+          "path": "packages/broadcast-lib/src/index.ts"
+        }
+      ],
+      "badges": [
+        "new package"
+      ]
+    },
+    {
+      "id": "process-broadcast",
+      "label": "processBroadcast",
+      "kind": "function",
+      "delta": "removed",
+      "lane": "functions",
+      "subtitle": "onWrite trigger",
+      "summary": "The per-recipient loop this change replaces.",
+      "files": [
+        {
+          "path": "functions/src/broadcast/processBroadcast.ts",
+          "startLine": 1,
+          "endLine": 118,
+          "revision": "base"
+        }
+      ],
+      "badges": []
+    },
+    {
+      "id": "send-single-email",
+      "label": "sendSingleEmail",
+      "kind": "function",
+      "delta": "removed",
+      "lane": "functions",
+      "summary": "One Postmark request per recipient. Gone with the loop that called it.",
+      "files": [
+        {
+          "path": "functions/src/broadcast/sendSingleEmail.ts",
+          "startLine": 1,
+          "endLine": 46,
+          "revision": "base"
+        }
+      ],
+      "badges": []
+    },
+    {
+      "id": "postmark",
+      "label": "Postmark",
+      "kind": "external",
+      "delta": "modified",
+      "lane": "external",
+      "subtitle": "Email API",
+      "summary": "Same provider, different endpoints: the batch endpoint and the suppression dump replace repeated single sends.",
+      "files": [],
+      "badges": []
+    }
+  ],
+  "edges": [
+    {
+      "id": "composer-to-queue",
+      "from": "broadcast-composer",
+      "to": "queue-route",
+      "kind": "http",
+      "delta": "unchanged",
+      "label": "send broadcast",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "queue-to-firestore",
+      "from": "queue-route",
+      "to": "broadcast-queue",
+      "kind": "data",
+      "delta": "modified",
+      "label": "enqueue job",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "queue-to-lib",
+      "from": "queue-route",
+      "to": "broadcast-lib",
+      "kind": "dependency",
+      "delta": "added",
+      "label": "batch size",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "firestore-to-bulk",
+      "from": "broadcast-queue",
+      "to": "send-broadcast-bulk",
+      "kind": "event",
+      "delta": "added",
+      "label": "onWrite",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "firestore-to-process",
+      "from": "broadcast-queue",
+      "to": "process-broadcast",
+      "kind": "event",
+      "delta": "removed",
+      "label": "onWrite",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "process-to-single",
+      "from": "process-broadcast",
+      "to": "send-single-email",
+      "kind": "call",
+      "delta": "removed",
+      "label": "per recipient",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "single-to-postmark",
+      "from": "send-single-email",
+      "to": "postmark",
+      "kind": "http",
+      "delta": "removed",
+      "label": "POST /email · 1 msg/call",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "bulk-to-payload",
+      "from": "send-broadcast-bulk",
+      "to": "build-bulk-payload",
+      "kind": "call",
+      "delta": "added",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "bulk-to-suppressions",
+      "from": "send-broadcast-bulk",
+      "to": "get-suppressed-emails",
+      "kind": "call",
+      "delta": "added",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "bulk-to-lib",
+      "from": "send-broadcast-bulk",
+      "to": "broadcast-lib",
+      "kind": "dependency",
+      "delta": "added",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    },
+    {
+      "id": "suppressions-to-postmark",
+      "from": "get-suppressed-emails",
+      "to": "postmark",
+      "kind": "http",
+      "delta": "added",
+      "label": "GET suppression dump",
+      "emphasis": "normal",
+      "animated": true,
+      "files": []
+    },
+    {
+      "id": "bulk-to-postmark",
+      "from": "send-broadcast-bulk",
+      "to": "postmark",
+      "kind": "http",
+      "delta": "added",
+      "label": "500 msgs/call",
+      "emphasis": "hero",
+      "animated": true,
+      "summary": "The change in one edge: a broadcast to 10,000 recipients drops from 10,000 requests to 20.",
+      "files": []
+    },
+    {
+      "id": "bulk-to-firestore",
+      "from": "send-broadcast-bulk",
+      "to": "broadcast-queue",
+      "kind": "data",
+      "delta": "added",
+      "label": "write results",
+      "emphasis": "normal",
+      "animated": false,
+      "files": []
+    }
+  ],
+  "flows": [
+    {
+      "id": "send-pipeline",
+      "title": "Sending a broadcast",
+      "summary": "The path a queued broadcast takes now, from enqueue to per-message results.",
+      "delta": "modified",
+      "participants": [
+        {
+          "node": "queue-route",
+          "label": "queue route"
+        },
+        {
+          "node": "broadcast-queue",
+          "label": "Firestore"
+        },
+        {
+          "node": "send-broadcast-bulk",
+          "label": "sendBroadcastBulk"
+        },
+        {
+          "node": "postmark",
+          "label": "Postmark"
+        }
+      ],
+      "messages": [
+        {
+          "id": "enqueue",
+          "from": "queue-route",
+          "to": "broadcast-queue",
+          "label": "enqueue broadcast job",
+          "kind": "async",
+          "delta": "modified",
+          "animated": true,
+          "files": []
+        },
+        {
+          "id": "trigger",
+          "from": "broadcast-queue",
+          "to": "send-broadcast-bulk",
+          "label": "onWrite trigger",
+          "kind": "async",
+          "delta": "added",
+          "animated": true,
+          "files": []
+        },
+        {
+          "id": "suppressions-request",
+          "from": "send-broadcast-bulk",
+          "to": "postmark",
+          "label": "GET suppression dump",
+          "kind": "sync",
+          "delta": "added",
+          "animated": true,
+          "files": []
+        },
+        {
+          "id": "suppressions-response",
+          "from": "postmark",
+          "to": "send-broadcast-bulk",
+          "label": "suppressed addresses",
+          "kind": "return",
+          "delta": "added",
+          "animated": true,
+          "note": "Fetched once per broadcast, not once per recipient.",
+          "files": []
+        },
+        {
+          "id": "batch-post",
+          "from": "send-broadcast-bulk",
+          "to": "postmark",
+          "label": "POST /email/batch · 500 msgs",
+          "kind": "sync",
+          "delta": "added",
+          "animated": true,
+          "repeat": 4,
+          "note": "One request per 500 recipients; four for this 2,000-recipient broadcast.",
+          "files": []
+        },
+        {
+          "id": "batch-results",
+          "from": "postmark",
+          "to": "send-broadcast-bulk",
+          "label": "per-message results",
+          "kind": "return",
+          "delta": "added",
+          "animated": true,
+          "files": []
+        },
+        {
+          "id": "write-results",
+          "from": "send-broadcast-bulk",
+          "to": "broadcast-queue",
+          "label": "write results",
+          "kind": "async",
+          "delta": "added",
+          "animated": true,
+          "files": []
+        }
+      ]
+    }
+  ],
+  "stats": {
+    "filesChanged": 14,
+    "additions": 486,
+    "deletions": 212,
+    "chips": [
+      {
+        "label": "Postmark calls",
+        "value": "500× fewer",
+        "tone": "hero"
+      },
+      {
+        "label": "New",
+        "value": "4 units",
+        "tone": "added"
+      },
+      {
+        "label": "Retired",
+        "value": "2 units",
+        "tone": "removed"
+      }
+    ]
+  },
+  "views": [
+    {
+      "id": "overview",
+      "title": "Architecture — blast radius",
+      "lens": "architecture",
+      "summary": "Everything this change touches, across all three lanes.",
+      "scope": {
+        "kind": "all"
+      },
+      "defaultOpen": true,
+      "children": [
+        {
+          "id": "new-batch-path",
+          "title": "The new batch path",
+          "lens": "architecture",
+          "summary": "What replaced the per-recipient loop.",
+          "scope": {
+            "kind": "selection",
+            "lanes": [],
+            "nodes": [
+              "send-broadcast-bulk",
+              "build-bulk-payload",
+              "get-suppressed-emails",
+              "broadcast-lib",
+              "postmark"
+            ],
+            "edges": [
+              "bulk-to-payload",
+              "bulk-to-suppressions",
+              "bulk-to-lib",
+              "suppressions-to-postmark",
+              "bulk-to-postmark",
+              "bulk-to-firestore"
+            ],
+            "flows": []
+          },
+          "defaultOpen": false,
+          "children": []
+        },
+        {
+          "id": "retired-path",
+          "title": "What was retired",
+          "lens": "architecture",
+          "summary": "The single-send path, kept visible so a reviewer can confirm nothing else called it.",
+          "scope": {
+            "kind": "selection",
+            "lanes": [],
+            "nodes": [
+              "process-broadcast",
+              "send-single-email"
+            ],
+            "edges": [
+              "firestore-to-process",
+              "process-to-single",
+              "single-to-postmark"
+            ],
+            "flows": []
+          },
+          "defaultOpen": false,
+          "children": []
+        }
+      ]
+    },
+    {
+      "id": "send-pipeline-view",
+      "title": "Data flow — sending a broadcast",
+      "lens": "data-flow",
+      "scope": {
+        "kind": "selection",
+        "lanes": [],
+        "nodes": [],
+        "edges": [],
+        "flows": [
+          "send-pipeline"
+        ]
+      },
+      "defaultOpen": false,
+      "children": []
+    }
+  ],
+  "layout": {
+    "direction": "right",
+    "laneOrder": [
+      "web",
+      "functions",
+      "external"
+    ],
+    "rank": {
+      "queue-route": 0,
+      "send-broadcast-bulk": 1,
+      "postmark": 2
+    }
+  }
+}

--- a/harlan-agent-kit/skills/pr-lens/references/graph-document.md
+++ b/harlan-agent-kit/skills/pr-lens/references/graph-document.md
@@ -1,0 +1,233 @@
+# Authoring a graph document
+
+This page is the whole shape, and what a schema cannot tell you besides: which parts matter, and where documents actually go wrong. `references/example.graph.json` is one document that validates, if you would rather read than be told.
+
+The validator enforces the same thing from a JSON Schema, published at `https://unpkg.com/@coldtea/pr-lens-schema/json-schema/graph-doc.schema.json` if you want it machine-readable.
+
+Every schema here is **strict**: an unknown key is a rejection, not a warning. A field with a default may be left out.
+
+## The document
+
+```json
+{
+  "schemaVersion": "0.1.0",
+  "kind": "graph",
+  "title": "Batch broadcast sending through Postmark",
+  "summary": "One paragraph answering: what does this change do?",
+  "lenses": ["architecture", "data-flow"],
+  "provenance": { "repo": { "owner": "…", "name": "…" }, "base": { "sha": "…" }, "head": { "sha": "…" } },
+  "lanes": [],
+  "nodes": [],
+  "edges": [],
+  "flows": [],
+  "stats": {},
+  "views": []
+}
+```
+
+`lenses` declares what the document carries enough detail to draw: `architecture`, `data-flow`, or both. A document carrying flows must declare `data-flow`.
+
+`provenance` is where the document came from: the repository, the base and head commit shas (lowercase hex, 7-40 characters), optionally the pull request and the generator. When you produce a document through the CLI these are filled in from the repository, so do not invent them.
+
+## Ids
+
+`^[A-Za-z0-9][A-Za-z0-9._:/-]*$`, at most 128 characters, unique within their own collection. Use readable kebab-case: `broadcast-sender`, not `n1`. An id ends up in an SVG id, a URL fragment and a comment anchor, so nothing else is allowed through.
+
+## Deltas
+
+Every node, edge, flow and flow step declares one: `added`, `modified`, `removed`, `unchanged`.
+
+`unchanged` is not padding. It is the neighbouring code the change touches, and it is what turns a diagram into a blast radius. A document whose every element is `added` describes a change nobody can place.
+
+## Lanes
+
+1 to 16. Every node belongs to exactly one.
+
+```json
+{ "id": "functions", "label": "Cloud Functions", "subtitle": "Node 20", "order": 1 }
+```
+
+`order` (0-64) places lanes left to right; ties fall back to array order. Give a lane a `delta` only when the lane itself is new or gone.
+
+## Nodes
+
+1 to 256.
+
+```json
+{
+  "id": "send-broadcast-bulk",
+  "label": "sendBroadcastBulk",
+  "kind": "function",
+  "delta": "added",
+  "lane": "functions",
+  "group": "broadcast-lib",
+  "subtitle": "(broadcastId) => Promise<void>",
+  "summary": "Claims the broadcast, builds one bulk payload and posts it.",
+  "files": [{ "path": "functions/src/broadcast/sendBroadcastBulk.ts", "startLine": 1, "endLine": 142 }],
+  "badges": ["retry"]
+}
+```
+
+`kind` is one of `service app module function route job queue datastore cache external ui config test package other`. It drives the card's icon and shape and nothing else; when in doubt, `other` still renders.
+
+`group` clusters nodes inside a lane: a package, a folder that means something. `files` (up to 64) become diff permalinks. `badges` (up to 6) are extra chips; the delta badge is drawn for you, so do not restate it.
+
+## Edges
+
+Up to 512.
+
+```json
+{
+  "id": "bulk-to-postmark",
+  "from": "send-broadcast-bulk",
+  "to": "postmark",
+  "kind": "http",
+  "delta": "added",
+  "label": "POST /email/bulk",
+  "emphasis": "hero",
+  "animated": true
+}
+```
+
+`kind` is one of `call http rpc event queue data dependency render other`. `emphasis` is `normal` (default), `hero` or `muted`. More than one or two heroes and the emphasis stops meaning anything. `from` and `to` must be node ids you declared. This is the single most common failure.
+
+## Flows
+
+Up to 16, for the data-flow lens.
+
+```json
+{
+  "id": "send-pipeline",
+  "title": "Sending a broadcast",
+  "delta": "modified",
+  "participants": [{ "node": "queue-route" }, { "node": "send-broadcast-bulk" }, { "node": "postmark" }],
+  "messages": [
+    { "id": "enqueue", "from": "queue-route", "to": "send-broadcast-bulk", "label": "enqueue job", "kind": "async", "delta": "modified" },
+    { "id": "send", "from": "send-broadcast-bulk", "to": "postmark", "label": "POST /email/bulk", "kind": "sync", "delta": "added", "repeat": 4 },
+    { "id": "accepted", "from": "postmark", "to": "send-broadcast-bulk", "label": "200 Accepted", "kind": "return", "delta": "added" }
+  ]
+}
+```
+
+- 2 to 12 participants, ordered by array position; each names a node id.
+- 1 to 64 messages. **Step order is array order**: there is no step number field, so a document cannot disagree with its own animation.
+- `kind` is `sync`, `async`, `return` or `self`. `self` requires `from === to`, and no other kind may have them equal.
+- Both endpoints must be participants of that flow, not merely nodes of the document.
+- `repeat` says a step happens more than once per run, e.g. 4 batched requests.
+
+## Stats
+
+```json
+{ "filesChanged": 27, "additions": 1979, "deletions": 1370, "chips": [{ "label": "Postmark calls", "value": "500x fewer", "tone": "hero" }] }
+```
+
+Up to 8 chips, `tone` one of `neutral added modified removed hero`. Per-delta element counts are deliberately absent from the schema: they are derivable from the document, and a stored copy can only go stale.
+
+## Views
+
+The drill-down tree in the comment: up to 32 at the root, nesting up to 32 children each. A document with no views renders as one picture and nothing else.
+
+```json
+{
+  "id": "the-new-path",
+  "title": "The new batch path",
+  "lens": "architecture",
+  "summary": "What replaced the per-recipient loop.",
+  "defaultOpen": false,
+  "scope": { "kind": "selection", "nodes": ["send-broadcast-bulk", "postmark"] },
+  "children": []
+}
+```
+
+`scope` is either `{ "kind": "all" }` (the default) or a selection naming at least one lane, node, edge or flow. The two are distinct states on purpose: removing the last element a view pointed at can never quietly turn it into a view of everything. A view's `lens` must be one the document declares.
+
+### Choosing architecture views
+
+Treat the architecture tree as a set of decisions, not a quota:
+
+1. Ask whether the change affects a user, an external system or a system boundary. If it does, start with a system-context view. If it does not, leave that level out.
+2. Show affected applications, services, jobs, data stores and runtimes in a container view. Make it the root when there is no useful context view; otherwise make it a child of that context.
+3. Add a component child only when the internals of an affected container matter to the change. Components may be modules, routes or functions, but the view should explain their responsibilities and relationships rather than mirror folders.
+4. Stop at components unless someone explicitly asks for code-level detail.
+
+One architecture view may be the right answer for a small change. Each child must move down exactly one level and cover a materially narrower scope. Skip a level when it would be empty, speculative or a repeat of its parent. Do not create two views with substantially the same nodes and edges, and do not infer a boundary from a folder name alone. Keep unchanged direct neighbours when they make the blast radius clear.
+
+Set `defaultOpen: true` on the highest useful architecture view. Lower levels should normally stay collapsed. A data-flow view describes an ordered sequence, so keep it as a separate root instead of placing it inside the architecture hierarchy.
+
+This compact fragment shows the shape. The selected ids refer to elements declared elsewhere in the document:
+
+```json
+{
+  "views": [
+    {
+      "id": "checkout-context",
+      "title": "Checkout in its environment",
+      "lens": "architecture",
+      "defaultOpen": true,
+      "scope": {
+        "kind": "selection",
+        "nodes": ["shopper", "commerce-platform", "payment-provider", "fulfilment-system"],
+        "edges": ["shopper-to-commerce", "commerce-to-payment", "commerce-to-fulfilment"]
+      },
+      "children": [
+        {
+          "id": "checkout-containers",
+          "title": "Checkout containers",
+          "lens": "architecture",
+          "scope": {
+            "kind": "selection",
+            "nodes": ["storefront", "checkout-api", "orders-db", "payment-provider"],
+            "edges": ["storefront-to-checkout", "checkout-to-orders", "checkout-to-payment"]
+          },
+          "children": [
+            {
+              "id": "checkout-components",
+              "title": "Checkout API components",
+              "lens": "architecture",
+              "scope": {
+                "kind": "selection",
+                "nodes": ["checkout-route", "order-service", "payment-client"],
+                "edges": ["route-to-orders", "orders-to-payment-client"]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "place-order-flow",
+      "title": "Placing an order",
+      "lens": "data-flow",
+      "scope": { "kind": "selection", "flows": ["place-order"] }
+    }
+  ]
+}
+```
+
+## Layout
+
+```json
+{ "direction": "right", "laneOrder": ["api", "functions", "external"], "rank": { "send-broadcast-bulk": 2 } }
+```
+
+Hints, not instructions: the renderer owns final placement, so a diagram stays deterministic and a stale hint cannot break it. Absolute coordinates are not expressible. Omitting `layout` entirely is normal.
+
+## File references
+
+```json
+{ "path": "functions/src/broadcast/sendBroadcastBulk.ts", "startLine": 1, "endLine": 142, "revision": "head" }
+```
+
+Repository-relative POSIX paths: no leading `/`, no drive letter, no backslash, no `..` segment. Lines are 1-based, `endLine` requires `startLine` and may not precede it. `revision` defaults to `head`; use `base` on elements the change removes.
+
+## Length limits
+
+Labels 120 characters, summaries 2000, chip values 32. They are display fields: a label that needs 120 characters is a label the diagram cannot draw.
+
+## Then validate
+
+```bash
+pnpm dlx @coldtea/pr-lens-cli validate .pr-lens/graph.json
+```
+
+Every problem is reported at once, with a path into the document. Fix them all and run it again until it is clean.

--- a/harlan-agent-kit/skills/pr-lens/references/setup.md
+++ b/harlan-agent-kit/skills/pr-lens/references/setup.md
@@ -1,0 +1,28 @@
+# Setting up PR Lens on a repository
+
+Three ways to get a diagram into a pull request. Pick one per repository.
+
+| | Who draws | Key | Interactive comment |
+| --- | --- | --- | --- |
+| This skill | the coding agent, from the diff it wrote | none | no, the diagram sits in the PR body |
+| [GitHub App](https://github.com/apps/coldtea-pr-lens) | Coldtea's hosted service, Gemini today | none of yours | yes, one sticky comment, redrawn on every push |
+| [Action](../templates/pr-lens.yml) | your CI, on your key | `GEMINI_API_KEY` or OpenAI-compatible | no, one static comment |
+
+## GitHub App
+
+1. Open https://github.com/apps/coldtea-pr-lens and press Install.
+2. Choose the account. Pick **Only select repositories** and tick each repository where you review pull requests. Add more later from https://github.com/settings/installations.
+3. Approve the permissions: read contents and metadata, read and write pull requests.
+4. Open or push to a pull request. The comment appears within a minute and updates in place on every push.
+
+Free for open source. The diff goes to Coldtea's service and to Gemini. Do not install it on a repository whose source may not leave the organisation.
+
+## Action
+
+1. Copy [`templates/pr-lens.yml`](../templates/pr-lens.yml) to `.github/workflows/pr-lens.yml`.
+2. Add a `GEMINI_API_KEY` repository secret. For OpenAI or a compatible endpoint, set `provider`, `model`, and `base-url` in the workflow and name the secret to match.
+3. The Action publishes SVGs to an orphan `pr-lens` branch and posts one comment per pull request. Pull requests from forks get no secret, so they get no diagram.
+
+## Corrections
+
+When a diagram names a file badly or puts a node in the wrong lane, commit `.github/pr-lens.yml`. Every mode reads it. The format is in [config.md](./config.md).

--- a/harlan-agent-kit/skills/pr-lens/templates/pr-lens.yml
+++ b/harlan-agent-kit/skills/pr-lens/templates/pr-lens.yml
@@ -1,0 +1,34 @@
+# PR Lens from CI, on a key of your own. Prefer the GitHub App
+# (https://github.com/apps/coldtea-pr-lens) when you do not need to own the key:
+# it needs no workflow, no secret, and its comment carries interactive checkboxes.
+#
+# Setup: add a GEMINI_API_KEY repository secret. For OpenAI or a compatible
+# endpoint, set `provider`, `model`, and `base-url` and rename the secret.
+name: PR Lens
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+
+permissions:
+  contents: write # publish the rendered SVGs to the orphan pr-lens branch
+  pull-requests: write # post and update the one comment
+
+concurrency: # one run per pull request; a push supersedes the last
+  group: pr-lens-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lens:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # the diff is between two commits, so both must be here
+      - uses: coldteadotai/pr-lens/packages/action@v0
+        with:
+          api-key: ${{ secrets.GEMINI_API_KEY }}
+          # provider: openai            # or openai-compatible
+          # model: gpt-4.1
+          # base-url: https://openrouter.ai/api/v1

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -170,6 +170,12 @@ Modelled on Harlan's hand-written PRs to `nuxt/nuxt`. These are the moves that r
 - **Motivation before mechanism** for a feature: who needs this, what they do today, what is bad about that, then the change.
 - **Do not perform completeness.** Leave the repo template's HTML comments untouched. Tick a checklist box only if it is true. Shipping with boxes unticked is normal and correct.
 
+### Diagram
+
+Before writing the description, decide whether the change earns a diagram. Read the [pr-lens skill](../pr-lens/SKILL.md) and use its threshold: three or more modules, a crossed boundary, or a sequence a reviewer must follow. If it qualifies, author and render the graph document there, then reference the top architecture view from the description with a Markdown image and pass the same path to `--attach` on `gh pr create` or `gh pr edit`. One view is normal. Two is the ceiling unless the change is a large refactor.
+
+A diagram goes in the description, after the why and before the AI disclosure. Never in a trailing comment.
+
 **Strip AI tells from the title and description** before pushing, run them through `/humanize-writing`. For PRs specifically: no em-dashes, drop the over-explained "this means that..." takeaway, and use specifics (issue numbers, real before/after behaviour, measured figures) instead of vague claims like "improves performance". A PR body that reads as AI-generated erodes reviewer trust.
 
 **Reads-human check.** Before pushing, reread the body and cut anything that exists to show effort rather than to help the reviewer. This is the target shape:
@@ -224,6 +230,8 @@ BODY
 EOF
 )"
 ```
+
+When Step 3 rendered a diagram, add `--attach .pr-lens/<view>-dark-<hash>.svg` for each image the body references. GitHub CLI rewrites the Markdown path to the uploaded asset.
 
 Output the PR URL when done. Log to `${CLAUDE_PLUGIN_DATA}/pr-history.log`.
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Reviewing #153 meant rebuilding the call graph across three sweeps, the edit they share, and the store from eleven diffs. That is the job PR Lens does: draw the blast radius and the sequence before anyone reads a line.

The skill is vendored from [coldteadotai/pr-lens](https://github.com/coldteadotai/pr-lens) so Claude and Codex both pick it up from `skills/`, with `pnpm dlx` in place of `npx`. The agent authors the graph document itself from the diff, so no model key is needed. The `pr` skill now calls it in Step 3, but only when a change crosses three or more modules, a boundary, or a sequence; one-file fixes and Markdown work get no diagram. This PR is docs plus a template, so it would carry none; the two below are here as the worked example.

![Where the skill sits: instructions set the threshold, the pr skill calls pr-lens, pr-lens calls the CLI and hands a path back for gh](https://github.com/user-attachments/assets/bbb40301-a7f8-42cd-a640-b65fcdd5bb18)

![Opening a qualifying pull request: the pr skill decides, pr-lens authors and validates, the CLI renders, gh attaches](https://github.com/user-attachments/assets/8c4a248d-5df8-4881-bb28-a7679252d5e6)

A setup reference covers the hosted GitHub App, and `templates/pr-lens.yml` covers the Action for a repository that wants its own key.

One open question: the diagram rules in #154's `references/diagrams.md` overlap this for code changes. If this lands first, that file may shrink to non-code diagrams.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01MJv8UaQZeFCiW5Zgjy6tZS
