### PR TITLE
feat(agent): run repository prepare commands before a mutating Agent starts

### DIFF
--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -60,3 +60,15 @@ repositories: []
 # Maintained repositories need an explicit policy. Without an installation,
 # the controller uses the authenticated GitHub account.
 # Set repositories[].max_open_pull_requests to hold new Issue work for one busy repository.
+# Set repositories[].prepare to the repository's own prepare step. Worktrunk
+# installs node_modules; these commands run after it, in the task worktree,
+# before a Repair, conflict resolution, Baseline repair, or Issue work Agent
+# starts. Review and Issue triage skip them. Each entry is one plain command
+# with the worktree's node_modules/.bin on PATH, no shell syntax. A failing or
+# timed out command stops the Agent and records a Task Incident with the output.
+# prepare_timeout_seconds bounds each command. Default 600.
+# - github: harlan-zw/nuxtseo.com
+#   prepare:
+#     - pnpm ensure-prepared
+#     - pnpm --filter @nuxtseo/protocol build
+#   prepare_timeout_seconds: 900

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -12,6 +12,7 @@ import { runAgentTurn } from './agent-turn.ts'
 import { withBaselineRepairMarker } from './baseline-repair-state.ts'
 import { classifyCheckFailure } from './failure.ts'
 import { canRepairBaseline } from './repository-policy.ts'
+import { preparedCommandsLine } from './repository-prepare.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
 
@@ -221,6 +222,8 @@ function checkBlock(context: FailedCheckContext): string {
 
 export interface BaselineRepairPromptInput {
   repository: string
+  /** The repository prepare commands the controller already ran in the worktree. */
+  prepareCommands: readonly string[]
   baseSha: string
   repairable: FailedCheckContext[]
   infrastructure: Array<{ check: GitHubCheck, reason: string }>
@@ -243,7 +246,7 @@ export function baselineRepairPrompt(input: BaselineRepairPromptInput): string {
 Own the work end to end. Find the root cause, implement the complete fix, and verify it.
 Work as a normal local agent session. Use the user's global agent context and installed skills.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before you return a result.
-${agents}Apply the unit-tests skill for a bug fix.
+${preparedCommandsLine(input.prepareCommands)}${agents}Apply the unit-tests skill for a bug fix.
 
 Failing checks:
 ${input.repairable.map(checkBlock).join('\n')}
@@ -347,6 +350,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
         progress: { current: { percent: 35, label: 'Git worktree ready' }, report: progress, work: 'baseline' },
         prompt: baselineRepairPrompt({
           repository: task.repository,
+          prepareCommands: task.repositoryMapping.prepare.commands,
           baseSha: task.pullRequest.baseSha,
           repairable,
           infrastructure,

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -1,7 +1,7 @@
 import type { AgentProviderName } from './agent-provider.ts'
 import type { AutoMergePolicy } from './auto-merge.ts'
 import type { Result } from './result.ts'
-import type { AgentConfig, ExternalRepositoryWatch, RepositoryMapping, RepositoryOwnership, ServiceTrigger, TakeOwnershipConfig, ValidatedAgentConfig, WebhookConfig } from './types.ts'
+import type { AgentConfig, ExternalRepositoryWatch, RepositoryMapping, RepositoryOwnership, RepositoryPrepare, ServiceTrigger, TakeOwnershipConfig, ValidatedAgentConfig, WebhookConfig } from './types.ts'
 import { execFile } from 'node:child_process'
 import { lstat, readFile, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
@@ -74,6 +74,38 @@ function stringArray(source: UnknownRecord, key: string, path: string, issues: C
     return value.map(item => (item as string).trim())
 
   issues.push({ path: `${path}.${key}`, message: 'Expected a list of non-empty strings.' })
+}
+
+/** Ten minutes covers a Nuxt workspace prepare plus one dist build. */
+const DEFAULT_PREPARE_TIMEOUT_SECONDS = 600
+
+/** A shell would let one line run anything; each command is one argv with nothing to interpret. */
+const shellSyntax = /[;&|<>$`\\'"()]/u
+
+/**
+ * The repository prepare step. Absent means no command, which is the common
+ * case and needs no key.
+ */
+function repositoryPrepare(source: UnknownRecord, path: string, issues: ConfigIssue[]): RepositoryPrepare | undefined {
+  const commands = source.prepare === undefined ? [] : stringArray(source, 'prepare', path, issues)
+  if (commands === undefined)
+    return undefined
+  if (commands.length === 0 && source.prepare !== undefined) {
+    issues.push({ path: `${path}.prepare`, message: 'Expected at least one command, or leave prepare out.' })
+    return undefined
+  }
+  if (commands.some(command => shellSyntax.test(command))) {
+    issues.push({ path: `${path}.prepare`, message: 'Every prepare command must be one plain command with no shell syntax.' })
+    return undefined
+  }
+  const timeout = source.prepare_timeout_seconds
+  if (timeout === undefined)
+    return { commands, timeoutSeconds: DEFAULT_PREPARE_TIMEOUT_SECONDS }
+  if (typeof timeout !== 'number' || !Number.isInteger(timeout) || timeout < 1 || timeout > 3600) {
+    issues.push({ path: `${path}.prepare_timeout_seconds`, message: 'Expected an integer from 1 to 3600.' })
+    return undefined
+  }
+  return { commands, timeoutSeconds: timeout }
 }
 
 /** Auto merge is off unless the configuration turns it on. */
@@ -365,6 +397,7 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
       : undefined
   const pullRequestReview = requiredBoolean(value, 'pr_review', path, issues)
   const conflictResolution = requiredBoolean(value, 'conflict_resolution', path, issues)
+  const prepare = repositoryPrepare(value, path, issues)
   const ownershipConfig = takeOwnership(value, path, repositoryOwnership, issues)
 
   if (github !== undefined && !/^[\w.-]+\/[\w.-]+$/.test(github))
@@ -400,6 +433,7 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
     || maxOpenPullRequests === undefined
     || pullRequestReview === undefined
     || conflictResolution === undefined
+    || prepare === undefined
     || ownershipConfig === undefined
   ) {
     return undefined
@@ -418,6 +452,7 @@ function repositoryMapping(value: unknown, index: number, issues: ConfigIssue[])
     maxOpenPullRequests,
     pullRequestReview,
     conflictResolution,
+    prepare,
     takeOwnership: ownershipConfig,
   }
 }

--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -7,6 +7,7 @@ import type { AgentProgress, ClaimedConflictResolutionTask, MutationWorkerOutcom
 import type { ConflictWorktreeManager, PreparedConflictWorktree } from './worktree.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { isAutomatedGitHubActor } from './github.ts'
+import { preparedCommandsLine } from './repository-prepare.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
 
@@ -50,7 +51,7 @@ function workerPrompt(task: ClaimedConflictResolutionTask, worktree: PreparedCon
 
 Work as a normal local agent session inside this Git worktree. Use the user's global agent context, installed skills, environment, and authenticated GitHub CLI.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before returning a result.
-The controller already merged the base branch into this worktree. Do not rediscover the merge state.
+${preparedCommandsLine(task.repositoryMapping.prepare.commands)}The controller already merged the base branch into this worktree. Do not rediscover the merge state.
 Pull request head: ${worktree.headSha}
 Base branch: ${baseRef} at ${worktree.baseSha}
 Conflicted files:

--- a/packages/harlan-github-agent/src/failure.ts
+++ b/packages/harlan-github-agent/src/failure.ts
@@ -181,6 +181,10 @@ const networkPatterns: RegExp[] = [
   /\bENETUNREACH\b/,
   /\bsocket hang up\b/i,
   /\bfetch failed\b/i,
+  /\bERR_PNPM_FETCH_\w+\b/,
+  // A repository prepare command that outlived its timeout was most often
+  // waiting on a registry or a cold cache. The same command finishes on retry.
+  /\bprepare command\b.+\btimed out\b/i,
   /\bnetwork\b.+\berror\b/i,
   /\brequest\b.+\btimed out\b/i,
   // The article varies by caller, so it must not decide the class.

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -12,6 +12,7 @@ import { runAgentTurn } from './agent-turn.ts'
 import { parseStoredIssueTriage } from './issue-triage.ts'
 import { issueSnapshotDigest } from './item-agent.ts'
 import { canWorkIssues } from './repository-policy.ts'
+import { preparedCommandsLine } from './repository-prepare.ts'
 import { err, ok } from './result.ts'
 import { chooseOverlappingStackBase, chooseStackBase } from './stack.ts'
 import { cleanLine } from './text.ts'
@@ -223,7 +224,7 @@ ${storedTriageLines(input.triage)}
 Plan, implement, and verify the complete fix.
 Work as a normal local agent session inside this Git worktree. Use the user's global agent context and installed skills.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before returning a result.
-${instructionFilesLine(input.instructionFiles)}
+${preparedCommandsLine(task.repositoryMapping.prepare.commands)}${instructionFilesLine(input.instructionFiles)}
 Select every installed code-domain skill whose trigger matches the affected implementation. Do not load workflow skills such as pr, unit-tests, or humanize-writing. Their rules are inlined below.
 ${UNIT_TEST_LINES}
 ${CHECK_BUDGET_LINES}

--- a/packages/harlan-github-agent/src/repository-discovery.ts
+++ b/packages/harlan-github-agent/src/repository-discovery.ts
@@ -113,6 +113,7 @@ function defaultMapping(repository: InstalledRepository, checkout: string): Repo
     writablePullRequestHeadPrefixes: ['fix/', 'feat/', 'chore/', 'docs/', 'refactor/', 'perf/', 'test/', 'ci/'],
     issueWork: ownership === 'owned',
     maxOpenPullRequests: null,
+    prepare: { commands: [], timeoutSeconds: 600 },
     pullRequestReview: true,
     conflictResolution: ownership === 'owned',
     takeOwnership: { _tag: 'Disabled' },

--- a/packages/harlan-github-agent/src/repository-policy.ts
+++ b/packages/harlan-github-agent/src/repository-policy.ts
@@ -1,4 +1,4 @@
-import type { GitHubPullRequestItem, RepositoryMapping } from './types.ts'
+import type { AgentTask, GitHubPullRequestItem, RepositoryMapping } from './types.ts'
 
 /**
  * What Harlan may do in a repository, named once instead of compared everywhere.
@@ -62,4 +62,25 @@ export function canWorkIssues(mapping: RepositoryMapping): boolean {
     && canPushBranch(mapping)
     && mapping.issueWork
     && mapping.writablePullRequestHeadPrefixes.length > 0
+}
+
+/**
+ * True when a Task of this kind changes the repository, so its worktree gets
+ * the repository prepare step before the Agent starts.
+ *
+ * Review and Issue triage read the tree and never run a check, so they skip
+ * the step. Every kind that may publish a change runs it.
+ */
+export function preparesRepository(kind: AgentTask['kind'] | 'routine'): boolean {
+  switch (kind) {
+    case 'review_fix':
+    case 'resolve_conflict':
+    case 'baseline_repair':
+    case 'issue_work':
+      return true
+    case 'adversarial_review':
+    case 'issue_triage':
+    case 'routine':
+      return false
+  }
 }

--- a/packages/harlan-github-agent/src/repository-prepare.ts
+++ b/packages/harlan-github-agent/src/repository-prepare.ts
@@ -117,16 +117,31 @@ export function createPrepareCommandRunner(environment: NodeJS.ProcessEnv = proc
     }
     let timedOut = false
     let spawnError: string | null = null
+    // The command leads its own process group. pnpm and nuxt wrappers spawn
+    // worker processes, and killing only the direct child left those running
+    // and writing into a worktree the controller had already given up on.
     const child = spawn(command, args, {
       cwd: request.cwd,
+      detached: true,
       env: { ...environment, PATH: path },
       signal: request.signal,
       stdio: ['ignore', 'pipe', 'pipe'],
     })
+    const killTree = () => {
+      if (child.pid === undefined)
+        return
+      try {
+        process.kill(-child.pid, 'SIGKILL')
+      }
+      catch {
+        // The group is already gone. Nothing is left to kill.
+      }
+    }
     const timer = setTimeout(() => {
       timedOut = true
-      child.kill('SIGKILL')
+      killTree()
     }, request.timeoutMilliseconds)
+    request.signal.addEventListener('abort', killTree, { once: true })
     child.stdout.on('data', collect)
     child.stderr.on('data', collect)
     let settled = false
@@ -136,6 +151,7 @@ export function createPrepareCommandRunner(environment: NodeJS.ProcessEnv = proc
         return
       settled = true
       clearTimeout(timer)
+      request.signal.removeEventListener('abort', killTree)
       if (graceTimer !== null)
         clearTimeout(graceTimer)
       // A pipe a grandchild still holds would otherwise stay open in the service.

--- a/packages/harlan-github-agent/src/repository-prepare.ts
+++ b/packages/harlan-github-agent/src/repository-prepare.ts
@@ -1,0 +1,172 @@
+import type { Result } from './result.ts'
+import type { RepositoryMapping } from './types.ts'
+import { spawn } from 'node:child_process'
+import { delimiter, join } from 'node:path'
+import process from 'node:process'
+import { err, ok } from './result.ts'
+
+/**
+ * The repository's own prepare step, run once per task worktree.
+ *
+ * The Worktrunk pre-start hook installs `node_modules` and seeds ignored files,
+ * but it disables lifecycle scripts and knows nothing about a repository's own
+ * generated output. Every Repair and conflict session on a Nuxt workspace spent
+ * its first minute on `nuxt prepare` and a dist build, and one spent 22 minutes
+ * finding the script. The controller runs the mapped commands instead, before
+ * any mutating Agent starts, so the Agent's first check already passes.
+ */
+
+export interface PrepareCommandRequest {
+  /** One plain command, split on whitespace. Never a shell line. */
+  argv: string[]
+  cwd: string
+  timeoutMilliseconds: number
+  signal: AbortSignal
+}
+
+export type PrepareCommandOutcome
+  = | { _tag: 'Exited', exitCode: number, outputTail: string[] }
+    | { _tag: 'TimedOut', outputTail: string[] }
+    /** The process never started, or died on a signal. */
+    | { _tag: 'Failed', reason: string, outputTail: string[] }
+
+export type PrepareCommandRunner = (request: PrepareCommandRequest) => Promise<PrepareCommandOutcome>
+
+/** How many final output lines a failure keeps, oldest first. */
+const OUTPUT_TAIL_LINES = 40
+
+/** How long the runner waits after exit for the last buffered output. */
+const OUTPUT_GRACE_MILLISECONDS = 500
+
+export function repositoryPrepareCommands(mapping: RepositoryMapping): readonly string[] {
+  return mapping.prepare.commands
+}
+
+/** One prompt line naming what already ran, or nothing when the repository lists no command. */
+export function preparedCommandsLine(commands: readonly string[]): string {
+  return commands.length === 0
+    ? ''
+    : `The repository prepare commands already ran in this worktree: ${commands.map(command => `\`${command}\``).join(', ')}. Do not run them again.\n`
+}
+
+function outputTailText(outputTail: string[]): string {
+  return outputTail.length === 0 ? '' : `\n${outputTail.join('\n')}`
+}
+
+/**
+ * Runs every mapped prepare command in order inside one task worktree.
+ *
+ * The first failure stops the run and names the command with its output tail,
+ * so the Incident says what to fix without a person re-running it.
+ */
+export async function runRepositoryPrepare(
+  mapping: RepositoryMapping,
+  worktree: string,
+  runner: PrepareCommandRunner,
+  signal: AbortSignal,
+): Promise<Result<void, string>> {
+  const timeoutMilliseconds = mapping.prepare.timeoutSeconds * 1000
+  for (const command of repositoryPrepareCommands(mapping)) {
+    const outcome = await runner({ argv: command.split(/\s+/u), cwd: worktree, timeoutMilliseconds, signal })
+    switch (outcome._tag) {
+      case 'Exited':
+        if (outcome.exitCode !== 0)
+          return err(`Repository prepare command \`${command}\` exited with code ${outcome.exitCode}.${outputTailText(outcome.outputTail)}`)
+        break
+      case 'TimedOut':
+        return err(`Repository prepare command \`${command}\` timed out after ${mapping.prepare.timeoutSeconds} seconds.${outputTailText(outcome.outputTail)}`)
+      case 'Failed':
+        return err(`Repository prepare command \`${command}\` failed: ${outcome.reason}${outputTailText(outcome.outputTail)}`)
+    }
+  }
+  return ok(undefined)
+}
+
+/**
+ * Runs one command the way `pnpm exec` would: the worktree's `node_modules/.bin`
+ * leads PATH, lifecycle scripts stay enabled, and the Agent's own environment
+ * carries through so a prepare step sees the same tokens the Agent will.
+ */
+export function createPrepareCommandRunner(environment: NodeJS.ProcessEnv = process.env): PrepareCommandRunner {
+  return request => new Promise((resolve) => {
+    const [command, ...args] = request.argv
+    if (command === undefined) {
+      resolve({ _tag: 'Failed', reason: 'The command is empty.', outputTail: [] })
+      return
+    }
+    const binDirectory = join(request.cwd, 'node_modules', '.bin')
+    const path = environment.PATH === undefined ? binDirectory : `${binDirectory}${delimiter}${environment.PATH}`
+    const lines: string[] = []
+    let pending = ''
+    const collect = (chunk: Buffer) => {
+      const text = pending + chunk.toString('utf8')
+      const parts = text.split(/\r?\n/u)
+      pending = parts.pop() ?? ''
+      for (const part of parts) {
+        if (part.trim().length > 0)
+          lines.push(part)
+      }
+      if (lines.length > OUTPUT_TAIL_LINES)
+        lines.splice(0, lines.length - OUTPUT_TAIL_LINES)
+    }
+    const outputTail = () => {
+      if (pending.trim().length > 0)
+        lines.push(pending)
+      pending = ''
+      return lines.slice(-OUTPUT_TAIL_LINES)
+    }
+    let timedOut = false
+    let spawnError: string | null = null
+    const child = spawn(command, args, {
+      cwd: request.cwd,
+      env: { ...environment, PATH: path },
+      signal: request.signal,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, request.timeoutMilliseconds)
+    child.stdout.on('data', collect)
+    child.stderr.on('data', collect)
+    let settled = false
+    let graceTimer: NodeJS.Timeout | null = null
+    const settle = (code: number | null, killSignal: NodeJS.Signals | null) => {
+      if (settled)
+        return
+      settled = true
+      clearTimeout(timer)
+      if (graceTimer !== null)
+        clearTimeout(graceTimer)
+      // A pipe a grandchild still holds would otherwise stay open in the service.
+      child.stdout.destroy()
+      child.stderr.destroy()
+      if (timedOut) {
+        resolve({ _tag: 'TimedOut', outputTail: outputTail() })
+        return
+      }
+      if (spawnError !== null) {
+        resolve({ _tag: 'Failed', reason: spawnError, outputTail: outputTail() })
+        return
+      }
+      if (code !== null) {
+        resolve({ _tag: 'Exited', exitCode: code, outputTail: outputTail() })
+        return
+      }
+      resolve({ _tag: 'Failed', reason: `The process died on ${killSignal ?? 'an unknown signal'}.`, outputTail: outputTail() })
+    }
+    // `close` waits for both pipes to end. A prepare step that leaves a daemon
+    // behind, or a sandbox that holds the pipe, would then never settle, so
+    // `exit` starts a short grace for the last buffered output instead.
+    child.on('exit', (code, killSignal) => {
+      graceTimer = setTimeout(settle, OUTPUT_GRACE_MILLISECONDS, code, killSignal)
+    })
+    child.on('close', settle)
+    child.on('error', (error: Error) => {
+      spawnError = error.message
+      // A process that never started emits no exit, so settle here.
+      if (child.pid === undefined)
+        settle(null, null)
+    })
+  })
+}

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -11,6 +11,7 @@ import { CHECK_BUDGET_LINES, instructionFilesLine, listInstructionFiles, TOOLCHA
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { repairRoundHistory } from './repair-rounds.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
+import { preparedCommandsLine } from './repository-prepare.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
 
@@ -105,7 +106,7 @@ export function reviewFixPrompt(input: ReviewFixPromptInput): string {
   return `Repair the exact material Review findings for ${task.repository}#${task.pullRequestNumber}.
 
 Work as a fresh local Agent session inside this prepared Git worktree.
-${instructionFilesLine(input.instructionFiles)}
+${preparedCommandsLine(task.repositoryMapping.prepare.commands)}${instructionFilesLine(input.instructionFiles)}
 Treat the findings below as the complete Repair scope.
 ${repairRoundHistory(task.rounds)}
 ${UNIT_TEST_LINES}

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -16,6 +16,17 @@ export type TakeOwnershipConfig
 
 export type RepositoryAuthentication = 'app' | 'user'
 
+/**
+ * The repository's own prepare step, run in every task worktree before a
+ * mutating Agent starts. Worktrunk installs `node_modules`; this fills in what
+ * the repository generates on top, such as `nuxt prepare` output.
+ */
+export interface RepositoryPrepare {
+  /** Plain commands run in order with the worktree's `node_modules/.bin` on PATH. Empty when the repository needs none. */
+  commands: string[]
+  timeoutSeconds: number
+}
+
 export interface RepositoryMapping {
   github: string
   checkout: string
@@ -34,6 +45,7 @@ export interface RepositoryMapping {
   maxOpenPullRequests: number | null
   pullRequestReview: boolean
   conflictResolution: boolean
+  prepare: RepositoryPrepare
   takeOwnership: TakeOwnershipConfig
 }
 

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -2,6 +2,7 @@ import type { GitIdentity } from './git-identity.ts'
 import type { GitHubTokenProvider } from './github-auth.ts'
 import type { GitHubPullRequestPublisher, GitHubSource } from './github.ts'
 import type { PublicationRemote } from './publication-scheduler.ts'
+import type { PrepareCommandRunner } from './repository-prepare.ts'
 import type { Result } from './result.ts'
 import type { ClaimedAdversarialReviewTask, ClaimedBaselineRepairTask, ClaimedConflictResolutionTask, ClaimedIssueTriageTask, ClaimedIssueWorkTask, ClaimedPublicationCommand, ClaimedReviewFixTask, ClaimedRoutineRun, PullRequestBase } from './types.ts'
 import { Buffer } from 'node:buffer'
@@ -12,7 +13,8 @@ import { isAbsolute, join } from 'node:path'
 import process from 'node:process'
 import { StringDecoder } from 'node:string_decoder'
 import { BASELINE_REPAIR_LABEL_SPEC } from './baseline-repair-state.ts'
-import { canPushBranch, canRepairBaseline, canWorkIssues, canWritePullRequestHead } from './repository-policy.ts'
+import { canPushBranch, canRepairBaseline, canWorkIssues, canWritePullRequestHead, preparesRepository } from './repository-policy.ts'
+import { createPrepareCommandRunner, runRepositoryPrepare } from './repository-prepare.ts'
 import { err, ok } from './result.ts'
 import { cleanLine } from './text.ts'
 
@@ -47,6 +49,8 @@ export interface ConflictWorktreeManager {
 
 export interface ConflictWorktreeManagerOptions {
   gitIdentity?: GitIdentity
+  /** Runs one repository prepare command. Defaults to a real process. */
+  prepare?: PrepareCommandRunner
   remoteUrl?: (repository: string) => string
   root: string
   tokens: GitHubTokenProvider
@@ -579,6 +583,7 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
   if (options.gitIdentity === undefined)
     throw new Error('A Git commit identity is required.')
   const gitIdentity = options.gitIdentity
+  const prepareRunner = options.prepare ?? createPrepareCommandRunner()
   async function prepare(task: ClaimedConflictResolutionTask, signal: AbortSignal): Promise<Result<PreparedConflictWorktree, string>> {
     const branch = agentWorktreeBranch(`pull-${task.pullRequestNumber}-${task.revisionId.slice(0, 12)}`, { taskId: task.id, fence: task.state.fence })
     const repository = task.repositoryMapping.checkout
@@ -614,6 +619,11 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
     const worktree = await prepareWtWorktree(repository, branch, head.stdout, signal)
     if (worktree._tag === 'Err')
       return worktree
+    // Prepare runs on the clean head. After the merge below, conflict markers
+    // would break any generator that reads the tree.
+    const prepared = await runRepositoryPrepare(task.repositoryMapping, worktree.value, prepareRunner, signal)
+    if (prepared._tag === 'Err')
+      return prepared
 
     const merge = await runGit(worktree.value, [
       '-c',
@@ -739,6 +749,7 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
 }
 
 export function createAgentWorkspaceManager(options: ConflictWorktreeManagerOptions): AgentWorkspaceManager {
+  const prepareRunner = options.prepare ?? createPrepareCommandRunner()
   async function prepareRepository(
     task: ClaimedAdversarialReviewTask | ClaimedReviewFixTask | ClaimedBaselineRepairTask | ClaimedIssueTriageTask | ClaimedIssueWorkTask | ClaimedRoutineRun,
     label: string,
@@ -761,9 +772,16 @@ export function createAgentWorkspaceManager(options: ConflictWorktreeManagerOpti
       return err(`Could not resolve the Worker head: ${head.stderr}`)
     const branch = agentWorktreeBranch(label, { taskId: task.id, fence: task.state.fence })
     const worktree = await prepareWtWorktree(repository, branch, head.stdout, signal)
-    return worktree._tag === 'Err'
-      ? worktree
-      : ok({ path: worktree.value, baseSha: head.stdout, headSha: head.stdout })
+    if (worktree._tag === 'Err')
+      return worktree
+    // Worktrunk's pre-start hook has finished by now. A mutating Agent gets the
+    // repository's own prepare step on top; a read only one never needs it.
+    if (preparesRepository('kind' in task ? task.kind : 'routine')) {
+      const prepared = await runRepositoryPrepare(task.repositoryMapping, worktree.value, prepareRunner, signal)
+      if (prepared._tag === 'Err')
+        return prepared
+    }
+    return ok({ path: worktree.value, baseSha: head.stdout, headSha: head.stdout })
   }
 
   return {

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -43,6 +43,39 @@ repositories:
 `
 
 describe('configuration boundary', () => {
+  it('reads the repository prepare commands with the default timeout', () => {
+    const parsed = parseConfigText(configText.replace('    take_ownership:', '    prepare: [\'pnpm exec nuxt prepare\']\n    take_ownership:'))
+
+    expect(parsed._tag === 'Ok' && parsed.value.repositories[0]?.prepare).toEqual({ commands: ['pnpm exec nuxt prepare'], timeoutSeconds: 600 })
+  })
+
+  it('keeps a repository without prepare commands runnable', () => {
+    const parsed = parseConfigText(configText)
+
+    expect(parsed._tag === 'Ok' && parsed.value.repositories[0]?.prepare).toEqual({ commands: [], timeoutSeconds: 600 })
+  })
+
+  it('reads a repository prepare timeout', () => {
+    const parsed = parseConfigText(configText.replace('    take_ownership:', '    prepare: [\'pnpm ensure-prepared\']\n    prepare_timeout_seconds: 120\n    take_ownership:'))
+
+    expect(parsed._tag === 'Ok' && parsed.value.repositories[0]?.prepare.timeoutSeconds).toBe(120)
+  })
+
+  it.each([
+    ['[\'pnpm build && rm -rf .nuxt\']', '$.repositories[0].prepare', 'Every prepare command must be one plain command with no shell syntax.'],
+    ['[]', '$.repositories[0].prepare', 'Expected at least one command, or leave prepare out.'],
+  ])('rejects prepare %s', (value, path, message) => {
+    const parsed = parseConfigText(configText.replace('    take_ownership:', `    prepare: ${value}\n    take_ownership:`))
+
+    expect(parsed).toEqual({ _tag: 'Err', error: [{ path, message }] })
+  })
+
+  it('rejects a prepare timeout outside one second to one hour', () => {
+    const parsed = parseConfigText(configText.replace('    take_ownership:', '    prepare: [\'pnpm ensure-prepared\']\n    prepare_timeout_seconds: 0\n    take_ownership:'))
+
+    expect(parsed).toEqual({ _tag: 'Err', error: [{ path: '$.repositories[0].prepare_timeout_seconds', message: 'Expected an integer from 1 to 3600.' }] })
+  })
+
   it('accepts the Portless dashboard origin', () => {
     const parsed = parseConfigText(configText)
 

--- a/packages/harlan-github-agent/test/failure.test.ts
+++ b/packages/harlan-github-agent/test/failure.test.ts
@@ -11,6 +11,8 @@ describe('classifyFailure', () => {
     ['Request quota exhausted for request GET https://api.github.com/repos', 'rate_limit'],
     ['request to https://api.github.com failed, reason: ECONNRESET', 'network'],
     ['fetch failed', 'network'],
+    ['Repository prepare command `pnpm exec nuxt prepare` timed out after 600 seconds.\nstill resolving', 'network'],
+    ['Repository prepare command `pnpm ensure-prepared` exited with code 1.\nERR_PNPM_FETCH_404 GET https://registry.npmjs.org/nuxt', 'network'],
     ['The opencode session stopped sending output.', 'agent_provider'],
     ['The opencode session exited with code 1.', 'agent_provider'],
     ['The opencode session failed: Unexpected server error. Check server logs for details.', 'agent_provider'],
@@ -239,5 +241,13 @@ describe('classifyCheckFailure', () => {
   it('reads a lost runner as Infrastructure without a log', () => {
     const failure = classifyCheckFailure({ name: 'test', conclusion: 'failure', runnerLost: true, logTail: [] })
     expect(failure).toEqual({ _tag: 'Infrastructure', reason: expect.stringContaining('runner lost the job') })
+  })
+})
+
+describe('classifyFailure for a repository prepare failure', () => {
+  it('leaves a prepare command that failed on the repository itself for a person', () => {
+    const reason = 'Repository prepare command `pnpm exec nuxt prepare` exited with code 1.\nERROR Cannot find module nuxt'
+
+    expect(classifyFailure({ message: reason })).toEqual({ _tag: 'Permanent', kind: 'unknown' })
   })
 })

--- a/packages/harlan-github-agent/test/fixtures.ts
+++ b/packages/harlan-github-agent/test/fixtures.ts
@@ -22,6 +22,7 @@ export function repositoryMapping(overrides: Partial<RepositoryMapping> = {}): R
     maxOpenPullRequests: null,
     pullRequestReview: true,
     conflictResolution: true,
+    prepare: { commands: [], timeoutSeconds: 600 },
     takeOwnership: { _tag: 'Disabled' },
     ...overrides,
   }

--- a/packages/harlan-github-agent/test/repository-prepare.test.ts
+++ b/packages/harlan-github-agent/test/repository-prepare.test.ts
@@ -1,7 +1,7 @@
 import type { PrepareCommandRequest } from '../src/repository-prepare.ts'
 import type { ClaimedIssueTriageTask, ClaimedIssueWorkTask } from '../src/types.ts'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -134,7 +134,39 @@ describe('prepare command runner', () => {
 
     expect(result).toEqual({ _tag: 'TimedOut', outputTail: ['started'] })
   })
+
+  it('kills the grandchildren of a command that outlives its timeout', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'harlan-prepare-runner-'))
+    temporaryDirectories.push(cwd)
+    const pidFile = join(cwd, 'grandchild.pid')
+    const result = await createPrepareCommandRunner()({
+      argv: ['node', '-e', `
+        const { spawn } = require('node:child_process')
+        const grandchild = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60_000)'], { stdio: 'ignore' })
+        require('node:fs').writeFileSync(${JSON.stringify(pidFile)}, String(grandchild.pid))
+        setTimeout(() => {}, 60_000)
+      `],
+      cwd,
+      timeoutMilliseconds: 500,
+      signal: new AbortController().signal,
+    })
+    const grandchild = Number(readFileSync(pidFile, 'utf8'))
+
+    expect(result).toEqual({ _tag: 'TimedOut', outputTail: [] })
+    await expect.poll(() => isRunning(grandchild), { timeout: 3_000 }).toBe(false)
+  })
 })
+
+/** True while the process exists. A zombie of this test's own tree still counts as gone once it is reaped. */
+function isRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return readFileSync(`/proc/${pid}/stat`, 'utf8').split(') ')[1]?.[0] !== 'Z'
+  }
+  catch {
+    return false
+  }
+}
 
 describe('prepare command runner spawn failure', () => {
   it('names a command that never started', async () => {

--- a/packages/harlan-github-agent/test/repository-prepare.test.ts
+++ b/packages/harlan-github-agent/test/repository-prepare.test.ts
@@ -1,0 +1,145 @@
+import type { PrepareCommandRequest } from '../src/repository-prepare.ts'
+import type { ClaimedIssueTriageTask, ClaimedIssueWorkTask } from '../src/types.ts'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createPrepareCommandRunner } from '../src/repository-prepare.ts'
+import { createAgentWorkspaceManager } from '../src/worktree.ts'
+import { issueItem, repositoryMapping } from './fixtures.ts'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach(path => rmSync(path, { recursive: true, force: true }))
+})
+
+function git(checkout: string, ...args: string[]): string {
+  return execFileSync('git', ['-c', 'credential.helper=', '-c', 'core.hooksPath=/dev/null', '-C', checkout, ...args], {
+    encoding: 'utf8',
+    env: { PATH: process.env.PATH, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null', GIT_TERMINAL_PROMPT: '0' },
+  }).trim()
+}
+
+function fixture(commands: string[], runner: (request: PrepareCommandRequest) => ReturnType<ReturnType<typeof createPrepareCommandRunner>>) {
+  const directory = mkdtempSync(join(tmpdir(), 'harlan-prepare-'))
+  temporaryDirectories.push(directory)
+  const remote = join(directory, 'remote.git')
+  const checkout = join(directory, 'checkout')
+  execFileSync('git', ['init', '--bare', remote])
+  execFileSync('git', ['clone', remote, checkout])
+  git(checkout, 'config', 'user.name', 'Test Author')
+  git(checkout, 'config', 'user.email', 'author@example.com')
+  git(checkout, 'checkout', '-b', 'main')
+  writeFileSync(join(checkout, 'file.ts'), 'export const value = 1\n')
+  git(checkout, 'add', 'file.ts')
+  git(checkout, 'commit', '-m', 'initial')
+  git(checkout, 'push', 'origin', 'main')
+  const mapping = repositoryMapping({ checkout, prepare: { commands, timeoutSeconds: 5 } })
+  const manager = createAgentWorkspaceManager({
+    prepare: runner,
+    remoteUrl: () => remote,
+    root: join(directory, 'controller'),
+    tokens: { getToken: () => Promise.resolve({ _tag: 'Ok', value: { token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' } }), invalidate: () => undefined },
+  })
+  const base = { id: 'issue-1', repository: mapping.github, issueNumber: 12, revisionId: 'revision-1', updatedAt: '2026-08-13T01:00:00.000Z', state: { _tag: 'Running' as const, workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T01:10:00.000Z' }, repositoryMapping: mapping, issue: issueItem() }
+  const work: ClaimedIssueWorkTask = { ...base, kind: 'issue_work' }
+  const triage: ClaimedIssueTriageTask = { ...base, kind: 'issue_triage' }
+  return { manager, work, triage }
+}
+
+describe('repository prepare', () => {
+  it('runs every prepare command inside the task worktree before Issue work starts', async () => {
+    const requests: PrepareCommandRequest[] = []
+    const { manager, work } = fixture(['pnpm exec nuxt prepare', 'pnpm build:protocol'], (request) => {
+      requests.push(request)
+      return Promise.resolve({ _tag: 'Exited', exitCode: 0, outputTail: [] })
+    })
+
+    const prepared = await manager.prepareIssue(work, { _tag: 'DefaultBranch', ref: 'main' }, new AbortController().signal)
+
+    if (prepared._tag === 'Err')
+      throw new Error(prepared.error)
+    expect(requests).toEqual([
+      { argv: ['pnpm', 'exec', 'nuxt', 'prepare'], cwd: prepared.value.path, timeoutMilliseconds: 5_000, signal: expect.any(AbortSignal) },
+      { argv: ['pnpm', 'build:protocol'], cwd: prepared.value.path, timeoutMilliseconds: 5_000, signal: expect.any(AbortSignal) },
+    ])
+  })
+
+  it('never runs prepare for read only Issue triage', async () => {
+    const requests: PrepareCommandRequest[] = []
+    const { manager, triage } = fixture(['pnpm exec nuxt prepare'], (request) => {
+      requests.push(request)
+      return Promise.resolve({ _tag: 'Exited', exitCode: 0, outputTail: [] })
+    })
+
+    const prepared = await manager.prepareIssue(triage, { _tag: 'DefaultBranch', ref: 'main' }, new AbortController().signal)
+
+    expect(prepared._tag).toBe('Ok')
+    expect(requests).toEqual([])
+  })
+
+  it('stops the workspace with the command and output tail when a prepare command fails', async () => {
+    const { manager, work } = fixture(['pnpm exec nuxt prepare'], () => Promise.resolve({
+      _tag: 'Exited',
+      exitCode: 1,
+      outputTail: ['[nuxt] preparing', 'ERROR Cannot find module nuxt'],
+    }))
+
+    const prepared = await manager.prepareIssue(work, { _tag: 'DefaultBranch', ref: 'main' }, new AbortController().signal)
+
+    expect(prepared).toEqual({
+      _tag: 'Err',
+      error: 'Repository prepare command `pnpm exec nuxt prepare` exited with code 1.\n[nuxt] preparing\nERROR Cannot find module nuxt',
+    })
+  })
+
+  it('reports a timed out prepare command with its output tail', async () => {
+    const { manager, work } = fixture(['pnpm exec nuxt prepare'], () => Promise.resolve({ _tag: 'TimedOut', outputTail: ['still resolving'] }))
+
+    const prepared = await manager.prepareIssue(work, { _tag: 'DefaultBranch', ref: 'main' }, new AbortController().signal)
+
+    expect(prepared).toEqual({
+      _tag: 'Err',
+      error: 'Repository prepare command `pnpm exec nuxt prepare` timed out after 5 seconds.\nstill resolving',
+    })
+  })
+})
+
+describe('prepare command runner', () => {
+  it('runs the command with the worktree bin directory on PATH and keeps the output tail', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'harlan-prepare-runner-'))
+    temporaryDirectories.push(cwd)
+    const result = await createPrepareCommandRunner()({
+      argv: ['node', '-e', 'console.log(process.env.PATH.split(":")[0]); console.error("warned"); process.exit(3)'],
+      cwd,
+      timeoutMilliseconds: 5_000,
+      signal: new AbortController().signal,
+    })
+
+    expect(result).toEqual({ _tag: 'Exited', exitCode: 3, outputTail: [join(cwd, 'node_modules', '.bin'), 'warned'] })
+  })
+
+  it('kills a command that outlives its timeout', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'harlan-prepare-runner-'))
+    temporaryDirectories.push(cwd)
+    const result = await createPrepareCommandRunner()({
+      argv: ['node', '-e', 'console.log("started"); setTimeout(() => {}, 60_000)'],
+      cwd,
+      timeoutMilliseconds: 300,
+      signal: new AbortController().signal,
+    })
+
+    expect(result).toEqual({ _tag: 'TimedOut', outputTail: ['started'] })
+  })
+})
+
+describe('prepare command runner spawn failure', () => {
+  it('names a command that never started', async () => {
+    const result = await createPrepareCommandRunner()({ argv: ['definitely-missing-prepare-binary'], cwd: tmpdir(), timeoutMilliseconds: 3_000, signal: new AbortController().signal })
+
+    expect(result).toEqual({ _tag: 'Failed', reason: expect.stringContaining('ENOENT'), outputTail: [] })
+  })
+})

--- a/packages/harlan-github-agent/test/review-fix-worker.test.ts
+++ b/packages/harlan-github-agent/test/review-fix-worker.test.ts
@@ -97,6 +97,60 @@ describe('review fix Worker', () => {
     expect(capture.requests[0]?.prompt).toContain('Download images only from GitHub-hosted media URLs')
   })
 
+  it('starts no Repair Agent when the repository prepare command fails', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const mapping = repositoryMapping({ ownership: 'maintained', prepare: { commands: ['pnpm exec nuxt prepare'], timeoutSeconds: 600 } })
+    const task: ClaimedReviewFixTask = {
+      id: 'repair-task-prepare',
+      kind: 'review_fix',
+      repository: mapping.github,
+      pullRequestNumber: pullRequest.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'repair-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: mapping,
+      pullRequest,
+      rounds: { number: 1, limit: 3, prior: [] },
+    }
+    const capture: ProviderCapture = { requests: [] }
+    const reason = 'Repository prepare command `pnpm exec nuxt prepare` exited with code 1.\nERROR Cannot find module nuxt'
+
+    const result = await createReviewFixWorker({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [] },
+          body: '',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: { _tag: 'None' },
+          pullRequest,
+          requiredChecks: { _tag: 'None' },
+          reviews: [],
+        })),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({ outcome: 'repaired', summary: '', checks: [], commitMessage: 'fix: x' }), capture)),
+      status: { publishRepair: () => Promise.resolve(ok(undefined)) },
+      store: {
+        getReviewFixFindings: () => [{ _tag: 'Open', summary: 'A finding.', nextAction: 'Fix it.', details: { fingerprint: 'f'.repeat(64), location: { path: 'src/parser.ts', line: 1 }, proof: 'proof', regressionTest: 'test' } }],
+        recordRepairReport: () => true,
+        getWorkerSession: () => null,
+        requestReviewRerun: () => { throw new Error('A failed prepare must not queue another Review.') },
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: () => Promise.resolve(ok(mapping)),
+      worktrees: {
+        prepare: () => Promise.resolve(err(reason)),
+        verify: () => { throw new Error('Nothing to verify without an Agent turn.') },
+        commit: () => { throw new Error('Nothing to commit without an Agent turn.') },
+      },
+    }).run(task, new AbortController().signal)
+
+    expect(result).toEqual(err(reason))
+    expect(capture.requests).toEqual([])
+  })
+
   it('hands a later round the earlier rounds and stores its own report', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const mapping = repositoryMapping({ ownership: 'maintained' })


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

Every nuxtseo.com Repair and conflict session spent its first minute on `ensure-prepared` and a `@nuxtseo/protocol` build before its first check, and one skew-protection Repair spent 22 minutes finding `pnpm dev:prepare`. Worktrunk installs `node_modules` but nothing runs the repository's own prepare step.

A Repository mapping can now list `prepare` commands. The controller runs them in the task worktree before Repair, conflict resolution, Baseline repair, or Issue work starts; Review and Issue triage skip them. A failing or timed out command stops the Agent and records a Task Incident with the command and its output tail. The prompt tells the Agent which commands already ran.

Not sure about the 600 second default. nuxtseo.com on a cold pnpm store may need more, so the snippet below raises it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

### 📝 Migration

The live config on Hogwild is not version controlled. Add these keys to the matching `repositories` entries, then `pnpm service:hogwild:update`.

```yaml
- github: harlan-zw/nuxtseo.com
  prepare:
    - pnpm ensure-prepared
    - pnpm --filter @nuxtseo/protocol build
  prepare_timeout_seconds: 900

- github: harlan-zw/nuxt-skew-protection
  prepare:
    - pnpm dev:prepare
```

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz