### PR TITLE
feat(agent): per-role Reasoning effort override in configuration

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -100,7 +100,7 @@ Automatic selection picks the Agent provider by remaining capacity. It walks `or
 
 For `codex`, use `gpt-5.6-luna` with low reasoning for Pull request triage. Use `gpt-5.6-sol` with high reasoning for adversarial review. Use `gpt-5.6-terra` with medium reasoning for Repair, conflict resolution, issue triage, issue work, and Baseline repair.
 
-For `opencode`, use `zai-coding-plan/glm-5.3-flash` at the `high` Reasoning effort for every role.
+For `opencode`, use `zai-coding-plan/glm-5.3-flash` at the `high` Reasoning effort for every role. `agent.reasoning_effort.<provider>.<role>` in the configuration replaces one role's default, for example `agent.reasoning_effort.opencode.review_fix: medium`. A pinned Agent selection with an explicit Reasoning effort still wins over the file.
 
 A saved session belongs to the Agent provider that created it. Switching providers starts new sessions.
 

--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -14,6 +14,16 @@ agent:
   reserve_percent:
     codex: 20
     opencode: 50
+  # Reasoning effort per Agent provider and role. A listed role replaces that
+  # provider's own default. A pinned Agent selection with an explicit
+  # Reasoning effort still wins. Values: none, low, medium, high, xhigh, max.
+  # Roles: adversarial_review, baseline_repair, conflict_resolution,
+  # pull_request_triage, issue_triage, issue_work, review_fix, routine_scan,
+  # routine_fix.
+  # reasoning_effort:
+  #   opencode:
+  #     review_fix: medium
+  #     pull_request_triage: low
 github:
   app_id: 12345
   private_key_path: /home/harlan/.config/harlan-github-agent/app.pem

--- a/packages/harlan-github-agent/src/agent-profile.ts
+++ b/packages/harlan-github-agent/src/agent-profile.ts
@@ -1,6 +1,6 @@
 import type { AgentProvider, AgentProviderName } from './agent-provider.ts'
 import type { Result } from './result.ts'
-import type { AgentModel, AgentProfile, AgentRole, AgentSelection, CodexReasoningEffort, PinnedAgentSelection, RoleProfile } from './types.ts'
+import type { AgentModel, AgentProfile, AgentRole, AgentSelection, CodexReasoningEffort, PinnedAgentSelection, RoleProfile, RoleReasoningEfforts } from './types.ts'
 import { err, ok } from './result.ts'
 
 export const CODEX_AGENT_PROFILE = {
@@ -20,7 +20,10 @@ export const CODEX_AGENT_PROFILE = {
   },
 } as const satisfies AgentProfile
 
-/** GLM 5.3 Flash on the GLM Coding Plan answers every role at its highest reasoning effort. */
+/**
+ * GLM 5.3 Flash on the GLM Coding Plan answers every role at its highest
+ * reasoning effort unless `agent.reasoning_effort.opencode` lowers one role.
+ */
 export const OPENCODE_AGENT_PROFILE = {
   provider: 'opencode',
   authentication: 'opencode-go',
@@ -205,9 +208,10 @@ export function parseAgentSelection(value: unknown): Result<AgentSelection, stri
   return ok({ _tag: 'Pinned', provider, model, reasoningEffort })
 }
 
-function roleWithSelection(role: RoleProfile, selection: PinnedAgentSelection): RoleProfile {
+/** A pinned Reasoning effort wins, then the configured override, then the provider default. */
+function roleWithSelection(role: RoleProfile, selection: PinnedAgentSelection, configured: CodexReasoningEffort | undefined): RoleProfile {
   const model = selection.model ?? role.model
-  const reasoningEffort = selection.reasoningEffort ?? role.reasoningEffort
+  const reasoningEffort = selection.reasoningEffort ?? configured ?? role.reasoningEffort
   return reasoningEffort === undefined ? { model } : { model, reasoningEffort }
 }
 
@@ -217,10 +221,15 @@ function roleWithSelection(role: RoleProfile, selection: PinnedAgentSelection): 
  * The service sizes its agent permits when it starts, so agent capacity comes
  * from the caller and never from the selected provider's own profile.
  */
-export function resolveAgentProfile(selection: PinnedAgentSelection, maximumActiveAgents: number): AgentProfile {
+export function resolveAgentProfile(
+  selection: PinnedAgentSelection,
+  maximumActiveAgents: number,
+  roleReasoningEfforts: RoleReasoningEfforts = {},
+): AgentProfile {
   const base = agentProfile(selection.provider)
+  const configured = roleReasoningEfforts[selection.provider] ?? {}
   const roles = Object.fromEntries(
-    AGENT_ROLES.map(role => [role, roleWithSelection(base.roles[role], selection)]),
+    AGENT_ROLES.map(role => [role, roleWithSelection(base.roles[role], selection, configured[role])]),
   ) as Record<AgentRole, RoleProfile>
   return { ...base, maximumActiveAgents, roles }
 }
@@ -232,6 +241,8 @@ export interface AgentRuntimeSourceOptions {
   configuredProvider: AgentProviderName
   maximumActiveAgents: number
   providers: Record<AgentProviderName, AgentProvider>
+  /** Reasoning effort overrides the configuration file names, per provider and role. */
+  roleReasoningEfforts?: RoleReasoningEfforts
   selection: () => AgentSelection
 }
 
@@ -246,7 +257,7 @@ export function createAgentRuntimeSource(options: AgentRuntimeSourceOptions): Ag
   return () => {
     const selection = resolveAgentSelection(options.selection(), configured, options.chooseProvider)
     return {
-      profile: resolveAgentProfile(selection, options.maximumActiveAgents),
+      profile: resolveAgentProfile(selection, options.maximumActiveAgents, options.roleReasoningEfforts),
       provider: options.providers[selection.provider],
     }
   }

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -1,13 +1,14 @@
 import type { AgentProviderName } from './agent-provider.ts'
 import type { AutoMergePolicy } from './auto-merge.ts'
 import type { Result } from './result.ts'
-import type { AgentConfig, ExternalRepositoryWatch, RepositoryMapping, RepositoryOwnership, ServiceTrigger, TakeOwnershipConfig, ValidatedAgentConfig, WebhookConfig } from './types.ts'
+import type { AgentConfig, AgentRole, CodexReasoningEffort, ExternalRepositoryWatch, RepositoryMapping, RepositoryOwnership, RoleReasoningEfforts, ServiceTrigger, TakeOwnershipConfig, ValidatedAgentConfig, WebhookConfig } from './types.ts'
 import { execFile } from 'node:child_process'
 import { lstat, readFile, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { isAbsolute, join, relative, resolve } from 'node:path'
 import process from 'node:process'
 import { parse } from 'yaml'
+import { AGENT_ROLES, REASONING_EFFORTS } from './agent-profile.ts'
 import { err, ok } from './result.ts'
 
 export interface ConfigIssue {
@@ -184,6 +185,44 @@ function reservePercent(value: unknown, issues: ConfigIssue[]): Record<AgentProv
   return reserve
 }
 
+/** Reads `agent.reasoning_effort`, one Reasoning effort per Agent provider and role. */
+function roleReasoningEfforts(value: unknown, issues: ConfigIssue[]): RoleReasoningEfforts | undefined {
+  if (value === undefined)
+    return {}
+  if (!isRecord(value)) {
+    issues.push({ path: '$.agent.reasoning_effort', message: 'Expected a Reasoning effort per Agent provider and role.' })
+    return undefined
+  }
+  const efforts: RoleReasoningEfforts = {}
+  for (const [providerKey, roles] of Object.entries(value)) {
+    const provider = providerName(providerKey)
+    if (provider === undefined) {
+      issues.push({ path: `$.agent.reasoning_effort.${providerKey}`, message: 'Expected codex or opencode.' })
+      return undefined
+    }
+    if (!isRecord(roles)) {
+      issues.push({ path: `$.agent.reasoning_effort.${provider}`, message: 'Expected a Reasoning effort per Agent role.' })
+      return undefined
+    }
+    const providerEfforts: Partial<Record<AgentRole, CodexReasoningEffort>> = {}
+    for (const [roleKey, effort] of Object.entries(roles)) {
+      const role = AGENT_ROLES.find(candidate => candidate === roleKey)
+      if (role === undefined) {
+        issues.push({ path: `$.agent.reasoning_effort.${provider}.${roleKey}`, message: `Expected one Agent role: ${AGENT_ROLES.join(', ')}.` })
+        return undefined
+      }
+      const known = REASONING_EFFORTS.find(candidate => candidate === effort)
+      if (known === undefined) {
+        issues.push({ path: `$.agent.reasoning_effort.${provider}.${role}`, message: `Expected one Reasoning effort: ${REASONING_EFFORTS.join(', ')}.` })
+        return undefined
+      }
+      providerEfforts[role] = known
+    }
+    efforts[provider] = providerEfforts
+  }
+  return efforts
+}
+
 function providerName(value: unknown): AgentProviderName | undefined {
   return value === 'codex' || value === 'opencode' ? value : undefined
 }
@@ -205,7 +244,7 @@ function isDashboardOrigin(value: string): boolean {
 function agentSettings(source: UnknownRecord, issues: ConfigIssue[]): AgentConfig['agent'] | undefined {
   const agent = source.agent
   if (agent === undefined)
-    return { provider: 'codex', reservePercent: DEFAULT_RESERVE_PERCENT, order: DEFAULT_PROVIDER_ORDER, maximumActiveAgents: null }
+    return { provider: 'codex', reservePercent: DEFAULT_RESERVE_PERCENT, order: DEFAULT_PROVIDER_ORDER, maximumActiveAgents: null, reasoningEffort: {} }
   if (!isRecord(agent)) {
     issues.push({ path: '$.agent', message: 'Expected an object.' })
     return undefined
@@ -239,9 +278,11 @@ function agentSettings(source: UnknownRecord, issues: ConfigIssue[]): AgentConfi
   if (maximumActiveAgents === undefined)
     issues.push({ path: '$.agent.maximum_active_agents', message: 'Expected a whole number from 1 to 16.' })
 
-  if (provider === undefined || reserve === undefined || order === undefined || maximumActiveAgents === undefined)
+  const reasoningEffort = roleReasoningEfforts(agent.reasoning_effort, issues)
+
+  if (provider === undefined || reserve === undefined || order === undefined || maximumActiveAgents === undefined || reasoningEffort === undefined)
     return undefined
-  return { provider, reservePercent: reserve, order, maximumActiveAgents }
+  return { provider, reservePercent: reserve, order, maximumActiveAgents, reasoningEffort }
 }
 
 /** The webhook listener is off unless the configuration turns it on. */

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -270,7 +270,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     ...providerProfile,
     maximumActiveAgents: config.agent.maximumActiveAgents ?? providerProfile.maximumActiveAgents,
   }
-  const store = openJournalStore(config.storage.path, config.mutationsEnabled, configuredProfile, config.maxOpenPullRequests, options.serviceUpdate.read)
+  const store = openJournalStore(config.storage.path, config.mutationsEnabled, configuredProfile, config.maxOpenPullRequests, options.serviceUpdate.read, config.agent.reasoningEffort)
   const processId = randomUUID()
   const restartController = createRestartController({
     store,
@@ -320,6 +320,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     chooseProvider,
     configuredProvider: configuredProfile.provider,
     maximumActiveAgents: configuredProfile.maximumActiveAgents,
+    roleReasoningEfforts: config.agent.reasoningEffort,
     providers: {
       codex: createCircuitProtectedProvider({
         credential: agentProfile('codex').authentication,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -80,6 +80,7 @@ import type {
   ReviewResolution,
   ReviewRun,
   ReviewStatusTaskPhase,
+  RoleReasoningEfforts,
   Routine,
   RoutineIssueSource,
   RoutineReportCommand,
@@ -5764,6 +5765,8 @@ export function openJournalStore(
   /** Issue work stops when open pull requests reach this limit. Matches the configuration default. */
   maxOpenPullRequests = 8,
   serviceUpdate: () => ServiceUpdateStatus = () => ({ _tag: 'Checking', deployedCommit: '' }),
+  /** Reasoning effort overrides the configuration names, per Agent provider and role. */
+  roleReasoningEfforts: RoleReasoningEfforts = {},
 ): JournalStore {
   const database = openDatabase(path)
   const configuredSelection = providerAgentSelection(profile.provider)
@@ -10972,7 +10975,7 @@ export function openJournalStore(
       selectionMode: currentSelectionMode,
       openPullRequests: countOpenPullRequests(),
       maxOpenPullRequests,
-      agentProfile: resolveAgentProfile(activeSelection(), profile.maximumActiveAgents),
+      agentProfile: resolveAgentProfile(activeSelection(), profile.maximumActiveAgents, roleReasoningEfforts),
       agentSelection: getAgentSelection(),
       agentStart: !mutationsEnabled
         ? { _tag: 'WritesDisabled' }

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -83,6 +83,14 @@ export interface AgentConfig {
      * not against core count: each Agent runs a whole coding session.
      */
     maximumActiveAgents: number | null
+    /**
+     * Reasoning effort overrides per Agent provider and role.
+     *
+     * A listed role replaces that provider's own per-role default. An absent
+     * provider or role keeps the default. A pinned Agent selection with an
+     * explicit Reasoning effort still wins over this.
+     */
+    reasoningEffort: RoleReasoningEfforts
   }
   github: {
     appId: number
@@ -1123,6 +1131,9 @@ export type OpencodeAgentModel
     | 'opencode-go/qwen3.7-plus'
 export type AgentModel = CodexAgentModel | OpencodeAgentModel
 export type CodexReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
+
+/** Reasoning effort overrides keyed by Agent provider, then by Agent role. */
+export type RoleReasoningEfforts = Partial<Record<AgentProviderName, Partial<Record<AgentRole, CodexReasoningEffort>>>>
 
 export interface RoleProfile {
   model: AgentModel

--- a/packages/harlan-github-agent/test/agent-selection.test.ts
+++ b/packages/harlan-github-agent/test/agent-selection.test.ts
@@ -89,6 +89,48 @@ describe('agent profile resolution', () => {
       expect(role).toEqual({ model: 'gpt-5.6-luna', reasoningEffort: 'low' })
   })
 
+  it('replaces one role default with the configured Reasoning effort and keeps the others', () => {
+    const profile = resolveAgentProfile(
+      { provider: 'opencode', model: null, reasoningEffort: null },
+      3,
+      { opencode: { review_fix: 'medium', pull_request_triage: 'low' } },
+    )
+
+    expect(profile.roles.review_fix).toEqual({ model: 'zai-coding-plan/glm-5.3-flash', reasoningEffort: 'medium' })
+    expect(profile.roles.pull_request_triage).toEqual({ model: 'zai-coding-plan/glm-5.3-flash', reasoningEffort: 'low' })
+    expect(profile.roles.adversarial_review).toEqual({ model: 'zai-coding-plan/glm-5.3-flash', reasoningEffort: 'high' })
+  })
+
+  it('applies the configured Reasoning effort only to its own Agent provider', () => {
+    const profile = resolveAgentProfile(
+      { provider: 'codex', model: null, reasoningEffort: null },
+      3,
+      { opencode: { review_fix: 'low' } },
+    )
+
+    expect(profile.roles.review_fix).toEqual({ model: 'gpt-5.6-terra', reasoningEffort: 'medium' })
+  })
+
+  it('lets a pinned Reasoning effort beat the configured override', () => {
+    const profile = resolveAgentProfile(
+      { provider: 'opencode', model: null, reasoningEffort: 'xhigh' },
+      3,
+      { opencode: { review_fix: 'medium' } },
+    )
+
+    expect(profile.roles.review_fix.reasoningEffort).toBe('xhigh')
+  })
+
+  it('answers with the configured override for a pinned selection that names no Reasoning effort', () => {
+    const profile = resolveAgentProfile(
+      { provider: 'opencode', model: 'zai-coding-plan/glm-5.3', reasoningEffort: null },
+      3,
+      { opencode: { review_fix: 'medium' } },
+    )
+
+    expect(profile.roles.review_fix).toEqual({ model: 'zai-coding-plan/glm-5.3', reasoningEffort: 'medium' })
+  })
+
   it('takes agent capacity from the caller, because the service fixes it at start', () => {
     const profile = resolveAgentProfile({ provider: 'opencode', model: null, reasoningEffort: null }, 5)
 

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -85,6 +85,63 @@ agent:
     expect(parsed._tag === 'Err' && parsed.error.map(issue => issue.path)).toContain('$.agent.maximum_active_agents')
   })
 
+  it('reads one Reasoning effort override per Agent provider and role', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  reasoning_effort:
+    opencode:
+      review_fix: medium
+      pull_request_triage: low
+`)
+
+    expect(parsed._tag === 'Ok' && parsed.value.agent.reasoningEffort).toEqual({
+      opencode: { review_fix: 'medium', pull_request_triage: 'low' },
+    })
+  })
+
+  it('keeps every provider default when the file names no Reasoning effort override', () => {
+    const parsed = parseConfigText(configText)
+
+    expect(parsed._tag === 'Ok' && parsed.value.agent.reasoningEffort).toEqual({})
+  })
+
+  it('refuses a Reasoning effort override for a role no Agent has', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  reasoning_effort:
+    opencode:
+      repair: medium
+`)
+
+    expect(parsed._tag === 'Err' && parsed.error.map(issue => issue.path)).toContain('$.agent.reasoning_effort.opencode.repair')
+  })
+
+  it('refuses a Reasoning effort no Agent provider offers', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  reasoning_effort:
+    opencode:
+      review_fix: ultra
+`)
+
+    expect(parsed._tag === 'Err' && parsed.error.map(issue => issue.path)).toContain('$.agent.reasoning_effort.opencode.review_fix')
+  })
+
+  it('refuses a Reasoning effort override for an unknown Agent provider', () => {
+    const parsed = parseConfigText(`${configText}
+agent:
+  provider: opencode
+  reasoning_effort:
+    claude:
+      review_fix: medium
+`)
+
+    expect(parsed._tag === 'Err' && parsed.error.map(issue => issue.path)).toContain('$.agent.reasoning_effort.claude')
+  })
+
   it('accepts an HTTPS Tailscale dashboard origin', () => {
     const parsed = parseConfigText(configText.replace(
       'https://harlan-github-agent.localhost',


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

The 3 Sep retro found glm-5.3-flash at `high` Reasoning effort spending 3 to 8 minutes in silent thinking on Repair, with no better outcome than a 5 minute run, and giving one-sentence reasoning on Pull request triage. The retro asked for a measured comparison before any switch, but opencode pins `high` for every role in code, so there was nothing to compare against. `agent.reasoning_effort.<provider>.<role>` now lowers one role without touching the others. A pinned Agent selection with an explicit Reasoning effort still wins over the file.

The `review_runs` row only stores the model, so the effective Reasoning effort is not recorded per Review run. The next retro reads it from the opencode session `model.variant` field.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

### 📝 Migration

To run the comparison, add this under `agent:` in the Hogwild configuration file, then restart the service:

```yaml
agent:
  reasoning_effort:
    opencode:
      review_fix: medium
      pull_request_triage: low
```

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz