### PR TITLE
fix(agent): give the conflict Agent its files, SHAs, and a check budget

### DIFF
--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -4,7 +4,7 @@ import type { GitHubSource } from './github.ts'
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedConflictResolutionTask, MutationWorkerOutcome, RepositoryMapping } from './types.ts'
-import type { ConflictWorktreeManager } from './worktree.ts'
+import type { ConflictWorktreeManager, PreparedConflictWorktree } from './worktree.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { isAutomatedGitHubActor } from './github.ts'
 import { err, ok } from './result.ts'
@@ -43,19 +43,35 @@ const outputSchema = {
   },
 }
 
-function workerPrompt(task: ClaimedConflictResolutionTask): string {
+function workerPrompt(task: ClaimedConflictResolutionTask, worktree: PreparedConflictWorktree): string {
+  const baseRef = task.pullRequest.baseRef ?? task.repositoryMapping.defaultBranch
+  const files = worktree.conflictedFiles.map(file => `- ${file}`).join('\n')
   return `Resolve the existing merge conflicts for ${task.repository}#${task.pullRequestNumber}.
 
 Work as a normal local agent session inside this Git worktree. Use the user's global agent context, installed skills, environment, and authenticated GitHub CLI.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before returning a result.
-Select every installed skill whose trigger matches the work. Apply the unit-tests skill before regression repair.
-The controller already merged the current base into this worktree. Only resolve the conflicted files.
+The controller already merged the base branch into this worktree. Do not rediscover the merge state.
+Pull request head: ${worktree.headSha}
+Base branch: ${baseRef} at ${worktree.baseSha}
+Conflicted files:
+${files}
+
+Edit the conflicted files only. Do not change a file the merge did not touch. The controller rejects such a change.
+Leave no conflict markers in any file. Search for <<<<<<<, =======, and >>>>>>> before you return.
 Follow repository AGENTS.md and contributor instructions. Preserve the pull request intent.
-Use live search when useful. Run focused checks and repository-required checks.
-Edit the conflicted files only. Do not stage files. The controller stages verified conflict files.
+Use GitHub read commands when issue or pull request history clarifies intent. Do not post comments.
+
+Run only these focused checks:
+- eslint on the conflicted files
+- vitest on the test files that import the conflicted files
+- git diff --check
+Run package scripts with pnpm exec. Never use npx.
+Do not run the full test suite, the full typecheck, a build, or a toolchain install. CI runs those after publication.
+A failure outside the conflicted files is pre-existing. Do not chase it.
+
+Do not stage files. The controller stages verified conflict files.
 Do not commit, push, amend, rebase, abort the merge, or edit Git configuration.
 Choose a commit message that describes the resolved conflict.
-Use GitHub read commands when issue or pull request history clarifies intent. Do not post comments.
 Return the required JSON result. Use outcome blocked when intent is ambiguous or safe verification cannot finish.
 The controller rejects a resolved outcome without a commit message. Return an empty commit message only with outcome blocked.`
 }
@@ -128,7 +144,7 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
         freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
         progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'conflict' },
-        prompt: workerPrompt(currentTask),
+        prompt: workerPrompt(currentTask, prepared.value),
         repository: task.repository,
         role: 'conflict_resolution',
         schema: outputSchema,

--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -67,7 +67,8 @@ Run only these focused checks:
 - git diff --check
 Run package scripts with pnpm exec. Never use npx.
 Do not run the full test suite, the full typecheck, a build, or a toolchain install. CI runs those after publication.
-A failure outside the conflicted files is pre-existing. Do not chase it.
+A failure in a file that neither side of the merge changed is pre-existing. Do not chase it.
+If the resolution breaks a test or call site that the base branch moved, fix that file too. The controller accepts edits to files the merge touched.
 
 Do not stage files. The controller stages verified conflict files.
 Do not commit, push, amend, rebase, abort the merge, or edit Git configuration.

--- a/packages/harlan-github-agent/test/conflict-worker.test.ts
+++ b/packages/harlan-github-agent/test/conflict-worker.test.ts
@@ -148,4 +148,33 @@ describe('conflict worker', () => {
     expect(result._tag).toBe('Ok')
     expect(preparedBaseSha).toBe('current-base')
   })
+
+  it('tells the agent the conflicted files, both SHAs, and the check budget', async () => {
+    const repository = repositoryMapping()
+    const current = pullRequestItem({ baseSha: 'current-base', headSha: 'head-sha', baseRef: 'feat/parent' })
+    const capture: ProviderCapture = { requests: [] }
+    const worker = createConflictWorker({
+      ...conflictWorkerOptions(repository, current),
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(resolved), capture)),
+      worktrees: {
+        ...conflictWorkerOptions(repository, current).worktrees,
+        prepare: () => Promise.resolve(ok({ path: '/tmp/worktree', headSha: 'head-sha', baseSha: 'current-base', conflictedFiles: ['src/a.ts', 'src/b.vue'] })),
+      },
+    })
+
+    const result = await worker.run(conflictTask(repository, current), new AbortController().signal)
+
+    expect(result._tag).toBe('Ok')
+    const prompt = capture.requests[0]?.prompt ?? ''
+    expect(prompt).toContain('Pull request head: head-sha')
+    expect(prompt).toContain('Base branch: feat/parent at current-base')
+    expect(prompt).toContain('- src/a.ts\n- src/b.vue')
+    expect(prompt).toContain('- eslint on the conflicted files')
+    expect(prompt).toContain('- vitest on the test files that import the conflicted files')
+    expect(prompt).toContain('- git diff --check')
+    expect(prompt).toContain('Do not run the full test suite, the full typecheck, a build, or a toolchain install.')
+    expect(prompt).toContain('Never use npx.')
+    expect(prompt).toContain('Leave no conflict markers in any file.')
+    expect(prompt).not.toContain('unit-tests skill')
+  })
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Follows #158, which is already merged, so this lands on main. A seven day retro of conflict resolution sessions showed every session spending 3 to 6 tool calls rediscovering the conflicted files and both SHAs, which the controller already holds. Half of wall time went to full `test:run` and `typecheck:pro` runs that surfaced only pre-existing errors; one hit the 900 s tool timeout and lost its lease. The prompt now names the files, head, and base with SHA, limits checks to eslint on the conflicted files, vitest on their tests, and `git diff --check`, and says `pnpm exec` since `npx` fails on the devEngines pin. The unit-tests skill line is gone for this role; five sessions loaded it and declared it not applicable.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz