### PR TITLE
feat(sentry-checkin): digest command and Routine mode rules

### DIFF
--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -16,8 +16,9 @@ A Routine names one site and one repository. The turn is read only for that repo
 - Use the installed `sentry-cli`. Fall back to `pnpm dlx @sentry/cli` only if none is installed.
 - Never read `~/.sentryclirc`. `scripts/sentry_api.py` reads it for you. It redacts the output. Its `digest` command reads no token at all.
 - Fetch evidence once with `bulk-bundles`. Then run `digest`. Read the digest, not the raw bundles.
-- Run `digest` without `--no-record`. It writes local run state. That state is neither a Sentry write nor a repository write. It is what makes the next run cheap.
 - If `all_unchanged` is true, stop. Do not read code. Return `Candidates: []` and give the reason: the issue set and every issue match the last run.
+- After the report is complete, run `digest` again with `--record`. That writes local run state. The state is neither a Sentry write nor a repository write. It is what makes the next run cheap.
+- Never pass `--record` before the analysis is complete. A run that aborts after recording would hide the backlog from the next run.
 - Return one JSON object only. Put no prose before it. Put no prose after it. The Routine parses the answer with `JSON.parse`.
 - Put the report text in the `report` field. Use one `fingerprint` from the digest per Candidate, so the same defect keeps one identity.
 
@@ -31,6 +32,13 @@ python3 scripts/sentry_api.py --org ORG bulk-bundles --project PROJECT \
   --snapshot "$RUN_DIR/PROJECT.snapshot.json" --output "$RUN_DIR/PROJECT" --workers 4
 python3 scripts/sentry_api.py --org ORG digest --project PROJECT \
   --bundles "$RUN_DIR/PROJECT" --run-id "$(basename "$RUN_DIR")" --output "$RUN_DIR/PROJECT.digest.json"
+```
+
+The last command of the run, after the report exists:
+
+```bash
+python3 scripts/sentry_api.py --org ORG digest --project PROJECT \
+  --bundles "$RUN_DIR/PROJECT" --run-id "$(basename "$RUN_DIR")" --record
 ```
 
 ## Worktree isolation
@@ -131,9 +139,9 @@ The digest also compares this run with the last digest for the project:
 - `unchanged_since_last_run`: the issue kept its last-seen time and event count.
 - `snapshot_unchanged`: the issue ID set matches the last run.
 - `all_unchanged`: both hold for every issue.
-- `runs_seen`: how many digests saw this issue.
+- `runs_seen`: how many recorded digests saw this issue.
 
-Pass `--no-record` to compare without writing the state file.
+`digest` compares only. It writes the state file only with `--record`. Run `--record` once, after every ledger for the project is complete. An aborted run then leaves no state, and the next run analyses the backlog in full.
 
 ## Read the prior dispositions
 

--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -7,6 +7,31 @@ description: "Triage and repair all open Sentry issues across Harlan's sites. Us
 
 Turn the complete open Sentry backlog into one verified PR per affected site. Account for every issue present at discovery time.
 
+## Routine mode
+
+A Routine names one site and one repository. The turn is read only for that repository. Follow these rules and skip the rest of this file where they conflict.
+
+- Skip the site inventory. The Routine names the site.
+- Skip `references/site-agent-contract.md`. It describes delegated site agents. There are none.
+- Use the installed `sentry-cli`. Fall back to `pnpm dlx @sentry/cli` only if none is installed.
+- Never read `~/.sentryclirc`. `scripts/sentry_api.py` reads it for you. It redacts the output. Its `digest` command reads no token at all.
+- Fetch evidence once with `bulk-bundles`. Then run `digest`. Read the digest, not the raw bundles.
+- Run `digest` without `--no-record`. It writes local run state. That state is neither a Sentry write nor a repository write. It is what makes the next run cheap.
+- If `all_unchanged` is true, stop. Do not read code. Return `Candidates: []` and give the reason: the issue set and every issue match the last run.
+- Return one JSON object only. Put no prose before it. Put no prose after it. The Routine parses the answer with `JSON.parse`.
+- Put the report text in the `report` field. Use one `fingerprint` from the digest per Candidate, so the same defect keeps one identity.
+
+The Routine command sequence for site PROJECT in org ORG:
+
+```bash
+RUN_DIR=$(mktemp -d "${XDG_STATE_HOME:-$HOME/.local/state}/sentry-checkin/run-XXXXXXXX")
+python3 scripts/sentry_api.py --org ORG snapshot --project PROJECT --output "$RUN_DIR/PROJECT.snapshot.json"
+python3 scripts/sentry_api.py --org ORG bulk-bundles --project PROJECT \
+  --snapshot "$RUN_DIR/PROJECT.snapshot.json" --output "$RUN_DIR/PROJECT" --workers 4
+python3 scripts/sentry_api.py --org ORG digest --project PROJECT \
+  --bundles "$RUN_DIR/PROJECT" --run-id "$(basename "$RUN_DIR")" --output "$RUN_DIR/PROJECT.digest.json"
+```
+
 ## Worktree isolation
 
 Before site edits, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.
@@ -31,18 +56,20 @@ If no inventory exists, stop before spawning agents or editing repositories. Rep
 
 ## Verify Sentry access
 
-Prefer an installed `sentry-cli`. Otherwise use `pnpm dlx @sentry/cli`.
+Use the installed `sentry-cli`. Fall back to `pnpm dlx @sentry/cli` only if none is installed.
 
 ```bash
-pnpm dlx @sentry/cli info
-pnpm dlx @sentry/cli organizations list
+sentry-cli info
+sentry-cli organizations list
 ```
 
 Use the sole organization when only one exists. If two or more exist and the request names none, ask which organization is in scope.
 
 Use `sentry-cli` for authentication, project discovery, and issue discovery. Sentry CLI 3.6 does not expose issue or stack details. The bundled `scripts/sentry_api.py` fills that gap. It uses the CLI token from `~/.sentryclirc` and redacts common secrets and personal data.
 
-Every command in that script reads, except `resolve`. `resolve` reports its plan and writes only with `--apply`.
+Never read `~/.sentryclirc` yourself. Never print the token. The script holds the token. The `digest` command gives event and user counts, so nobody needs a raw API call.
+
+Every command in that script reads Sentry only, except `resolve`. `resolve` reports its plan and writes only with `--apply`. `digest` writes one local state file per project. That file is run memory, not a Sentry write.
 
 Create a persistent run directory outside every repository:
 
@@ -57,7 +84,7 @@ SENTRY_CHECKIN_RUN_DIR=$(mktemp -d "${XDG_STATE_HOME:-$HOME/.local/state}/sentry
 2. List current Sentry projects with the CLI:
 
    ```bash
-   pnpm dlx @sentry/cli projects list --org ORG
+   sentry-cli projects list --org ORG
    ```
 
 3. Match each project to a site using the site's tracked Sentry configuration. Search for exact project slugs with `rg` or `git grep`.
@@ -79,6 +106,33 @@ The wrapper parses exact numeric and short IDs, writes a checksum, and stops at 
 The CLI paginates a live query, so one issue can appear on two pages. The wrapper keeps the first row per ID and lists every dropped ID in `duplicate_ids_dropped`. Report a non-empty list with the run. `issue_ids_sha256` covers the unique IDs in numeric order, so it compares directly with the `ledger.py audit` checksum.
 
 The snapshot is the run contract. New issues after discovery belong to the next run. Disappearing issues still need a ledger disposition.
+
+## Digest the evidence
+
+Fetch full bundles once per project, then summarize them:
+
+```bash
+python3 scripts/sentry_api.py --org ORG bulk-bundles --project PROJECT \
+  --snapshot "$SENTRY_CHECKIN_RUN_DIR/PROJECT.snapshot.json" \
+  --output "$SENTRY_CHECKIN_RUN_DIR/PROJECT" --workers 4
+python3 scripts/sentry_api.py --org ORG digest --project PROJECT \
+  --bundles "$SENTRY_CHECKIN_RUN_DIR/PROJECT" \
+  --run-id "$(basename "$SENTRY_CHECKIN_RUN_DIR")" \
+  --output "$SENTRY_CHECKIN_RUN_DIR/PROJECT.digest.json"
+```
+
+Full bundles are the default. `--compact` keeps exception frames only and drops thread and raw frames. Use it only when bundle size is the problem.
+
+The digest lists each issue once: title, culprit, top in-app frames, first and last seen, event and user counts, release, and a stable `fingerprint`. Read the digest before any bundle. Open a raw bundle only when the digest lacks the evidence for one issue.
+
+The digest also compares this run with the last digest for the project:
+
+- `unchanged_since_last_run`: the issue kept its last-seen time and event count.
+- `snapshot_unchanged`: the issue ID set matches the last run.
+- `all_unchanged`: both hold for every issue.
+- `runs_seen`: how many digests saw this issue.
+
+Pass `--no-record` to compare without writing the state file.
 
 ## Read the prior dispositions
 

--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -24,6 +24,7 @@ A Routine names one site and one repository. The turn is read only for that repo
 The Routine command sequence for site PROJECT in org ORG:
 
 ```bash
+mkdir -p "${XDG_STATE_HOME:-$HOME/.local/state}/sentry-checkin"
 RUN_DIR=$(mktemp -d "${XDG_STATE_HOME:-$HOME/.local/state}/sentry-checkin/run-XXXXXXXX")
 python3 scripts/sentry_api.py --org ORG snapshot --project PROJECT --output "$RUN_DIR/PROJECT.snapshot.json"
 python3 scripts/sentry_api.py --org ORG bulk-bundles --project PROJECT \

--- a/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/site-agent-contract.md
@@ -14,22 +14,18 @@ All fixes, tests, commits, and PR actions for this site happen in the selected t
 
 ## Inspect every issue
 
-For snapshots with at most 25 issues, fetch the latest compact event for each issue:
-
-```bash
-python3 SKILL_DIR/scripts/sentry_api.py --org ORG bundle \
-  --project PROJECT --issue ISSUE_ID --events 1 --compact
-```
-
-For larger snapshots, use the resumable bulk command. Use at most four workers:
+Fetch the latest full event for every issue with the resumable bulk command. Use at most four workers:
 
 ```bash
 python3 SKILL_DIR/scripts/sentry_api.py --org ORG bulk-bundles \
   --project PROJECT --snapshot PROJECT.snapshot.json \
   --output SITE_ARTIFACTS/PROJECT --events 1 --workers 4
+python3 SKILL_DIR/scripts/sentry_api.py --org ORG digest \
+  --project PROJECT --bundles SITE_ARTIFACTS/PROJECT \
+  --output SITE_ARTIFACTS/PROJECT.digest.json
 ```
 
-Rerun the same command after transient failures. It preserves completed redacted bundles and writes a checksum manifest. Read the latest event stack, release, environment, request path, breadcrumbs, tags, and source context. Fetch up to five events with `bundle` only when the latest event lacks evidence.
+Rerun the same command after transient failures. It preserves completed redacted bundles and writes a checksum manifest. Read the digest first. It holds the title, culprit, top in-app frames, counts, release, and a stable fingerprint per issue. Open a raw bundle for the request path, breadcrumbs, tags, and source context only when the digest lacks the evidence. Fetch up to five events with `bundle` only when the latest event lacks evidence. `--compact` drops thread and raw frames, so leave it off.
 
 Initialize one site ledger from every project manifest before editing:
 

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -537,6 +537,8 @@ def issue_fingerprint(project, fields, exception, frames):
     Sentry issues an ID per grouping, and a resolved issue that regresses can
     come back under a new one. The exception type, culprit, and innermost
     in-app frame name the defect itself, so the Candidate keeps its identity.
+    Without an exception type the remaining parts cannot tell defects apart,
+    so the title (or issue ID) stands in.
     """
     frame = frames[0] if frames else {}
     parts = [
@@ -546,7 +548,7 @@ def issue_fingerprint(project, fields, exception, frames):
         frame.get("file") or "",
         frame.get("function") or "",
     ]
-    if not any(parts[1:]):
+    if not exception.get("type"):
         parts.append(fields.get("title") or fields["id"])
     return "sentry:" + sha256_text("|".join(parts))[:16]
 

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Snapshot with sentry-cli, fetch redacted issue evidence, resolve proven fixes.
 
-Every command except resolve is read-only. Resolve writes only with --apply.
+Every command except resolve is read-only against Sentry. Resolve writes only
+with --apply. Digest writes local run state so the next run can see what changed.
 """
 
 import argparse
@@ -26,6 +27,11 @@ DEFAULT_URL = "https://sentry.io"
 PAGE_SIZE = 100
 SAFETY_CAP = 10_000
 RESOLVE_CAP = 200
+TOP_FRAMES = 5
+COMPACT_WARNING = (
+    "Warning: --compact keeps exception frames only. It drops thread and raw "
+    "frames, so digest may find no frames. Full bundles are the default."
+)
 SECRET_KEYS = {
     "authorization",
     "cookie",
@@ -276,6 +282,7 @@ def issue_summary(issue):
         "level": issue.get("level"),
         "status": issue.get("status"),
         "count": issue.get("count"),
+        "user_count": issue.get("userCount"),
         "first_seen": issue.get("firstSeen"),
         "last_seen": issue.get("lastSeen"),
         "permalink": issue.get("permalink"),
@@ -411,7 +418,7 @@ def bulk_bundles(args, base_url, token):
             args.project,
             issue_id,
             args.events,
-            True,
+            args.compact,
             base_url,
             token,
         )
@@ -448,6 +455,200 @@ def bulk_bundles(args, base_url, token):
             f"Evidence fetch failed for {len(errors)} issues; rerun to resume."
         )
     return manifest
+
+
+def default_digest_state_path(org, project):
+    state = os.environ.get("XDG_STATE_HOME") or Path.home() / ".local" / "state"
+    return Path(state) / "sentry-checkin" / "digest" / org / f"{project}.json"
+
+
+def event_frames(event):
+    """Every stack frame in one event, innermost last, from a full or compact event."""
+    frames = []
+    for exception in event.get("exceptions") or []:
+        frames.extend(exception.get("frames") or [])
+    for entry in event.get("entries") or []:
+        data = entry.get("data") or {}
+        if entry.get("type") in ("exception", "threads"):
+            for value in data.get("values") or []:
+                frames.extend((value.get("stacktrace") or {}).get("frames") or [])
+        elif entry.get("type") == "stacktrace":
+            frames.extend(data.get("frames") or [])
+    return frames
+
+
+def event_exception(event):
+    for exception in event.get("exceptions") or []:
+        return {"type": exception.get("type"), "value": exception.get("value")}
+    for entry in event.get("entries") or []:
+        if entry.get("type") != "exception":
+            continue
+        for value in (entry.get("data") or {}).get("values") or []:
+            return {"type": value.get("type"), "value": value.get("value")}
+    return {"type": None, "value": None}
+
+
+def top_frames(frames):
+    """The innermost in-app frames. Falls back to the innermost frames of any kind."""
+    in_app = [frame for frame in frames if frame.get("in_app")]
+    chosen = list(reversed(in_app or frames))[:TOP_FRAMES]
+    return [
+        {
+            "file": frame.get("filename") or frame.get("abs_path") or frame.get("module"),
+            "function": frame.get("function"),
+            "line": frame.get("lineno"),
+            "in_app": bool(frame.get("in_app")),
+        }
+        for frame in chosen
+    ]
+
+
+def event_release(event):
+    release = event.get("release")
+    if isinstance(release, dict):
+        return release.get("version")
+    return release
+
+
+def issue_fields(issue):
+    """One shape for a full API issue and a compact issue_summary."""
+    return {
+        "id": str(issue.get("id")),
+        "short_id": issue.get("short_id") or issue.get("shortId"),
+        "title": issue.get("title"),
+        "culprit": issue.get("culprit"),
+        "level": issue.get("level"),
+        "status": issue.get("status"),
+        "permalink": issue.get("permalink"),
+        "first_seen": issue.get("first_seen") or issue.get("firstSeen"),
+        "last_seen": issue.get("last_seen") or issue.get("lastSeen"),
+        "event_count": issue.get("count"),
+        "user_count": issue.get("user_count") or issue.get("userCount"),
+    }
+
+
+def issue_fingerprint(project, fields, exception, frames):
+    """A fingerprint that survives a new Sentry issue ID for the same defect.
+
+    Sentry issues an ID per grouping, and a resolved issue that regresses can
+    come back under a new one. The exception type, culprit, and innermost
+    in-app frame name the defect itself, so the Candidate keeps its identity.
+    """
+    frame = frames[0] if frames else {}
+    parts = [
+        project,
+        exception.get("type") or "",
+        fields.get("culprit") or "",
+        frame.get("file") or "",
+        frame.get("function") or "",
+    ]
+    if not any(parts[1:]):
+        parts.append(fields.get("title") or fields["id"])
+    return "sentry:" + sha256_text("|".join(parts))[:16]
+
+
+def digest_bundle(project, bundle):
+    fields = issue_fields(bundle.get("issue") or {})
+    events = bundle.get("events") or []
+    latest = events[0] if events else {}
+    exception = event_exception(latest)
+    frames = top_frames(event_frames(latest))
+    return {
+        **fields,
+        "exception": exception,
+        "frames": frames,
+        "release": event_release(latest),
+        "environment": latest.get("environment"),
+        "fingerprint": issue_fingerprint(project, fields, exception, frames),
+    }
+
+
+def compare_with_previous(entries, previous):
+    """Mark each issue unchanged when the last run saw the same count and last-seen time."""
+    seen = previous.get("issues") or {}
+    for entry in entries:
+        prior = seen.get(entry["id"])
+        entry["runs_seen"] = (prior or {}).get("runs_seen", 0) + 1
+        entry["unchanged_since_last_run"] = bool(prior) and (
+            prior.get("last_seen") == entry["last_seen"]
+            and prior.get("event_count") == entry["event_count"]
+        )
+    return entries
+
+
+def digest_bundles(args):
+    """Summarize every bundle in a bulk-bundles directory and record what was seen.
+
+    The state file is local run memory, not a Sentry or repository write. It is
+    what lets a read-only Routine run skip a backlog it already analysed.
+    """
+    bundles_dir = Path(args.bundles)
+    manifest = json.loads((bundles_dir / "manifest.json").read_text())
+    project = manifest.get("project")
+    if manifest.get("org") != args.org or project != args.project:
+        raise RuntimeError("Manifest organization or project does not match arguments.")
+    if manifest.get("errors"):
+        raise RuntimeError("Manifest lists fetch errors; rerun bulk-bundles first.")
+    entries = []
+    for issue_id in manifest.get("completed", {}):
+        bundle = json.loads((bundles_dir / f"{issue_id}.json").read_text())
+        entry = digest_bundle(project, bundle)
+        if entry["id"] != issue_id:
+            raise RuntimeError(f"Bundle {issue_id} does not match its manifest.")
+        entries.append(entry)
+    entries.sort(key=lambda entry: int(entry["id"]))
+    issue_ids = [entry["id"] for entry in entries]
+    checksum = issue_ids_checksum(issue_ids)
+
+    state_path = Path(args.state) if args.state else default_digest_state_path(args.org, project)
+    previous = json.loads(state_path.read_text()) if state_path.exists() else {}
+    compare_with_previous(entries, previous)
+    changed = [entry["id"] for entry in entries if not entry["unchanged_since_last_run"]]
+    snapshot_unchanged = previous.get("issue_ids_sha256") == checksum
+    result = {
+        "org": args.org,
+        "project": project,
+        "run_id": args.run_id,
+        "issue_count": len(entries),
+        "issue_ids_sha256": checksum,
+        "previous_run": {
+            "run_id": previous.get("run_id"),
+            "recorded_at": previous.get("recorded_at"),
+            "issue_ids_sha256": previous.get("issue_ids_sha256"),
+        },
+        "snapshot_unchanged": snapshot_unchanged,
+        "all_unchanged": snapshot_unchanged and not changed,
+        "changed_issue_ids": changed,
+        "state": str(state_path.resolve()),
+        "recorded": False,
+        "issues": entries,
+    }
+    if not args.no_record:
+        state = {
+            "org": args.org,
+            "project": project,
+            "run_id": args.run_id,
+            "recorded_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "issue_ids_sha256": checksum,
+            "issues": {
+                entry["id"]: {
+                    "last_seen": entry["last_seen"],
+                    "event_count": entry["event_count"],
+                    "runs_seen": entry["runs_seen"],
+                }
+                for entry in entries
+            },
+        }
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = state_path.with_suffix(".json.tmp")
+        temporary.write_text(stable_json(state))
+        temporary.replace(state_path)
+        result["recorded"] = True
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(stable_json(redact(result)))
+    return result
 
 
 def request_write(base_url, token, path, payload, params=None, method="PUT"):
@@ -571,20 +772,40 @@ def build_parser():
     snapshot.add_argument("--query", default="is:unresolved")
     snapshot.add_argument("--output")
 
+    compact_help = "Keep exception frames only. Drops thread and raw frames."
     bundle = subparsers.add_parser("bundle", help="Fetch issue and recent full events")
     bundle.add_argument("--project", required=True)
     bundle.add_argument("--issue", required=True)
     bundle.add_argument("--events", type=int, default=1)
-    bundle.add_argument("--compact", action="store_true")
+    bundle.add_argument("--compact", action="store_true", help=compact_help)
 
     bulk = subparsers.add_parser(
-        "bulk-bundles", help="Fetch compact evidence for every snapshot issue"
+        "bulk-bundles", help="Fetch full evidence for every snapshot issue"
     )
     bulk.add_argument("--project", required=True)
     bulk.add_argument("--snapshot", required=True)
     bulk.add_argument("--output", required=True)
     bulk.add_argument("--events", type=int, default=1)
     bulk.add_argument("--workers", type=int, default=4)
+    bulk.add_argument("--compact", action="store_true", help=compact_help)
+
+    digest = subparsers.add_parser(
+        "digest",
+        help=(
+            "Summarize a bulk-bundles directory: title, culprit, top in-app frames, "
+            "first and last seen, event and user counts, release, and a stable "
+            "fingerprint per issue. Records what it saw so the next run can tell "
+            "what changed. Needs no Sentry token."
+        ),
+    )
+    digest.add_argument("--project", required=True)
+    digest.add_argument("--bundles", required=True, help="bulk-bundles output directory")
+    digest.add_argument("--run-id", default=None, help="Run identity to record")
+    digest.add_argument("--state", help="Override the local state file path")
+    digest.add_argument(
+        "--no-record", action="store_true", help="Compare only. Leave the state file alone."
+    )
+    digest.add_argument("--output", help="Also write the digest JSON to this path")
 
     resolve = subparsers.add_parser(
         "resolve", help="Resolve issues this run proved fixed"
@@ -608,8 +829,12 @@ def main():
         raise RuntimeError("--events must be between 1 and 20.")
     if getattr(args, "workers", 1) < 1 or getattr(args, "workers", 1) > 8:
         raise RuntimeError("--workers must be between 1 and 8.")
+    if getattr(args, "compact", False):
+        print(COMPACT_WARNING, file=sys.stderr)
     if args.command == "snapshot":
         result = snapshot_issues(args)
+    elif args.command == "digest":
+        result = digest_bundles(args)
     else:
         token, base_url = load_cli_config()
         if args.command == "bundle":

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -537,8 +537,8 @@ def issue_fingerprint(project, fields, exception, frames):
     Sentry issues an ID per grouping, and a resolved issue that regresses can
     come back under a new one. The exception type, culprit, and innermost
     in-app frame name the defect itself, so the Candidate keeps its identity.
-    Without an exception type the remaining parts cannot tell defects apart,
-    so the title (or issue ID) stands in.
+    A frameless issue carries no stack to tell defects apart, so the title
+    (or issue ID) stands in.
     """
     frame = frames[0] if frames else {}
     parts = [
@@ -548,7 +548,7 @@ def issue_fingerprint(project, fields, exception, frames):
         frame.get("file") or "",
         frame.get("function") or "",
     ]
-    if not exception.get("type"):
+    if not frames:
         parts.append(fields.get("title") or fields["id"])
     return "sentry:" + sha256_text("|".join(parts))[:16]
 

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -512,18 +512,22 @@ def event_release(event):
 
 def issue_fields(issue):
     """One shape for a full API issue and a compact issue_summary."""
+    def pick(key, fallback):
+        value = issue.get(key)
+        return value if value is not None else issue.get(fallback)
+
     return {
         "id": str(issue.get("id")),
-        "short_id": issue.get("short_id") or issue.get("shortId"),
+        "short_id": pick("short_id", "shortId"),
         "title": issue.get("title"),
         "culprit": issue.get("culprit"),
         "level": issue.get("level"),
         "status": issue.get("status"),
         "permalink": issue.get("permalink"),
-        "first_seen": issue.get("first_seen") or issue.get("firstSeen"),
-        "last_seen": issue.get("last_seen") or issue.get("lastSeen"),
+        "first_seen": pick("first_seen", "firstSeen"),
+        "last_seen": pick("last_seen", "lastSeen"),
         "event_count": issue.get("count"),
-        "user_count": issue.get("user_count") or issue.get("userCount"),
+        "user_count": pick("user_count", "userCount"),
     }
 
 

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -541,21 +541,21 @@ def issue_fingerprint(project, fields, exception, frames):
     """A fingerprint that survives a new Sentry issue ID for the same defect.
 
     Sentry issues an ID per grouping, and a resolved issue that regresses can
-    come back under a new one. The exception type, culprit, and innermost
-    in-app frame name the defect itself, so the Candidate keeps its identity.
-    A frameless issue carries no stack to tell defects apart, so the title
-    (or issue ID) stands in.
+    come back under a new one. The exception type and value, culprit, and
+    innermost in-app frame name the defect itself, so the Candidate keeps its
+    identity. One function can raise two different errors, so the value is
+    always part of the name. Without an exception the title stands in, and
+    without a title the issue ID does.
     """
     frame = frames[0] if frames else {}
     parts = [
         project,
         exception.get("type") or "",
+        exception.get("value") or fields.get("title") or fields["id"],
         fields.get("culprit") or "",
         frame.get("file") or "",
         frame.get("function") or "",
     ]
-    if not frames:
-        parts.append(fields.get("title") or fields["id"])
     return "sentry:" + sha256_text("|".join(parts))[:16]
 
 
@@ -589,10 +589,13 @@ def compare_with_previous(entries, previous):
 
 
 def digest_bundles(args):
-    """Summarize every bundle in a bulk-bundles directory and record what was seen.
+    """Summarize every bundle in a bulk-bundles directory.
 
-    The state file is local run memory, not a Sentry or repository write. It is
-    what lets a read-only Routine run skip a backlog it already analysed.
+    With --record it also writes what it saw. The state file is local run
+    memory, not a Sentry or repository write. It is what lets a read-only
+    Routine run skip a backlog it already analysed. Recording is a separate
+    step so that a run which aborts after the digest leaves no state behind:
+    the next run then sees an unanalysed backlog, not an unchanged one.
     """
     bundles_dir = Path(args.bundles)
     manifest = json.loads((bundles_dir / "manifest.json").read_text())
@@ -635,7 +638,7 @@ def digest_bundles(args):
         "recorded": False,
         "issues": entries,
     }
-    if not args.no_record:
+    if args.record:
         state = {
             "org": args.org,
             "project": project,
@@ -817,7 +820,12 @@ def build_parser():
     digest.add_argument("--run-id", default=None, help="Run identity to record")
     digest.add_argument("--state", help="Override the local state file path")
     digest.add_argument(
-        "--no-record", action="store_true", help="Compare only. Leave the state file alone."
+        "--record",
+        action="store_true",
+        help=(
+            "Write the state file. Run this only after the analysis is complete. "
+            "Without it the command compares only."
+        ),
     )
     digest.add_argument("--output", help="Also write the digest JSON to this path")
 

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/sentry_api.py
@@ -373,6 +373,7 @@ def fetch_issue_bundle(org, project, issue_id, events, compact, base_url, token)
         detailed_events.append(compact_event(detail) if compact else detail)
     return {
         "project": project,
+        "compact": compact,
         "issue": issue_summary(issue) if compact else issue,
         "events": detailed_events,
     }
@@ -410,7 +411,11 @@ def bulk_bundles(args, base_url, token):
         path = output_dir / f"{issue_id}.json"
         if path.exists():
             existing = json.loads(path.read_text())
-            if str(existing.get("issue", {}).get("id")) == issue_id:
+            # A bundle written before the mode was recorded is compact, because
+            # this command was compact-only then. Reuse only a bundle of the
+            # requested mode, or a resumed run keeps evidence with no frames.
+            same_mode = existing.get("compact", True) == args.compact
+            if str(existing.get("issue", {}).get("id")) == issue_id and same_mode:
                 text = stable_json(existing)
                 return issue_id, text
         value = fetch_issue_bundle(
@@ -445,6 +450,7 @@ def bulk_bundles(args, base_url, token):
         "issue_count": len(issue_ids),
         "issue_ids_sha256": issue_ids_checksum(issue_ids),
         "events_per_issue": args.events,
+        "compact": args.compact,
         "completed": dict(sorted(checksums.items())),
         "errors": dict(sorted(errors.items())),
     }
@@ -646,7 +652,9 @@ def digest_bundles(args):
             },
         }
         state_path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = state_path.with_suffix(".json.tmp")
+        # One temp name per process, so two digests of one project cannot
+        # interleave writes into a shared file and publish a torn state.
+        temporary = state_path.with_name(f"{state_path.name}.{os.getpid()}.tmp")
         temporary.write_text(stable_json(state))
         temporary.replace(state_path)
         result["recorded"] = True

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_routine.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_routine.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+
+FAKE_PYTHON3 = """#!/bin/sh
+out=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--output" ]; then out="$arg"; fi
+  prev="$arg"
+done
+if [ -n "$out" ]; then printf '{}' > "$out"; fi
+exit 0
+"""
+
+
+class RoutineSequenceTest(unittest.TestCase):
+    def routine_sequence(self):
+        lines = (SKILL_DIR / "SKILL.md").read_text().splitlines()
+        marker = next(
+            index for index, line in enumerate(lines) if "Routine command sequence" in line
+        )
+        opener = next(
+            index
+            for index in range(marker, len(lines))
+            if lines[index].startswith("```bash")
+        )
+        closer = next(
+            index for index in range(opener + 1, len(lines)) if lines[index].startswith("```")
+        )
+        return "\n".join(lines[opener + 1 : closer])
+
+    def test_routine_sequence_runs_from_a_fresh_state_home(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_home = Path(directory) / "state"
+            state_home.mkdir()
+            bin_dir = Path(directory) / "bin"
+            bin_dir.mkdir()
+            stub = bin_dir / "python3"
+            stub.write_text(FAKE_PYTHON3)
+            stub.chmod(0o755)
+            script = "set -e\n" + self.routine_sequence() + "\n"
+            script += 'test -f "$RUN_DIR/PROJECT.digest.json"\n'
+            result = subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True,
+                text=True,
+                cwd=SKILL_DIR,
+                env={
+                    **os.environ,
+                    "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                    "XDG_STATE_HOME": str(state_home),
+                },
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(
+                any(state_home.joinpath("sentry-checkin").iterdir()),
+                "the sequence must create runs under the state home",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -491,6 +491,31 @@ class DigestTest(unittest.TestCase):
             digest = self.run_digest(bundles_dir, Path(directory) / "state.json")
             self.assertEqual(digest["issues"][0]["user_count"], 0)
 
+    def test_digest_gives_frameless_issues_with_one_culprit_distinct_fingerprints(self):
+        frameless = {
+            "project": "site",
+            "issue": {
+                "id": "10",
+                "short_id": "SITE-10",
+                "title": "Error: first",
+                "culprit": "server/api/gone.ts",
+                "count": "1",
+                "user_count": 1,
+                "first_seen": "2026-08-20T00:00:00Z",
+                "last_seen": "2026-08-21T00:00:00Z",
+            },
+            "events": [{"eventID": "event-a"}],
+        }
+        sibling = json.loads(json.dumps(frameless))
+        sibling["issue"]["id"] = "11"
+        sibling["issue"]["short_id"] = "SITE-11"
+        sibling["issue"]["title"] = "Error: second"
+        with tempfile.TemporaryDirectory() as directory:
+            bundles_dir = self.write_bundles(directory, [frameless, sibling])
+            digest = self.run_digest(bundles_dir, Path(directory) / "state.json")
+            first, second = digest["issues"]
+            self.assertNotEqual(first["fingerprint"], second["fingerprint"])
+
     def test_digest_flags_an_unchanged_backlog_on_the_next_run(self):
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory) / "state.json"

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -607,8 +607,8 @@ class DigestTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory) / "state.json"
             bundles_dir = self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE])
-            first = self.run_digest(bundles_dir, state, "--run-id", "run-1")
-            second = self.run_digest(bundles_dir, state, "--run-id", "run-2")
+            first = self.run_digest(bundles_dir, state, "--run-id", "run-1", "--record")
+            second = self.run_digest(bundles_dir, state, "--run-id", "run-2", "--record")
             self.assertTrue(second["snapshot_unchanged"])
             self.assertTrue(second["all_unchanged"])
             self.assertEqual(second["previous_run"]["run_id"], "run-1")
@@ -622,17 +622,45 @@ class DigestTest(unittest.TestCase):
             grown["issue"]["count"] = "13"
             grown["issue"]["lastSeen"] = "2026-09-01T00:00:00Z"
             bundles_dir = self.write_bundles(directory, [grown, COMPACT_BUNDLE])
-            third = self.run_digest(bundles_dir, state, "--no-record")
+            third = self.run_digest(bundles_dir, state)
             self.assertTrue(third["snapshot_unchanged"])
             self.assertFalse(third["all_unchanged"])
             self.assertEqual(third["changed_issue_ids"], ["1"])
             self.assertFalse(third["recorded"])
             self.assertEqual(json.loads(state.read_text())["run_id"], "run-2")
 
+    def test_digest_never_skips_a_backlog_an_aborted_run_only_looked_at(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "state.json"
+            bundles_dir = self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE])
+            looked = self.run_digest(bundles_dir, state, "--run-id", "run-1")
+            self.assertFalse(looked["recorded"])
+            self.assertFalse(state.exists())
+            again = self.run_digest(bundles_dir, state, "--run-id", "run-2")
+            self.assertFalse(again["snapshot_unchanged"])
+            self.assertFalse(again["all_unchanged"])
+            recorded = self.run_digest(bundles_dir, state, "--run-id", "run-2", "--record")
+            self.assertTrue(recorded["recorded"])
+            self.assertTrue(self.run_digest(bundles_dir, state, "--run-id", "run-3")["all_unchanged"])
+
+    def test_digest_keeps_two_defects_apart_when_they_share_frames_and_culprit(self):
+        first = json.loads(json.dumps(FULL_BUNDLE))
+        second = json.loads(json.dumps(FULL_BUNDLE))
+        second["issue"]["id"] = "3"
+        second["issue"]["shortId"] = "SITE-3"
+        second["issue"]["title"] = "TypeError: y is not a function"
+        second["events"][0]["entries"][0]["data"]["values"][0]["value"] = "y is not a function"
+        with tempfile.TemporaryDirectory() as directory:
+            bundles_dir = self.write_bundles(directory, [first, second])
+            digest = self.run_digest(bundles_dir, Path(directory) / "state.json")
+            one, two = digest["issues"]
+            self.assertEqual(one["frames"], two["frames"])
+            self.assertNotEqual(one["fingerprint"], two["fingerprint"])
+
     def test_digest_sees_a_new_issue_set_as_changed(self):
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory) / "state.json"
-            self.run_digest(self.write_bundles(directory, [FULL_BUNDLE]), state)
+            self.run_digest(self.write_bundles(directory, [FULL_BUNDLE]), state, "--record")
             digest = self.run_digest(
                 self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE]), state
             )
@@ -655,6 +683,7 @@ class DigestTest(unittest.TestCase):
                 str(bundles_dir),
                 "--state",
                 str(state),
+                "--record",
             ]
             processes = [
                 subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -483,6 +483,14 @@ class DigestTest(unittest.TestCase):
             self.assertFalse(digest["snapshot_unchanged"])
             self.assertEqual([entry["runs_seen"] for entry in digest["issues"]], [1, 1])
 
+    def test_digest_reports_a_zero_user_count_from_a_compact_bundle(self):
+        zero = json.loads(json.dumps(COMPACT_BUNDLE))
+        zero["issue"]["user_count"] = 0
+        with tempfile.TemporaryDirectory() as directory:
+            bundles_dir = self.write_bundles(directory, [zero])
+            digest = self.run_digest(bundles_dir, Path(directory) / "state.json")
+            self.assertEqual(digest["issues"][0]["user_count"], 0)
+
     def test_digest_flags_an_unchanged_backlog_on_the_next_run(self):
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory) / "state.json"

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -348,5 +348,209 @@ print('''+----------+----------+----------------------+-------------------------
         self.assertEqual(SentryHandler.writes, [])
 
 
+FULL_BUNDLE = {
+    "project": "site",
+    "issue": {
+        "id": "1",
+        "shortId": "SITE-1",
+        "title": "TypeError: x is undefined",
+        "culprit": "app/pages/index.vue",
+        "level": "error",
+        "status": "unresolved",
+        "count": "12",
+        "userCount": 4,
+        "firstSeen": "2026-08-10T00:00:00Z",
+        "lastSeen": "2026-08-28T00:00:00Z",
+    },
+    "events": [
+        {
+            "eventID": "event-1",
+            "release": {"version": "abc123"},
+            "environment": "production",
+            "entries": [
+                {
+                    "type": "exception",
+                    "data": {
+                        "values": [
+                            {
+                                "type": "TypeError",
+                                "value": "x is undefined",
+                                "stacktrace": {
+                                    "frames": [
+                                        {"filename": "node_modules/vue/runtime.js", "function": "render", "lineno": 1, "in_app": False},
+                                        {"filename": "app/pages/index.vue", "function": "setup", "lineno": 42, "in_app": True},
+                                        {"filename": "app/utils/read.ts", "function": "read", "lineno": 7, "in_app": True},
+                                    ]
+                                },
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+    ],
+}
+COMPACT_BUNDLE = {
+    "project": "site",
+    "issue": {
+        "id": "2",
+        "short_id": "SITE-2",
+        "title": "Error: boom",
+        "culprit": "server/api/boom.ts",
+        "count": "3",
+        "user_count": 1,
+        "first_seen": "2026-08-20T00:00:00Z",
+        "last_seen": "2026-08-21T00:00:00Z",
+    },
+    "events": [
+        {
+            "release": "def456",
+            "exceptions": [
+                {
+                    "type": "Error",
+                    "value": "boom",
+                    "frames": [
+                        {"filename": "server/api/boom.ts", "function": "handler", "lineno": 3, "in_app": True}
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+class DigestTest(unittest.TestCase):
+    def write_bundles(self, directory, bundles):
+        bundles_dir = Path(directory) / "bundles"
+        bundles_dir.mkdir(exist_ok=True)
+        for bundle in bundles:
+            issue_id = str(bundle["issue"]["id"])
+            (bundles_dir / f"{issue_id}.json").write_text(json.dumps(bundle))
+        (bundles_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "org": "test",
+                    "project": "site",
+                    "completed": {str(bundle["issue"]["id"]): "x" for bundle in bundles},
+                    "errors": {},
+                }
+            )
+        )
+        return bundles_dir
+
+    def run_digest(self, bundles_dir, state, *arguments):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).with_name("sentry_api.py")),
+                "--org",
+                "test",
+                "digest",
+                "--project",
+                "site",
+                "--bundles",
+                str(bundles_dir),
+                "--state",
+                str(state),
+                *arguments,
+            ],
+            capture_output=True,
+            check=False,
+            env={**os.environ, "SENTRY_AUTH_TOKEN": ""},
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+        return json.loads(result.stdout)
+
+    def test_digest_summarizes_full_and_compact_bundles_without_a_token(self):
+        with tempfile.TemporaryDirectory() as directory:
+            bundles_dir = self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE])
+            digest = self.run_digest(bundles_dir, Path(directory) / "state.json")
+            full, compact = digest["issues"]
+            self.assertEqual(full["short_id"], "SITE-1")
+            self.assertEqual(full["event_count"], "12")
+            self.assertEqual(full["user_count"], 4)
+            self.assertEqual(full["release"], "abc123")
+            self.assertEqual(full["exception"]["type"], "TypeError")
+            self.assertEqual(
+                [(frame["file"], frame["function"]) for frame in full["frames"]],
+                [("app/utils/read.ts", "read"), ("app/pages/index.vue", "setup")],
+            )
+            self.assertEqual(compact["release"], "def456")
+            self.assertEqual(compact["frames"][0]["file"], "server/api/boom.ts")
+            self.assertTrue(all(entry["fingerprint"].startswith("sentry:") for entry in digest["issues"]))
+            self.assertFalse(digest["snapshot_unchanged"])
+            self.assertEqual([entry["runs_seen"] for entry in digest["issues"]], [1, 1])
+
+    def test_digest_flags_an_unchanged_backlog_on_the_next_run(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "state.json"
+            bundles_dir = self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE])
+            first = self.run_digest(bundles_dir, state, "--run-id", "run-1")
+            second = self.run_digest(bundles_dir, state, "--run-id", "run-2")
+            self.assertTrue(second["snapshot_unchanged"])
+            self.assertTrue(second["all_unchanged"])
+            self.assertEqual(second["previous_run"]["run_id"], "run-1")
+            self.assertEqual([entry["runs_seen"] for entry in second["issues"]], [2, 2])
+            self.assertEqual(
+                [entry["fingerprint"] for entry in first["issues"]],
+                [entry["fingerprint"] for entry in second["issues"]],
+            )
+
+            grown = json.loads(json.dumps(FULL_BUNDLE))
+            grown["issue"]["count"] = "13"
+            grown["issue"]["lastSeen"] = "2026-09-01T00:00:00Z"
+            bundles_dir = self.write_bundles(directory, [grown, COMPACT_BUNDLE])
+            third = self.run_digest(bundles_dir, state, "--no-record")
+            self.assertTrue(third["snapshot_unchanged"])
+            self.assertFalse(third["all_unchanged"])
+            self.assertEqual(third["changed_issue_ids"], ["1"])
+            self.assertFalse(third["recorded"])
+            self.assertEqual(json.loads(state.read_text())["run_id"], "run-2")
+
+    def test_digest_sees_a_new_issue_set_as_changed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "state.json"
+            self.run_digest(self.write_bundles(directory, [FULL_BUNDLE]), state)
+            digest = self.run_digest(
+                self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE]), state
+            )
+            self.assertFalse(digest["snapshot_unchanged"])
+            self.assertEqual(digest["changed_issue_ids"], ["2"])
+
+    def test_compact_bundle_warns_that_frames_are_dropped(self):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), SentryHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        env = dict(os.environ)
+        env["SENTRY_AUTH_TOKEN"] = "test-token"
+        env["SENTRY_URL"] = f"http://127.0.0.1:{server.server_port}"
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("sentry_api.py")),
+                    "--org",
+                    "test",
+                    "bundle",
+                    "--project",
+                    "site",
+                    "--issue",
+                    "1",
+                    "--compact",
+                ],
+                capture_output=True,
+                check=False,
+                env=env,
+                text=True,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("drops thread and raw frames", result.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -265,6 +265,60 @@ print('''+----------+----------+----------------------+-------------------------
             self.assertEqual(json.loads((output / "1.json").read_text())["project"], "site")
 
 
+    def test_bulk_bundle_refetches_a_compact_bundle_when_full_evidence_is_requested(self):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), SentryHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot = Path(directory) / "snapshot.json"
+            snapshot.write_text(
+                json.dumps(
+                    {"org": "test", "project": "site", "issues": [{"id": "1", "short_id": "TEST-1"}]}
+                )
+            )
+            output = Path(directory) / "bundles"
+            output.mkdir()
+            (output / "1.json").write_text(
+                json.dumps(
+                    {
+                        "project": "site",
+                        "issue": {"id": "1", "short_id": "TEST-1"},
+                        "events": [{"eventID": "event-1", "exceptions": []}],
+                    }
+                )
+            )
+            env = dict(os.environ)
+            env["SENTRY_AUTH_TOKEN"] = "test-token"
+            env["SENTRY_URL"] = f"http://127.0.0.1:{server.server_port}"
+            try:
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(Path(__file__).with_name("sentry_api.py")),
+                        "--org",
+                        "test",
+                        "bulk-bundles",
+                        "--project",
+                        "site",
+                        "--snapshot",
+                        str(snapshot),
+                        "--output",
+                        str(output),
+                    ],
+                    capture_output=True,
+                    check=False,
+                    env=env,
+                    text=True,
+                )
+            finally:
+                server.shutdown()
+                server.server_close()
+            self.assertEqual(result.returncode, 0, result.stderr)
+            bundle = json.loads((output / "1.json").read_text())
+            self.assertFalse(bundle["compact"])
+            self.assertIn("entries", bundle["events"][0])
+            self.assertFalse(json.loads((output / "manifest.json").read_text())["compact"])
+
     def run_resolve(self, *arguments):
         SentryHandler.writes = []
         server = ThreadingHTTPServer(("127.0.0.1", 0), SentryHandler)
@@ -584,6 +638,33 @@ class DigestTest(unittest.TestCase):
             )
             self.assertFalse(digest["snapshot_unchanged"])
             self.assertEqual(digest["changed_issue_ids"], ["2"])
+
+    def test_concurrent_digests_leave_the_state_file_readable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory) / "state.json"
+            bundles_dir = self.write_bundles(directory, [FULL_BUNDLE, COMPACT_BUNDLE])
+            command = [
+                sys.executable,
+                str(Path(__file__).with_name("sentry_api.py")),
+                "--org",
+                "test",
+                "digest",
+                "--project",
+                "site",
+                "--bundles",
+                str(bundles_dir),
+                "--state",
+                str(state),
+            ]
+            processes = [
+                subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True)
+                for _ in range(4)
+            ]
+            for process in processes:
+                _, stderr = process.communicate()
+                self.assertEqual(process.returncode, 0, stderr)
+            self.assertEqual(json.loads(state.read_text())["project"], "site")
+            self.assertEqual(list(Path(directory).glob("state.json.*.tmp")), [])
 
     def test_compact_bundle_warns_that_frames_are_dropped(self):
         server = ThreadingHTTPServer(("127.0.0.1", 0), SentryHandler)

--- a/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
+++ b/harlan-agent-kit/skills/sentry-checkin/scripts/test_sentry_api.py
@@ -516,6 +516,39 @@ class DigestTest(unittest.TestCase):
             first, second = digest["issues"]
             self.assertNotEqual(first["fingerprint"], second["fingerprint"])
 
+    def test_digest_gives_typed_frameless_issues_with_one_culprit_distinct_fingerprints(self):
+        frameless = {
+            "project": "site",
+            "issue": {
+                "id": "12",
+                "short_id": "SITE-12",
+                "title": "Error: first",
+                "culprit": "server/api/gone.ts",
+                "count": "1",
+                "user_count": 1,
+                "first_seen": "2026-08-20T00:00:00Z",
+                "last_seen": "2026-08-21T00:00:00Z",
+            },
+            "events": [
+                {
+                    "entries": [
+                        {"type": "exception", "data": {"values": [{"type": "Error", "value": "first"}]}}
+                    ]
+                }
+            ],
+        }
+        sibling = json.loads(json.dumps(frameless))
+        sibling["issue"]["id"] = "13"
+        sibling["issue"]["short_id"] = "SITE-13"
+        sibling["issue"]["title"] = "Error: second"
+        sibling["events"][0]["entries"][0]["data"]["values"][0]["value"] = "second"
+        with tempfile.TemporaryDirectory() as directory:
+            bundles_dir = self.write_bundles(directory, [frameless, sibling])
+            digest = self.run_digest(bundles_dir, Path(directory) / "state.json")
+            first, second = digest["issues"]
+            self.assertEqual(first["exception"]["type"], "Error")
+            self.assertNotEqual(first["fingerprint"], second["fingerprint"])
+
     def test_digest_flags_an_unchanged_backlog_on_the_next_run(self):
         with tempfile.TemporaryDirectory() as directory:
             state = Path(directory) / "state.json"


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

Every sentry-checkin Routine run re-analysed the same 10 to 12 stale issues across seven sites, about 14 minutes and 80k input tokens per site, because read-only mode never recorded what it saw and every issue came back `new`. Agents also refetched compact bundles that lacked frames, wrote a throwaway Python summariser each session, and one grepped `~/.sentryclirc` for event counts and printed the token.

`sentry_api.py digest` now summarises full bundles per issue with counts, frames, release, and a stable fingerprint, and keeps local run state so the next run can see `all_unchanged` and stop before reading code. SKILL.md gains a Routine mode section: single site, installed `sentry-cli`, no token reads, JSON only.

Not sure whether digest's own state file or the ledger history should be the long-term memory; the state file was the smallest change that gives `runs_seen` without an audited ledger.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz