### PR TITLE
fix(agent): seed gscdump.com environment and drop the central secrets file

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -85,7 +85,7 @@ harlan-github-agent control routine-run --routine OWNER/REPOSITORY:NAME --config
 
 `routine-run` opens one Routine run for the current minute, ahead of its cron.
 
-A `daily-checkin` Routine runs the repository's own `.claude/skills/daily-checkin/SKILL.md`. Its data script reads Cloudflare and Sentry with tokens from the process environment. On Hogwild, put read-only tokens in `~/.config/harlan-github-agent/secrets.env` as `NAME=value` lines. The service unit loads that file when it exists, and every Agent turn inherits it. Use it to prove a new Routine end to end. The next cron instant still opens on its own.
+A `daily-checkin` Routine runs the repository's own `.claude/skills/daily-checkin/SKILL.md`. Its data script reads Cloudflare, Sentry, and the `nuxtseo` CLI with tokens from the environment. Put `CLOUDFLARE_API_TOKEN` and `NUXTSEO_TOKEN` in that repository's `.env`, list the file in `scripts/repository-env-files`, and run `pnpm service:hogwild:sync-env`. Worktrunk seeds the file into every agent worktree, and the Agent turn loads it. The `nuxtseo` CLI is installed at `~/.local/bin/nuxtseo` on Hogwild.
 
 Use `pause`, `resume`, `restart`, `update`, or `cancel --task TASK_ID` for the matching durable control.
 Every command prints one JSON value. A tagged JSON error exits with status 1.

--- a/scripts/hogwild-service.conf
+++ b/scripts/hogwild-service.conf
@@ -2,8 +2,6 @@
 ConditionHost=hogwild
 
 [Service]
-# Read tokens the check-in Routines need, such as CLOUDFLARE_API_TOKEN. Optional.
-EnvironmentFile=-%h/.config/harlan-github-agent/secrets.env
 CPUQuota=1600%
 MemoryHigh=14G
 MemoryMax=18G

--- a/scripts/repository-env-files
+++ b/scripts/repository-env-files
@@ -7,3 +7,4 @@ harlan-zw/nuxtseo.com sites/nuxtseo.com/apps/admin/.env
 skilld-dev/skilld.dev sites/skilld.dev/.env
 skilld-dev/skilld.dev sites/skilld.dev/.dev.vars
 harlan-zw/scripts.nuxt.com sites/scripts.nuxt.com/.env
+harlan-zw/gscdump.com sites/gscdump.com/.env


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

#156 was merged before its last three commits landed, so main still has the `secrets.env` line in the Hogwild unit and no `gscdump.com/.env` in the repository environment manifest. This carries those three commits over: the gscdump entry the check-in needs for its admin key, the removal of the central secrets file that #166 replaced, and the matching doc line.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ