### PR TITLE
fix(github-agent): run Pull request triage before Review

### DIFF
--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -931,6 +931,7 @@ async function triagePullRequest(
 
   let outcome: RecordPullRequestTriageRunInput['outcome']
   let skipped: PullRequestTriageResult | null = null
+  let overridden = false
   if (triage._tag === 'Err') {
     outcome = { _tag: 'ReviewRequiredAfterFailure', reason: triage.error }
   }
@@ -940,10 +941,12 @@ async function triagePullRequest(
   else {
     // A person may add the manual override while the low-cost Agent runs.
     // Re-read the labels before settling so that late authority always wins.
+    // A failed re-read could hide a fresh override, so only a successful read
+    // without the label settles on a skip: the safe direction is always Review.
     const current = await options.github.getPullRequestReviewSnapshot(task.repositoryMapping, task.pullRequestNumber, signal)
-    const overridden = current._tag === 'Ok'
-      && current.value.pullRequest.headSha === task.pullRequest.headSha
-      && current.value.pullRequest.approvalLabels.includes('review')
+    overridden = current._tag === 'Err'
+      || (current.value.pullRequest.headSha === task.pullRequest.headSha
+        && current.value.pullRequest.approvalLabels.includes('review'))
     outcome = overridden
       ? { _tag: 'ReviewRequired', reason: `rule: The ${APPROVAL_LABELS.review} label requires Review for this head commit.` }
       : { _tag: 'ReviewSkipped', reason: triage.value.reason }
@@ -964,6 +967,19 @@ async function triagePullRequest(
     return err('The pull request changed before its triage decision was recorded.')
   if (skipped === null || recorded._tag === 'Conflict') {
     await stampAgentLabel(options, task, 'ADVERSARIAL_REVIEW_REQUIRED', signal)
+    if (overridden) {
+      // The review label approves one head only, so consume it here exactly
+      // like the manualReview branch: a later head must not inherit it.
+      const consumed = await options.github.consumeApprovalLabel(
+        task.repositoryMapping,
+        'pull_request',
+        task.pullRequestNumber,
+        APPROVAL_LABELS.review,
+        signal,
+      )
+      if (consumed._tag === 'Err')
+        options.onProgressPublishFailure?.(task, consumed.error)
+    }
     return ok({ _tag: 'ReviewRequired' })
   }
 

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1,12 +1,14 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { AgentLabelState } from './agent-label.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { AgentTokenUsage } from './agent-provider.ts'
 import type { GitHubAgentSource, GitHubCheck, GitHubChecksSnapshot, IssueTriageSnapshot, PullRequestReviewSnapshot, RequiredChecks } from './github-agent-source.ts'
 import type { IssueTriageCommentController } from './issue-triage-comment-controller.ts'
 import type { IssueTriageResult } from './issue-triage.ts'
-import type { PullRequestTriageAgent } from './pull-request-triage.ts'
+import type { PullRequestTriageAgent, PullRequestTriageResult } from './pull-request-triage.ts'
 import type { Result } from './result.ts'
 import type { ReviewStatusController } from './review-status-controller.ts'
+import type { RecordPullRequestTriageRunInput } from './stats.ts'
 import type { JournalStore } from './store.ts'
 import type {
   AgentProgress,
@@ -674,6 +676,19 @@ Base branch CI fails at \`${baseSha.slice(0, 12)}\`.
 Next: merge or repair the marked Baseline repair pull request.`
 }
 
+function reviewSkippedComment(headSha: string, baseSha: string, result: PullRequestTriageResult, at: string): string {
+  const workflow = JSON.stringify({ _tag: 'ReviewSkipped', headSha, baseSha })
+  return `${AUTOMATED_REVIEW_MARKER}
+<!-- reviewed-sha: ${headSha} -->
+<!-- workflow-state: ${workflow} -->
+### 🤖 REVIEW SKIPPED
+
+${automatedDisclosure({ kind: 'triage', updatedAt: updatedAtLabel(at) })}
+
+- **Reason:** ${cleanLine(result.reason)}
+- **Override:** Add the \`${APPROVAL_LABELS.review}\` label to force an adversarial Review.`
+}
+
 function gateSummary(name: 'Merge' | 'Review' | 'CI', gate: ReviewGateState, findings: ReviewFinding[]): string {
   if (gate._tag === 'Passed')
     return `- **${name} gate:** Passed.${name === 'Review' && findings.length === 0 ? ' No material issues.' : ''}`
@@ -873,10 +888,10 @@ function recordRunnerLostIncident(options: ReviewWorkerOptions, repository: stri
 async function stampAgentLabel(
   options: ReviewWorkerOptions,
   task: ClaimedAdversarialReviewTask,
-  outcome: ReviewOutcomeName,
+  state: AgentLabelState,
   signal: AbortSignal,
 ): Promise<void> {
-  const stamped = await options.github.stampAgentLabel(task.repositoryMapping, task.pullRequestNumber, outcome, signal)
+  const stamped = await options.github.stampAgentLabel(task.repositoryMapping, task.pullRequestNumber, state, signal)
   if (stamped._tag === 'Err' && !signal.aborted)
     options.onProgressPublishFailure?.(task, stamped.error)
 }
@@ -885,6 +900,81 @@ function storedOutcomeName(run: ReviewRun): ReviewOutcomeName {
   return run.outcome._tag === 'Ready'
     ? 'READY'
     : run.outcome._tag === 'Pending' ? 'PENDING' : 'BLOCKED'
+}
+
+type PullRequestTriageRoute
+  = | { _tag: 'ReviewRequired' }
+    | { _tag: 'ReviewSkipped', reason: string }
+
+/**
+ * Pull request triage in front of Review. The Agent decides by path rule
+ * first, then a stored decision for this head commit, then the low-cost
+ * model for a prose-only pull request. A failed or malformed answer never
+ * waives the Review, and a stored decision that disagrees is left alone: the
+ * safe direction is always Review.
+ *
+ * A skip is durable before it is visible. The triage row is recorded first, so
+ * a retry after a failed publication reuses the decision instead of paying for
+ * the model again.
+ */
+async function triagePullRequest(
+  options: ReviewWorkerOptions,
+  agent: PullRequestTriageAgent,
+  task: ClaimedAdversarialReviewTask,
+  signal: AbortSignal,
+): Promise<Result<PullRequestTriageRoute, string>> {
+  const startedAt = options.now().toISOString()
+  const files = await options.github.listPullRequestFiles(task.repositoryMapping, task.pullRequestNumber, signal)
+  const triage = files._tag === 'Err'
+    ? files
+    : await agent.run(task, { changedFiles: files.value }, signal)
+
+  let outcome: RecordPullRequestTriageRunInput['outcome']
+  let skipped: PullRequestTriageResult | null = null
+  if (triage._tag === 'Err') {
+    outcome = { _tag: 'ReviewRequiredAfterFailure', reason: triage.error }
+  }
+  else if (triage.value._tag === 'ADVERSARIAL_REVIEW_REQUIRED') {
+    outcome = { _tag: 'ReviewRequired', reason: triage.value.reason }
+  }
+  else {
+    // A person may add the manual override while the low-cost Agent runs.
+    // Re-read the labels before settling so that late authority always wins.
+    const current = await options.github.getPullRequestReviewSnapshot(task.repositoryMapping, task.pullRequestNumber, signal)
+    const overridden = current._tag === 'Ok'
+      && current.value.pullRequest.headSha === task.pullRequest.headSha
+      && current.value.pullRequest.approvalLabels.includes('review')
+    outcome = overridden
+      ? { _tag: 'ReviewRequired', reason: `rule: The ${APPROVAL_LABELS.review} label requires Review for this head commit.` }
+      : { _tag: 'ReviewSkipped', reason: triage.value.reason }
+    skipped = overridden ? null : triage.value
+  }
+
+  const recorded = options.store.recordPullRequestTriageRun({
+    taskId: task.id,
+    repository: task.repository,
+    pullRequestNumber: task.pullRequestNumber,
+    revisionId: task.revisionId,
+    headSha: task.pullRequest.headSha,
+    startedAt,
+    completedAt: options.now().toISOString(),
+    outcome,
+  })
+  if (recorded._tag === 'Rejected')
+    return err('The pull request changed before its triage decision was recorded.')
+  if (skipped === null || recorded._tag === 'Conflict') {
+    await stampAgentLabel(options, task, 'ADVERSARIAL_REVIEW_REQUIRED', signal)
+    return ok({ _tag: 'ReviewRequired' })
+  }
+
+  const body = reviewSkippedComment(task.pullRequest.headSha, task.pullRequest.baseSha, skipped, options.now().toISOString())
+  const staged = options.status.stageTerminal === undefined
+    ? await options.status.publish(task, 'terminal', body, signal).then(result => result._tag === 'Err' ? result : ok({ commandId: `legacy:${result.value.commentId}` }))
+    : options.status.stageTerminal(task, body, 'SKIPPED')
+  if (staged._tag === 'Err')
+    return staged
+  await stampAgentLabel(options, task, 'ADVERSARIAL_REVIEW_SKIPPED', signal)
+  return ok({ _tag: 'ReviewSkipped', reason: skipped.reason })
 }
 
 /**
@@ -1006,15 +1096,20 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         }
         freshReviewSession = true
       }
+      else if (task.rerun._tag === 'NotRequested' && options.pullRequestTriage !== undefined) {
+        const route = await triagePullRequest(options, options.pullRequestTriage, task, signal)
+        if (route._tag === 'Err')
+          return route
+        if (route.value._tag === 'ReviewSkipped') {
+          return ok({
+            evidence: JSON.stringify({ _tag: 'ADVERSARIAL_REVIEW_SKIPPED', reason: route.value.reason }),
+            resolution: { _tag: 'ReviewSkipped', reason: route.value.reason },
+          })
+        }
+        freshReviewSession = true
+      }
       else if (task.rerun._tag === 'NotRequested') {
-        const routed = await options.github.stampAgentLabel(
-          task.repositoryMapping,
-          task.pullRequestNumber,
-          'ADVERSARIAL_REVIEW_REQUIRED',
-          signal,
-        )
-        if (routed._tag === 'Err' && !signal.aborted)
-          options.onProgressPublishFailure?.(task, routed.error)
+        await stampAgentLabel(options, task, 'ADVERSARIAL_REVIEW_REQUIRED', signal)
         freshReviewSession = true
       }
       const markedBaselineRepair = snapshot.value.pullRequest.purpose._tag === 'BaselineRepair'

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -160,6 +160,8 @@ describe('subject Workers', () => {
     providerReply: unknown
     title: string
     triageFailure?: string
+    lateApprovalLabels?: GitHubPullRequestItem['approvalLabels']
+    rereadFailure?: string
   }) {
     const pullRequest = pullRequestItem({
       approvalLabels: input.approvalLabels ?? [],
@@ -171,9 +173,27 @@ describe('subject Workers', () => {
     const stamped: string[] = []
     const triageRuns: RecordPullRequestTriageRunInput[] = []
     const worktrees: string[] = []
-    const runtime = agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(input.providerReply), capture))
+    const consumedApprovalLabels: string[] = []
+    let snapshotReads = 0
+    const replies = Array.isArray(input.providerReply) ? input.providerReply : [input.providerReply]
+    let providerCalls = 0
+    const runtime = agentRuntime(CODEX_AGENT_PROFILE, {
+      name: 'codex',
+      runTurn: (request) => {
+        capture.requests.push(request)
+        const reply = replies[Math.min(providerCalls, replies.length - 1)]
+        providerCalls += 1
+        async function* replay() {
+          yield* turnEvents(reply)
+        }
+        return replay()
+      },
+    })
     const github: Parameters<typeof createReviewWorker>[0]['github'] = {
-      consumeApprovalLabel: () => Promise.resolve(ok(undefined)),
+      consumeApprovalLabel: (_repository, _subjectKind, _number, label) => {
+        consumedApprovalLabels.push(label)
+        return Promise.resolve(ok(undefined))
+      },
       editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
       ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
       clearAgentLabels: () => Promise.reject(new Error('Unexpected label clear.')),
@@ -188,16 +208,24 @@ describe('subject Workers', () => {
       getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
       getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
       listPullRequestFiles: () => Promise.resolve(input.triageFailure === undefined ? ok(input.changedFiles) : err(input.triageFailure)),
-      getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-        baseChecks: { _tag: 'Available', checks: [] },
-        body: 'Pull request body.',
-        checks: { _tag: 'Available', checks: [] },
-        comments: [],
-        priorAutomatedReview: { _tag: 'None' },
-        pullRequest,
-        requiredChecks: { _tag: 'None' },
-        reviews: [],
-      })),
+      getPullRequestReviewSnapshot: () => {
+        snapshotReads += 1
+        if (snapshotReads === 2 && input.rereadFailure !== undefined)
+          return Promise.resolve(err(input.rereadFailure))
+        const readPullRequest = snapshotReads === 2 && input.lateApprovalLabels !== undefined
+          ? { ...pullRequest, approvalLabels: input.lateApprovalLabels }
+          : pullRequest
+        return Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [] },
+          body: 'Pull request body.',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest: readPullRequest,
+          requiredChecks: { _tag: 'None' },
+          reviews: [],
+        }))
+      },
       upsertIssueTriageComment: () => Promise.reject(new Error('Review must not post issue triage.')),
       upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
     }
@@ -262,7 +290,7 @@ describe('subject Workers', () => {
       pullRequest,
       rerun: { _tag: 'NotRequested' },
     }, new AbortController().signal)
-    return { capture, comments, run, stamped, triageRuns, worktrees }
+    return { capture, comments, consumedApprovalLabels, run, stamped, triageRuns, worktrees }
   }
 
   const cleanReview = {
@@ -329,6 +357,46 @@ describe('subject Workers', () => {
     expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-sol'])
     expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
     expect(harness.triageRuns).toEqual([])
+  })
+
+  it('reviews the pull request when the late override re-read fails', async () => {
+    const harness = triagedReviewWorker({
+      changedFiles: ['README.md'],
+      providerReply: [
+        { _tag: 'ADVERSARIAL_REVIEW_SKIPPED', reason: 'Only a typo in the guide changed.' },
+        cleanReview,
+      ],
+      rereadFailure: 'GitHub rate limited the label re-read.',
+      title: 'docs: fix a typo in the guide',
+    })
+
+    const result = await harness.run()
+
+    expect(result._tag).toBe('Ok')
+    expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-luna', 'gpt-5.6-sol'])
+    expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
+    expect(harness.triageRuns).toEqual([expect.objectContaining({
+      outcome: { _tag: 'ReviewRequired', reason: 'rule: The harlan-agent-review label requires Review for this head commit.' },
+    })])
+  })
+
+  it('consumes the override label that arrives while triage runs', async () => {
+    const harness = triagedReviewWorker({
+      changedFiles: ['README.md'],
+      lateApprovalLabels: ['review'],
+      providerReply: [
+        { _tag: 'ADVERSARIAL_REVIEW_SKIPPED', reason: 'Only a typo in the guide changed.' },
+        cleanReview,
+      ],
+      title: 'docs: fix a typo in the guide',
+    })
+
+    const result = await harness.run()
+
+    expect(result._tag).toBe('Ok')
+    expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-luna', 'gpt-5.6-sol'])
+    expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
+    expect(harness.consumedApprovalLabels).toEqual(['harlan-agent-review'])
   })
 
   it('reviews the pull request anyway when triage fails', async () => {

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -1,9 +1,11 @@
-import type { RecordReviewRunInput } from '../src/types.ts'
+import type { RecordPullRequestTriageRunInput } from '../src/stats.ts'
+import type { GitHubPullRequestItem, RecordReviewRunInput } from '../src/types.ts'
 import type { ProviderCapture } from './fixtures.ts'
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { createIssueTriageWorker, createReviewWorker, issueMovedUnderTriage, reviewSnapshotDigest } from '../src/item-agent.ts'
-import { ok } from '../src/result.ts'
+import { createPullRequestTriageAgent } from '../src/pull-request-triage.ts'
+import { err, ok } from '../src/result.ts'
 import { agentRuntime, issueItem, pullRequestItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
 describe('subject Workers', () => {
@@ -147,66 +149,73 @@ describe('subject Workers', () => {
     expect(capture.requests[0]?.prompt).toContain('stays inaccessible after authenticated retrieval')
   })
 
-  it('runs Review directly without pull request triage', async () => {
+  /**
+   * One Review worker whose Pull request triage is the real Agent over a stub
+   * provider. `providerReply` is what the provider answers, and the
+   * captured requests say which role asked.
+   */
+  function triagedReviewWorker(input: {
+    approvalLabels?: GitHubPullRequestItem['approvalLabels']
+    changedFiles: string[]
+    providerReply: unknown
+    title: string
+    triageFailure?: string
+  }) {
     const pullRequest = pullRequestItem({
+      approvalLabels: input.approvalLabels ?? [],
       mergeState: 'clean',
-      title: 'chore: update workspace dependencies',
+      title: input.title,
     })
+    const capture: ProviderCapture = { requests: [] }
     const comments: string[] = []
     const stamped: string[] = []
-    let triageCalls = 0
-    let fileReads = 0
-    const capture: ProviderCapture = { requests: [] }
-    const worker = createReviewWorker({
-      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
-        premise: { verdict: 'sound', reason: 'The dependency update remains valid.' },
-        findings: [],
-        confidence: 94,
-      }), capture)),
-      github: {
-        consumeApprovalLabel: () => Promise.reject(new Error('A direct Review must not consume a missing manual override.')),
-        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
-        ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
-        clearAgentLabels: () => Promise.reject(new Error('Unexpected label clear.')),
-        clearRunningLabel: () => Promise.reject(new Error('Unexpected Running label clear.')),
-        listRunningLabelledItems: () => Promise.reject(new Error('Unexpected Running label read.')),
-        stampAgentLabel: (_repository, _number, outcome) => {
-          stamped.push(outcome)
-          return Promise.resolve(ok(undefined))
-        },
-        findOpenPullRequestForBranch: () => Promise.reject(new Error('Unexpected pull request lookup.')),
-        getFailedJobContext: () => Promise.reject(new Error('Unexpected job log read.')),
-        getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
-        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
-        listPullRequestFiles: () => {
-          fileReads += 1
-          return Promise.resolve(ok(['package.json', 'pnpm-lock.yaml']))
-        },
-        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [] },
-          body: 'Update workspace dependencies.',
-          checks: { _tag: 'Available', checks: [] },
-          comments: [],
-          priorAutomatedReview: { _tag: 'None' },
-          pullRequest,
-          requiredChecks: { _tag: 'None' },
-          reviews: [],
-        })),
-        upsertIssueTriageComment: () => Promise.reject(new Error('Review must not post issue triage.')),
-        upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
+    const triageRuns: RecordPullRequestTriageRunInput[] = []
+    const worktrees: string[] = []
+    const runtime = agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(input.providerReply), capture))
+    const github: Parameters<typeof createReviewWorker>[0]['github'] = {
+      consumeApprovalLabel: () => Promise.resolve(ok(undefined)),
+      editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
+      ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+      clearAgentLabels: () => Promise.reject(new Error('Unexpected label clear.')),
+      clearRunningLabel: () => Promise.reject(new Error('Unexpected Running label clear.')),
+      listRunningLabelledItems: () => Promise.reject(new Error('Unexpected Running label read.')),
+      stampAgentLabel: (_repository, _number, outcome) => {
+        stamped.push(outcome)
+        return Promise.resolve(ok(undefined))
       },
+      findOpenPullRequestForBranch: () => Promise.reject(new Error('Unexpected pull request lookup.')),
+      getFailedJobContext: () => Promise.reject(new Error('Unexpected job log read.')),
+      getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
+      getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+      listPullRequestFiles: () => Promise.resolve(input.triageFailure === undefined ? ok(input.changedFiles) : err(input.triageFailure)),
+      getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+        baseChecks: { _tag: 'Available', checks: [] },
+        body: 'Pull request body.',
+        checks: { _tag: 'Available', checks: [] },
+        comments: [],
+        priorAutomatedReview: { _tag: 'None' },
+        pullRequest,
+        requiredChecks: { _tag: 'None' },
+        reviews: [],
+      })),
+      upsertIssueTriageComment: () => Promise.reject(new Error('Review must not post issue triage.')),
+      upsertReviewStatus: () => Promise.reject(new Error('The Worker must use the status controller.')),
+    }
+    const worker = createReviewWorker({
+      runtime,
+      github,
       now: () => new Date('2026-08-28T01:00:00.000Z'),
       preflightRepair: () => Promise.resolve(ok(undefined)),
-      pullRequestTriage: {
-        run: () => {
-          triageCalls += 1
-          return Promise.resolve(ok({
-            _tag: 'ADVERSARIAL_REVIEW_SKIPPED',
-            reason: 'model: The old triage Agent waived this Review.',
-            source: 'model',
-          }))
+      pullRequestTriage: createPullRequestTriageAgent({
+        now: () => new Date('2026-08-28T01:00:00.000Z'),
+        runtime,
+        store: {
+          getLatestPullRequestTriageRun: () => null,
+          getWorkerSession: () => null,
+          saveWorkerSession: () => undefined,
         },
-      },
+        workspace: '/tmp/harlan-github-agent',
+      }),
       store: {
         queueReviewFixTaskForReview: () => { throw new Error('A clean Review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
@@ -214,7 +223,10 @@ describe('subject Workers', () => {
         listReviewRuns: () => [],
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
-        recordPullRequestTriageRun: () => { throw new Error('A direct Review must not record pull request triage.') },
+        recordPullRequestTriageRun: (run) => {
+          triageRuns.push(run)
+          return { _tag: 'Inserted' }
+        },
         queueBaselineRepairForReview: () => { throw new Error('Healthy base CI must not queue Baseline repair.') },
         retireBaselineRepairForReview: () => 0,
         saveWorkerSession: () => undefined,
@@ -231,12 +243,14 @@ describe('subject Workers', () => {
       triageStatus: { publish: () => Promise.reject(new Error('Review must not publish issue triage.')) },
       workspaces: {
         prepareIssue: () => Promise.reject(new Error('Unexpected issue workspace.')),
-        prepareReview: () => Promise.resolve(ok({ path: '/tmp/review-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha })),
+        prepareReview: () => {
+          worktrees.push(pullRequest.headSha)
+          return Promise.resolve(ok({ path: '/tmp/review-worktree', baseSha: pullRequest.baseSha, headSha: pullRequest.headSha }))
+        },
         verifyReview: () => Promise.resolve(ok(undefined)),
       },
     })
-
-    const result = await worker.run({
+    const run = () => worker.run({
       id: 'review-task',
       kind: 'adversarial_review',
       repository: 'harlan-zw/example',
@@ -248,15 +262,90 @@ describe('subject Workers', () => {
       pullRequest,
       rerun: { _tag: 'NotRequested' },
     }, new AbortController().signal)
+    return { capture, comments, run, stamped, triageRuns, worktrees }
+  }
+
+  const cleanReview = {
+    premise: { verdict: 'sound', reason: 'The change remains valid.' },
+    findings: [],
+    confidence: 94,
+  }
+
+  it('skips Review for a Markdown-only pull request without a Review Agent', async () => {
+    const harness = triagedReviewWorker({
+      changedFiles: ['README.md', 'docs/guide.md'],
+      providerReply: { _tag: 'ADVERSARIAL_REVIEW_SKIPPED', reason: 'Only a typo in the guide changed.' },
+      title: 'docs: fix a typo in the guide',
+    })
+
+    const result = await harness.run()
+
+    expect(result).toEqual(ok({
+      evidence: JSON.stringify({ _tag: 'ADVERSARIAL_REVIEW_SKIPPED', reason: 'model: Only a typo in the guide changed.' }),
+      resolution: { _tag: 'ReviewSkipped', reason: 'model: Only a typo in the guide changed.' },
+    }))
+    expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-luna'])
+    expect(harness.worktrees).toEqual([])
+    expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_SKIPPED'])
+    expect(harness.comments).toHaveLength(1)
+    expect(harness.comments[0]).toContain('REVIEW SKIPPED')
+    expect(harness.comments[0]).toContain('harlan-agent-review')
+    expect(harness.triageRuns).toEqual([expect.objectContaining({
+      taskId: 'review-task',
+      headSha: 'abc123',
+      outcome: { _tag: 'ReviewSkipped', reason: 'model: Only a typo in the guide changed.' },
+    })])
+  })
+
+  it('reaches Review for a TypeScript pull request without a triage model call', async () => {
+    const harness = triagedReviewWorker({
+      changedFiles: ['README.md', 'src/deployment.ts'],
+      providerReply: cleanReview,
+      title: 'chore: update workspace dependencies',
+    })
+
+    const result = await harness.run()
 
     expect(result._tag).toBe('Ok')
-    expect(triageCalls).toBe(0)
-    expect(fileReads).toBe(0)
-    expect(stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
-    expect(comments.at(-1)).toContain('READY · 94/100')
-    expect(capture.requests).toEqual([expect.objectContaining({
-      model: 'gpt-5.6-sol',
-      reasoningEffort: 'high',
+    expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-sol'])
+    expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
+    expect(harness.comments.at(-1)).toContain('READY · 94/100')
+    expect(harness.triageRuns).toEqual([expect.objectContaining({
+      outcome: { _tag: 'ReviewRequired', reason: 'rule: src/deployment.ts is outside the prose set.' },
+    })])
+  })
+
+  it('reviews a prose-only pull request that carries the manual override label', async () => {
+    const harness = triagedReviewWorker({
+      approvalLabels: ['review'],
+      changedFiles: ['README.md'],
+      providerReply: cleanReview,
+      title: 'docs: fix a typo in the guide',
+    })
+
+    const result = await harness.run()
+
+    expect(result._tag).toBe('Ok')
+    expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-sol'])
+    expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
+    expect(harness.triageRuns).toEqual([])
+  })
+
+  it('reviews the pull request anyway when triage fails', async () => {
+    const harness = triagedReviewWorker({
+      changedFiles: ['README.md'],
+      providerReply: cleanReview,
+      title: 'docs: fix a typo in the guide',
+      triageFailure: 'GitHub could not list the changed files.',
+    })
+
+    const result = await harness.run()
+
+    expect(result._tag).toBe('Ok')
+    expect(harness.capture.requests.map(request => request.model)).toEqual(['gpt-5.6-sol'])
+    expect(harness.stamped).toEqual(['ADVERSARIAL_REVIEW_REQUIRED', 'READY'])
+    expect(harness.triageRuns).toEqual([expect.objectContaining({
+      outcome: { _tag: 'ReviewRequiredAfterFailure', reason: 'GitHub could not list the changed files.' },
     })])
   })
 


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Since #119 the Review worker stamped `harlan-agent-review-required` and started a full adversarial Review Agent for every pull request, so the path rule and stored-decision reuse from #162 never ran and every Markdown-only pull request still paid for a Review session. Triage now runs first: the path rule, then the stored decision for the head commit, then the low-cost model for prose-only changes. A skip stamps `harlan-agent-review-skipped`, records the triage run, and publishes the skip comment with no Review Agent; a failed triage still requires Review, and the `harlan-agent-review` label wins for the exact head.

The bug #119 removed was a title rule: `pull-request-triage.ts` waived Review for any `chore:` title, so `chore: update workspace dependencies` with `package.json` and `pnpm-lock.yaml` changed skipped Review. That rule is gone. The path rule decides from the changed files only, and the model sees nothing but prose-only pull requests.

One loose end: a stored `ReviewRequiredAfterFailure` row is not reused, so a retry that then skips records a conflicting decision. The worker treats that conflict as Review required rather than failing the Task.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz