### PR TITLE
feat(agent): reuse a Review when a new head keeps the same diff

### DIFF
--- a/packages/harlan-github-agent/src/review-reuse.ts
+++ b/packages/harlan-github-agent/src/review-reuse.ts
@@ -1,0 +1,160 @@
+import type { GitHubAgentSource } from './github-agent-source.ts'
+import type { ReviewWorker } from './item-agent.ts'
+import type { Result } from './result.ts'
+import type { ReviewStatusController } from './review-status-controller.ts'
+import type { JournalStore, ReusableReviewRun } from './store.ts'
+import type { ClaimedAdversarialReviewTask, GitHubPullRequestItem, ReviewResolution } from './types.ts'
+import type { AgentWorkspaceManager, DiffIdentity } from './worktree.ts'
+import { randomUUID } from 'node:crypto'
+import { refreshControllerGates, reviewOutcome, terminalComment } from './item-agent.ts'
+import { err, ok } from './result.ts'
+
+export type ReviewReuseCandidate
+  = | { _tag: 'Candidate', prior: ReusableReviewRun }
+    | { _tag: 'Fresh', reason: string }
+
+/**
+ * Whether the newest Review report may answer for a new head at all.
+ *
+ * Pure. The diff identity is the expensive check, so it runs only after this
+ * one passes. A Repair handoff belongs to the fresh Review path, so a report
+ * with an open repairable finding never comes through here.
+ */
+export function reviewReuseCandidate(input: {
+  prior: ReusableReviewRun | null
+  /** The live pull request. A stored Revision carries no labels. */
+  pullRequest: Pick<GitHubPullRequestItem, 'approvalLabels' | 'baseRef' | 'headSha'>
+}): ReviewReuseCandidate {
+  const { prior, pullRequest } = input
+  if (prior === null)
+    return { _tag: 'Fresh', reason: 'No completed Review exists for this pull request.' }
+  if (prior.headSha === pullRequest.headSha)
+    return { _tag: 'Fresh', reason: 'The current head commit already has an automated review.' }
+  if (pullRequest.approvalLabels.includes('review'))
+    return { _tag: 'Fresh', reason: 'The manual Review label asks for a fresh Review.' }
+  if (prior.baseRef === undefined || pullRequest.baseRef === undefined || prior.baseRef !== pullRequest.baseRef)
+    return { _tag: 'Fresh', reason: 'The base branch changed since the last Review.' }
+  if (prior.findings.some(finding => finding._tag === 'Open' && finding.resolution !== 'Dismissal'))
+    return { _tag: 'Fresh', reason: 'The last Review holds an open finding that Repair must answer.' }
+  return { _tag: 'Candidate', prior }
+}
+
+/** Two heads carry the same change only when both diffs exist and share one patch id. */
+export function sameDiff(prior: DiffIdentity, current: DiffIdentity): boolean {
+  return prior._tag === 'Patch' && current._tag === 'Patch' && prior.patchId === current.patchId
+}
+
+export function reusedReviewLine(priorHeadSha: string): string {
+  return `Reused the Review of \`${priorHeadSha.slice(0, 12)}\`. This head has the same diff against the base branch.`
+}
+
+export interface ReviewReuseOptions {
+  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot'>
+  now: () => Date
+  /** The reuse path failed, so the fresh Review runs. Reported, never swallowed. */
+  onReuseFailure?: (task: ClaimedAdversarialReviewTask, reason: string) => void
+  onReused?: (task: ClaimedAdversarialReviewTask, priorHeadSha: string) => void
+  status: Pick<ReviewStatusController, 'stageTerminal'>
+  store: Pick<JournalStore, 'getReusableReviewRun' | 'reuseReviewRun'>
+  workspaces: Pick<AgentWorkspaceManager, 'reviewDiffIdentity'>
+}
+
+export type ReviewReuseOutcome
+  = | { _tag: 'Reused', evidence: string, resolution: ReviewResolution, priorHeadSha: string }
+    | { _tag: 'Fresh', reason: string }
+
+/**
+ * Answers a new head with the newest Review report when its diff did not change.
+ *
+ * A merge of the base branch into the head, by a contributor or by Conflict
+ * resolution, moves the head commit and leaves `git diff base...head` byte
+ * for byte the same. A fresh Review of that head reads the same diff for ten
+ * minutes and reaches the same verdict. This path stores the prior report
+ * for the new head and publishes it through the ordinary terminal status.
+ * Review stays read only: no Agent session starts.
+ */
+export async function reuseReview(
+  options: ReviewReuseOptions,
+  task: ClaimedAdversarialReviewTask,
+  signal: AbortSignal,
+): Promise<Result<ReviewReuseOutcome, string>> {
+  if (!task.repositoryMapping.enabled || !task.repositoryMapping.pullRequestReview)
+    return ok({ _tag: 'Fresh', reason: 'Repository policy does not authorize an automated review comment.' })
+  // An explicit rerun request already took the newest report out of the store's answer.
+  const prior = options.store.getReusableReviewRun(task.repository, task.pullRequestNumber)
+  if (prior === null)
+    return ok({ _tag: 'Fresh', reason: 'No completed Review exists for this pull request.' })
+  const snapshot = await options.github.getPullRequestReviewSnapshot(task.repositoryMapping, task.pullRequestNumber, signal)
+  if (snapshot._tag === 'Err')
+    return snapshot
+  const live = snapshot.value.pullRequest
+  if (live.headSha !== task.pullRequest.headSha || live.state !== 'open')
+    return ok({ _tag: 'Fresh', reason: 'The pull request changed before review started.' })
+  const candidate = reviewReuseCandidate({ prior, pullRequest: live })
+  if (candidate._tag === 'Fresh')
+    return ok(candidate)
+
+  const previous = await options.workspaces.reviewDiffIdentity(task, { baseSha: candidate.prior.baseSha, headSha: candidate.prior.headSha }, signal)
+  if (previous._tag === 'Err')
+    return previous
+  const current = await options.workspaces.reviewDiffIdentity(task, { baseSha: live.baseSha, headSha: live.headSha }, signal)
+  if (current._tag === 'Err')
+    return current
+  if (!sameDiff(previous.value, current.value))
+    return ok({ _tag: 'Fresh', reason: 'The diff against the base branch changed since the last Review.' })
+
+  const refreshed = refreshControllerGates(candidate.prior.gates, snapshot.value, task.repositoryMapping)
+  const reviewRunId = randomUUID()
+  const reason = reusedReviewLine(candidate.prior.headSha)
+  const recorded = options.store.reuseReviewRun({
+    id: reviewRunId,
+    repository: task.repository,
+    pullRequestNumber: task.pullRequestNumber,
+    revisionId: task.revisionId,
+    headSha: live.headSha,
+    reusesReviewRunId: candidate.prior.reviewRunId,
+    controllerGates: { merge: refreshed.gates.merge, ci: refreshed.gates.ci },
+    reason,
+    at: options.now().toISOString(),
+  })
+  if (recorded._tag === 'Rejected')
+    return err(`The reused review could not be saved: ${recorded.reason._tag}.`)
+
+  const gates = { ...refreshed.gates, review: candidate.prior.gates.review }
+  const outcome = reviewOutcome(gates)
+  const confidence = outcome === 'READY' ? candidate.prior.confidence : undefined
+  const body = `${terminalComment(live.headSha, live.baseSha, gates, candidate.prior.findings, confidence, refreshed.reportedChecks)}\n\n${reason}`
+  const staged = options.status.stageTerminal?.(task, body, outcome, reviewRunId) ?? err('The terminal Review status could not be staged.')
+  if (staged._tag === 'Err')
+    return staged
+  return ok({
+    _tag: 'Reused',
+    evidence: reviewRunId,
+    resolution: { _tag: 'Reviewed', reviewRunId },
+    priorHeadSha: candidate.prior.headSha,
+  })
+}
+
+/**
+ * Wraps the Review worker so an unchanged diff never starts an Agent.
+ *
+ * A failure on the reuse path is reported and the fresh Review runs. The
+ * expensive path is the safe one, so nothing here can make a head go unreviewed.
+ */
+export function createReviewReuseWorker(options: ReviewReuseOptions, inner: ReviewWorker): ReviewWorker {
+  return {
+    async run(task, signal) {
+      const reused = await reuseReview(options, task, signal)
+      if (reused._tag === 'Err') {
+        if (signal.aborted)
+          return reused
+        options.onReuseFailure?.(task, reused.error)
+        return inner.run(task, signal)
+      }
+      if (reused.value._tag === 'Fresh')
+        return inner.run(task, signal)
+      options.onReused?.(task, reused.value.priorHeadSha)
+      return ok({ evidence: reused.value.evidence, resolution: reused.value.resolution })
+    },
+  }
+}

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -53,6 +53,7 @@ import { AGENT_ACTOR_LOGIN } from './review-comment.ts'
 import { createReviewFixWorker } from './review-fix-worker.ts'
 import { refreshReviewGates } from './review-gate-sweep.ts'
 import { syncOpenReviewRerunRequests } from './review-rerun-controller.ts'
+import { createReviewReuseWorker } from './review-reuse.ts'
 import { createReviewStatusController } from './review-status-controller.ts'
 import { createReviewStatusScheduler } from './review-status-scheduler.ts'
 import { publishStoppedReviews } from './review-stop-sweep.ts'
@@ -713,7 +714,15 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         worker: withGitHubWritePreflight({
           accesses: ['item_write'],
           source: tokens,
-          worker: createReviewWorker(subjectWorkerOptions),
+          worker: createReviewReuseWorker({
+            github: workerGithub,
+            now,
+            onReuseFailure: (task, reason) => options.logger.error(`${task.repository}#${task.pullRequestNumber}: the Review could not be reused, so a fresh Review runs: ${reason}`),
+            onReused: (task, priorHeadSha) => options.logger.info(`${task.repository}#${task.pullRequestNumber}: reused the Review of ${priorHeadSha.slice(0, 12)} for ${task.pullRequest.headSha.slice(0, 12)}. The diff did not change.`),
+            status: reviewStatus,
+            store,
+            workspaces,
+          }, createReviewWorker(subjectWorkerOptions)),
         }),
         workerId: randomUUID(),
       })),

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -468,7 +468,7 @@ export interface ReuseReviewRunInput {
 export type ReuseReviewRunResult
   = | { _tag: 'Inserted', reviewRunId: string }
     | { _tag: 'Duplicate', reviewRunId: string }
-    | { _tag: 'Rejected', reason: { _tag: 'RunNotFound' } | { _tag: 'AlreadySuperseded' } | { _tag: 'RevisionMismatch' } | { _tag: 'ReviewApprovalRequired' } | { _tag: 'OpenFindingRequiresBlocked' } }
+    | { _tag: 'Rejected', reason: { _tag: 'RunNotFound' } | { _tag: 'AlreadySuperseded' } | { _tag: 'RerunRequested' } | { _tag: 'RevisionMismatch' } | { _tag: 'ReviewApprovalRequired' } | { _tag: 'OpenFindingRequiresBlocked' } }
 
 export interface ReviewGateRefresh {
   reviewRunId: string
@@ -983,7 +983,7 @@ export interface JournalStore {
   recordReviewRun: (input: RecordReviewRunInput) => RecordReviewRunResult
   /** Atomically stores a refreshed Review and its published GitHub projection. */
   supersedeReviewRun: (input: SupersedeReviewRunInput) => SupersedeReviewRunResult
-  /** The newest Review report on one pull request that no later row restates and no rerun request set aside. */
+  /** The newest Review report on one pull request that no later row restates and no unanswered rerun request disputes. */
   getReusableReviewRun: (repository: string, pullRequestNumber: number) => ReusableReviewRun | null
   /** Stores a prior Review report for a new head whose diff did not change. Starts no Agent. */
   reuseReviewRun: (input: ReuseReviewRunInput) => ReuseReviewRunResult
@@ -7118,6 +7118,29 @@ export function openJournalStore(
     }
   }
 
+  /**
+   * A rerun request nothing answered yet.
+   *
+   * The request follows the subject, not one head: a person who disputes the
+   * report on head A still disputes it when head B carries the same diff. A
+   * later head supersedes the requeued Task, so only a Review completed after
+   * the request, by an Agent rather than a reused row, can retire it.
+   */
+  const pendingRerunRequestSql = (subjectColumn: string): string => `
+    EXISTS (
+      SELECT 1 FROM review_rerun_requests AS pending
+      JOIN worker_tasks AS requested ON requested.id = pending.task_id
+      WHERE requested.subject_id = ${subjectColumn}
+        AND requested.kind = 'adversarial_review'
+        AND NOT EXISTS (
+          SELECT 1 FROM review_runs AS answered
+          WHERE answered.subject_id = requested.subject_id
+            AND answered.kind = 'adversarial_review'
+            AND answered.supersedes_review_run_id IS NULL
+            AND answered.completed_at > pending.requested_at
+        )
+    )`
+
   const getReusableReviewRun: JournalStore['getReusableReviewRun'] = (repository, pullRequestNumber) => {
     const row = database.prepare(`
       SELECT review_runs.id, review_runs.revision_id, review_runs.head_sha, review_runs.gates,
@@ -7142,13 +7165,7 @@ export function openJournalStore(
           WHERE review_publications.review_run_id = review_runs.id
             AND review_publications.result_tag = 'Published'
         )
-        AND NOT EXISTS (
-          SELECT 1 FROM review_rerun_requests
-          JOIN worker_tasks ON worker_tasks.id = review_rerun_requests.task_id
-          WHERE worker_tasks.subject_id = subjects.id
-            AND worker_tasks.revision_id = subjects.current_revision_id
-            AND worker_tasks.kind = 'adversarial_review'
-        )
+        AND NOT ${pendingRerunRequestSql('subjects.id')}
       ORDER BY review_runs.completed_at DESC, review_runs.id DESC
       LIMIT 1
     `).get(repository, pullRequestNumber, digest((database.prepare(`
@@ -7238,6 +7255,11 @@ export function openJournalStore(
       if (prior === undefined || prior.superseded === 1) {
         database.exec('COMMIT')
         return { _tag: 'Rejected', reason: { _tag: prior === undefined ? 'RunNotFound' : 'AlreadySuperseded' } }
+      }
+      const rerunRequested = database.prepare(`SELECT ${pendingRerunRequestSql('?')} AS pending`).get(revision.subject_id) as { pending: number }
+      if (rerunRequested.pending === 1) {
+        database.exec('COMMIT')
+        return { _tag: 'Rejected', reason: { _tag: 'RerunRequested' } }
       }
       const priorGates = JSON.parse(prior.gates) as ReviewGates
       const gates: ReviewGates = { merge: input.controllerGates.merge, review: priorGates.review, ci: input.controllerGates.ci }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -436,6 +436,40 @@ export interface StoppedReview {
 }
 
 /** A published clean Review whose moving controller gates need another read. */
+/** The newest completed Review on one pull request, with the Revision it answered for. */
+export interface ReusableReviewRun {
+  reviewRunId: string
+  revisionId: string
+  headSha: string
+  baseSha: string
+  /** Absent on a Revision observed before the controller recorded the base branch. */
+  baseRef: string | undefined
+  gates: ReviewGates
+  findings: ReviewFinding[]
+  confidence: number | undefined
+  completedAt: string
+}
+
+export interface ReuseReviewRunInput {
+  id: string
+  repository: string
+  pullRequestNumber: number
+  revisionId: string
+  headSha: string
+  /** The completed Review whose report this head inherits. */
+  reusesReviewRunId: string
+  /** The moving gates, read again for this head. The review gate is the prior run's. */
+  controllerGates: Pick<ReviewGates, 'ci' | 'merge'>
+  /** Why the report applies: the earlier head this diff matches. */
+  reason: string
+  at: string
+}
+
+export type ReuseReviewRunResult
+  = | { _tag: 'Inserted', reviewRunId: string }
+    | { _tag: 'Duplicate', reviewRunId: string }
+    | { _tag: 'Rejected', reason: { _tag: 'RunNotFound' } | { _tag: 'AlreadySuperseded' } | { _tag: 'RevisionMismatch' } | { _tag: 'ReviewApprovalRequired' } | { _tag: 'OpenFindingRequiresBlocked' } }
+
 export interface ReviewGateRefresh {
   reviewRunId: string
   repository: string
@@ -949,6 +983,10 @@ export interface JournalStore {
   recordReviewRun: (input: RecordReviewRunInput) => RecordReviewRunResult
   /** Atomically stores a refreshed Review and its published GitHub projection. */
   supersedeReviewRun: (input: SupersedeReviewRunInput) => SupersedeReviewRunResult
+  /** The newest Review report on one pull request that no later row restates and no rerun request set aside. */
+  getReusableReviewRun: (repository: string, pullRequestNumber: number) => ReusableReviewRun | null
+  /** Stores a prior Review report for a new head whose diff did not change. Starts no Agent. */
+  reuseReviewRun: (input: ReuseReviewRunInput) => ReuseReviewRunResult
   recordReviewPublication: (input: RecordReviewPublicationInput) => RecordReviewPublicationResult
   requestReviewRerun: (input: {
     repository: string
@@ -7080,6 +7118,204 @@ export function openJournalStore(
     }
   }
 
+  const getReusableReviewRun: JournalStore['getReusableReviewRun'] = (repository, pullRequestNumber) => {
+    const row = database.prepare(`
+      SELECT review_runs.id, review_runs.revision_id, review_runs.head_sha, review_runs.gates,
+        review_runs.findings, review_runs.completed_at,
+        COALESCE(projection.confidence, review_runs.confidence) AS confidence,
+        revisions.payload
+      FROM review_runs
+      JOIN subjects ON subjects.id = review_runs.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
+      JOIN revisions ON revisions.id = review_runs.revision_id AND revisions.subject_id = subjects.id
+      JOIN review_evidence_scopes ON review_evidence_scopes.review_run_id = review_runs.id
+      LEFT JOIN review_gate_projections AS projection ON projection.review_run_id = review_runs.id
+      WHERE repositories.github = ? AND subjects.github_number = ? AND subjects.kind = 'pull_request'
+        AND review_runs.kind = 'adversarial_review'
+        AND review_evidence_scopes.policy_digest = ?
+        AND NOT EXISTS (
+          SELECT 1 FROM review_runs AS settled
+          WHERE settled.supersedes_review_run_id = review_runs.id
+        )
+        AND EXISTS (
+          SELECT 1 FROM review_publications
+          WHERE review_publications.review_run_id = review_runs.id
+            AND review_publications.result_tag = 'Published'
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM review_rerun_requests
+          JOIN worker_tasks ON worker_tasks.id = review_rerun_requests.task_id
+          WHERE worker_tasks.subject_id = subjects.id
+            AND worker_tasks.revision_id = subjects.current_revision_id
+            AND worker_tasks.kind = 'adversarial_review'
+        )
+      ORDER BY review_runs.completed_at DESC, review_runs.id DESC
+      LIMIT 1
+    `).get(repository, pullRequestNumber, digest((database.prepare(`
+      SELECT policy_json FROM repositories WHERE github = ?
+    `).get(repository) as { policy_json: string } | undefined)?.policy_json ?? '')) as {
+      id: string
+      revision_id: string
+      head_sha: string
+      gates: string
+      findings: string
+      completed_at: string
+      confidence: number | null
+      payload: string
+    } | undefined
+    if (row === undefined)
+      return null
+    const pullRequest = JSON.parse(row.payload) as GitHubItem
+    if (pullRequest.kind !== 'pull_request')
+      return null
+    return {
+      reviewRunId: row.id,
+      revisionId: row.revision_id,
+      headSha: row.head_sha,
+      baseSha: pullRequest.baseSha,
+      baseRef: pullRequest.baseRef,
+      gates: JSON.parse(row.gates) as ReviewGates,
+      findings: JSON.parse(row.findings) as ReviewFinding[],
+      confidence: row.confidence ?? undefined,
+      completedAt: row.completed_at,
+    }
+  }
+
+  const reuseReviewRun: JournalStore['reuseReviewRun'] = (input) => {
+    const revision = database.prepare(`
+      SELECT subjects.id AS subject_id, revisions.payload, repositories.policy_json,
+        EXISTS (
+          SELECT 1 FROM pull_request_approvals
+          WHERE subject_id = subjects.id AND revision_id = revisions.id AND kind = 'review'
+        ) AS review_approved
+      FROM revisions
+      JOIN subjects ON subjects.id = revisions.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
+      WHERE repositories.github = ? AND subjects.github_number = ?
+        AND subjects.kind = 'pull_request' AND revisions.id = ?
+        AND subjects.current_revision_id = revisions.id
+    `).get(input.repository, input.pullRequestNumber, input.revisionId) as {
+      subject_id: number
+      payload: string
+      policy_json: string
+      review_approved: number
+    } | undefined
+    const pullRequest = revision === undefined ? undefined : JSON.parse(revision.payload) as GitHubItem
+    if (revision === undefined || pullRequest?.kind !== 'pull_request' || pullRequest.headSha !== input.headSha)
+      return { _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }
+    const mapping = JSON.parse(revision.policy_json) as RepositoryMapping
+    if (requiresPullRequestApproval(database, mapping, pullRequest.author) && revision.review_approved !== 1)
+      return { _tag: 'Rejected', reason: { _tag: 'ReviewApprovalRequired' } }
+
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      const existing = database.prepare('SELECT 1 FROM review_runs WHERE id = ?').get(input.id)
+      if (existing !== undefined) {
+        database.exec('COMMIT')
+        return { _tag: 'Duplicate', reviewRunId: input.id }
+      }
+      const prior = database.prepare(`
+        SELECT id, head_sha, provider, session_id, model, agent_version, skill_digest, gates, findings, confidence,
+          EXISTS (
+            SELECT 1 FROM review_runs AS settled
+            WHERE settled.supersedes_review_run_id = review_runs.id
+          ) AS superseded
+        FROM review_runs
+        WHERE id = ? AND subject_id = ? AND kind = 'adversarial_review'
+      `).get(input.reusesReviewRunId, revision.subject_id) as {
+        id: string
+        head_sha: string
+        provider: string
+        session_id: string
+        model: string
+        agent_version: string
+        skill_digest: string
+        gates: string
+        findings: string
+        confidence: number | null
+        superseded: number
+      } | undefined
+      if (prior === undefined || prior.superseded === 1) {
+        database.exec('COMMIT')
+        return { _tag: 'Rejected', reason: { _tag: prior === undefined ? 'RunNotFound' : 'AlreadySuperseded' } }
+      }
+      const priorGates = JSON.parse(prior.gates) as ReviewGates
+      const gates: ReviewGates = { merge: input.controllerGates.merge, review: priorGates.review, ci: input.controllerGates.ci }
+      const findings = JSON.parse(prior.findings) as ReviewFinding[]
+      const outcome = derivedReviewOutcome(gates)
+      if (findings.some(finding => finding._tag === 'Open') && outcome !== 'Blocked') {
+        database.exec('COMMIT')
+        return { _tag: 'Rejected', reason: { _tag: 'OpenFindingRequiresBlocked' } }
+      }
+      const policyDigest = digest(revision.policy_json)
+      const gatesJson = JSON.stringify(gates)
+      const contentDigest = digest(JSON.stringify({
+        reusesReviewRunId: prior.id,
+        repository: input.repository,
+        pullRequestNumber: input.pullRequestNumber,
+        revisionId: input.revisionId,
+        headSha: input.headSha,
+        policyDigest,
+        gates,
+        outcome,
+        findings,
+      }))
+      database.prepare(`
+        INSERT INTO review_runs (
+          id, subject_id, revision_id, kind, provider, session_id, model, agent_version,
+          skill_digest, head_sha, started_at, completed_at, gates, outcome_tag,
+          confidence, findings, content_digest, usage, supersedes_review_run_id
+        ) VALUES (?, ?, ?, 'adversarial_review', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        input.id,
+        revision.subject_id,
+        input.revisionId,
+        prior.provider,
+        prior.session_id,
+        prior.model,
+        prior.agent_version,
+        prior.skill_digest,
+        input.headSha,
+        input.at,
+        input.at,
+        gatesJson,
+        outcome,
+        prior.confidence,
+        prior.findings,
+        contentDigest,
+        JSON.stringify({ _tag: 'Unavailable' } satisfies AgentTokenUsage),
+        prior.id,
+      )
+      database.prepare(`
+        INSERT INTO review_evidence_scopes (review_run_id, policy_digest, created_at)
+        VALUES (?, ?, ?)
+      `).run(input.id, policyDigest, input.at)
+      database.prepare(`
+        INSERT INTO review_gate_projections (
+          review_run_id, gates, outcome_tag, confidence, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+      `).run(input.id, gatesJson, outcome, prior.confidence, input.at)
+      recordWorkflowEvent(database, {
+        stream: 'review_run',
+        event: 'Reused',
+        entityId: input.id,
+        repository: input.repository,
+        itemNumber: input.pullRequestNumber,
+        revisionId: input.revisionId,
+        from: prior.head_sha,
+        to: input.headSha,
+        reason: input.reason,
+        at: input.at,
+      })
+      database.exec('COMMIT')
+      return { _tag: 'Inserted', reviewRunId: input.id }
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
   const recordReviewPublication: JournalStore['recordReviewPublication'] = (input) => {
     const bodySha256 = digest(input.body)
     const contentDigest = digest(JSON.stringify({
@@ -13071,6 +13307,8 @@ export function openJournalStore(
     recordPollSuccess,
     recordReviewRun,
     supersedeReviewRun,
+    getReusableReviewRun,
+    reuseReviewRun,
     recordReviewPublication,
     requestReviewRerun,
     resumeAgents,

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -309,13 +309,27 @@ function runGitPatchId(checkout: string, range: DiffRange, signal: AbortSignal):
     })
     const stdout: Buffer[] = []
     const stderr: Buffer[] = []
-    let diffExit: number | null = null
+    // Both processes report before anything is decided. `patch-id` can close
+    // first, on a diff that failed after partial output, and a decision taken
+    // then would accept a truncated identity as a real one.
+    const exits: { diff: number | null, patchId: number | null } = { diff: null, patchId: null }
     let settled = false
     const fail = (reason: string) => {
       if (settled)
         return
       settled = true
       resolve(err(reason))
+    }
+    const decide = () => {
+      if (settled || exits.diff === null || exits.patchId === null)
+        return
+      settled = true
+      if (exits.diff !== 0 || exits.patchId !== 0) {
+        resolve(err(`Could not read the diff identity: ${Buffer.concat(stderr).toString('utf8').trim()}`))
+        return
+      }
+      const id = Buffer.concat(stdout).toString('utf8').trim().split(/\s+/)[0]
+      resolve(id === undefined || id.length === 0 ? ok({ _tag: 'Empty' }) : ok({ _tag: 'Patch', patchId: id }))
     }
     diff.stdout.pipe(patchId.stdin)
     diff.stderr.on('data', (chunk: Buffer) => stderr.push(chunk))
@@ -324,19 +338,12 @@ function runGitPatchId(checkout: string, range: DiffRange, signal: AbortSignal):
     diff.on('error', error => fail(`Could not read the diff: ${error.message}`))
     patchId.on('error', error => fail(`Could not read the patch id: ${error.message}`))
     diff.on('close', (code) => {
-      diffExit = code
+      exits.diff = code ?? 1
+      decide()
     })
     patchId.on('close', (code) => {
-      if (settled)
-        return
-      settled = true
-      const errors = Buffer.concat(stderr).toString('utf8').trim()
-      if (code !== 0 || (diffExit !== null && diffExit !== 0)) {
-        resolve(err(`Could not read the diff identity: ${errors}`))
-        return
-      }
-      const id = Buffer.concat(stdout).toString('utf8').trim().split(/\s+/)[0]
-      resolve(id === undefined || id.length === 0 ? ok({ _tag: 'Empty' }) : ok({ _tag: 'Patch', patchId: id }))
+      exits.patchId = code ?? 1
+      decide()
     })
   })
 }

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -83,6 +83,23 @@ export type RestackOutcome
   = | { _tag: 'Restacked', workspace: PreparedWorkerWorkspace, patch: VerifiedIssuePatch }
     | { _tag: 'Unstacked', reason: string }
 
+/**
+ * What one pull request changes against its base, independent of the commits
+ * that carry it.
+ *
+ * `git patch-id --stable` over `git diff base...head` ignores commit ids,
+ * line numbers, and whitespace, so a merge of the base branch into the head
+ * keeps the same identity while any real change to the diff gets a new one.
+ */
+export type DiffIdentity
+  = | { _tag: 'Patch', patchId: string }
+    | { _tag: 'Empty' }
+
+export interface DiffRange {
+  baseSha: string
+  headSha: string
+}
+
 export interface AgentWorkspaceManager {
   prepareBaseline: (task: ClaimedBaselineRepairTask, signal: AbortSignal) => Promise<Result<PreparedWorkerWorkspace, string>>
   prepareFix: (task: ClaimedReviewFixTask, signal: AbortSignal) => Promise<Result<PreparedWorkerWorkspace, string>>
@@ -90,6 +107,8 @@ export interface AgentWorkspaceManager {
   prepareReview: (task: ClaimedAdversarialReviewTask, signal: AbortSignal) => Promise<Result<PreparedWorkerWorkspace, string>>
   /** A Routine scan reads the default branch. It never starts from a pull request head. */
   prepareRoutine: (task: ClaimedRoutineRun, signal: AbortSignal) => Promise<Result<PreparedWorkerWorkspace, string>>
+  /** Reads one diff identity from the repository checkout. Fetches missing commits read only; opens no worktree. */
+  reviewDiffIdentity: (task: ClaimedAdversarialReviewTask, range: DiffRange, signal: AbortSignal) => Promise<Result<DiffIdentity, string>>
   verifyReview: (task: ClaimedAdversarialReviewTask, worktree: PreparedWorkerWorkspace, signal: AbortSignal) => Promise<Result<void, string>>
 }
 
@@ -265,6 +284,59 @@ function runGitDigest(checkout: string, args: string[], signal: AbortSignal): Pr
         exitCode: code ?? 1,
         stderr: Buffer.concat(stderr).toString('utf8').trim() || spawnError,
       })
+    })
+  })
+}
+
+/**
+ * `git diff base...head | git patch-id --stable`, as one pipeline.
+ *
+ * The diff can be large, so it streams between the two processes and never
+ * enters this process. An empty diff produces no patch id at all.
+ */
+function runGitPatchId(checkout: string, range: DiffRange, signal: AbortSignal): Promise<Result<DiffIdentity, string>> {
+  return new Promise((resolve) => {
+    const common = ['-c', 'credential.helper=', '-c', 'core.hooksPath=/dev/null', '-C', checkout]
+    const diff = spawn('git', [...common, 'diff', '--no-color', '--no-ext-diff', `${range.baseSha}...${range.headSha}`], {
+      env: gitEnvironment(),
+      signal,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const patchId = spawn('git', [...common, 'patch-id', '--stable'], {
+      env: gitEnvironment(),
+      signal,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    let diffExit: number | null = null
+    let settled = false
+    const fail = (reason: string) => {
+      if (settled)
+        return
+      settled = true
+      resolve(err(reason))
+    }
+    diff.stdout.pipe(patchId.stdin)
+    diff.stderr.on('data', (chunk: Buffer) => stderr.push(chunk))
+    patchId.stdout.on('data', (chunk: Buffer) => stdout.push(chunk))
+    patchId.stderr.on('data', (chunk: Buffer) => stderr.push(chunk))
+    diff.on('error', error => fail(`Could not read the diff: ${error.message}`))
+    patchId.on('error', error => fail(`Could not read the patch id: ${error.message}`))
+    diff.on('close', (code) => {
+      diffExit = code
+    })
+    patchId.on('close', (code) => {
+      if (settled)
+        return
+      settled = true
+      const errors = Buffer.concat(stderr).toString('utf8').trim()
+      if (code !== 0 || (diffExit !== null && diffExit !== 0)) {
+        resolve(err(`Could not read the diff identity: ${errors}`))
+        return
+      }
+      const id = Buffer.concat(stdout).toString('utf8').trim().split(/\s+/)[0]
+      resolve(id === undefined || id.length === 0 ? ok({ _tag: 'Empty' }) : ok({ _tag: 'Patch', patchId: id }))
     })
   })
 }
@@ -885,6 +957,33 @@ export function createAgentWorkspaceManager(options: ConflictWorktreeManagerOpti
       if (base.exitCode !== 0 || base.stdout !== task.pullRequest.baseSha)
         return err('Fetched base branch no longer matches the claimed review base commit SHA.')
       return ok({ ...prepared.value, baseSha: base.stdout })
+    },
+
+    async reviewDiffIdentity(task, range, signal) {
+      const repository = task.repositoryMapping.checkout
+      const missing: string[] = []
+      for (const sha of [range.baseSha, range.headSha]) {
+        if (!/^[a-f\d]{40}$/.test(sha))
+          return err(`The commit ${sha} is not a full SHA.`)
+        const present = await runGit(repository, ['cat-file', '-e', `${sha}^{commit}`], signal)
+        if (present.exitCode !== 0)
+          missing.push(sha)
+      }
+      if (missing.length > 0) {
+        const token = await options.tokens.getToken(task.repository, 'read', signal)
+        if (token._tag === 'Err')
+          return err(token.error.message)
+        const remoteUrl = options.remoteUrl?.(task.repository) ?? `https://github.com/${task.repository}.git`
+        const fetch = await runGit(repository, [
+          'fetch',
+          '--no-tags',
+          remoteUrl,
+          ...missing.map(sha => `+${sha}:refs/harlan-github-agent/reviews/${task.pullRequestNumber}/identity/${sha}`),
+        ], signal, token.value.token, options.remoteUrl !== undefined)
+        if (fetch.exitCode !== 0)
+          return err(`Git fetch failed: ${fetch.stderr}`)
+      }
+      return runGitPatchId(repository, range, signal)
     },
 
     async verifyReview(task, worktree, signal) {

--- a/packages/harlan-github-agent/test/review-reuse.test.ts
+++ b/packages/harlan-github-agent/test/review-reuse.test.ts
@@ -1,0 +1,282 @@
+import type { PullRequestReviewSnapshot } from '../src/github-agent-source.ts'
+import type { ReviewWorker } from '../src/item-agent.ts'
+import type { ClaimedAdversarialReviewTask, GitHubPullRequestItem } from '../src/types.ts'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { err, ok } from '../src/result.ts'
+import { createReviewReuseWorker, reviewReuseCandidate } from '../src/review-reuse.ts'
+import { createReviewStatusController } from '../src/review-status-controller.ts'
+import { openJournalStore } from '../src/store.ts'
+import { createAgentWorkspaceManager } from '../src/worktree.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const temporaryDirectories: string[] = []
+const stores: Array<ReturnType<typeof openJournalStore>> = []
+
+afterEach(() => {
+  temporaryDirectories.splice(0).forEach(path => rmSync(path, { recursive: true, force: true }))
+  stores.splice(0).forEach(store => store.close())
+})
+
+function git(checkout: string, ...args: string[]): string {
+  return execFileSync('git', ['-c', 'credential.helper=', '-c', 'core.hooksPath=/dev/null', '-C', checkout, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    env: { PATH: process.env.PATH, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null', GIT_TERMINAL_PROMPT: '0' },
+  }).trim()
+}
+
+/**
+ * One pull request whose head moved twice: once by a merge of the base branch
+ * that keeps the diff, once by a real change. The controller checkout is
+ * cloned before either move, so the identity read has to fetch.
+ */
+function repository() {
+  const directory = mkdtempSync(join(tmpdir(), 'harlan-review-reuse-'))
+  temporaryDirectories.push(directory)
+  const remote = join(directory, 'remote.git')
+  const author = join(directory, 'author')
+  const checkout = join(directory, 'checkout')
+  const root = join(directory, 'controller')
+  execFileSync('git', ['init', '--bare', '--quiet', remote])
+  execFileSync('git', ['clone', '--quiet', remote, author], { stdio: 'ignore' })
+  git(author, 'config', 'user.name', 'Test Author')
+  git(author, 'config', 'user.email', 'author@example.com')
+  git(author, 'checkout', '-b', 'main')
+  writeFileSync(join(author, 'file.ts'), 'export const value = 1\n')
+  writeFileSync(join(author, 'other.ts'), 'export const other = 1\n')
+  git(author, 'add', '.')
+  git(author, 'commit', '-m', 'initial')
+  git(author, 'push', 'origin', 'main')
+  const base1 = git(author, 'rev-parse', 'HEAD')
+  git(author, 'checkout', '-b', 'fix/review')
+  writeFileSync(join(author, 'file.ts'), 'export const value = 2\n')
+  git(author, 'commit', '-am', 'change')
+  const head1 = git(author, 'rev-parse', 'HEAD')
+  git(author, 'push', 'origin', 'HEAD:refs/pull/24/head')
+  execFileSync('git', ['clone', '--quiet', remote, checkout], { stdio: 'ignore' })
+  git(checkout, 'fetch', 'origin', `+${head1}:refs/harlan-github-agent/reviews/24/head`)
+
+  git(author, 'checkout', 'main')
+  writeFileSync(join(author, 'other.ts'), 'export const other = 2\n')
+  git(author, 'commit', '-am', 'base moves')
+  git(author, 'push', 'origin', 'main')
+  const base2 = git(author, 'rev-parse', 'HEAD')
+  git(author, 'checkout', 'fix/review')
+  git(author, 'merge', '--no-edit', 'main')
+  const head2 = git(author, 'rev-parse', 'HEAD')
+  git(author, 'push', 'origin', 'HEAD:refs/pull/24/head')
+  writeFileSync(join(author, 'file.ts'), 'export const value = 3\n')
+  git(author, 'commit', '-am', 'more change')
+  const head3 = git(author, 'rev-parse', 'HEAD')
+  git(author, 'push', 'origin', 'HEAD:refs/pull/24/head')
+
+  return { remote, checkout, root, base1, base2, head1, head2, head3 }
+}
+
+const passed = { _tag: 'Passed' as const, evidence: [{ label: 'gate', sha256: 'b'.repeat(64) }] }
+const check = { id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun' as const, appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }
+
+function snapshot(pullRequest: GitHubPullRequestItem): PullRequestReviewSnapshot {
+  return {
+    baseChecks: { _tag: 'Available', checks: [check] },
+    body: '',
+    checks: { _tag: 'Available', checks: [check] },
+    comments: [],
+    priorAutomatedReview: { _tag: 'None' },
+    pullRequest,
+    requiredChecks: { _tag: 'None' },
+    reviews: [],
+  } as PullRequestReviewSnapshot
+}
+
+/** A store holding one completed, published Review of the first head. */
+function reviewedFirstHead(input: { checkout: string, base1: string, head1: string }) {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  const mapping = repositoryMapping({ checkout: input.checkout })
+  store.syncRepositories([mapping], '2026-09-01T00:00:00.000Z')
+  const first = pullRequestItem({ baseSha: input.base1, headSha: input.head1, headRef: 'fix/review', mergeState: 'clean' })
+  const observed = store.recordObservation({ externalId: 'obs-1', observedAt: '2026-09-01T01:00:00.000Z', source: 'poll', subject: first })
+  if (observed._tag !== 'Inserted')
+    throw new Error('Expected a pull request.')
+  const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-09-01T01:01:00.000Z', 60_000)
+  if (task === null)
+    throw new Error('Expected a Review Task.')
+  const recorded = store.recordReviewRun({
+    id: 'run-1',
+    repository: mapping.github,
+    pullRequestNumber: 24,
+    revisionId: observed.revisionId,
+    headSha: input.head1,
+    provider: 'codex',
+    sessionId: 'session-1',
+    model: 'gpt-5.6-sol',
+    agentVersion: '0.0.0',
+    skillDigest: 'a'.repeat(64),
+    startedAt: '2026-09-01T01:01:00.000Z',
+    completedAt: '2026-09-01T01:12:00.000Z',
+    gates: { merge: passed, review: passed, ci: passed },
+    confidence: 91,
+    findings: [],
+  })
+  if (recorded._tag !== 'Inserted')
+    throw new Error(`Expected the first Review to be stored: ${recorded._tag}`)
+  store.recordReviewPublication({
+    id: 'publication-1',
+    reviewRunId: 'run-1',
+    body: '### 🤖 READY · 91/100',
+    at: '2026-09-01T01:12:30.000Z',
+    result: { _tag: 'Published', githubCommentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' },
+  })
+  store.completeReviewTask({
+    taskId: task.id,
+    workerId: task.state.workerId,
+    fence: task.state.fence,
+    at: '2026-09-01T01:13:00.000Z',
+    evidence: 'run-1',
+    resolution: { _tag: 'Reviewed', reviewRunId: 'run-1' },
+  })
+  return { mapping, store }
+}
+
+function claimNewHead(store: ReturnType<typeof openJournalStore>, pullRequest: GitHubPullRequestItem): ClaimedAdversarialReviewTask {
+  const observed = store.recordObservation({ externalId: 'obs-2', observedAt: '2026-09-01T02:00:00.000Z', source: 'poll', subject: pullRequest })
+  if (observed._tag !== 'Inserted')
+    throw new Error('Expected a new pull request head.')
+  const task = store.claimNextAdversarialReviewTask('reviewer-2', '2026-09-01T02:01:00.000Z', 60_000)
+  if (task === null)
+    throw new Error('Expected a Review Task for the new head.')
+  return task
+}
+
+function harness(input: { remote: string, root: string, store: ReturnType<typeof openJournalStore>, live: GitHubPullRequestItem }) {
+  const started: string[] = []
+  const failures: string[] = []
+  const inner: ReviewWorker = {
+    run: (task) => {
+      started.push(task.pullRequest.headSha)
+      return Promise.resolve(err('A fresh Review started.'))
+    },
+  }
+  const worker = createReviewReuseWorker({
+    onReuseFailure: (_task, reason) => failures.push(reason),
+    github: { getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot(input.live))) },
+    now: () => new Date('2026-09-01T02:01:30.000Z'),
+    status: createReviewStatusController({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.reject(new Error('Staging reads nothing.')),
+        stampAgentLabel: () => Promise.reject(new Error('Staging stamps nothing.')),
+        upsertReviewStatus: () => Promise.reject(new Error('Staging writes nothing.')),
+      },
+      leaseMilliseconds: 60_000,
+      now: () => new Date('2026-09-01T02:01:30.000Z'),
+      store: input.store,
+      workerId: 'status-1',
+    }),
+    store: input.store,
+    workspaces: createAgentWorkspaceManager({
+      remoteUrl: () => input.remote,
+      root: input.root,
+      tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-09-01T03:00:00.000Z' })), invalidate: () => undefined },
+    }),
+  }, inner)
+  return { failures, started, worker }
+}
+
+describe('review reuse', () => {
+  it('reuses the prior Review for a merge of the base branch that keeps the diff', async () => {
+    const repo = repository()
+    const { mapping, store } = reviewedFirstHead(repo)
+    const merged = pullRequestItem({ baseSha: repo.base2, headSha: repo.head2, headRef: 'fix/review', mergeState: 'clean' })
+    const task = claimNewHead(store, merged)
+    const { failures, started, worker } = harness({ remote: repo.remote, root: repo.root, store, live: merged })
+
+    const result = await worker.run(task, new AbortController().signal)
+
+    expect(failures).toEqual([])
+    expect(started).toEqual([])
+    if (result._tag !== 'Ok')
+      throw new Error(result.error)
+    expect(result.value.resolution._tag).toBe('Reviewed')
+    const reviewRunId = result.value.evidence
+    // The reused row restates run-1, so the list counts the Agent turn once.
+    const runs = store.listReviewRuns(mapping.github, 24)
+    expect(runs.map(run => ({ id: run.id, headSha: run.headSha, outcome: run.outcome, findings: run.findings }))).toEqual([
+      { id: reviewRunId, headSha: repo.head2, outcome: { _tag: 'Ready', confidence: 91 }, findings: [] },
+    ])
+    expect(store.listWorkflowEvents({ stream: 'review_run' }).map(event => [event.event, event.from, event.to, event.reason]))
+      .toContainEqual(['Reused', repo.head1, repo.head2, expect.stringContaining(repo.head1.slice(0, 12))])
+
+    expect(store.completeReviewTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-09-01T02:01:40.000Z',
+      evidence: reviewRunId,
+      resolution: result.value.resolution,
+    })).toBe(true)
+    const command = store.claimNextTerminalReviewStatus('publisher-1', '2026-09-01T02:01:50.000Z', 60_000)
+    expect(command?.expectedHeadSha).toBe(repo.head2)
+    expect(command?.body).toContain(`<!-- reviewed-sha: ${repo.head2} -->`)
+    expect(command?.body).toContain('### 🤖 READY · 91/100')
+    expect(command?.body).toContain(`Reused the Review of \`${repo.head1.slice(0, 12)}\``)
+  })
+
+  it('starts a fresh Review when the diff changed', async () => {
+    const repo = repository()
+    const { mapping, store } = reviewedFirstHead(repo)
+    const changed = pullRequestItem({ baseSha: repo.base2, headSha: repo.head3, headRef: 'fix/review', mergeState: 'clean' })
+    const task = claimNewHead(store, changed)
+    const { started, worker } = harness({ remote: repo.remote, root: repo.root, store, live: changed })
+
+    const result = await worker.run(task, new AbortController().signal)
+
+    expect(result).toEqual(err('A fresh Review started.'))
+    expect(started).toEqual([repo.head3])
+    expect(store.listReviewRuns(mapping.github, 24).map(run => run.id)).toEqual(['run-1'])
+  })
+
+  it('starts a fresh Review when the manual Review label is on the new head', async () => {
+    const repo = repository()
+    const { store } = reviewedFirstHead(repo)
+    const labelled = pullRequestItem({ approvalLabels: ['review'], baseSha: repo.base2, headSha: repo.head2, headRef: 'fix/review', mergeState: 'clean' })
+    const task = claimNewHead(store, labelled)
+    const { started, worker } = harness({ remote: repo.remote, root: repo.root, store, live: labelled })
+
+    await worker.run(task, new AbortController().signal)
+
+    expect(started).toEqual([repo.head2])
+  })
+})
+
+describe('reviewReuseCandidate', () => {
+  const prior = {
+    reviewRunId: 'run-1',
+    revisionId: 'revision-1',
+    headSha: 'a'.repeat(40),
+    baseSha: 'b'.repeat(40),
+    baseRef: 'main',
+    gates: { merge: passed, review: passed, ci: passed },
+    findings: [],
+    confidence: 91,
+    completedAt: '2026-09-01T01:12:00.000Z',
+  }
+  const pullRequest = { approvalLabels: [], baseRef: 'main', headSha: 'c'.repeat(40) }
+
+  it.each([
+    ['a base branch change', { prior: { ...prior, baseRef: 'release' }, pullRequest }],
+    ['an open repairable finding', { prior: { ...prior, findings: [{ _tag: 'Open' as const, summary: 'Bug.', nextAction: 'Fix.', resolution: 'Repair' as const }] }, pullRequest }],
+    ['the same head', { prior, pullRequest: { ...pullRequest, headSha: prior.headSha } }],
+  ])('refuses %s', (_label, input) => {
+    expect(reviewReuseCandidate(input)._tag).toBe('Fresh')
+  })
+
+  it('accepts a dismissal verdict, which needs no Repair', () => {
+    const dismissal = { ...prior, findings: [{ _tag: 'Open' as const, summary: 'Wrong premise.', nextAction: 'Close.', resolution: 'Dismissal' as const }] }
+    expect(reviewReuseCandidate({ prior: dismissal, pullRequest })).toEqual({ _tag: 'Candidate', prior: dismissal })
+  })
+})

--- a/packages/harlan-github-agent/test/review-reuse.test.ts
+++ b/packages/harlan-github-agent/test/review-reuse.test.ts
@@ -103,7 +103,7 @@ function reviewedFirstHead(input: { checkout: string, base1: string, head1: stri
   const observed = store.recordObservation({ externalId: 'obs-1', observedAt: '2026-09-01T01:00:00.000Z', source: 'poll', subject: first })
   if (observed._tag !== 'Inserted')
     throw new Error('Expected a pull request.')
-  const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-09-01T01:01:00.000Z', 60_000)
+  const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-09-01T01:01:00.000Z', 30 * 60_000)
   if (task === null)
     throw new Error('Expected a Review Task.')
   const recorded = store.recordReviewRun({
@@ -132,7 +132,7 @@ function reviewedFirstHead(input: { checkout: string, base1: string, head1: stri
     at: '2026-09-01T01:12:30.000Z',
     result: { _tag: 'Published', githubCommentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' },
   })
-  store.completeReviewTask({
+  const completed = store.completeReviewTask({
     taskId: task.id,
     workerId: task.state.workerId,
     fence: task.state.fence,
@@ -140,6 +140,8 @@ function reviewedFirstHead(input: { checkout: string, base1: string, head1: stri
     evidence: 'run-1',
     resolution: { _tag: 'Reviewed', reviewRunId: 'run-1' },
   })
+  if (!completed)
+    throw new Error('Expected the first Review Task to complete.')
   return { mapping, store }
 }
 
@@ -238,6 +240,58 @@ describe('review reuse', () => {
     expect(result).toEqual(err('A fresh Review started.'))
     expect(started).toEqual([repo.head3])
     expect(store.listReviewRuns(mapping.github, 24).map(run => run.id)).toEqual(['run-1'])
+  })
+
+  it('starts a fresh Review when a rerun was requested on the reviewed head and the head then moved', async () => {
+    const repo = repository()
+    const { mapping, store } = reviewedFirstHead(repo)
+    const [first] = store.listReviewRuns(mapping.github, 24)
+    const rerun = store.requestReviewRerun({
+      repository: mapping.github,
+      pullRequestNumber: 24,
+      revisionId: first!.revisionId,
+      requestId: 'comment-7',
+      source: 'github_comment',
+      requestedBy: 'harlan-zw',
+      at: '2026-09-01T01:20:00.000Z',
+    })
+    expect(rerun._tag).toBe('Queued')
+    const merged = pullRequestItem({ baseSha: repo.base2, headSha: repo.head2, headRef: 'fix/review', mergeState: 'clean' })
+    const task = claimNewHead(store, merged)
+    const { failures, started, worker } = harness({ remote: repo.remote, root: repo.root, store, live: merged })
+
+    await worker.run(task, new AbortController().signal)
+
+    expect(failures).toEqual([])
+    expect(started).toEqual([repo.head2])
+    // The transaction refuses the same reuse on its own, whatever the caller read first.
+    expect(store.reuseReviewRun({
+      id: 'reused-anyway',
+      repository: mapping.github,
+      pullRequestNumber: 24,
+      revisionId: task.revisionId,
+      headSha: repo.head2,
+      reusesReviewRunId: 'run-1',
+      controllerGates: { merge: passed, ci: passed },
+      reason: 'test',
+      at: '2026-09-01T02:01:30.000Z',
+    })).toEqual({ _tag: 'Rejected', reason: { _tag: 'RerunRequested' } })
+  })
+
+  it('reports a failed diff read and starts a fresh Review', async () => {
+    const repo = repository()
+    const { store } = reviewedFirstHead(repo)
+    const merged = pullRequestItem({ baseSha: repo.base2, headSha: repo.head2, headRef: 'fix/review', mergeState: 'clean' })
+    const task = claimNewHead(store, merged)
+    const { failures, started, worker } = harness({ remote: repo.remote, root: repo.root, store, live: merged })
+    // The blob the prior head's diff needs is gone, so git diff fails mid read.
+    const blob = git(repo.checkout, 'rev-parse', `${repo.head1}:file.ts`)
+    rmSync(join(repo.checkout, '.git', 'objects', blob.slice(0, 2), blob.slice(2)))
+
+    await worker.run(task, new AbortController().signal)
+
+    expect(failures).toEqual([expect.stringContaining('Could not read the diff identity')])
+    expect(started).toEqual([repo.head2])
   })
 
   it('starts a fresh Review when the manual Review label is on the new head', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Related to the 2026-09-03 agent retro, adversarial review §2 and §4 item 1.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

A merge of the base branch into a pull request head moves the head commit and leaves `git diff base...head` unchanged. Each such push started a fresh 11 to 18 minute Review of a diff the agent had already read. The Review worker now reads `git patch-id --stable` for the prior head and the new head in the repository checkout, read only. When they match, the store records a Review run for the new head that supersedes the prior one with the same findings, gates, and confidence, the ordinary terminal status publishes it, and the canonical comment names the reused head. Reuse never crosses a base branch change, an open repairable finding, a rerun request, or the manual Review label. No schema migration.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz