### PR TITLE
fix(agent): decide Pull request triage by path rule first

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -19,10 +19,12 @@ Require an explicit configuration file. Start from `config.example.yml` only whe
 
 Use `github.allowed_owners` before GitHub access. Ignore installations and personal-account repositories from every other GitHub owner. Scan only immediate directories under `~/pkg` and `~/sites` to find trusted local checkouts. Treat configured repositories as policy overrides. Never act on a checkout without matching its GitHub origin and discovered authentication.
 
-Skip a tracked pull request with a conventional non-breaking `chore:` title before starting an Agent.
-For every other tracked pull request authored by `harlan-zw`, run low-cost Pull request triage.
-Require an adversarial Review for code, tests, configuration, dependencies, workflows, schemas, generated runtime output, security boundaries, public APIs, performance-sensitive files, behavior claims, or uncertainty.
-Skip only clearly judgment-free prose, formatting, or comment-only changes.
+For every tracked pull request authored by `harlan-zw`, run Pull request triage. The path rule decides first.
+If one changed path is outside the prose set, require an adversarial Review without an Agent. The prose set is `*.md`, `*.mdx`, `*.txt`, `LICENSE*`, `CHANGELOG*`, and `docs/**`.
+Treat `SKILL.md`, `AGENTS.md`, `CLAUDE.md`, `.github/**`, `.claude/**`, and `.codex*/**` as behaviour, not prose. They always require Review.
+If every changed path is prose, reuse the stored decision for the same head commit. If none exists, ask the low-cost Agent with the title and changed paths only.
+The Agent skips only clearly judgment-free prose, formatting, or comment-only changes. Uncertainty requires Review.
+Store the decision source in the reason. A stored reason starts with `rule: ` or `model: `.
 Stamp `harlan-agent-review-skipped` when Review is skipped.
 Stamp `harlan-agent-review-required` when Pull request triage requires Review.
 Replace that route label with exactly one Review outcome label when Review finishes.

--- a/packages/harlan-github-agent/GLOSSARY.md
+++ b/packages/harlan-github-agent/GLOSSARY.md
@@ -420,9 +420,9 @@ One self identified automated triage record on an issue. Re-runs update the cano
 
 One routing decision for one exact pull request head commit.
 
-A conventional non-breaking `chore:` title skips Review without starting an Agent.
+The path rule decides first. One changed path outside the prose set requires Review without starting an Agent. Agent instruction files and `.github/**` count as behaviour, not prose.
 
-Every other pull request uses a low-cost Agent decision. It requires or skips an adversarial Review. Any uncertainty requires Review.
+A prose-only pull request reuses the stored decision for the same head commit. Otherwise it uses a low-cost Agent decision from the title and changed paths. Any uncertainty requires Review.
 
 `harlan-agent-review-required` records the automatic route to Review. `harlan-agent-review-skipped` records a skipped Review.
 

--- a/packages/harlan-github-agent/src/pull-request-triage.ts
+++ b/packages/harlan-github-agent/src/pull-request-triage.ts
@@ -19,15 +19,23 @@ function isPullRequestTriageState(value: unknown): value is PullRequestTriageSta
   return typeof value === 'string' && PULL_REQUEST_TRIAGE_STATES.includes(value as PullRequestTriageState)
 }
 
+/**
+ * Who decided. `rule` is the path classifier, `model` is a fresh Agent turn,
+ * `reuse` is a stored decision for the same head commit.
+ */
+export type PullRequestTriageSource = 'rule' | 'model' | 'reuse'
+
 export interface PullRequestTriageResult {
   _tag: PullRequestTriageState
+  /** Starts with `rule: ` or `model: ` so a stored row still names its source. */
   reason: string
+  source: PullRequestTriageSource
 }
 
 export interface PullRequestTriageAgent {
   run: (
     task: ClaimedAdversarialReviewTask,
-    input: { body: string, changedFiles: string[] },
+    input: { changedFiles: string[] },
     signal: AbortSignal,
   ) => Promise<Result<PullRequestTriageResult, string>>
 }
@@ -36,9 +44,44 @@ interface PullRequestTriageAgentOptions {
   activityLog?: Pick<AgentActivityLog, 'record'>
   now: () => Date
   runtime: AgentRuntimeSource
-  store: Pick<JournalStore, 'getWorkerSession' | 'saveWorkerSession'>
+  store: Pick<JournalStore, 'getLatestPullRequestTriageRun' | 'getWorkerSession' | 'saveWorkerSession'>
   /** A service-owned directory. Pull request triage never runs in a Repository mapping. */
   workspace: string
+}
+
+const PROSE_FILE_PATTERN = /(?:^|\/)(?:[^/]+\.(?:md|mdx|txt)|LICENSE[^/]*|CHANGELOG[^/]*)$/i
+const PROSE_DIRECTORY_PATTERN = /(?:^|\/)docs\//
+/** Agent instructions are behaviour, so they leave the prose set even when they end in `.md`. */
+const BEHAVIOUR_PATTERN = /(?:^|\/)(?:SKILL\.md|AGENTS\.md|CLAUDE\.md)$|(?:^|\/)(?:\.github|\.claude|\.codex[^/]*)\//
+
+export function isProsePath(path: string): boolean {
+  if (BEHAVIOUR_PATTERN.test(path))
+    return false
+  return PROSE_FILE_PATTERN.test(path) || PROSE_DIRECTORY_PATTERN.test(path)
+}
+
+export type PullRequestPathVerdict
+  = | { _tag: 'ReviewRequired', path: string }
+    | { _tag: 'ProseOnly' }
+
+/**
+ * The path rule. One path outside the prose set requires Review with no
+ * Agent. Only a prose-only pull request needs a judgment.
+ */
+export function classifyPullRequestPaths(changedFiles: readonly string[]): PullRequestPathVerdict {
+  const path = changedFiles.find(candidate => !isProsePath(candidate))
+  return path === undefined ? { _tag: 'ProseOnly' } : { _tag: 'ReviewRequired', path }
+}
+
+function reuseStoredVerdict(store: PullRequestTriageAgentOptions['store'], task: ClaimedAdversarialReviewTask): PullRequestTriageResult | null {
+  const stored = store.getLatestPullRequestTriageRun(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
+  if (stored === null || stored.outcome === 'ReviewRequiredAfterFailure')
+    return null
+  return {
+    _tag: stored.outcome === 'ReviewSkipped' ? 'ADVERSARIAL_REVIEW_SKIPPED' : 'ADVERSARIAL_REVIEW_REQUIRED',
+    reason: stored.reason,
+    source: 'reuse',
+  }
 }
 
 const schema = {
@@ -57,16 +100,17 @@ function parseResponse(text: string): Promise<Result<PullRequestTriageResult, st
     .then((value): Result<PullRequestTriageResult, string> => {
       if (!isPullRequestTriageState(value._tag) || typeof value.reason !== 'string' || cleanLine(value.reason) === '')
         return err('The Agent returned an invalid pull request triage result.')
-      return ok({ _tag: value._tag, reason: cleanLine(value.reason) })
+      return ok({ _tag: value._tag, reason: `model: ${cleanLine(value.reason)}`, source: 'model' })
     })
     .catch((): Result<PullRequestTriageResult, string> => err('The Agent returned malformed pull request triage JSON.'))
 }
 
-function prompt(task: ClaimedAdversarialReviewTask, input: { body: string, changedFiles: string[] }): string {
+function prompt(task: ClaimedAdversarialReviewTask, changedFiles: string[]): string {
   return `Decide whether this pull request needs an adversarial Review.
-Do not use tools or inspect the repository. Use only the supplied pull request metadata and changed file paths.
+Every changed file is prose: Markdown, text, licence, changelog, or docs. Nothing else reached you.
+Do not use tools or inspect the repository. Use only the supplied title and changed file paths.
 Return ADVERSARIAL_REVIEW_SKIPPED only for clearly judgment-free prose, formatting, or comment-only changes.
-Require ADVERSARIAL_REVIEW_REQUIRED for source code, tests, configuration, dependencies, workflows, schemas, generated runtime output, security boundaries, public APIs, performance-sensitive files, or behavior claims.
+Require ADVERSARIAL_REVIEW_REQUIRED for behavior claims, public API documentation that states a contract, or security guidance.
 Any uncertainty requires ADVERSARIAL_REVIEW_REQUIRED.
 Return only the required JSON.
 
@@ -75,21 +119,28 @@ ${JSON.stringify({
   repository: task.repository,
   number: task.pullRequestNumber,
   title: task.pullRequest.title,
-  body: input.body.slice(0, 4_000),
-  changedFiles: input.changedFiles.slice(0, 300),
+  changedFiles: changedFiles.slice(0, 300),
 })}`
 }
 
 export function createPullRequestTriageAgent(options: PullRequestTriageAgentOptions): PullRequestTriageAgent {
   return {
     async run(task, input, signal) {
+      const verdict = classifyPullRequestPaths(input.changedFiles)
+      if (verdict._tag === 'ReviewRequired')
+        return ok({ _tag: 'ADVERSARIAL_REVIEW_REQUIRED', reason: `rule: ${verdict.path} is outside the prose set.`, source: 'rule' })
+
+      const reused = reuseStoredVerdict(options.store, task)
+      if (reused !== null)
+        return ok(reused)
+
       const scopeDigest = createHash('sha256')
-        .update(JSON.stringify({ headSha: task.pullRequest.headSha, ...input }))
+        .update(JSON.stringify({ headSha: task.pullRequest.headSha, changedFiles: input.changedFiles }))
         .digest('hex')
       const turn = await runParsedAgentTurn({ ...options, parse: parseResponse }, {
         freshSession: true,
         number: task.pullRequestNumber,
-        prompt: prompt(task, input),
+        prompt: prompt(task, input.changedFiles),
         repository: task.repository,
         role: 'pull_request_triage',
         schema,

--- a/packages/harlan-github-agent/src/pull-request-triage.ts
+++ b/packages/harlan-github-agent/src/pull-request-triage.ts
@@ -50,7 +50,7 @@ interface PullRequestTriageAgentOptions {
 }
 
 const PROSE_FILE_PATTERN = /(?:^|\/)(?:[^/]+\.(?:md|mdx|txt)|LICENSE[^/]*|CHANGELOG[^/]*)$/i
-const PROSE_DIRECTORY_PATTERN = /(?:^|\/)docs\//
+const PROSE_DIRECTORY_PATTERN = /^docs\//
 /** Agent instructions are behaviour, so they leave the prose set even when they end in `.md`. */
 const BEHAVIOUR_PATTERN = /(?:^|\/)(?:SKILL\.md|AGENTS\.md|CLAUDE\.md)$|(?:^|\/)(?:\.github|\.claude|\.codex[^/]*)\//
 
@@ -77,9 +77,11 @@ function reuseStoredVerdict(store: PullRequestTriageAgentOptions['store'], task:
   const stored = store.getLatestPullRequestTriageRun(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
   if (stored === null || stored.outcome === 'ReviewRequiredAfterFailure')
     return null
+  // Rows recorded before the prefix contract were all model decisions.
+  const reason = /^(?:rule|model): /.test(stored.reason) ? stored.reason : `model: ${stored.reason}`
   return {
     _tag: stored.outcome === 'ReviewSkipped' ? 'ADVERSARIAL_REVIEW_SKIPPED' : 'ADVERSARIAL_REVIEW_REQUIRED',
-    reason: stored.reason,
+    reason,
     source: 'reuse',
   }
 }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -2,7 +2,7 @@ import type { AgentProviderName, AgentTokenUsage } from './agent-provider.ts'
 import type { TransientKind } from './failure.ts'
 import type { ForeignReviewCommentReason } from './github-agent-source.ts'
 import type { IssueTriageState } from './issue-triage.ts'
-import type { RecordPullRequestTriageRunInput, RecordPullRequestTriageRunResult, StatsFact, StatsRange, StatsSnapshot, StatsTaskKind } from './stats.ts'
+import type { PullRequestTriageStatsOutcome, RecordPullRequestTriageRunInput, RecordPullRequestTriageRunResult, StatsFact, StatsRange, StatsSnapshot, StatsTaskKind } from './stats.ts'
 import type {
   AdversarialReviewTask,
   AgentFeedback,
@@ -605,6 +605,12 @@ type UnpositionedQueueEntry = QueueEntry extends infer Entry
   ? Entry extends QueueEntry ? Omit<Entry, 'position'> : never
   : never
 
+export interface LatestPullRequestTriageRun {
+  outcome: PullRequestTriageStatsOutcome
+  reason: string
+  completedAt: string
+}
+
 export interface JournalStore {
   approveIssueWork: (input: {
     repository: string
@@ -623,6 +629,8 @@ export interface JournalStore {
   authorizePublication: (input: { commandId: string, workerId: string, fence: number, at: string }) => boolean
   cancelTask: (input: { taskId: string, at: string }) => CancelTaskResult
   recordPullRequestTriageRun: (input: RecordPullRequestTriageRunInput) => RecordPullRequestTriageRunResult
+  /** The newest recorded Pull request triage decision for one exact head commit, or null. */
+  getLatestPullRequestTriageRun: (repository: string, pullRequestNumber: number, headSha: string) => LatestPullRequestTriageRun | null
   claimNextAdversarialReviewTask: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedAdversarialReviewTask | null
   claimNextBaselineRepairTask: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedBaselineRepairTask | null
   claimNextConflictTask: (workerId: string, now: string, leaseMilliseconds: number) => ClaimedConflictResolutionTask | null
@@ -6738,6 +6746,26 @@ export function openJournalStore(
       database.exec('ROLLBACK')
       throw error
     }
+  }
+
+  const getLatestPullRequestTriageRun: JournalStore['getLatestPullRequestTriageRun'] = (repository, pullRequestNumber, headSha) => {
+    const row = database.prepare(`
+      SELECT pull_request_triage_runs.outcome_tag, pull_request_triage_runs.reason, pull_request_triage_runs.completed_at
+      FROM pull_request_triage_runs
+      JOIN subjects ON subjects.id = pull_request_triage_runs.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
+      WHERE repositories.github = ? AND subjects.github_number = ? AND subjects.kind = 'pull_request'
+        AND pull_request_triage_runs.head_sha = ?
+      ORDER BY pull_request_triage_runs.completed_at DESC
+      LIMIT 1
+    `).get(repository, pullRequestNumber, headSha) as {
+      outcome_tag: PullRequestTriageStatsOutcome
+      reason: string
+      completed_at: string
+    } | undefined
+    return row === undefined
+      ? null
+      : { outcome: row.outcome_tag, reason: row.reason, completedAt: row.completed_at }
   }
 
   const recordReviewRun: JournalStore['recordReviewRun'] = (input) => {
@@ -12948,6 +12976,7 @@ export function openJournalStore(
     authorizePublication,
     cancelTask,
     recordPullRequestTriageRun,
+    getLatestPullRequestTriageRun,
     claimNextAdversarialReviewTask,
     claimNextBaselineRepairTask,
     claimNextConflictTask,

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -198,7 +198,8 @@ describe('subject Workers', () => {
           triageCalls += 1
           return Promise.resolve(ok({
             _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
-            reason: 'The old triage Agent waived this Review.',
+            reason: 'model: The old triage Agent waived this Review.',
+            source: 'model',
           }))
         },
       },

--- a/packages/harlan-github-agent/test/pull-request-triage.test.ts
+++ b/packages/harlan-github-agent/test/pull-request-triage.test.ts
@@ -52,6 +52,8 @@ describe('classifyPullRequestPaths', () => {
     ['a Claude command', ['CHANGELOG.md', '.claude/commands/ship.md'], '.claude/commands/ship.md'],
     ['a Codex prompt', ['LICENSE', '.codex/prompts/review.md'], '.codex/prompts/review.md'],
     ['a Markdown file under .github', ['.github/PULL_REQUEST_TEMPLATE.md'], '.github/PULL_REQUEST_TEMPLATE.md'],
+    ['a code file under a nested docs directory', ['src/docs/parser.ts'], 'src/docs/parser.ts'],
+    ['a fixture under a nested docs directory', ['test/docs/fixture.json'], 'test/docs/fixture.json'],
     ['no changed files', [], undefined],
   ])('requires Review for %s', (_label, changedFiles, path) => {
     const verdict = classifyPullRequestPaths(changedFiles)
@@ -119,6 +121,32 @@ describe('pull request triage Agent', () => {
       value: {
         _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
         reason: 'model: Only a typo in the README changed.',
+        source: 'reuse',
+      },
+    })
+    expect(capture.requests).toHaveLength(0)
+  })
+
+  it('prefixes a legacy stored reason with model:', async () => {
+    const capture: ProviderCapture = { requests: [] }
+    const agent = triageAgent({
+      capture,
+      stored: {
+        outcome: 'ReviewSkipped',
+        reason: 'Only prose changed.',
+        completedAt: '2026-08-27T23:00:00.000Z',
+      },
+    })
+
+    const result = await agent.run(reviewTask('docs: fix a typo'), {
+      changedFiles: ['README.md'],
+    }, new AbortController().signal)
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: {
+        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
+        reason: 'model: Only prose changed.',
         source: 'reuse',
       },
     })

--- a/packages/harlan-github-agent/test/pull-request-triage.test.ts
+++ b/packages/harlan-github-agent/test/pull-request-triage.test.ts
@@ -1,47 +1,90 @@
+import type { LatestPullRequestTriageRun } from '../src/store.ts'
+import type { ClaimedAdversarialReviewTask } from '../src/types.ts'
 import type { ProviderCapture } from './fixtures.ts'
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
-import { createPullRequestTriageAgent } from '../src/pull-request-triage.ts'
+import { classifyPullRequestPaths, createPullRequestTriageAgent } from '../src/pull-request-triage.ts'
 import { agentRuntime, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
-describe('pull request triage Agent', () => {
-  it('does not waive Review from a conventional chore title', async () => {
-    const capture: ProviderCapture = { requests: [] }
-    const agent = createPullRequestTriageAgent({
-      now: () => new Date('2026-08-28T01:00:00.000Z'),
-      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
-        _tag: 'ADVERSARIAL_REVIEW_REQUIRED',
-        reason: 'The pull request changes dependencies and executable tests.',
-      }), capture)),
-      store: {
-        getWorkerSession: () => null,
-        saveWorkerSession: () => undefined,
-      },
-      workspace: '/tmp/harlan-github-agent',
-    })
+function reviewTask(title: string): ClaimedAdversarialReviewTask {
+  return {
+    id: 'review-task',
+    kind: 'adversarial_review',
+    repository: 'harlan-zw/example',
+    pullRequestNumber: 24,
+    revisionId: 'revision-1',
+    state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-28T02:00:00.000Z' },
+    updatedAt: '2026-08-28T01:00:00.000Z',
+    repositoryMapping: repositoryMapping(),
+    pullRequest: pullRequestItem({ mergeState: 'clean', title }),
+    rerun: { _tag: 'NotRequested' },
+  }
+}
 
-    const result = await agent.run({
-      id: 'review-task',
-      kind: 'adversarial_review',
-      repository: 'harlan-zw/gscdump',
-      pullRequestNumber: 35,
-      revisionId: 'revision-1',
-      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-28T02:00:00.000Z' },
-      updatedAt: '2026-08-28T01:00:00.000Z',
-      repositoryMapping: repositoryMapping(),
-      pullRequest: pullRequestItem({
-        mergeState: 'clean',
-        title: 'chore: update workspace dependencies',
-      }),
-      rerun: { _tag: 'NotRequested' },
-    }, {
-      body: 'Refresh the workspace dependencies.',
+function triageAgent(options: {
+  capture: ProviderCapture
+  modelReply?: unknown
+  stored?: LatestPullRequestTriageRun | null
+}) {
+  return createPullRequestTriageAgent({
+    now: () => new Date('2026-08-28T01:00:00.000Z'),
+    runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(options.modelReply ?? {
+      _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
+      reason: 'Only a typo in the README changed.',
+    }), options.capture)),
+    store: {
+      getLatestPullRequestTriageRun: () => options.stored ?? null,
+      getWorkerSession: () => null,
+      saveWorkerSession: () => undefined,
+    },
+    workspace: '/tmp/harlan-github-agent',
+  })
+}
+
+describe('classifyPullRequestPaths', () => {
+  it.each([
+    ['a TypeScript source file', ['README.md', 'src/deployment.ts'], 'src/deployment.ts'],
+    ['a Vue component', ['docs/guide.md', 'app/components/Hero.vue'], 'app/components/Hero.vue'],
+    ['dependencies', ['package.json', 'pnpm-lock.yaml'], 'package.json'],
+    ['a skill next to docs', ['README.md', 'skills/pr/SKILL.md'], 'skills/pr/SKILL.md'],
+    ['agent instructions', ['docs/index.md', 'AGENTS.md'], 'AGENTS.md'],
+    ['a workflow under docs-only prose', ['docs/setup.md', '.github/workflows/ci.yml'], '.github/workflows/ci.yml'],
+    ['a Claude command', ['CHANGELOG.md', '.claude/commands/ship.md'], '.claude/commands/ship.md'],
+    ['a Codex prompt', ['LICENSE', '.codex/prompts/review.md'], '.codex/prompts/review.md'],
+    ['a Markdown file under .github', ['.github/PULL_REQUEST_TEMPLATE.md'], '.github/PULL_REQUEST_TEMPLATE.md'],
+    ['no changed files', [], undefined],
+  ])('requires Review for %s', (_label, changedFiles, path) => {
+    const verdict = classifyPullRequestPaths(changedFiles)
+    if (path === undefined) {
+      expect(verdict).toEqual({ _tag: 'ProseOnly' })
+      return
+    }
+    expect(verdict).toEqual({ _tag: 'ReviewRequired', path })
+  })
+
+  it('leaves a prose-only pull request to the model', () => {
+    expect(classifyPullRequestPaths([
+      'README.md',
+      'docs/guide/getting-started.mdx',
+      'packages/engine/CHANGELOG.md',
+      'LICENSE',
+      'LICENSE.md',
+      'notes/todo.txt',
+      'docs/assets/diagram.svg',
+    ])).toEqual({ _tag: 'ProseOnly' })
+  })
+})
+
+describe('pull request triage Agent', () => {
+  it('requires Review from the path rule without an Agent turn', async () => {
+    const capture: ProviderCapture = { requests: [] }
+    const agent = triageAgent({ capture })
+
+    const result = await agent.run(reviewTask('chore: update workspace dependencies'), {
       changedFiles: [
         'package.json',
         'packages/engine/test/icebird-bigint-stringify.test.ts',
-        'patches/icebird@0.8.26.patch',
         'pnpm-lock.yaml',
-        'pnpm-workspace.yaml',
       ],
     }, new AbortController().signal)
 
@@ -49,51 +92,72 @@ describe('pull request triage Agent', () => {
       _tag: 'Ok',
       value: {
         _tag: 'ADVERSARIAL_REVIEW_REQUIRED',
-        reason: 'The pull request changes dependencies and executable tests.',
+        reason: 'rule: package.json is outside the prose set.',
+        source: 'rule',
       },
     })
-    expect(capture.requests).toHaveLength(1)
+    expect(capture.requests).toHaveLength(0)
   })
 
-  it('uses the cheap profile and returns one conservative route', async () => {
+  it('reuses the stored decision for the same head commit before an Agent turn', async () => {
     const capture: ProviderCapture = { requests: [] }
-    const agent = createPullRequestTriageAgent({
-      now: () => new Date('2026-08-28T01:00:00.000Z'),
-      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
-        _tag: 'ADVERSARIAL_REVIEW_REQUIRED',
-        reason: 'The pull request declares a breaking change.',
-      }), capture)),
-      store: {
-        getWorkerSession: () => null,
-        saveWorkerSession: () => undefined,
+    const agent = triageAgent({
+      capture,
+      stored: {
+        outcome: 'ReviewSkipped',
+        reason: 'model: Only a typo in the README changed.',
+        completedAt: '2026-08-27T23:00:00.000Z',
       },
-      workspace: '/tmp/harlan-github-agent',
     })
 
-    const result = await agent.run({
-      id: 'review-task',
-      kind: 'adversarial_review',
-      repository: 'harlan-zw/example',
-      pullRequestNumber: 24,
-      revisionId: 'revision-1',
-      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-28T02:00:00.000Z' },
-      updatedAt: '2026-08-28T01:00:00.000Z',
-      repositoryMapping: repositoryMapping(),
-      pullRequest: pullRequestItem({
-        mergeState: 'clean',
-        title: 'chore!: replace the deployment contract',
-      }),
-      rerun: { _tag: 'NotRequested' },
-    }, {
-      body: 'Replace the deployment contract.',
-      changedFiles: ['src/deployment.ts'],
+    const result = await agent.run(reviewTask('docs: fix a typo'), {
+      changedFiles: ['README.md'],
     }, new AbortController().signal)
 
     expect(result).toEqual({
       _tag: 'Ok',
       value: {
-        _tag: 'ADVERSARIAL_REVIEW_REQUIRED',
-        reason: 'The pull request declares a breaking change.',
+        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
+        reason: 'model: Only a typo in the README changed.',
+        source: 'reuse',
+      },
+    })
+    expect(capture.requests).toHaveLength(0)
+  })
+
+  it('does not reuse a failed decision', async () => {
+    const capture: ProviderCapture = { requests: [] }
+    const agent = triageAgent({
+      capture,
+      stored: {
+        outcome: 'ReviewRequiredAfterFailure',
+        reason: 'spawn opencode ENOENT',
+        completedAt: '2026-08-27T23:00:00.000Z',
+      },
+    })
+
+    const result = await agent.run(reviewTask('docs: fix a typo'), {
+      changedFiles: ['README.md'],
+    }, new AbortController().signal)
+
+    expect(result._tag).toBe('Ok')
+    expect(capture.requests).toHaveLength(1)
+  })
+
+  it('sends a prose-only pull request to the cheap model with title and paths only', async () => {
+    const capture: ProviderCapture = { requests: [] }
+    const agent = triageAgent({ capture })
+
+    const result = await agent.run(reviewTask('docs: fix a typo'), {
+      changedFiles: ['README.md', 'docs/guide.md'],
+    }, new AbortController().signal)
+
+    expect(result).toEqual({
+      _tag: 'Ok',
+      value: {
+        _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
+        reason: 'model: Only a typo in the README changed.',
+        source: 'model',
       },
     })
     expect(capture.requests).toEqual([expect.objectContaining({
@@ -101,7 +165,22 @@ describe('pull request triage Agent', () => {
       reasoningEffort: 'low',
       sessionId: null,
     })])
-    expect(capture.requests[0]?.prompt).toContain('Do not use tools or inspect the repository')
-    expect(capture.requests[0]?.prompt).toContain('Any uncertainty requires ADVERSARIAL_REVIEW_REQUIRED')
+    const prompt = capture.requests[0]?.prompt ?? ''
+    expect(prompt).toContain('Do not use tools or inspect the repository')
+    expect(prompt).toContain('Any uncertainty requires ADVERSARIAL_REVIEW_REQUIRED')
+    expect(prompt).toContain('"title":"docs: fix a typo"')
+    expect(prompt).toContain('"changedFiles":["README.md","docs/guide.md"]')
+    expect(prompt).not.toContain('"body"')
+  })
+
+  it('rejects a malformed model answer instead of waiving Review', async () => {
+    const capture: ProviderCapture = { requests: [] }
+    const agent = triageAgent({ capture, modelReply: { _tag: 'MAYBE', reason: '' } })
+
+    const result = await agent.run(reviewTask('docs: fix a typo'), {
+      changedFiles: ['README.md'],
+    }, new AbortController().signal)
+
+    expect(result).toEqual({ _tag: 'Err', error: 'The Agent returned an invalid pull request triage result.' })
   })
 })

--- a/packages/harlan-github-agent/test/stats.test.ts
+++ b/packages/harlan-github-agent/test/stats.test.ts
@@ -125,7 +125,14 @@ describe('pull request triage Stats', () => {
       outcome: { _tag: 'ReviewSkipped' as const, reason: 'Only prose changed.' },
     }
 
+    expect(store.getLatestPullRequestTriageRun(task.repository, task.pullRequestNumber, task.pullRequest.headSha)).toBeNull()
     expect(store.recordPullRequestTriageRun(input)).toEqual({ _tag: 'Inserted' })
+    expect(store.getLatestPullRequestTriageRun(task.repository, task.pullRequestNumber, task.pullRequest.headSha)).toEqual({
+      outcome: 'ReviewSkipped',
+      reason: 'Only prose changed.',
+      completedAt: '2026-08-02T00:01:02.000Z',
+    })
+    expect(store.getLatestPullRequestTriageRun(task.repository, task.pullRequestNumber, 'f'.repeat(40))).toBeNull()
     expect(store.recordPullRequestTriageRun({
       ...input,
       startedAt: '2026-08-02T00:02:01.000Z',


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

In seven days the triage model answered 78 times and returned SKIPPED 0 times. Every verdict followed from the changed paths, and 8 of 86 calls re-decided a head commit the journal already knew, because a body edit makes a new revision. A path rule now decides first, a stored decision for the same head commit is reused, and only a prose-only pull request reaches the model, with the title and paths and no body. The reason string starts with `rule: ` or `model: ` so a stored row names its source.

One loose end: since #119 the Review worker stamps `ADVERSARIAL_REVIEW_REQUIRED` directly and never calls the triage Agent, so this lands the rule but nothing invokes it until the worker is rewired.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz