### PR TITLE
fix(agent): say why the GLM Coding Plan quota read failed

### DIFF
--- a/packages/harlan-github-agent/src/provider-capacity.ts
+++ b/packages/harlan-github-agent/src/provider-capacity.ts
@@ -222,6 +222,20 @@ export interface ZaiCapacityOptions {
   timeoutMilliseconds?: number
 }
 
+function zaiFailureReason(error: unknown): string {
+  if (!(error instanceof Error))
+    return 'The GLM Coding Plan quota could not be read.'
+  if (error.name === 'AbortError')
+    return 'The GLM Coding Plan quota request timed out.'
+  if (error.message.startsWith('The GLM Coding Plan answered '))
+    return error.message
+  const cause = error.cause
+  const code = typeof cause === 'object' && cause !== null && 'code' in cause && typeof cause.code === 'string' ? cause.code : null
+  return code === null
+    ? `The GLM Coding Plan quota could not be read: ${error.message}`
+    : `The GLM Coding Plan quota could not be read: ${code}.`
+}
+
 /** Asks the GLM Coding Plan what its windows have left. */
 export async function readZaiCapacity(options: ZaiCapacityOptions = {}): Promise<ProviderCapacity> {
   const apiKey = options.apiKey === undefined ? readZaiApiKey() : options.apiKey
@@ -245,13 +259,10 @@ export async function readZaiCapacity(options: ZaiCapacityOptions = {}): Promise
     return zaiPlanCapacity(body)
   }
   catch (error) {
-    // Never let the key reach a log. Only the shape of the failure is reported.
-    return {
-      _tag: 'Unavailable',
-      reason: error instanceof Error && error.name === 'AbortError'
-        ? 'The GLM Coding Plan quota request timed out.'
-        : 'The GLM Coding Plan quota could not be read.',
-    }
+    // Never let the key reach a log. The status or the socket error code is
+    // enough to tell a rate limit from a DNS failure, which one bare "could
+    // not be read" hid for a whole afternoon of stalled Tasks.
+    return { _tag: 'Unavailable', reason: zaiFailureReason(error) }
   }
   finally {
     clearTimeout(timeout)

--- a/packages/harlan-github-agent/test/provider-capacity.test.ts
+++ b/packages/harlan-github-agent/test/provider-capacity.test.ts
@@ -8,6 +8,7 @@ import {
   createProviderCapacitySource,
   hasSpendableCapacity,
   readZaiApiKey,
+  readZaiCapacity,
   WEEKLY_WINDOW_MINUTES,
   weeklyCodexCapacity,
   zaiPlanCapacity,
@@ -458,6 +459,24 @@ describe('reading the GLM Coding Plan quota', () => {
 
   it('ignores a window whose allowance is zero, so it never divides by it', () => {
     expect(zaiPlanCapacity({ data: { limits: [{ usage: 0, currentValue: 0 }] } })).toMatchObject({ _tag: 'Unavailable' })
+  })
+
+  it('names the HTTP status when the plan refuses the quota read', async () => {
+    const capacity = await readZaiCapacity({
+      apiKey: 'key',
+      fetchQuota: async () => { throw new Error('The GLM Coding Plan answered 429.') },
+    })
+
+    expect(capacity).toEqual({ _tag: 'Unavailable', reason: 'The GLM Coding Plan answered 429.' })
+  })
+
+  it('names the socket error when the quota request never connects', async () => {
+    const capacity = await readZaiCapacity({
+      apiKey: 'key',
+      fetchQuota: async () => { throw new TypeError('fetch failed', { cause: { code: 'ENETUNREACH' } }) },
+    })
+
+    expect(capacity).toEqual({ _tag: 'Unavailable', reason: 'The GLM Coding Plan quota could not be read: ENETUNREACH.' })
   })
 
   it('answers no key when opencode declares no plan, which is not a fault', () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

This afternoon the fleet sat with 47 queued Tasks behind "The GLM Coding Plan quota could not be read", while the same reader run by hand on Hogwild answered fine every time. The reason string gave nothing to go on. It now carries the HTTP status the plan answered, or the socket error code from the failed fetch, and never the key.

What I suspect, and could not prove without this: `api.z.ai` resolves to an IPv6 address first and Hogwild has no IPv6 route. A hand run of node falls back to IPv4; the long-lived service process may not.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_014tmLtbNAPpmyMomBQrxyHQ