### PR TITLE
chore(agent): seed unlighthouse.dev environment into agent worktrees

### DIFF
--- a/scripts/repository-env-files
+++ b/scripts/repository-env-files
@@ -8,3 +8,4 @@ skilld-dev/skilld.dev sites/skilld.dev/.env
 skilld-dev/skilld.dev sites/skilld.dev/.dev.vars
 harlan-zw/scripts.nuxt.com sites/scripts.nuxt.com/.env
 harlan-zw/gscdump.com sites/gscdump.com/.env
+harlan-zw/unlighthouse.dev sites/unlighthouse.dev/.env


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

unlighthouse.dev now has a `.env` carrying the Cloudflare read token its daily check-in needs, so it joins the repository environment manifest and gets seeded into Hogwild worktrees like the other sites.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ