### PR TITLE
fix(agent): merge the pull request base branch when resolving conflicts

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3458,6 +3458,21 @@ function supersedeTasks(
   })
 }
 
+/**
+ * Whether the last supersede of a Task caught it after it had left Queued.
+ *
+ * The state machine records this, not the reason text: a task superseded while
+ * Running or Publishing had finished or started agent work for its head commit.
+ */
+function supersededAfterStarting(database: DatabaseSync, taskId: string): boolean {
+  const row = database.prepare(`
+    SELECT from_tag FROM task_transitions
+    WHERE task_id = ? AND to_tag = 'Superseded'
+    ORDER BY id DESC LIMIT 1
+  `).get(taskId) as { from_tag: TaskRow['state_tag'] | null } | undefined
+  return row?.from_tag === 'Running' || row?.from_tag === 'Publishing'
+}
+
 function planConflictResolution(
   database: DatabaseSync,
   subject: GitHubItem,
@@ -3498,6 +3513,25 @@ function planConflictResolution(
     && existing.reason !== null
     && existing.recovery_attempts < MAXIMUM_RECOVERY_ATTEMPTS
     && isTransientFailure({ message: existing.reason })
+  // A Superseded task that had already left Queued spent an agent turn on this
+  // exact head commit, and the controller then threw that work away. Doing it
+  // again is a retry, so it spends recovery budget. One stacked pull request
+  // lost the publication base check two hundred times in two days because this
+  // path requeued it free of charge. A task superseded while still Queued
+  // never ran, so GitHub reporting the same conflict again stays unbudgeted.
+  const repeatedTurn = existing?.state_tag === 'Superseded'
+    && existing.cancelled === 0
+    && supersededAfterStarting(database, existing.id)
+  if (repeatedTurn && existing.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS) {
+    const reason = `${existing.reason ?? 'The publication was retired.'} The controller resolved this conflict ${existing.recovery_attempts + 1} times without publishing. Resolve it by hand, or push a new commit to the pull request.`
+    database.prepare(`
+      UPDATE tasks
+      SET state_tag = 'ActionRequired', reason = ?, updated_at = ?
+      WHERE id = ? AND state_tag = 'Superseded'
+    `).run(reason, observedAt, existing.id)
+    recordTransition(database, { taskId: existing.id, from: 'Superseded', to: 'ActionRequired', reason, fence: existing.fence, at: observedAt })
+    return
+  }
   if ((existing?.state_tag === 'Superseded' && existing.cancelled === 0) || recoverableFailure) {
     database.prepare(`
       UPDATE tasks
@@ -3505,14 +3539,16 @@ function planConflictResolution(
         command_id = NULL, lease_expires_at = NULL, updated_at = ?,
         recovery_attempts = recovery_attempts + ?
       WHERE id = ? AND state_tag = ?
-    `).run(observedAt, recoverableFailure ? 1 : 0, existing.id, existing.state_tag)
+    `).run(observedAt, recoverableFailure || repeatedTurn ? 1 : 0, existing.id, existing.state_tag)
     recordTransition(database, {
       taskId: existing.id,
       from: existing.state_tag,
       to: 'Queued',
       reason: recoverableFailure
         ? 'The previous conflict resolution failed for a transient reason.'
-        : 'GitHub reports merge conflicts again.',
+        : repeatedTurn
+          ? 'The previous conflict resolution was retired before publication.'
+          : 'GitHub reports merge conflicts again.',
       fence: existing.fence,
       at: observedAt,
     })
@@ -3522,7 +3558,9 @@ function planConflictResolution(
   const canWriteHead = canWritePullRequestHead(mapping, subject)
   const canRepairHead = canRepairPullRequestHead(mapping, subject) && reviewApproved
   const ready = canWriteHead || canRepairHead
-  if (existing?.state_tag === 'ActionRequired' && existing.cancelled === 0 && ready) {
+  // An exhausted budget waits for a person. A new head commit makes a new task.
+  if (existing?.state_tag === 'ActionRequired' && existing.cancelled === 0 && ready
+    && existing.recovery_attempts < MAXIMUM_RECOVERY_ATTEMPTS) {
     database.prepare(`
       UPDATE tasks
       SET state_tag = 'Queued', reason = NULL, attempts = 0, worker_id = NULL,

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -585,6 +585,12 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
 
     const headRef = `refs/harlan-github-agent/pull/${task.pullRequestNumber}`
     const baseRef = `refs/harlan-github-agent/base/${task.pullRequestNumber}`
+    // A stacked pull request merges into another pull request's head branch.
+    // Publication pins that same branch, so merging the default branch here
+    // resolved the wrong conflict and no publication ever matched its base.
+    const baseBranch = task.pullRequest.baseRef ?? task.repositoryMapping.defaultBranch
+    if (!isSafeGitRef(baseBranch))
+      return err('The pull request base branch is unsafe.')
     const token = await options.tokens.getToken(task.repository, 'read', signal)
     if (token._tag === 'Err')
       return err(token.error.message)
@@ -594,7 +600,7 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
       '--no-tags',
       remoteUrl,
       `+refs/pull/${task.pullRequestNumber}/head:${headRef}`,
-      `+refs/heads/${task.repositoryMapping.defaultBranch}:${baseRef}`,
+      `+refs/heads/${baseBranch}:${baseRef}`,
     ], signal, token.value.token, options.remoteUrl !== undefined)
     if (fetch.exitCode !== 0)
       return err(`Git fetch failed: ${fetch.stderr}`)

--- a/packages/harlan-github-agent/test/conflict-worktree.test.ts
+++ b/packages/harlan-github-agent/test/conflict-worktree.test.ts
@@ -93,6 +93,31 @@ describe('conflict worktree', () => {
     expect(result).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ baseSha: currentBaseSha, conflictedFiles: ['file.txt'] }) }))
   })
 
+  it('merges the stacked base branch instead of the default branch', async () => {
+    const { checkout, remote, root, task } = fixture()
+    // A stack: the pull request merges into another branch that diverged from
+    // main. Merging main here resolves the wrong conflict and the publication
+    // base check never matches.
+    git(checkout, 'checkout', '-b', 'feature/parent', task.pullRequest.baseSha)
+    writeFileSync(join(checkout, 'file.txt'), 'parent base\n')
+    git(checkout, 'commit', '-am', 'parent change')
+    git(checkout, 'push', 'origin', 'feature/parent')
+    const parentSha = git(checkout, 'rev-parse', 'HEAD')
+    const manager = createConflictWorktreeManager({
+      gitIdentity: { name: 'Harlan Wilton', email: 'harlan@harlanzw.com' },
+      remoteUrl: () => remote,
+      root,
+      tokens: { getToken: () => Promise.resolve({ _tag: 'Ok', value: { token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' } }), invalidate: () => undefined },
+    })
+
+    const result = await manager.prepare({ ...task, pullRequest: { ...task.pullRequest, baseRef: 'feature/parent' } }, new AbortController().signal)
+
+    expect(result).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ baseSha: parentSha, conflictedFiles: ['file.txt'] }) }))
+    if (result._tag === 'Err')
+      throw new Error(result.error)
+    expect(git(result.value.path, 'rev-parse', 'MERGE_HEAD')).toBe(parentSha)
+  })
+
   it('stages a verified conflict file in the controller-owned index', async () => {
     const { remote, root, task } = fixture()
     const manager = createConflictWorktreeManager({

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { agentProfile, CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
+import { MAXIMUM_RECOVERY_ATTEMPTS } from '../src/failure.ts'
 import { repositoryQuarantineReason } from '../src/github-write-gate.ts'
 import { routineReportCommand } from '../src/routine-report-controller.ts'
 import { openJournalStore } from '../src/store.ts'
@@ -903,6 +904,88 @@ describe('journal store', () => {
       _tag: 'Queued',
       work: 'conflict_resolution',
     })
+  })
+
+  it('requeues a re-conflict free of recovery budget', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const conflicting = pullRequestItem({ mergeState: 'conflicting' })
+    let elapsed = 0
+    const at = (): string => new Date(Date.parse('2026-08-13T01:00:00.000Z') + (elapsed += 1000)).toISOString()
+    store.recordObservation({ externalId: 'flapping', observedAt: at(), source: 'poll', subject: conflicting })
+    // More rounds than the recovery budget. GitHub changing its mind is not
+    // the controller's failure, so none of these spend budget.
+    for (let round = 0; round < MAXIMUM_RECOVERY_ATTEMPTS + 2; round += 1) {
+      store.recordObservation({ externalId: 'clean', observedAt: at(), source: 'poll', subject: pullRequestItem({ mergeState: 'clean' }) })
+      store.recordObservation({ externalId: 'flapping', observedAt: at(), source: 'poll', subject: conflicting })
+    }
+
+    expect(store.getDashboardSnapshot(at()).queue[0]?.state).toEqual({
+      _tag: 'Queued',
+      work: 'conflict_resolution',
+    })
+  })
+
+  it('stops requeueing a conflict whose publication keeps losing the base branch race', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const subject = pullRequestItem({ mergeState: 'conflicting' })
+    let elapsed = 0
+    const at = (): string => new Date(Date.parse('2026-08-13T01:00:00.000Z') + (elapsed += 1000)).toISOString()
+    store.recordObservation({ externalId: 'base-race', observedAt: at(), source: 'poll', subject })
+    const supersededPublication = (): boolean => {
+      const task = store.claimNextConflictTask('worker-1', at(), 600_000)
+      if (task === null)
+        return false
+      const staged = store.stagePublication({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at: at(),
+        publication: {
+          _tag: 'UpdatePullRequest',
+          taskKind: 'resolve_conflict',
+          pullRequestNumber: task.pullRequestNumber,
+          commitSha: `merge-${elapsed}`,
+          baseSha: task.pullRequest.baseSha,
+          baseRef: 'main',
+          expectedHeadSha: task.pullRequest.headSha,
+          headRef: task.pullRequest.headRef,
+          artifactRef: `refs/harlan-github-agent/publications/${elapsed}`,
+          patchDigest: 'patch',
+          changedFiles: 1,
+        },
+      })
+      if (staged._tag !== 'Staged')
+        throw new Error(`Expected a staged publication, got ${staged._tag}.`)
+      const command = store.claimNextPublication('publisher-1', at(), 600_000)
+      if (command === null)
+        throw new Error('Expected a claimed publication.')
+      store.supersedePublication({
+        commandId: command.id,
+        workerId: command.workerId,
+        fence: command.fence,
+        at: at(),
+        reason: 'The base branch changed before publication.',
+      })
+      // The next poll still sees the same head commit conflicting.
+      store.recordObservation({ externalId: 'base-race', observedAt: at(), source: 'poll', subject })
+      return true
+    }
+
+    // Each lost race repeats one whole agent turn for the same head commit.
+    // The first turn is free; every requeue after it spends one recovery.
+    for (let round = 0; round < MAXIMUM_RECOVERY_ATTEMPTS + 1; round += 1)
+      expect(supersededPublication()).toBe(true)
+
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at()).queue[0]?.state).toEqual({
+      _tag: 'ActionRequired',
+      reason: 'The base branch changed before publication. The controller resolved this conflict 6 times without publishing. Resolve it by hand, or push a new commit to the pull request.',
+    })
+    // A later poll of the same head commit must not wake it again.
+    store.recordObservation({ externalId: 'base-race', observedAt: at(), source: 'poll', subject })
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
   })
 
   it('keeps a manually cancelled task cancelled across later polls', () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

nuxtseo.com#725 is stacked on `feat/brand-kit-site-explorer`. Conflict prepare fetched `main` as the merge base, publication compared the real base branch SHA, so every turn ended with `The base branch changed before publication.` and the supersede path requeued it free. The journal shows 200 agent turns and 26.7 agent hours on that one task in 48 hours, found by the first agent-retro run (#157).

Prepare now merges the recorded base ref. A Superseded conflict task that had already left Queued spends one recovery attempt per requeue and stops in `ActionRequired` with the count when the budget is gone. A task superseded while still Queued, or a fresh re-conflict after a successful publication, still requeues free.

Open question: the last transition, not the reason text, decides "already ran", so a task superseded mid-run because GitHub flipped clean then conflicting also spends a unit. Bounded at five, so I left it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).