### PR TITLE
chore(skills): remove dated prompting patterns found by prompt-audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ pnpm release patch|minor|major  # Bump version, tag, push (syncs plugin.json, ma
 
 **Hook lifecycle** (`harlan-agent-kit/hooks/`, wired in `.claude-plugin/plugin.json`):
 - `SessionStart`: detect project type (Nuxt module/app, UnJS, Vue, Node), show git info, warn if not pnpm
-- `PreToolUse` (Bash): block npm/yarn/npx (`pnpm-only.sh`); block raw `git worktree` mutation and `.claude/worktrees` paths (`wt-only.sh`); on commit/push/PR run `check` and block on failure (`pre-commit-push.sh`)
+- `PreToolUse` (Bash): block npm/yarn/npx (`pnpm-only.sh`); block raw `git worktree` mutation and `.claude/worktrees` paths (`wt-only.sh`); on `git commit` inject the commit-format rule (`pre-commit-push.sh`)
 - `PostToolUse` (Write|Edit): eslint autofix on the edited file
 
 **Disable hooks per-project**: `.claude/hooks.json` with `{"disabled": ["eslint", "pre-commit-push"]}`

--- a/agent-context/context.md
+++ b/agent-context/context.md
@@ -6,8 +6,8 @@ Dyslexia + ADHD. Answer first, short lines, plain words, bullets. Need-to-knows 
 
 ## Replies
 
-- Extremely concise; sacrifice grammar. Under 6 lines.
-- Work done: state outcome, stop. No recap, tables, or rationale.
+- Extremely concise; sacrifice grammar. A few short lines, never a wall.
+- Work done: state the outcome, stop. Rationale only when the outcome is surprising.
 - End a work task with confidence /100 that it works end to end. Score what you verified, not how code reads. Below 90, name the untested path in one line.
 - 5+ tool calls: print `▓▓▓░░ 57% next-step` at real progress. Orchestrating: relay `(docs: 80%, cache: done)`.
 
@@ -39,12 +39,12 @@ Never publish under my name without approval. Draft it, show the exact text, wai
 
 - Never introduce a synonym for a term it defines. Never use a banned term.
 - Unnamed concept: propose the term, say which synonyms it displaces, confirm.
-- Bootstrap, audit, drift: read `skills/glossary/SKILL.md` (see Reference material).
+- Bootstrap, audit, drift: read the `glossary` skill.
 
 ## Tools
 
 - Find and search files: ripgrep (`rg`).
-- Rename, move, or import update spanning 2+ files: `npx -y @ripast/cli`. AST-aware across TS/JS/Vue SFCs; dry-run by default, `--apply` to write.
+- Rename, move, or import update spanning 2+ files: `pnpm dlx @ripast/cli`. AST-aware across TS/JS/Vue SFCs; dry-run by default, `--apply` to write.
 - Browser testing and automation: `dev-browser` (`--help`).
 - Give each task its own `dev-browser` name. Close every named page when browser work ends. Never run `dev-browser stop`; it stops shared browsers.
 
@@ -68,7 +68,7 @@ Never publish under my name without approval. Draft it, show the exact text, wai
 
 ### Design patterns (Effect-inspired, no Effect dependency)
 
-Canonical copy + review rubric: `skills/ts-design-patterns/SKILL.md`.
+Canonical copy + review rubric: the `ts-design-patterns` skill.
 
 - **Make illegal states unrepresentable.** `_tag` discriminated unions, not optional-field + boolean soup.
 - **Errors as values.** Tagged `Ok | Err` for expected domain failures, so signatures show them. Unexpected and infra errors propagate; prefer `.catch()` over try/catch when handling is needed.
@@ -88,7 +88,7 @@ Latest APIs (reactive prop destructure, array event defines). Prefer vueuse over
 - Bug fixes and validation logic: failing test first.
 - Unit tests exercise exported APIs: build an input, call the export, assert the return, throw, or boundary side effect. Never assert on file contents, module shape, key counts, or that a symbol exists.
 - Tests are scratchpad. Delete freely. Behaviour changed on purpose: delete the test, write the new one.
-- Full rubric: read `skills/unit-tests/SKILL.md`.
+- Full rubric: read the `unit-tests` skill.
 
 ## Agents
 
@@ -111,10 +111,10 @@ Unsure means no label. Rules: `harlan-agent-kit/references/auto-merge.md`.
 ## Workflow
 
 - Ship the smallest thing that solves it. Add structure when it fails.
-- A pull request that crosses three or more modules, a boundary, or a sequence carries a PR Lens diagram in its description. Smaller ones do not. Read `skills/pr-lens/SKILL.md`.
+- A pull request that crosses three or more modules, a boundary, or a sequence carries a PR Lens diagram in its description. Smaller ones do not. Read the `pr-lens` skill.
 - Production error: fix the category, not the instance.
 - Refactors and architecture audits: finish the whole change before stopping (imports updated, old code removed, tests pass).
 
 ## Reference material
 
-Rubrics and procedures live under `~/pkg/harlan-agent-kit/harlan-agent-kit/skills/*/SKILL.md`. Claude auto-loads them; you must read the file yourself. At the start of a coding task, list that directory and read any `SKILL.md` matching the work. Trust the listing, not memory.
+Rubrics and procedures live in `~/pkg/harlan-agent-kit/harlan-agent-kit/skills/*/SKILL.md`. The plugin lists them. Read the SKILL.md that matches the work before starting it. Trust the file, not memory.

--- a/harlan-agent-kit/hooks/pre-commit-push.sh
+++ b/harlan-agent-kit/hooks/pre-commit-push.sh
@@ -10,7 +10,7 @@ deny() {
 # Inject commit guidelines for git commit (additionalContext doesn't block)
 if [[ "$command" =~ ^git[[:space:]]+commit ]]; then
   cat <<EOF
-{"additionalContext": "Commit format: type(scope): description. Types: feat/fix/docs/refactor/test/chore. Scope: monorepo folder or treeshakable export name, omit if neither applies. Subject <72 chars."}
+{"additionalContext": "Commit format: type(scope): description. Types: feat/fix/docs/refactor/test/chore. Scope: monorepo folder or treeshakable export name, omit if neither applies. Subject under 70 chars."}
 EOF
 fi
 

--- a/harlan-agent-kit/skills/agent-retro/references/analyst-prompt.md
+++ b/harlan-agent-kit/skills/agent-retro/references/analyst-prompt.md
@@ -14,7 +14,7 @@ Context to read first (read-only, do not edit anything):
 - {controller file that builds the prompt for this role}
 - You may query the journal on Hogwild read-only: ssh hogwild 'sqlite3 ~/.local/share/harlan-github-agent/state.sqlite "..."'. Never write to it.
 
-Read every transcript in full. Then write a report to `REPORT.md` in that same directory and also return it. Structure, hard cap ~700 words, plain words, short sentences:
+Read every transcript in full. Then write a report to `REPORT.md` in that same directory and also return it. Structure, one page, plain words, short sentences:
 
 1. **Sessions**: one line each: id, subject, duration, tokens in/out, outcome, one-phrase description of what it spent its time on.
 2. **Redundant work within the group**: work repeated across sessions or within a session that the controller or prompt could supply once. Cite session id + timestamp for each claim.

--- a/harlan-agent-kit/skills/email-triage/SKILL.md
+++ b/harlan-agent-kit/skills/email-triage/SKILL.md
@@ -102,7 +102,7 @@ For any email classified as urgency 4-5 or `suggestedAction: reply`, read the fu
 himalaya message read <id> -f <folder> --no-headers
 ```
 
-Limit to 5 full reads per triage to keep things fast. Spawn these reads in parallel.
+Read only the bodies you need to decide the action. Spawn the reads in parallel.
 
 ### Step 4: Present triage table
 

--- a/harlan-agent-kit/skills/glossary/SKILL.md
+++ b/harlan-agent-kit/skills/glossary/SKILL.md
@@ -159,9 +159,9 @@ Rules for the map:
 - Keep node text to the term plus its table and owner. Definitions live in `## Terms`, not in the box.
 - Follow the diagram with a plain-text `Collisions` list. Mermaid does not render everywhere, and the collisions are the part that must survive a plain-text read.
 - Redraw whenever a term is added or a collision is resolved.
-- **`## Map` holds three things and nothing else**: the table, an optional diagram, and the `Collisions` list. No narrative, no rationale, no per-term commentary. Reasoning about a term belongs in `## Terms`; reasoning about an unresolved choice belongs in `## Open questions`. A real run let the Map section grow to 223 lines around a 63-line diagram, which buried the one artefact a reviewer opens the file for. The budget is on **prose, which should be zero**, not on the artefacts: a table needs one row per term and a diagram costs what it costs, so never drop a term or a required diagram to hit a line count.
+- **`## Map` holds three things and nothing else**: the table, an optional diagram, and the `Collisions` list. No narrative, no rationale, no per-term commentary. Reasoning about a term belongs in `## Terms`; reasoning about an unresolved choice belongs in `## Open questions`. The budget is on **prose, which should be zero**, not on the artefacts: a table needs one row per term and a diagram costs what it costs, so never drop a term or a required diagram to hit a line count.
 
-The worked examples in this skill use a Sprint/Finding/Ticket domain. They are illustrative only. Do not grep the target repo for the example's words; on a real run that produced a wasted sweep returning one hit.
+The worked examples in this skill use a Sprint/Finding/Ticket domain. They are illustrative only. Do not grep the target repo for the example's words.
 
 ### `## Open questions` format
 
@@ -227,10 +227,10 @@ Do not invent the vocabulary. Recover the one already in use, then pick winners.
 
 **Harvest three surfaces separately, and do the customer one first.** A schema is engineering vocabulary. It is evidence of what the team calls things, not of what the product calls them, and it may have drifted from the business names years ago. Starting from tables produces a tidy glossary that quietly contradicts the UI.
 
-0. **Find the glossary that already exists.** Before harvesting anything, grep the repo for an informal one: a Vocabulary, Terminology, Naming, Say/Don't say, or Copy section in `COPY.md`, `CONTEXT.md`, `STYLE.md`, `CONTRIBUTING.md`, `README.md`, or the docs tree. Projects that care about wording usually wrote one down without calling it `GLOSSARY.md`. Missing this ships a third competing list and is the worst outcome this skill can produce. One real repo had two, in `COPY.md` and `CONTEXT.md`, holding a ratified Say/Not table and 20 protocol terms. Never silently override a wording decision someone already made, and never write a second list beside an existing one without saying which wins.
+0. **Find the glossary that already exists.** Before harvesting anything, grep the repo for an informal one: a Vocabulary, Terminology, Naming, Say/Don't say, or Copy section in `COPY.md`, `CONTEXT.md`, `STYLE.md`, `CONTRIBUTING.md`, `README.md`, or the docs tree. Projects that care about wording usually wrote one down without calling it `GLOSSARY.md`. Missing this ships a third competing list and is the worst outcome this skill can produce. Never silently override a wording decision someone already made, and never write a second list beside an existing one without saying which wins.
 
    **0.5. Decide how you relate to what you found, and record the decision.** Three outcomes, and the skill will not choose for you:
-   - **Point to it** — the existing list is complete and better established than anything you would write. Cite it as authoritative, cover only what it omits, and say so in the intro. One real run found a 145-line vocabulary with 25 terms, per-term avoid lines, and dated ambiguity flags; writing a competing list would have been pure harm.
+   - **Point to it** — the existing list is complete and better established than anything you would write. Cite it as authoritative, cover only what it omits, and say so in the intro.
    - **Fold it in** — the existing list is partial or scattered. Move it in verbatim, credit where it came from, and leave a pointer behind in the old file so the two cannot drift.
    - **Supersede it** — the existing list is stale or contradicted by shipped surfaces. Say which entries you are overriding and why, one line each.
 
@@ -239,7 +239,7 @@ Do not invent the vocabulary. Recover the one already in use, then pick winners.
 2. **Internal surface**: table names, stored enum values, protocol contracts, layer and module directory names, unexported helpers. **Exported types are not internal** in a published package; file them under the customer surface, since an importer feels a rename exactly like a customer feels a changed route.
 3. **Decision surface**: `docs/adr/`, `docs/decisions/`, RFCs, whatever the project's decision log is called. Grep it for every candidate term. Skipping this step is how an agent proposes to "fix" a collapse the team ratified on purpose, which is worse than leaving the drift alone.
 4. Cluster synonyms within each surface, then across them. Look for the same concept appearing under 2 or more words, the exact drift being fixed.
-5. **Weight by surface, not by frequency.** Note where each variant appears and rank by switching cost: live URL, published protocol or MCP tool name, stored enum value, then UI string, then internal identifier, then prose. Do not spend effort counting occurrences; on a real run the counts decided nothing and location decided everything.
+5. **Weight by surface, not by frequency.** Note where each variant appears and rank by switching cost: live URL, published protocol or MCP tool name, stored enum value, then UI string, then internal identifier, then prose. Do not spend effort counting occurrences; location decides, counts do not.
 6. **Diff the surfaces and lead with the mismatch.** Where they disagree, that table is the most valuable output of `init`, more than the term list. Expect the internal surface to draw distinctions the UI collapses: three tables surfacing under one customer word is the common shape, and one of those words is usually already in a route. Then check the decision log: a ratified umbrella is recorded, never reopened.
 7. Present each cluster with a recommended canonical term and the evidence. **Ask before writing.** Naming is the user's call, not the agent's, and a surface mismatch is a product decision, not a refactor.
 

--- a/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/SKILL.md
@@ -3,7 +3,6 @@ name: nuxt-frontend-design
 description: "Build or polish Nuxt UI v4+ pages and design systems. Use for landing pages, dashboards, tokens, motion, or generic-looking UX."
 user_invocable: true
 argument-hint: "[component/page/area]"
-model: opus
 effort: max
 ---
 
@@ -66,7 +65,7 @@ IS_NUXT=false: this skill needs a Nuxt project (`nuxt.config.ts`). Say so and st
 
 Phase 2 depends on a complete design system. If any of the three indicators is missing, run Phase 1 first and tell the user you're doing so.
 
-Phase 1 consumes a lot of context. When Phase 1 completes in the current conversation, prefer emitting the handoff and telling the user: "Design system ready. Start a new conversation and run `/nuxt-frontend-design {page}` to build with fresh context." Continue in the same conversation only if the remaining build is small and context is still clean.
+After Phase 1, emit the handoff and continue into Phase 2 when pages were asked for. Offer a fresh conversation with `/nuxt-frontend-design {page}` only after repair passes or for multi-page builds.
 
 ## Content & Asset Rules
 

--- a/harlan-agent-kit/skills/nuxt-frontend-design/references/design-system.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/references/design-system.md
@@ -280,9 +280,6 @@ nuxt.config.ts             # Modules, fonts, colorMode
 
 ---
 
-## MCP Available
+## Component docs
 
-Use `nuxt-ui-remote` MCP for component docs:
-- `mcp__nuxt-ui-remote__get-component` — full docs for any component
-- `mcp__nuxt-ui-remote__get-component-metadata` — props/slots/events
-- `mcp__nuxt-ui-remote__list-components` — all available components
+If a Nuxt UI docs MCP server is connected, use it for props, slots, and emits instead of guessing.

--- a/harlan-agent-kit/skills/nuxt-frontend-design/references/workflow.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-design/references/workflow.md
@@ -89,7 +89,7 @@ For builds spanning multiple pages or phases:
 2. **Route smoke test**: curl the affected route on `$DEV_PORT`, then run the error-scan grep. On failure, read `$DEV_LOG` and fix. Full browser verification belongs to review.
 3. **Intermediate review**: after page 1 of a multi-page build, suggest running `/nuxt-frontend-review {JOB_ID}` before page 2. Systemic issues (wrong tokens, broken shared components) are cheaper to catch before they propagate.
 4. **Cross-page consistency**: before page N+1, re-read page N's files. Same number of states handled, same interaction detail, same token use? Page N+1 scope feeling smaller than page N is context degradation. Stop and emit the handoff.
-5. **Scope gate**: `PAGES_BUILT` is the source of truth. At ≥2 pages with a complex next page (forms, tables, multi-step flows), or ≥3 pages regardless, emit the handoff and tell the user: "Start a new conversation and run `/nuxt-frontend-design {next page}` to continue." Continuing past this point produces visibly thinner pages.
+5. **Scope gate**: if the cross-page consistency check shows page N+1 thinner than page N, emit the handoff and tell the user: "Start a new conversation and run `/nuxt-frontend-design {next page}` to continue."
 6. **No silent scope reduction**: contract criteria you cannot confirm get flagged explicitly in `build-progress.md` and the handoff.
 
 ## Handoff

--- a/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-review/SKILL.md
@@ -3,7 +3,6 @@ name: nuxt-frontend-review
 description: "Adversarially review a Nuxt frontend. Run it and verify its contract, UX, and visual behavior. Use for frontend review or testing."
 user_invocable: true
 argument-hint: "[job-id] [inline]"
-model: opus
 effort: high
 allowed-tools: Read, Bash, Glob, Grep
 ---
@@ -125,7 +124,7 @@ Only when the diff touches charts, dashboards, sparklines, stat cards, or quanti
 
 ### Suspicion check
 
-Zero issues found means re-examine the three highest-complexity components with fresh skepticism; a clean review on a non-trivial build is statistically unlikely. Look for subtle state gaps, missing form edge cases, interactions that appear to work but give no feedback. Still clean afterward, PASS is legitimate.
+A clean result on a non-trivial build is a legitimate PASS. Name the high-complexity components you exercised and the evidence that cleared them: state gaps, form edge cases, interactions that give no feedback.
 
 ## Step 4: Visual Verification
 

--- a/harlan-agent-kit/skills/nuxt-frontend-review/references/report-format.md
+++ b/harlan-agent-kit/skills/nuxt-frontend-review/references/report-format.md
@@ -100,5 +100,5 @@ Design-system-level issues get called out separately: "The contrast issues are d
 - Every item states the expected result.
 - Happy path first, then edge cases.
 - Include dark mode if anything visual changed, mobile if layout was touched.
-- 5-10 items.
+- One item per contract criterion plus the risky edge cases.
 - List each affected route URL.

--- a/harlan-agent-kit/skills/pkg-conform/SKILL.md
+++ b/harlan-agent-kit/skills/pkg-conform/SKILL.md
@@ -47,7 +47,7 @@ Determine project type from the **absolute path** of the working directory:
 
 If path doesn't match either pattern, fall back to heuristics: `private: true` + `nuxt` in deps -> Site, otherwise Package.
 
-**IMPORTANT:** The project type determines which rules apply. Do NOT apply Package-only rules (exports, obuild, test:attw, prepack, release) to Sites, and do NOT apply Site-only rules (nuxi scripts, generate, preview) to Packages.
+The project type selects the rule set. Package-only rules (exports, obuild, test:attw, prepack, release) never apply to Sites. Site-only rules (nuxi scripts, generate, preview) never apply to Packages.
 
 ---
 

--- a/harlan-agent-kit/skills/plan-ceo/SKILL.md
+++ b/harlan-agent-kit/skills/plan-ceo/SKILL.md
@@ -10,7 +10,7 @@ argument-hint: "[feature-name]"
 
 # /plan-ceo -- Strategic Product & Scope Review
 
-You are acting as a **Strategic Tech Lead / Founder**. Your goal is to ensure every plan is extraordinary, avoids rebuilds, and handles failure with absolute clarity.
+You are acting as a **Strategic Tech Lead / Founder**. Challenge scope, reuse existing code, and name every failure path before implementation starts.
 
 ## Step 1: Nuclear Scope Challenge
 Challenge the premise of the plan before looking at code.

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -153,7 +153,7 @@ These exist because the generated bodies drift the same way every time.
 - **Benchmarks when they are relevant and measured.** A performance or caching change earns a real before and after. Never invent, estimate, or infer a figure. If you did not measure it, say nothing, or offer to run it.
 - **No self-ticked checkboxes** beyond the ones the repo's own template asks for. A list of `- [x]` items you wrote and ticked yourself is not evidence, it reads as homework.
 - **Delete empty sections.** Never write "None.", "No linked issue.", or "N/A" under a heading. No linked issue means no Linked issue section.
-- **Length follows risk.** A fix gets 1 to 3 sentences. Spend more only where a reviewer must understand a behaviour change, a data migration, or a non-obvious tradeoff. Never narrate the diff; the diff is right there.
+- **Length follows risk.** A fix gets 1 to 3 sentences. Spend more only where a reviewer must understand a behaviour change, a data migration, or a non-obvious tradeoff.
 - **Earn every number.** Include a figure only if a reviewer would act differently for knowing it. `7,438 rows backfilled` earns its place in a migration note. `533 tests passed, 2 skipped` does not.
 - **Vary the shape.** Do not open every paragraph with `This `. Do not follow a past-tense problem sentence with a present-tense `This adds…` in every PR. For a small fix, one sentence is the whole description.
 - **Disclose AI writing visibly.** If Harlan Agent Kit drafts or edits the description, append the exact AI disclosure after the description. Never hide it in an HTML comment or template metadata.
@@ -200,13 +200,7 @@ changed. They are notifications now, so a dead client costs nothing.
 
 ## Step 4: Verify
 
-Run all checks before pushing:
-
-```bash
-pnpm lint && pnpm typecheck && pnpm build
-```
-
-Fix any failures before proceeding.
+Run `check` before pushing (lint, typecheck, tests). Add `pnpm build` when the package publishes a build. Fix any failures before proceeding.
 
 ## Step 5: Push & Create or Update
 

--- a/harlan-agent-kit/skills/ripast/SKILL.md
+++ b/harlan-agent-kit/skills/ripast/SKILL.md
@@ -19,13 +19,13 @@ Keep the primary checkout read only. Before a mutating `--apply`, run `wt list -
 ## Invocation
 
 ```bash
-npx -y @ripast/cli <command> ...
+pnpm dlx @ripast/cli <command> ...
 ```
 
 Or install once:
 
 ```bash
-npm i -g @ripast/cli
+pnpm add -g @ripast/cli
 ripast <command> ...
 ```
 
@@ -62,4 +62,4 @@ Mutating commands default to **dry-run** (unified diff). Pass `--apply` to write
 
 When in doubt, start with `scan` — its output tells you which of rename/move/Edit fits.
 
-Run `npx -y @ripast/cli <cmd> --help` for full flags.
+Run `pnpm dlx @ripast/cli <cmd> --help` for full flags.

--- a/harlan-agent-kit/skills/social-presence/SKILL.md
+++ b/harlan-agent-kit/skills/social-presence/SKILL.md
@@ -16,7 +16,7 @@ Research what works, find content opportunities from your recent work, and craft
 - **Visual-first platform** -- every tweet recommendation must include a visual suggestion. Text-only tweets from dev accounts get buried.
 - **Don't over-thread** -- single tweets outperform threads for most content. Only suggest threads for major launches with multiple features.
 - **Release notes are not tweets** -- never dump a changelog into a tweet. Extract the one thing a reader cares about and lead with that.
-- **Ecosystem tagging** -- always suggest relevant accounts to tag (@nuaboratory, @vuejs, @unaboratory, @anthropaboratorics, etc.) but max 2 per tweet. More looks desperate.
+- **Ecosystem tagging** -- always suggest relevant accounts to tag (@nuxt_js, @vuejs, @unjsio, @AnthropicAI, etc.) but max 2 per tweet. More looks desperate.
 - **Time zones** -- user is in Australia. Best posting times for global dev audience: 8-10am US Eastern = 11pm-1am AEST. Suggest scheduling if timing matters.
 
 ## Data Storage
@@ -110,11 +110,11 @@ Use WebSearch to find 2-3 recent successful launch tweets from accounts in the s
 - What engagement did they get?
 
 Check these accounts for recent launch patterns:
-- @antaboread (Anthony Fu, Vitest/UnoCSS/Slidev)
+- @antfu7 (Anthony Fu, Vitest/UnoCSS/Slidev)
 - @danielroe (Daniel Roe, Nuxt)
 - @haydenbleasel (Hayden Bleasel, next-forge)
 - @shadcn (shadcn/ui)
-- @saborail (Tailwind CSS)
+- @tailwindcss (Tailwind CSS)
 
 ### 2c. Generate Launch Strategy
 
@@ -159,7 +159,6 @@ Quickly check:
 
 Reference `references/playbook.md` for content rules. Key principles:
 - Lead with value to the reader, not what you did
-- Every tweet needs a visual suggestion
 - Frame around the reader's problem
 - Tag ecosystem accounts for amplification
 
@@ -208,13 +207,4 @@ Over any 2-week period, aim for this mix:
 
 A mediocre tweet posted is better than a perfect tweet drafted. The goal is 4+ posts per week. Suggest the user batch-create content on weekends for the coming week.
 
-### Visual Checklist
-
-Before finalizing any tweet, verify a visual is planned:
-- [ ] Screenshot of the feature/tool in action
-- [ ] Code snippet (use `/tweet` wrapper for polish)
-- [ ] Before/after comparison
-- [ ] Terminal output showing results
-- [ ] Stats/metrics image
-
-If no visual is obvious, suggest a code snippet screenshot as the default.
+If no visual is obvious, default to a code snippet screenshot.

--- a/harlan-agent-kit/skills/social-presence/references/playbook.md
+++ b/harlan-agent-kit/skills/social-presence/references/playbook.md
@@ -6,7 +6,7 @@ Research-backed content strategy for growing a developer Twitter presence, based
 
 | Account | Followers | Key Strategy |
 |---------|-----------|-------------|
-| Anthony Fu (@antaboread) | ~50k | Daily posts, visual demos, cross-project pollination, livestreams |
+| Anthony Fu (@antfu7) | ~50k | Daily posts, visual demos, cross-project pollination, livestreams |
 | Daniel Roe (@danielroe) | ~15k | Regular Nuxt updates, community engagement, conference presence |
 | Hayden Bleasel (@haydenbleasel) | ~10k | Build in public, polished visuals, ecosystem tagging, consistent cadence |
 | Sebastien Chopin (@Atinux) | ~20k | Creator authority, product launches, NuxtLabs updates |
@@ -90,13 +90,13 @@ Tag strategically (max 2 per tweet):
 
 | Topic | Tag |
 |-------|-----|
-| Nuxt | @nuaboratory |
+| Nuxt | @nuxt_js |
 | Vue | @vuejs |
-| UnJS | @unaboratory |
-| Vite | @vaboratoryite_js |
+| UnJS | @unjsio |
+| Vite | @vite_js |
 | TypeScript | @typescript |
 | Open source milestones | @github |
-| SEO specific | @anthropaboratorics (if AI/Claude related) |
+| SEO specific | @AnthropicAI (if AI/Claude related) |
 
 ## Posting Cadence
 
@@ -121,7 +121,7 @@ Tag strategically (max 2 per tweet):
 1. **Open source is distribution**: every GitHub star is a potential follower. Make repos discoverable (good README, demo screenshots).
 2. **Cross-platform**: same content on Threads and LinkedIn reaches different audiences.
 3. **Newsletter as hedge**: email subscribers can't be taken by algorithm changes.
-4. **Reply to bigger accounts**: thoughtful replies to @antaboread, @danielroe, @Atinux get seen by their audiences.
+4. **Reply to bigger accounts**: thoughtful replies to @antfu7, @danielroe, @Atinux get seen by their audiences.
 5. **Conference talks generate follow surges**: always tweet your slides/recording.
 
 ## Anti-Patterns

--- a/harlan-agent-kit/skills/tweet/SKILL.md
+++ b/harlan-agent-kit/skills/tweet/SKILL.md
@@ -106,11 +106,8 @@ For each variation show:
 
 - No hashtags unless the user explicitly includes them
 - No emojis unless the user's draft already uses them
-- Don't start with "I"
-- Avoid corporate/marketing speak
 - Match the user's voice
 - If referencing code/tech, be specific not vague
-- Thread-style (1/n) only if user asks for it
 - Front-load the hook in the first line
 
 ### Iterate
@@ -172,7 +169,7 @@ node /path/to/scratchpad/template.mjs
 Dependencies (`sharp`, `@resvg/resvg-js`) should be available globally or in the project. If not, install to scratchpad:
 
 ```bash
-cd /path/to/scratchpad && npm init -y && npm install sharp @resvg/resvg-js
+cd /path/to/scratchpad && pnpm init && pnpm add sharp @resvg/resvg-js
 ```
 
 ### 3e. Verify Output


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Ran `/claude-api prompt-audit` over the skills, the tracked Agent instructions, and the hook reason strings with Fable 5.1 as the target. Most of the surface was clean: no verification rituals, thoroughness boosters, or scratchpad scaffolds. What it did find was a `model: opus` pin on both nuxt-frontend skills that downgrades a Fable session on invoke, "start a new conversation" stops in the design workflow written for 200K context, a few numeric output caps, some run-history anecdotes in the glossary skill, duplicated rules, and `npx` commands that the pnpm hook rewrites on every run.

Two things a reviewer should check:

- The social-presence handles were corrupted (`@nuaboratory`, `@antaboread`, `@saborail`). I restored them to `@nuxt_js`, `@unjsio`, `@vite_js`, `@antfu7`, `@tailwindcss`, `@AnthropicAI` from memory, not from a lookup.
- Project CLAUDE.md said `pre-commit-push.sh` runs `check` and blocks; the hook only injects the commit-format rule. I made the doc match the hook. If the hook was meant to gate, that is a separate change.

Full report with every finding and the ones left as flags: `~/scratch/notes/prompt-audit-2026-09-03.md`.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01A9hYoWgJ1xEyuLjso96Q2U