### PR TITLE
fix(agent): hand Repair whole findings and accept fenced JSON

### DIFF
--- a/packages/harlan-github-agent/src/agent-turn.ts
+++ b/packages/harlan-github-agent/src/agent-turn.ts
@@ -79,6 +79,43 @@ Use no tool. Return no prose, no explanation, and no Markdown code fence.`
 }
 
 /**
+ * The JSON object inside an answer, without the Markdown a model adds around it.
+ *
+ * A model that was told to return bare JSON still fences it or opens with a
+ * sentence. The work behind such an answer is complete, so paying a repair
+ * turn for the wrapper is waste. Prose before the object is accepted only when
+ * the remainder parses, so a garbled answer still reaches the parser unchanged
+ * and fails with its own tagged error.
+ */
+function stripCodeFence(text: string): string {
+  if (!text.startsWith('```') || !text.endsWith('```'))
+    return text
+  const open = text.indexOf('\n')
+  if (open === -1)
+    return text
+  return text.slice(open + 1, text.length - 3).trim()
+}
+
+export function unwrapJsonResponse(response: string): string {
+  const body = stripCodeFence(response.trim())
+  if (body.startsWith('{'))
+    return body
+  const start = body.indexOf('{')
+  if (start === -1)
+    return response
+  const remainder = body.slice(start)
+  try {
+    JSON.parse(remainder)
+    return remainder
+  }
+  catch {
+    // The remainder is not JSON either, so the original answer goes to the
+    // parser and its own error names the failure.
+    return response
+  }
+}
+
+/**
  * Runs one agent turn against the configured provider.
  *
  * Owns session reuse, activity, and progress so every worker role behaves the
@@ -189,7 +226,7 @@ export async function runParsedAgentTurn<Value>(
   const turn = await runAgentTurn(frozen, input, signal)
   if (turn._tag === 'Err')
     return turn
-  const parsed = await options.parse(turn.value.response)
+  const parsed = await options.parse(unwrapJsonResponse(turn.value.response))
   if (parsed._tag === 'Ok')
     return ok({ value: parsed.value, sessionId: turn.value.sessionId, usage: turn.value.usage })
 
@@ -201,7 +238,7 @@ export async function runParsedAgentTurn<Value>(
   }, signal)
   if (repaired._tag === 'Err')
     return err(parsed.error)
-  const reparsed = await options.parse(repaired.value.response)
+  const reparsed = await options.parse(unwrapJsonResponse(repaired.value.response))
   return reparsed._tag === 'Ok'
     ? ok({
         value: reparsed.value,

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -34,7 +34,7 @@ import { repairRoundLabel } from './repair-rounds.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedDisclosure } from './review-comment.ts'
-import { cleanLine, updatedAtLabel } from './text.ts'
+import { cleanLine, cleanText, updatedAtLabel } from './text.ts'
 
 interface ReviewResponse {
   confidence: number
@@ -103,10 +103,12 @@ Check clipping, overlap, overflow, alignment, contrast, missing content, and bro
 Treat a clearly labelled Before image as historical evidence. Verify the current head separately.
 If an image stays inaccessible after authenticated retrieval, or is corrupt, return a material documentation finding.
 Trace each visual defect to the affected implementation and include screenshot proof.
-Use live search when current documentation or external context improves the review. The controller owns head stability, merge state, CI, and the final Review outcome.
+The controller owns head stability, merge state, CI, and the final Review outcome.
+Read only the changed hunks plus the symbols they call. Do not read a file over 300 lines whole.
+Run at most one test command. Never run a test file CI already runs.
 Never run a repository-wide test suite, typecheck, build, dev server, site crawl, or Lighthouse audit. If CI is missing or unavailable, continue the code review. The controller reports that state.
-Limit local commands to changed files, their direct dependants, and focused behavior. Run one focused test or command only to prove a material finding or verify touched behavior that CI does not cover.
-Use GitHub read commands when history, linked issues, pull requests, checks, or releases improve the review.
+Never pass -r to rg. It means replace, not recursive.
+Stay inside the worktree. Never search / or another worktree.
 Keep the worktree read only. Do not edit, stage, commit, push, or post comments. The controller rejects a Review that changes files.
 Return only the required JSON.
 
@@ -121,7 +123,8 @@ Do not call GitHub-first workflow state a wrong premise by itself.
 Call the premise wrong when the pull request removes local coordination before the required GitHub-backed replacement exists.
 Return one evidence-based finding for every material consequence of a wrong premise.
 Return every material defect.
-Each finding needs a stable identity, exact path and line, proof, summary, and next action.
+Each finding needs a stable identity, exact path and line, proof, summary, and next action. Every field is required, including summary.
+Example finding: {"identity":"buffered-byte-loss","path":"src/parser.ts","line":42,"proof":"A split UTF-8 sequence loses its first byte.","regressionTest":"Split one sequence across two chunks and assert the original string.","summary":"The parser drops data.","nextAction":"Keep the buffered bytes."}
 Keep the identity stable across line changes.
 For a sound premise, describe one test that fails before Repair and passes after it.
 For a wrong premise, return null for every regressionTest. The controller will recommend Dismissal.
@@ -320,12 +323,12 @@ function parseReviewResponse(text: string): Promise<Result<ReviewResponse, strin
           return typeof candidate.identity === 'string' && normalizedFindingIdentity(candidate.identity).length > 0
             && typeof candidate.path === 'string' && cleanLine(candidate.path).length > 0
             && (candidate.line === null || (Number.isInteger(candidate.line) && (candidate.line ?? 0) >= 1))
-            && typeof candidate.proof === 'string' && cleanLine(candidate.proof).length > 0
+            && typeof candidate.proof === 'string' && cleanText(candidate.proof).length > 0
             && (premise.verdict === 'sound'
-              ? typeof candidate.regressionTest === 'string' && cleanLine(candidate.regressionTest).length > 0
+              ? typeof candidate.regressionTest === 'string' && cleanText(candidate.regressionTest).length > 0
               : candidate.regressionTest === null)
             && typeof candidate.summary === 'string' && cleanLine(candidate.summary).length > 0
-            && typeof candidate.nextAction === 'string' && cleanLine(candidate.nextAction).length > 0
+            && typeof candidate.nextAction === 'string' && cleanText(candidate.nextAction).length > 0
         })
         || !(typeof confidence === 'number' && Number.isInteger(confidence) && confidence >= 0 && confidence <= 100)
       ) {
@@ -338,11 +341,13 @@ function parseReviewResponse(text: string): Promise<Result<ReviewResponse, strin
         findings: reviewed.map(finding => ({
           identity: normalizedFindingIdentity(finding.identity),
           line: finding.line,
+          // Only the summary must fit one line. The other fields reach the
+          // Repair Agent whole, so it never re-reads the diff to finish a cut sentence.
           summary: cleanLine(finding.summary),
-          nextAction: cleanLine(finding.nextAction),
+          nextAction: cleanText(finding.nextAction),
           path: cleanLine(finding.path),
-          proof: cleanLine(finding.proof),
-          regressionTest: finding.regressionTest === null ? null : cleanLine(finding.regressionTest),
+          proof: cleanText(finding.proof),
+          regressionTest: finding.regressionTest === null ? null : cleanText(finding.regressionTest),
         })),
       })
     })

--- a/packages/harlan-github-agent/src/text.ts
+++ b/packages/harlan-github-agent/src/text.ts
@@ -1,8 +1,27 @@
 /** One line, no markers, short enough for a dashboard row or a Git subject. */
 const maximumLineCharacters = 240
 
+const markerPattern = /<!--|-->|🤖/g
+
 export function cleanLine(value: string): string {
-  return value.replaceAll(/<!--|-->|[\r\n]|🤖/g, ' ').replaceAll(/\s+/g, ' ').trim().slice(0, maximumLineCharacters)
+  return value.replaceAll(markerPattern, ' ').replaceAll(/[\r\n]/g, ' ').replaceAll(/\s+/g, ' ').trim().slice(0, maximumLineCharacters)
+}
+
+/**
+ * Whole text, no markers, no control characters, no length cap.
+ *
+ * A Review finding's proof, regression test, and next action feed the next
+ * Repair Agent. Cut at 240 characters they ended mid-word, and every Repair
+ * re-read the diff to recover the intent. Line breaks and tabs stay because
+ * the Agent writes lists and code in them.
+ */
+export function cleanText(value: string): string {
+  return value
+    .replaceAll(markerPattern, ' ')
+    .replaceAll('\r\n', '\n')
+    // eslint-disable-next-line no-control-regex
+    .replaceAll(/[\u0000-\u0008\u000B-\u001F\u007F]/g, '')
+    .trim()
 }
 
 /**

--- a/packages/harlan-github-agent/test/agent-turn.test.ts
+++ b/packages/harlan-github-agent/test/agent-turn.test.ts
@@ -48,7 +48,71 @@ const input = {
   workspace: '/tmp/worktree',
 }
 
+function rawReplies(texts: string[], capture: { prompts: string[] }): AgentProvider {
+  return {
+    name: 'opencode',
+    runTurn: (request) => {
+      capture.prompts.push(request.prompt)
+      const text = texts[capture.prompts.length - 1] ?? ''
+      return (async function* () {
+        yield { _tag: 'SessionStarted', sessionId: 'session-1' } as AgentEvent
+        yield { _tag: 'Message', text } as AgentEvent
+        yield { _tag: 'TurnCompleted' } as AgentEvent
+      })()
+    },
+  }
+}
+
+function malformedAware(provider: AgentProvider) {
+  return {
+    ...options(provider),
+    parse: (response: string): Result<{ outcome: string }, string> => {
+      let value: { outcome?: string }
+      try {
+        value = JSON.parse(response) as { outcome?: string }
+      }
+      catch {
+        return err('The agent returned malformed conflict resolution JSON.')
+      }
+      return value.outcome === 'resolved'
+        ? ok({ outcome: value.outcome })
+        : err('The agent returned an invalid conflict resolution result.')
+    },
+  }
+}
+
 describe('runParsedAgentTurn', () => {
+  it('reads JSON inside a Markdown code fence without a repair turn', async () => {
+    const capture = { prompts: [] as string[] }
+    const provider = rawReplies(['```json\n{"outcome": "resolved"}\n```'], capture)
+
+    const result = await runParsedAgentTurn(malformedAware(provider), input, new AbortController().signal)
+
+    expect(result).toEqual(ok({ value: { outcome: 'resolved' }, sessionId: 'session-1', usage: { _tag: 'Unavailable' } }))
+    expect(capture.prompts).toHaveLength(1)
+  })
+
+  it('reads JSON after leading prose when the remainder parses', async () => {
+    const capture = { prompts: [] as string[] }
+    const provider = rawReplies(['Here is the result:\n{"outcome": "resolved", "note": "a {brace} inside"}'], capture)
+
+    const result = await runParsedAgentTurn(malformedAware(provider), input, new AbortController().signal)
+
+    expect(result).toEqual(ok({ value: { outcome: 'resolved' }, sessionId: 'session-1', usage: { _tag: 'Unavailable' } }))
+    expect(capture.prompts).toHaveLength(1)
+  })
+
+  it('still rejects an answer with no JSON object with the parser error', async () => {
+    const capture = { prompts: [] as string[] }
+    const provider = rawReplies(['I fixed it {but never', 'still prose'], capture)
+
+    const result = await runParsedAgentTurn(malformedAware(provider), input, new AbortController().signal)
+
+    expect(result).toEqual(err('The agent returned malformed conflict resolution JSON.'))
+    expect(capture.prompts).toHaveLength(2)
+    expect(capture.prompts[1]).toContain('The agent returned malformed conflict resolution JSON.')
+  })
+
   it('asks once for a corrected result, keeping the work behind it', async () => {
     const capture = { prompts: [] as string[] }
     const provider = replies([{ outcome: 'nearly' }, { outcome: 'resolved' }], capture)

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -137,7 +137,7 @@ describe('subject Workers', () => {
     expect(attempt).toEqual(expect.objectContaining({ model: 'gpt-5.6-sol', confidence: 96 }))
     expect(capture.requests).toEqual([expect.objectContaining({ model: 'gpt-5.6-sol', reasoningEffort: 'high' })])
     expect(capture.requests[0]?.prompt).toContain('Never run a repository-wide test suite, typecheck, build, dev server, site crawl, or Lighthouse audit')
-    expect(capture.requests[0]?.prompt).toContain('Limit local commands to changed files, their direct dependants, and focused behavior')
+    expect(capture.requests[0]?.prompt).toContain('Read only the changed hunks plus the symbols they call.')
     expect(capture.requests[0]?.prompt).toContain('Visually inspect every image embedded in the pull request description')
     expect(capture.requests[0]?.prompt).toContain('Download images only from GitHub-hosted media URLs')
     expect(capture.requests[0]?.prompt).toContain('private-user-images.githubusercontent.com')
@@ -458,6 +458,112 @@ describe('subject Workers', () => {
     expect(terminal).toContain('### 🤖 BLOCKED')
     expect(terminal).toContain('The parser drops data.')
     expect(worktreeVerified).toBe(true)
+  })
+
+  it('hands Repair the whole proof, regression test, and next action', async () => {
+    const repository = repositoryMapping({ ownership: 'maintained' })
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const longProof = `Byte 0x80 opens a sequence at line 42.\n${'The buffer drops it when the chunk ends there. '.repeat(21)}`.trim()
+    const longRegressionTest = `Split one sequence across two chunks.\n- assert the original string\n${'x'.repeat(300)}`
+    const longNextAction = `Preserve the buffered bytes.\t${'Carry the tail into the next chunk. '.repeat(10)}`.trim()
+    let attempt: RecordReviewRunInput | undefined
+    let queued = false
+    const worker = createReviewWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        premise: { verdict: 'sound', reason: 'The parser change remains valid after a focused fix.' },
+        findings: [{
+          identity: 'buffered-byte-loss',
+          path: 'src/parser.ts',
+          line: 42,
+          proof: longProof,
+          regressionTest: longRegressionTest,
+          summary: 'The parser drops data.',
+          nextAction: longNextAction,
+        }],
+        confidence: 90,
+      }))),
+      github: {
+        consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
+        ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        clearAgentLabels: () => Promise.reject(new Error('Unexpected label clear.')),
+        clearRunningLabel: () => Promise.reject(new Error('Unexpected Running label clear.')),
+        listRunningLabelledItems: () => Promise.reject(new Error('Unexpected Running label read.')),
+        stampAgentLabel: () => Promise.resolve(ok(undefined)),
+        getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+        listPullRequestFiles: () => Promise.resolve(ok([])),
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          body: 'Fixes the parser.',
+          checks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' as const },
+          reviews: [],
+        })),
+        upsertIssueTriageComment: () => Promise.reject(new Error('Unexpected issue comment.')),
+        upsertReviewStatus: () => Promise.reject(new Error('The status controller owns comments.')),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
+      store: {
+        queueReviewFixTaskForReview: () => {
+          queued = true
+          return { _tag: 'Queued', taskId: 'repair-task', rounds: { number: 1, limit: 3 } }
+        },
+        getRepairedHeadFindings: () => [],
+        getWorkerSession: () => null,
+        listReviewRuns: () => [],
+        supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
+        recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
+        queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
+        retireBaselineRepairForReview: () => 0,
+        recordReviewRun: (input) => {
+          attempt = input
+          return { _tag: 'Inserted', reviewRunId: input.id }
+        },
+        recordReviewPublication: () => { throw new Error('A repaired head must not publish the old terminal review.') },
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      status: {
+        publish: () => Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+      },
+      triageStatus: { publish: () => Promise.reject(new Error('Unexpected issue triage.')) },
+      workspaces: {
+        prepareIssue: () => Promise.reject(new Error('Unexpected issue workspace.')),
+        prepareReview: () => Promise.resolve(ok({ path: '/tmp/review-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+        verifyReview: () => Promise.resolve(ok(undefined)),
+      },
+    })
+
+    const result = await worker.run({
+      id: 'review-task',
+      kind: 'adversarial_review',
+      repository: repository.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: repository,
+      pullRequest,
+      rerun: { _tag: 'NotRequested' },
+    }, new AbortController().signal)
+
+    expect(result).toEqual(ok({ evidence: expect.any(String), resolution: { _tag: 'Reviewed', reviewRunId: expect.any(String) } }))
+    expect(longProof.length).toBeGreaterThan(1_000)
+    expect(attempt?.findings).toEqual([expect.objectContaining({
+      _tag: 'Open',
+      nextAction: longNextAction,
+      details: expect.objectContaining({
+        proof: longProof,
+        regressionTest: longRegressionTest,
+      }),
+    })])
+    expect(queued).toBe(true)
   })
 
   it('stamps a wrong premise for Dismissal without queuing Repair', async () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Ten exported Repair sessions all opened by re-running `git diff base..head`, because the findings they received ended mid-word ("stubbed to ", "assignMonitoringAlloca"). The controller cut proof, regression test, and next action at 240 characters along with the summary. Only the summary needs one line for the dashboard and the comment; the other fields now reach Repair whole. Two smaller Review costs go with it: a fenced or prose-prefixed JSON answer no longer buys a repair turn, and the Review prompt shows an example finding with `summary` present, since 2 of 10 sessions dropped it and retried.

The prompt also names a reading and test budget (changed hunks only, one test command, no `rg -r`, stay in the worktree) and drops the live search and `gh` read lines no session used.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz