### PR TITLE
feat(agent): load the worktree .env into every Agent turn

### DIFF
--- a/packages/harlan-github-agent/src/codex-provider.ts
+++ b/packages/harlan-github-agent/src/codex-provider.ts
@@ -1,7 +1,9 @@
 import type { CodexOptions, ThreadEvent, ThreadOptions } from '@openai/codex-sdk'
 import type { AgentEvent, AgentProvider, AgentTokenUsage, AgentTurnRequest } from './agent-provider.ts'
+import process from 'node:process'
 import { Codex } from '@openai/codex-sdk'
 import { agentProviderFailureReason, agentTextEvent } from './agent-provider.ts'
+import { workspaceEnvironment } from './workspace-environment.ts'
 
 interface CodexThread {
   runStreamed: (prompt: string, options: { outputSchema: unknown, signal: AbortSignal }) => Promise<{ events: AsyncIterable<ThreadEvent> }>
@@ -94,12 +96,18 @@ async function* providerEvents(events: AsyncIterable<ThreadEvent>): AsyncGenerat
  * comes from this provider. If the SDK adds per-step usage, meter it here the
  * way `opencode-provider.ts` meters `step_finish`.
  */
+function definedEntries(environment: NodeJS.ProcessEnv): Record<string, string> {
+  return Object.fromEntries(Object.entries(environment).filter((entry): entry is [string, string] => entry[1] !== undefined))
+}
+
 export function createCodexProvider(options: CodexProviderOptions = {}): AgentProvider {
   const factory = options.createCodex ?? (codexOptions => new Codex(codexOptions))
   return {
     name: 'codex',
     runTurn: (request: AgentTurnRequest) => (async function* () {
-      const client = factory({})
+      // The SDK replaces the inherited environment when `env` is set, so the
+      // whole service environment goes with the worktree's seeded .env on top.
+      const client = factory({ env: definedEntries(workspaceEnvironment(process.env, request.workspace)) })
       const baseOptions = {
         model: request.model,
         workingDirectory: request.workspace,

--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -5,6 +5,7 @@ import { spawn } from 'node:child_process'
 import process from 'node:process'
 import { createInterface } from 'node:readline'
 import { agentProviderFailureReason, agentTextEvent, DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
+import { workspaceEnvironment } from './workspace-environment.ts'
 
 /** Tools that write files, so activity shows a file change instead of a command. */
 const fileTools = new Set(['edit', 'write', 'patch', 'multiedit'])
@@ -183,7 +184,8 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
   }))
 
   async function* runOnce(request: AgentTurnRequest, prompt: string): AsyncGenerator<AgentEvent> {
-    const child = spawnOpencode(opencodeArguments(request, prompt), request.workspace, environment)
+    // The worktree's seeded .env carries the tokens its own scripts read.
+    const child = spawnOpencode(opencodeArguments(request, prompt), request.workspace, workspaceEnvironment(environment, request.workspace))
     const abort = () => child.kill('SIGTERM')
     request.signal.addEventListener('abort', abort, { once: true })
     let standardError = ''

--- a/packages/harlan-github-agent/src/workspace-environment.ts
+++ b/packages/harlan-github-agent/src/workspace-environment.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 /**
@@ -6,20 +6,33 @@ import { join } from 'node:path'
  *
  * A seeded `.env` carries the tokens a repository's own tooling reads. It is
  * not a place to change which binaries run, how shells start (BASH_ENV, ENV),
- * or how Node starts, and a checkout that commits one of these could otherwise
- * steer the controller's child process. Everything else passes through as the
- * repository wrote it.
+ * how Node starts, where child processes send their traffic (proxies,
+ * certificate trust, provider endpoints), or which config directories the
+ * Agent's tools read. Everything else passes through as the repository wrote
+ * it.
  */
 const REFUSED_NAMES = new Set([
+  'ALL_PROXY',
   'BASH_ENV',
+  'CURL_CA_BUNDLE',
   'ENV',
+  'GH_CONFIG_DIR',
+  'GITHUB_API_URL',
   'HOME',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'NODE_EXTRA_CA_CERTS',
   'NODE_OPTIONS',
   'NODE_PATH',
   'PATH',
   'PNPM_HOME',
+  'REQUESTS_CA_BUNDLE',
   'SHELL',
+  'SSL_CERT_DIR',
+  'SSL_CERT_FILE',
   'USER',
+  'XDG_CONFIG_HOME',
 ])
 
 const REFUSED_PREFIXES = ['DYLD_', 'GIT_', 'LD_', 'OPENCODE_', 'CODEX_']
@@ -48,7 +61,8 @@ export function parseEnvironmentFile(text: string): Record<string, string> {
     else {
       value = value.replace(/\s+#.*$/, '').trim()
     }
-    if (REFUSED_NAMES.has(name) || REFUSED_PREFIXES.some(prefix => name.startsWith(prefix)))
+    const upperName = name.toUpperCase()
+    if (REFUSED_NAMES.has(upperName) || REFUSED_PREFIXES.some(prefix => upperName.startsWith(prefix)))
       continue
     values[name] = value
   }
@@ -66,12 +80,20 @@ export function parseEnvironmentFile(text: string): Record<string, string> {
  * repository's configuration and the service has no better answer.
  *
  * Answers the same object when the worktree has no `.env`, so a provider that
- * shares one environment across turns keeps sharing it.
+ * shares one environment across turns keeps sharing it. A `.env` path that is
+ * unreadable or not a regular file (a tracked `.env/` directory, for example)
+ * falls back to the base environment rather than failing the turn.
  */
 export function workspaceEnvironment(base: NodeJS.ProcessEnv, workspace: string): NodeJS.ProcessEnv {
   const path = join(workspace, '.env')
-  if (!existsSync(path))
+  let values: Record<string, string>
+  try {
+    if (!statSync(path).isFile())
+      return base
+    values = parseEnvironmentFile(readFileSync(path, 'utf8'))
+  }
+  catch {
     return base
-  const values = parseEnvironmentFile(readFileSync(path, 'utf8'))
+  }
   return Object.keys(values).length === 0 ? base : { ...base, ...values }
 }

--- a/packages/harlan-github-agent/src/workspace-environment.ts
+++ b/packages/harlan-github-agent/src/workspace-environment.ts
@@ -1,0 +1,75 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Names a repository file must never set for an Agent process.
+ *
+ * A seeded `.env` carries the tokens a repository's own tooling reads. It is
+ * not a place to change which binaries run or how Node starts, and a checkout
+ * that commits one of these could otherwise steer the controller's child
+ * process. Everything else passes through as the repository wrote it.
+ */
+const REFUSED_NAMES = new Set([
+  'HOME',
+  'LD_LIBRARY_PATH',
+  'LD_PRELOAD',
+  'NODE_OPTIONS',
+  'PATH',
+  'PNPM_HOME',
+  'SHELL',
+  'USER',
+])
+
+const REFUSED_PREFIXES = ['DYLD_', 'GIT_', 'OPENCODE_', 'CODEX_']
+
+/** Reads a `.env` file, the way the repository's tooling would. */
+export function parseEnvironmentFile(text: string): Record<string, string> {
+  const values: Record<string, string> = {}
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (line === '' || line.startsWith('#'))
+      continue
+    const separator = line.indexOf('=')
+    if (separator < 1)
+      continue
+    const name = line.slice(0, separator).replace(/^export\s+/, '').trim()
+    if (!/^[A-Z_][\w.-]*$/i.test(name))
+      continue
+    const rawValue = line.slice(separator + 1).trim()
+    let value = rawValue
+    if ((value.startsWith('"') && value.endsWith('"') && value.length >= 2)
+      || (value.startsWith('\'') && value.endsWith('\'') && value.length >= 2)) {
+      value = value.slice(1, -1)
+      if (rawValue.startsWith('"'))
+        value = value.replaceAll('\\n', '\n')
+    }
+    else {
+      value = value.replace(/\s+#.*$/, '').trim()
+    }
+    if (REFUSED_NAMES.has(name) || REFUSED_PREFIXES.some(prefix => name.startsWith(prefix)))
+      continue
+    values[name] = value
+  }
+  return values
+}
+
+/**
+ * The environment one Agent turn runs with, given its worktree.
+ *
+ * Worktrunk seeds each repository's `.env` into the worktree from the trusted
+ * copy in the primary checkout. The check-in scripts read their Cloudflare,
+ * Sentry, and NuxtSEO tokens from the process environment, so the turn loads
+ * that file the way a person's shell would before running the same command.
+ * The repository's values win over the service's own, because they are that
+ * repository's configuration and the service has no better answer.
+ *
+ * Answers the same object when the worktree has no `.env`, so a provider that
+ * shares one environment across turns keeps sharing it.
+ */
+export function workspaceEnvironment(base: NodeJS.ProcessEnv, workspace: string): NodeJS.ProcessEnv {
+  const path = join(workspace, '.env')
+  if (!existsSync(path))
+    return base
+  const values = parseEnvironmentFile(readFileSync(path, 'utf8'))
+  return Object.keys(values).length === 0 ? base : { ...base, ...values }
+}

--- a/packages/harlan-github-agent/src/workspace-environment.ts
+++ b/packages/harlan-github-agent/src/workspace-environment.ts
@@ -5,22 +5,24 @@ import { join } from 'node:path'
  * Names a repository file must never set for an Agent process.
  *
  * A seeded `.env` carries the tokens a repository's own tooling reads. It is
- * not a place to change which binaries run or how Node starts, and a checkout
- * that commits one of these could otherwise steer the controller's child
- * process. Everything else passes through as the repository wrote it.
+ * not a place to change which binaries run, how shells start (BASH_ENV, ENV),
+ * or how Node starts, and a checkout that commits one of these could otherwise
+ * steer the controller's child process. Everything else passes through as the
+ * repository wrote it.
  */
 const REFUSED_NAMES = new Set([
+  'BASH_ENV',
+  'ENV',
   'HOME',
-  'LD_LIBRARY_PATH',
-  'LD_PRELOAD',
   'NODE_OPTIONS',
+  'NODE_PATH',
   'PATH',
   'PNPM_HOME',
   'SHELL',
   'USER',
 ])
 
-const REFUSED_PREFIXES = ['DYLD_', 'GIT_', 'OPENCODE_', 'CODEX_']
+const REFUSED_PREFIXES = ['DYLD_', 'GIT_', 'LD_', 'OPENCODE_', 'CODEX_']
 
 /** Reads a `.env` file, the way the repository's tooling would. */
 export function parseEnvironmentFile(text: string): Record<string, string> {

--- a/packages/harlan-github-agent/test/codex-provider.test.ts
+++ b/packages/harlan-github-agent/test/codex-provider.test.ts
@@ -1,5 +1,9 @@
 import type { ThreadEvent, ThreadOptions } from '@openai/codex-sdk'
 import type { AgentEvent, AgentTurnRequest } from '../src/agent-provider.ts'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { codexAgentEvent, createCodexProvider } from '../src/codex-provider.ts'
 
@@ -65,6 +69,26 @@ describe('codexAgentEvent', () => {
 })
 
 describe('createCodexProvider', () => {
+  it('starts Codex with the worktree .env layered over the service environment', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-env-'))
+    await writeFile(join(workspace, '.env'), 'CLOUDFLARE_API_TOKEN=from-repo\n')
+    let codexOptions: { env?: Record<string, string> } | undefined
+    const provider = createCodexProvider({
+      createCodex: (options) => {
+        codexOptions = options
+        return {
+          startThread: () => thread(messageEvents),
+          resumeThread: () => { throw new Error('A new turn must not resume.') },
+        }
+      },
+    })
+
+    await collect(provider.runTurn(request({ workspace })))
+
+    expect(codexOptions?.env?.CLOUDFLARE_API_TOKEN).toBe('from-repo')
+    expect(codexOptions?.env?.PATH).toBe(process.env.PATH)
+  })
+
   it('pins the model, reasoning effort, and worktree on a new thread', async () => {
     let threadOptions: ThreadOptions | undefined
     const provider = createCodexProvider({

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -197,6 +197,23 @@ printf '%s\\n' '${JSON.stringify(textLine)}'
     expect(launchedEnvironment).toBe(environment)
   })
 
+  it('layers the worktree .env over the Agent environment', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'opencode-env-'))
+    await writeFile(join(workspace, '.env'), 'NUXTSEO_TOKEN=from-repo\n')
+    let launchedEnvironment: NodeJS.ProcessEnv | undefined
+    const provider = createOpencodeProvider({
+      environment: { PATH: '/bin' },
+      spawnOpencode: (args, _workspace, receivedEnvironment) => {
+        launchedEnvironment = receivedEnvironment
+        return replay([textLine])(args)
+      },
+    })
+
+    await collect(provider.runTurn(request({ workspace })))
+
+    expect(launchedEnvironment).toEqual({ PATH: '/bin', NUXTSEO_TOKEN: 'from-repo' })
+  })
+
   it('reports the session before the events it produced', async () => {
     const provider = createOpencodeProvider({ spawnOpencode: replay([bashLine, textLine]) })
 

--- a/packages/harlan-github-agent/test/workspace-environment.test.ts
+++ b/packages/harlan-github-agent/test/workspace-environment.test.ts
@@ -26,6 +26,14 @@ BROKEN LINE
   it('refuses names that change how the Agent process runs', () => {
     expect(parseEnvironmentFile('PATH=/evil\nNODE_OPTIONS=--require x\nGIT_DIR=/x\nSENTRY_AUTH_TOKEN=ok\n'))
       .toEqual({ SENTRY_AUTH_TOKEN: 'ok' })
+    expect(parseEnvironmentFile('LD_AUDIT=/tmp/evil.so\nLD_LIBRARY_PATH=/x\nLD_PRELOAD=/y\nOK=1\n'))
+      .toEqual({ OK: '1' })
+    expect(parseEnvironmentFile('BASH_ENV=./pwn.sh\nENV=./pwn.sh\nOK=1\n'))
+      .toEqual({ OK: '1' })
+    expect(parseEnvironmentFile('NODE_PATH=/tmp/evil\nOK=1\n'))
+      .toEqual({ OK: '1' })
+    expect(parseEnvironmentFile('DYLD_INSERT_LIBRARIES=/tmp/evil.dylib\nDYLD_LIBRARY_PATH=/x\nOK=1\n'))
+      .toEqual({ OK: '1' })
   })
 })
 

--- a/packages/harlan-github-agent/test/workspace-environment.test.ts
+++ b/packages/harlan-github-agent/test/workspace-environment.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parseEnvironmentFile, workspaceEnvironment } from '../src/workspace-environment.ts'
+
+describe('reading a repository environment file', () => {
+  it('parses the shapes dotenv tooling writes', () => {
+    expect(parseEnvironmentFile(`
+# tokens
+CLOUDFLARE_API_TOKEN=abc123
+export NUXTSEO_TOKEN="nst_x y"
+QUOTED='single # not a comment'
+TRAILING=value # comment
+MULTI="a\\nb"
+BROKEN LINE
+`)).toEqual({
+      CLOUDFLARE_API_TOKEN: 'abc123',
+      NUXTSEO_TOKEN: 'nst_x y',
+      QUOTED: 'single # not a comment',
+      TRAILING: 'value',
+      MULTI: 'a\nb',
+    })
+  })
+
+  it('refuses names that change how the Agent process runs', () => {
+    expect(parseEnvironmentFile('PATH=/evil\nNODE_OPTIONS=--require x\nGIT_DIR=/x\nSENTRY_AUTH_TOKEN=ok\n'))
+      .toEqual({ SENTRY_AUTH_TOKEN: 'ok' })
+  })
+})
+
+describe('the environment one turn runs with', () => {
+  it('layers the worktree .env over the service environment', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'worktree-env-'))
+    writeFileSync(join(workspace, '.env'), 'CLOUDFLARE_API_TOKEN=repo\nONLY_HERE=1\n')
+
+    expect(workspaceEnvironment({ PATH: '/bin', CLOUDFLARE_API_TOKEN: 'service' }, workspace))
+      .toEqual({ PATH: '/bin', CLOUDFLARE_API_TOKEN: 'repo', ONLY_HERE: '1' })
+  })
+
+  it('keeps the same environment object when the worktree has no .env', () => {
+    const base = { PATH: '/bin' }
+    const workspace = mkdtempSync(join(tmpdir(), 'worktree-env-'))
+
+    expect(workspaceEnvironment(base, workspace)).toBe(base)
+  })
+})

--- a/packages/harlan-github-agent/test/workspace-environment.test.ts
+++ b/packages/harlan-github-agent/test/workspace-environment.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -35,6 +35,20 @@ BROKEN LINE
     expect(parseEnvironmentFile('DYLD_INSERT_LIBRARIES=/tmp/evil.dylib\nDYLD_LIBRARY_PATH=/x\nOK=1\n'))
       .toEqual({ OK: '1' })
   })
+
+  it('refuses names that redirect network traffic or replace certificate trust', () => {
+    expect(parseEnvironmentFile('HTTPS_PROXY=http://evil:8080\nSSL_CERT_FILE=./ca.pem\nNODE_EXTRA_CA_CERTS=./ca.pem\nOK=1\n'))
+      .toEqual({ OK: '1' })
+    expect(parseEnvironmentFile('HTTP_PROXY=http://evil:8080\nALL_PROXY=socks5://evil:1080\nNO_PROXY=api.github.com\nSSL_CERT_DIR=./ca\nCURL_CA_BUNDLE=./ca.pem\nREQUESTS_CA_BUNDLE=./ca.pem\nGITHUB_API_URL=http://evil\nOK=1\n'))
+      .toEqual({ OK: '1' })
+    expect(parseEnvironmentFile('https_proxy=http://evil:8080\nOK=1\n'))
+      .toEqual({ OK: '1' })
+  })
+
+  it('refuses names that repoint tooling config directories', () => {
+    expect(parseEnvironmentFile('XDG_CONFIG_HOME=./evil\nGH_CONFIG_DIR=./evil\nOK=1\n'))
+      .toEqual({ OK: '1' })
+  })
 })
 
 describe('the environment one turn runs with', () => {
@@ -49,6 +63,14 @@ describe('the environment one turn runs with', () => {
   it('keeps the same environment object when the worktree has no .env', () => {
     const base = { PATH: '/bin' }
     const workspace = mkdtempSync(join(tmpdir(), 'worktree-env-'))
+
+    expect(workspaceEnvironment(base, workspace)).toBe(base)
+  })
+
+  it('keeps the base environment when the .env path is not a readable file', () => {
+    const base = { PATH: '/bin' }
+    const workspace = mkdtempSync(join(tmpdir(), 'worktree-env-'))
+    mkdirSync(join(workspace, '.env'))
 
     expect(workspaceEnvironment(base, workspace)).toBe(base)
   })


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

The daily check-in scripts read `CLOUDFLARE_API_TOKEN`, `SENTRY_AUTH_TOKEN`, and `NUXTSEO_TOKEN` from the process environment. Worktrunk already seeds each repository's `.env` into the agent worktree from the trusted primary copy, but nothing loaded it, so on Hogwild those scripts found no tokens. Rather than a second, central secrets file on the service, the repository's own `.env` is the source: each Agent turn now starts with the worktree's `.env` layered over the service environment, for both the opencode and Codex providers.

A handful of names are refused from the file: `PATH`, `HOME`, `NODE_OPTIONS`, `LD_*`, `GIT_*`, and the providers' own prefixes. A checkout that commits a `.env` must not be able to steer the controller's child process.

To add a token for a site: put it in that site's `.env` on the desktop, make sure the file is listed in `scripts/repository-env-files`, and run `pnpm service:hogwild:sync-env`. unlighthouse.dev has no `.env` yet, so it is not in the manifest; the seed step refuses a listed file that does not exist.

Replaces the `secrets.env` idea from #156, which now only documents this.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ