### PR TITLE
fix(agent): treat a clean base merge as stale GitHub state, not a failure

### DIFF
--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -137,6 +137,14 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
       const prepared = await options.worktrees.prepare(currentTask, signal)
       if (prepared._tag === 'Err')
         return prepared
+      if (prepared.value._tag === 'CleanMerge') {
+        // GitHub's conflicting state is stale. A GET on the pull request makes
+        // GitHub recompute mergeability in the background. Its answer is stale
+        // by definition, so it is not read; the next poll reads the result.
+        await options.github.getPullRequest(validated.value, task.pullRequestNumber, signal)
+        return ok({ _tag: 'Completed', evidence: JSON.stringify(prepared.value) })
+      }
+      const worktree = prepared.value.worktree
       const worktreeReady = reportProgress({ percent: 35, label: 'Git worktree ready' })
       if (worktreeReady._tag === 'Err')
         return worktreeReady
@@ -145,12 +153,12 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
         freshSession: task.state.fence > 1,
         number: task.pullRequestNumber,
         progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'conflict' },
-        prompt: workerPrompt(currentTask, prepared.value),
+        prompt: workerPrompt(currentTask, worktree),
         repository: task.repository,
         role: 'conflict_resolution',
         schema: outputSchema,
         taskId: task.id,
-        workspace: prepared.value.path,
+        workspace: worktree.path,
       }, signal)
       if (turn._tag === 'Err')
         return turn
@@ -167,7 +175,7 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
         })
       }
 
-      const verified = await options.worktrees.verify(currentTask, prepared.value, signal)
+      const verified = await options.worktrees.verify(currentTask, worktree, signal)
       if (verified._tag === 'Err')
         return verified
       const checksPassed = reportProgress({ percent: 90, label: 'Conflict fix checked' })
@@ -182,7 +190,7 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
         publishSnapshot.value.state !== 'open'
         || publishSnapshot.value.draft
         || publishSnapshot.value.mergeState !== 'conflicting'
-        || publishSnapshot.value.headSha !== prepared.value.headSha
+        || publishSnapshot.value.headSha !== worktree.headSha
         || (publishForkHead && publishSnapshot.value.maintainerCanModify !== true)
       ) {
         return err('The pull request changed before the fix was committed.')
@@ -190,7 +198,7 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
 
       const committed = await options.worktrees.commit(
         currentTask,
-        prepared.value,
+        worktree,
         verified.value,
         cleanLine(parsed.value.commitMessage),
         signal,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -111,6 +111,7 @@ import { planRepairRound, REPAIR_ROUND_LIMIT } from './repair-rounds.ts'
 import { canRepairBaseline, canRepairPullRequestHead, canWorkIssues } from './repository-policy.ts'
 import { buildStats } from './stats.ts'
 import { cleanLine } from './text.ts'
+import { parseConflictCleanMergeEvidence } from './worktree.ts'
 
 export interface RecordIncidentInput {
   scope: IncidentScope
@@ -278,6 +279,66 @@ function resolveTaskIncidents(database: DatabaseSync, taskId: string, at: string
     UPDATE incidents SET resolved_at = ?
     WHERE resolved_at IS NULL AND scope_tag = 'Task' AND task_id = ?
   `).run(at, taskId)
+}
+
+/**
+ * Names a conflict Task whose real base merged cleanly while GitHub still said
+ * it conflicts.
+ *
+ * Nothing failed, so this is a warning and not an error, and it spends no
+ * Recovery budget. It is recorded after the Task completes, because completion
+ * closes every Incident the Task raised while it ran. The Task id already
+ * identifies one head and base pair, so a stale state seen twice stays one row.
+ */
+function recordCleanMergeIncident(database: DatabaseSync, taskId: string, evidence: string, at: string): void {
+  const cleanMerge = parseConflictCleanMergeEvidence(evidence)
+  if (cleanMerge === undefined)
+    return
+  const row = database.prepare(`
+    SELECT repositories.github AS repository, subjects.github_number
+    FROM tasks
+    JOIN subjects ON subjects.id = tasks.subject_id
+    JOIN repositories ON repositories.id = subjects.repository_id
+    WHERE tasks.id = ?
+  `).get(taskId) as { repository: string, github_number: number } | undefined
+  if (row === undefined)
+    return
+  upsertIncident(database, {
+    scope: { _tag: 'Task', taskId, repository: row.repository, itemNumber: row.github_number },
+    kind: 'subject_changed',
+    severity: 'warning',
+    operation: 'resolve_conflict',
+    message: `GitHub reports ${row.repository}#${row.github_number} as conflicting, but ${cleanMerge.baseRef} at ${cleanMerge.baseSha.slice(0, 12)} merges cleanly into head ${cleanMerge.headSha.slice(0, 12)}. GitHub's merge state is stale. Update the branch on GitHub, or push a new commit.`,
+    recovery: { _tag: 'ActionRequired' },
+    at,
+  })
+}
+
+/**
+ * Whether a completed conflict Task already proved this head and base merge cleanly.
+ *
+ * GitHub's stale state survives a Revision change that touches neither SHA,
+ * such as a title edit, so the Revision alone cannot answer this.
+ */
+function hasCleanMergeCompletion(database: DatabaseSync, subjectId: number, headSha: string, baseSha: string): boolean {
+  const rows = database.prepare(`
+    SELECT evidence FROM tasks
+    WHERE subject_id = ? AND kind = 'resolve_conflict' AND state_tag = 'Completed' AND evidence LIKE '{%'
+  `).all(subjectId) as unknown as Array<{ evidence: string }>
+  return rows.some((row) => {
+    const cleanMerge = parseConflictCleanMergeEvidence(row.evidence)
+    return cleanMerge !== undefined && cleanMerge.headSha === headSha && cleanMerge.baseSha === baseSha
+  })
+}
+
+/** Closes the stale-state warnings once the head or base moved, or GitHub agrees. */
+function resolveCleanMergeIncidents(database: DatabaseSync, subjectId: number, at: string): void {
+  database.prepare(`
+    UPDATE incidents SET resolved_at = ?
+    WHERE resolved_at IS NULL AND scope_tag = 'Task' AND task_id IN (
+      SELECT id FROM tasks WHERE subject_id = ? AND kind = 'resolve_conflict' AND state_tag = 'Completed'
+    )
+  `).run(at, subjectId)
 }
 
 /** Failure kinds an outage causes, and that a healthy GitHub therefore clears. */
@@ -3502,6 +3563,7 @@ function planConflictResolution(
 
   if (!eligible) {
     supersedeTasks(database, subjectId, observedAt, 'The pull request no longer needs conflict resolution.')
+    resolveCleanMergeIncidents(database, subjectId, observedAt)
     return
   }
 
@@ -3590,6 +3652,11 @@ function planConflictResolution(
   }
   if (existing !== undefined)
     return
+  // The base merged cleanly for this exact head and base, and GitHub has not
+  // caught up. Another turn proves the same thing and raises the same warning.
+  if (hasCleanMergeCompletion(database, subjectId, subject.headSha, subject.baseSha))
+    return
+  resolveCleanMergeIncidents(database, subjectId, observedAt)
 
   const state: TaskState = ready
     ? { _tag: 'Queued' }
@@ -9392,6 +9459,7 @@ export function openJournalStore(
       if (result.changes === 1) {
         recordTransition(database, { taskId: input.taskId, from: 'Running', to: 'Completed', reason: null, fence: input.fence, at: input.at })
         resolveTaskIncidents(database, input.taskId, input.at)
+        recordCleanMergeIncident(database, input.taskId, input.evidence, input.at)
       }
       database.exec('COMMIT')
       return result.changes === 1

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -23,6 +23,37 @@ export interface PreparedConflictWorktree {
   conflictedFiles: string[]
 }
 
+/**
+ * What merging the real base into the pull request head showed.
+ *
+ * GitHub reported two stacked pull requests as conflicting for days while
+ * their real base merged cleanly. A clean merge is a fact about GitHub's stale
+ * state, not a failure, so it is its own case and never spends Recovery budget.
+ */
+export type ConflictPrepareResult
+  = | { _tag: 'Conflicted', worktree: PreparedConflictWorktree }
+    | ConflictCleanMergeEvidence
+
+/** Stored as the Completed evidence of a conflict Task whose base merged cleanly. */
+export interface ConflictCleanMergeEvidence {
+  _tag: 'CleanMerge'
+  headSha: string
+  baseSha: string
+  baseRef: string
+}
+
+export function parseConflictCleanMergeEvidence(evidence: string | null): ConflictCleanMergeEvidence | undefined {
+  if (evidence === null || !evidence.startsWith('{'))
+    return undefined
+  const value = JSON.parse(evidence) as Partial<ConflictCleanMergeEvidence>
+  return value._tag === 'CleanMerge'
+    && typeof value.headSha === 'string'
+    && typeof value.baseSha === 'string'
+    && typeof value.baseRef === 'string'
+    ? { _tag: 'CleanMerge', headSha: value.headSha, baseSha: value.baseSha, baseRef: value.baseRef }
+    : undefined
+}
+
 export interface VerifiedConflictPatch {
   digest: string
   changedFiles: number
@@ -41,7 +72,7 @@ export interface PreparedConflictPublication extends VerifiedConflictPatch {
 
 export interface ConflictWorktreeManager {
   commit: (task: ClaimedConflictResolutionTask, worktree: PreparedConflictWorktree, patch: VerifiedConflictPatch, message: string, signal: AbortSignal) => Promise<Result<PreparedConflictPublication, string>>
-  prepare: (task: ClaimedConflictResolutionTask, signal: AbortSignal) => Promise<Result<PreparedConflictWorktree, string>>
+  prepare: (task: ClaimedConflictResolutionTask, signal: AbortSignal) => Promise<Result<ConflictPrepareResult, string>>
   verify: (task: ClaimedConflictResolutionTask, worktree: PreparedConflictWorktree, signal: AbortSignal) => Promise<Result<VerifiedConflictPatch, string>>
 }
 
@@ -579,7 +610,7 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
   if (options.gitIdentity === undefined)
     throw new Error('A Git commit identity is required.')
   const gitIdentity = options.gitIdentity
-  async function prepare(task: ClaimedConflictResolutionTask, signal: AbortSignal): Promise<Result<PreparedConflictWorktree, string>> {
+  async function prepare(task: ClaimedConflictResolutionTask, signal: AbortSignal): Promise<Result<ConflictPrepareResult, string>> {
     const branch = agentWorktreeBranch(`pull-${task.pullRequestNumber}-${task.revisionId.slice(0, 12)}`, { taskId: task.id, fence: task.state.fence })
     const repository = task.repositoryMapping.checkout
 
@@ -625,17 +656,31 @@ export function createConflictWorktreeManager(options: ConflictWorktreeManagerOp
       '--no-ff',
       base.stdout,
     ], signal)
-    const unmerged = await runGit(worktree.value, ['diff', '--name-only', '--diff-filter=U'], signal)
-    if (merge.exitCode === 0 || unmerged.stdout.length === 0) {
+    // `--no-commit` stops a clean merge before the commit and still exits 0.
+    // Only a conflict, or a merge that could not start, exits non-zero.
+    if (merge.exitCode === 0) {
       await runGit(worktree.value, ['merge', '--abort'], signal)
-      return err('Git no longer reports merge conflicts for this head commit.')
+      return ok({ _tag: 'CleanMerge', headSha: head.stdout, baseSha: base.stdout, baseRef: baseBranch })
+    }
+    const unmerged = await runGit(worktree.value, ['diff', '--name-only', '--diff-filter=U'], signal)
+    if (unmerged.exitCode !== 0)
+      return err(`Could not list the conflicted files: ${unmerged.stderr}`)
+    // A merge that never started, for unrelated histories or a file in the way,
+    // has no unmerged files either. That used to read as "no longer conflicts"
+    // and hid the real error behind a retry.
+    if (unmerged.stdout.length === 0) {
+      await runGit(worktree.value, ['merge', '--abort'], signal)
+      return err(`Git could not merge ${baseBranch} into the pull request head: ${cleanLine(merge.stderr || merge.stdout)}`)
     }
 
     return ok({
-      path: worktree.value,
-      headSha: head.stdout,
-      baseSha: base.stdout,
-      conflictedFiles: unmerged.stdout.split('\n').filter(Boolean).sort(),
+      _tag: 'Conflicted',
+      worktree: {
+        path: worktree.value,
+        headSha: head.stdout,
+        baseSha: base.stdout,
+        conflictedFiles: unmerged.stdout.split('\n').filter(Boolean).sort(),
+      },
     })
   }
 

--- a/packages/harlan-github-agent/test/conflict-worker.test.ts
+++ b/packages/harlan-github-agent/test/conflict-worker.test.ts
@@ -37,7 +37,7 @@ function conflictWorkerOptions(repository: ReturnType<typeof repositoryMapping>,
     },
     validateMapping: () => Promise.resolve(ok(repository)),
     worktrees: {
-      prepare: () => Promise.resolve(ok({ path: '/tmp/worktree', headSha: current.headSha, baseSha: current.baseSha, conflictedFiles: ['file.ts'] })),
+      prepare: () => Promise.resolve(ok({ _tag: 'Conflicted' as const, worktree: { path: '/tmp/worktree', headSha: current.headSha, baseSha: current.baseSha, conflictedFiles: ['file.ts'] } })),
       verify: () => Promise.resolve(ok({ digest: 'digest', changedFiles: 1 })),
       commit: () => Promise.resolve(ok({ commitSha: 'commit', baseSha: current.baseSha, artifactRef: 'artifact', digest: 'digest', changedFiles: 1 })),
     },
@@ -45,6 +45,37 @@ function conflictWorkerOptions(repository: ReturnType<typeof repositoryMapping>,
 }
 
 describe('conflict worker', () => {
+  it('completes a clean merge without an agent turn and asks GitHub to recompute once', async () => {
+    const repository = repositoryMapping()
+    const current = pullRequestItem({ baseSha: 'current-base' })
+    const capture: ProviderCapture = { requests: [] }
+    let reads = 0
+    const options = conflictWorkerOptions(repository, current)
+    const worker = createConflictWorker({
+      ...options,
+      github: { getPullRequest: () => {
+        reads += 1
+        return Promise.resolve(ok(current))
+      } },
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(resolved), capture)),
+      worktrees: {
+        ...options.worktrees,
+        prepare: () => Promise.resolve(ok({ _tag: 'CleanMerge' as const, headSha: current.headSha, baseSha: 'current-base', baseRef: 'main' })),
+      },
+    })
+
+    const result = await worker.run(conflictTask(repository), new AbortController().signal)
+
+    expect(result).toEqual(ok({
+      _tag: 'Completed',
+      evidence: JSON.stringify({ _tag: 'CleanMerge', headSha: current.headSha, baseSha: 'current-base', baseRef: 'main' }),
+    }))
+    expect(capture.requests).toEqual([])
+    // The first read claims the pull request. The second is the GET that makes
+    // GitHub recompute the stale mergeable state.
+    expect(reads).toBe(2)
+  })
+
   it('runs the Codex profile\'s conflict model against the prepared worktree', async () => {
     const repository = repositoryMapping()
     const current = pullRequestItem({ baseSha: 'current-base' })
@@ -133,7 +164,7 @@ describe('conflict worker', () => {
       worktrees: {
         prepare: (task) => {
           preparedBaseSha = task.pullRequest.baseSha
-          return Promise.resolve(ok({ path: '/tmp/worktree', headSha: current.headSha, baseSha: current.baseSha, conflictedFiles: ['file.ts'] }))
+          return Promise.resolve(ok({ _tag: 'Conflicted' as const, worktree: { path: '/tmp/worktree', headSha: current.headSha, baseSha: current.baseSha, conflictedFiles: ['file.ts'] } }))
         },
         verify: () => Promise.resolve(ok({ digest: 'digest', changedFiles: 1 })),
         commit: (_task, _worktree, _patch, message) => {
@@ -158,7 +189,7 @@ describe('conflict worker', () => {
       runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents(resolved), capture)),
       worktrees: {
         ...conflictWorkerOptions(repository, current).worktrees,
-        prepare: () => Promise.resolve(ok({ path: '/tmp/worktree', headSha: 'head-sha', baseSha: 'current-base', conflictedFiles: ['src/a.ts', 'src/b.vue'] })),
+        prepare: () => Promise.resolve(ok({ _tag: 'Conflicted' as const, worktree: { path: '/tmp/worktree', headSha: 'head-sha', baseSha: 'current-base', conflictedFiles: ['src/a.ts', 'src/b.vue'] } })),
       },
     })
 

--- a/packages/harlan-github-agent/test/conflict-worktree.test.ts
+++ b/packages/harlan-github-agent/test/conflict-worktree.test.ts
@@ -1,4 +1,5 @@
 import type { ClaimedConflictResolutionTask } from '../src/types.ts'
+import type { ConflictWorktreeManager, PreparedConflictWorktree } from '../src/worktree.ts'
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -78,6 +79,15 @@ function fixture(): { checkout: string, currentBaseSha: string, remote: string, 
   }
 }
 
+async function conflicted(manager: ConflictWorktreeManager, task: ClaimedConflictResolutionTask): Promise<PreparedConflictWorktree> {
+  const prepared = await manager.prepare(task, new AbortController().signal)
+  if (prepared._tag === 'Err')
+    throw new Error(prepared.error)
+  if (prepared.value._tag !== 'Conflicted')
+    throw new Error('Expected a conflicted worktree.')
+  return prepared.value.worktree
+}
+
 describe('conflict worktree', () => {
   it('uses the current base branch when the pull request base SHA is stale', async () => {
     const { currentBaseSha, remote, root, task } = fixture()
@@ -90,7 +100,50 @@ describe('conflict worktree', () => {
 
     const result = await manager.prepare(task, new AbortController().signal)
 
-    expect(result).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ baseSha: currentBaseSha, conflictedFiles: ['file.txt'] }) }))
+    expect(result).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ _tag: 'Conflicted', worktree: expect.objectContaining({ baseSha: currentBaseSha, conflictedFiles: ['file.txt'] }) }) }))
+  })
+
+  it('reports a clean merge instead of a failure when the base merges without conflicts', async () => {
+    const { checkout, remote, root, task } = fixture()
+    // GitHub kept reporting two stacked pull requests as conflicting while
+    // their real base merged cleanly. Prepare read that as a failure, spent
+    // the whole recovery budget, and raised an error Incident each time.
+    git(checkout, 'checkout', '-b', 'feature/clean', task.pullRequest.baseSha)
+    writeFileSync(join(checkout, 'helper.ts'), 'export const limit = 2\n')
+    git(checkout, 'commit', '-am', 'raise the limit')
+    git(checkout, 'push', 'origin', 'feature/clean')
+    const cleanBaseSha = git(checkout, 'rev-parse', 'HEAD')
+    const manager = createConflictWorktreeManager({
+      gitIdentity: { name: 'Harlan Wilton', email: 'harlan@harlanzw.com' },
+      remoteUrl: () => remote,
+      root,
+      tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
+    })
+
+    const result = await manager.prepare({ ...task, pullRequest: { ...task.pullRequest, baseRef: 'feature/clean' } }, new AbortController().signal)
+
+    expect(result).toEqual(ok({ _tag: 'CleanMerge', headSha: task.pullRequest.headSha, baseSha: cleanBaseSha, baseRef: 'feature/clean' }))
+  })
+
+  it('reports the Git error when the merge fails for a reason other than conflicts', async () => {
+    const { checkout, remote, root, task } = fixture()
+    // A merge that fails before it can conflict has no unmerged files either.
+    // That used to read as "no longer conflicts" and hid the real error.
+    git(checkout, 'checkout', '--orphan', 'feature/unrelated')
+    writeFileSync(join(checkout, 'file.txt'), 'unrelated\n')
+    git(checkout, 'add', '--all')
+    git(checkout, 'commit', '-m', 'unrelated history')
+    git(checkout, 'push', 'origin', 'feature/unrelated')
+    const manager = createConflictWorktreeManager({
+      gitIdentity: { name: 'Harlan Wilton', email: 'harlan@harlanzw.com' },
+      remoteUrl: () => remote,
+      root,
+      tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
+    })
+
+    const result = await manager.prepare({ ...task, pullRequest: { ...task.pullRequest, baseRef: 'feature/unrelated' } }, new AbortController().signal)
+
+    expect(result).toEqual({ _tag: 'Err', error: expect.stringContaining('refusing to merge unrelated histories') })
   })
 
   it('merges the stacked base branch instead of the default branch', async () => {
@@ -112,10 +165,10 @@ describe('conflict worktree', () => {
 
     const result = await manager.prepare({ ...task, pullRequest: { ...task.pullRequest, baseRef: 'feature/parent' } }, new AbortController().signal)
 
-    expect(result).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ baseSha: parentSha, conflictedFiles: ['file.txt'] }) }))
-    if (result._tag === 'Err')
-      throw new Error(result.error)
-    expect(git(result.value.path, 'rev-parse', 'MERGE_HEAD')).toBe(parentSha)
+    expect(result).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ _tag: 'Conflicted', worktree: expect.objectContaining({ baseSha: parentSha, conflictedFiles: ['file.txt'] }) }) }))
+    if (result._tag === 'Err' || result.value._tag !== 'Conflicted')
+      throw new Error('Expected a conflicted worktree.')
+    expect(git(result.value.worktree.path, 'rev-parse', 'MERGE_HEAD')).toBe(parentSha)
   })
 
   it('stages a verified conflict file in the controller-owned index', async () => {
@@ -126,15 +179,13 @@ describe('conflict worktree', () => {
       root,
       tokens: { getToken: () => Promise.resolve({ _tag: 'Ok', value: { token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' } }), invalidate: () => undefined },
     })
-    const prepared = await manager.prepare(task, new AbortController().signal)
-    if (prepared._tag === 'Err')
-      throw new Error(prepared.error)
-    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
+    const prepared = await conflicted(manager, task)
+    writeFileSync(join(prepared.path, 'file.txt'), 'resolved\n')
 
-    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    const verified = await manager.verify(task, prepared, new AbortController().signal)
 
     expect(verified).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ changedFiles: 1 }) }))
-    expect(git(prepared.value.path, 'diff', '--name-only', '--diff-filter=U')).toBe('')
+    expect(git(prepared.path, 'diff', '--name-only', '--diff-filter=U')).toBe('')
   })
 
   it('verifies conflict patches larger than the child process output buffer', async () => {
@@ -145,12 +196,10 @@ describe('conflict worktree', () => {
       root,
       tokens: { getToken: () => Promise.resolve({ _tag: 'Ok', value: { token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' } }), invalidate: () => undefined },
     })
-    const prepared = await manager.prepare(task, new AbortController().signal)
-    if (prepared._tag === 'Err')
-      throw new Error(prepared.error)
-    writeFileSync(join(prepared.value.path, 'file.txt'), `${'resolved line\n'.repeat(100_000)}`)
+    const prepared = await conflicted(manager, task)
+    writeFileSync(join(prepared.path, 'file.txt'), `${'resolved line\n'.repeat(100_000)}`)
 
-    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    const verified = await manager.verify(task, prepared, new AbortController().signal)
 
     expect(verified).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ changedFiles: 1 }) }))
   })
@@ -163,21 +212,19 @@ describe('conflict worktree', () => {
       root,
       tokens: { getToken: () => Promise.resolve({ _tag: 'Ok', value: { token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' } }), invalidate: () => undefined },
     })
-    const prepared = await manager.prepare(task, new AbortController().signal)
-    if (prepared._tag === 'Err')
-      throw new Error(prepared.error)
-    writeFileSync(join(prepared.value.path, 'file.txt'), 'pull request\n')
+    const prepared = await conflicted(manager, task)
+    writeFileSync(join(prepared.path, 'file.txt'), 'pull request\n')
 
-    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    const verified = await manager.verify(task, prepared, new AbortController().signal)
 
     expect(verified).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ changedFiles: 0 }) }))
     if (verified._tag === 'Err')
       throw new Error(verified.error)
-    const committed = await manager.commit(task, prepared.value, verified.value, 'merge: reconcile parser changes', new AbortController().signal)
+    const committed = await manager.commit(task, prepared, verified.value, 'merge: reconcile parser changes', new AbortController().signal)
 
     expect(committed).toEqual(expect.objectContaining({ _tag: 'Ok' }))
-    expect(git(prepared.value.path, 'show', '--no-patch', '--format=%an <%ae>')).toBe('Harlan Wilton <harlan@harlanzw.com>')
-    expect(git(prepared.value.path, 'show', '--no-patch', '--format=%s')).toBe('merge: reconcile parser changes')
+    expect(git(prepared.path, 'show', '--no-patch', '--format=%an <%ae>')).toBe('Harlan Wilton <harlan@harlanzw.com>')
+    expect(git(prepared.path, 'show', '--no-patch', '--format=%s')).toBe('merge: reconcile parser changes')
   })
   it('publishes a resolution whose digest was read where blob names abbreviate differently', async () => {
     // Git scales blob name abbreviation with the object count of a repository,
@@ -191,15 +238,13 @@ describe('conflict worktree', () => {
       tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
     }
     const manager = createConflictWorktreeManager(options)
-    const prepared = await manager.prepare(task, new AbortController().signal)
-    if (prepared._tag === 'Err')
-      throw new Error(prepared.error)
-    git(prepared.value.path, 'config', 'core.abbrev', '20')
-    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
-    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    const prepared = await conflicted(manager, task)
+    git(prepared.path, 'config', 'core.abbrev', '20')
+    writeFileSync(join(prepared.path, 'file.txt'), 'resolved\n')
+    const verified = await manager.verify(task, prepared, new AbortController().signal)
     if (verified._tag === 'Err')
       throw new Error(verified.error)
-    const committed = await manager.commit(task, prepared.value, verified.value, 'merge: resolve conflicts', new AbortController().signal)
+    const committed = await manager.commit(task, prepared, verified.value, 'merge: resolve conflicts', new AbortController().signal)
     if (committed._tag === 'Err')
       throw new Error(committed.error)
     git(join(root, 'repositories', `${task.repository.replace('/', '__')}.git`), 'config', 'core.abbrev', '7')
@@ -250,17 +295,15 @@ describe('conflict worktree', () => {
       root,
       tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
     })
-    const prepared = await manager.prepare(task, new AbortController().signal)
-    if (prepared._tag === 'Err')
-      throw new Error(prepared.error)
-    expect(prepared.value.conflictedFiles).toEqual(['file.txt'])
-    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
-    writeFileSync(join(prepared.value.path, 'helper.ts'), 'export const limit = 3\n')
+    const prepared = await conflicted(manager, task)
+    expect(prepared.conflictedFiles).toEqual(['file.txt'])
+    writeFileSync(join(prepared.path, 'file.txt'), 'resolved\n')
+    writeFileSync(join(prepared.path, 'helper.ts'), 'export const limit = 3\n')
 
-    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    const verified = await manager.verify(task, prepared, new AbortController().signal)
 
     expect(verified).toEqual(expect.objectContaining({ _tag: 'Ok', value: expect.objectContaining({ changedFiles: 2 }) }))
-    expect(git(prepared.value.path, 'diff', '--cached', '--name-only', 'HEAD').split('\n').sort()).toEqual(['file.txt', 'helper.ts'])
+    expect(git(prepared.path, 'diff', '--cached', '--name-only', 'HEAD').split('\n').sort()).toEqual(['file.txt', 'helper.ts'])
   })
 
   it('refuses a resolution that edits a file the merge never touched', async () => {
@@ -271,13 +314,11 @@ describe('conflict worktree', () => {
       root,
       tokens: { getToken: () => Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' })), invalidate: () => undefined },
     })
-    const prepared = await manager.prepare(task, new AbortController().signal)
-    if (prepared._tag === 'Err')
-      throw new Error(prepared.error)
-    writeFileSync(join(prepared.value.path, 'file.txt'), 'resolved\n')
-    writeFileSync(join(prepared.value.path, 'keep.ts'), 'export const kept = false\n')
+    const prepared = await conflicted(manager, task)
+    writeFileSync(join(prepared.path, 'file.txt'), 'resolved\n')
+    writeFileSync(join(prepared.path, 'keep.ts'), 'export const kept = false\n')
 
-    const verified = await manager.verify(task, prepared.value, new AbortController().signal)
+    const verified = await manager.verify(task, prepared, new AbortController().signal)
 
     expect(verified).toEqual({ _tag: 'Err', error: 'The worker changed a file the merge did not touch: keep.ts.' })
   })

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -988,6 +988,39 @@ describe('journal store', () => {
     expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
   })
 
+  it('does not requeue a conflict whose base merges cleanly until the head or the base changes', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const subject = pullRequestItem({ mergeState: 'conflicting', headSha: 'head-1', baseSha: 'base-1' })
+    let elapsed = 0
+    const at = (): string => new Date(Date.parse('2026-08-13T01:00:00.000Z') + (elapsed += 1000)).toISOString()
+    store.recordObservation({ externalId: 'clean-merge', observedAt: at(), source: 'poll', subject })
+    const task = store.claimNextConflictTask('worker-1', at(), 600_000)
+    if (task === null)
+      throw new Error('Expected a running conflict task.')
+    const cleanMerge = JSON.stringify({ _tag: 'CleanMerge', headSha: 'head-1', baseSha: 'base-1', baseRef: 'main' })
+
+    expect(store.completeTask({ taskId: task.id, workerId: 'worker-1', fence: task.state.fence, at: at(), evidence: cleanMerge })).toBe(true)
+
+    // GitHub keeps reporting the same stale state for the same head and base.
+    store.recordObservation({ externalId: 'clean-merge', observedAt: at(), source: 'poll', subject })
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
+    // A new Revision with the same head and base, such as a title edit, must not spend a turn either.
+    store.recordObservation({ externalId: 'clean-merge-renamed', observedAt: at(), source: 'poll', subject: { ...subject, title: 'Renamed' } })
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
+    expect(store.listIncidents()).toEqual([expect.objectContaining({
+      scope: { _tag: 'Task', taskId: task.id, repository: 'harlan-zw/example', itemNumber: subject.number },
+      severity: 'warning',
+      operation: 'resolve_conflict',
+      occurrences: 1,
+    })])
+
+    // The base moved, so the merge must be redone and the stale warning closes.
+    store.recordObservation({ externalId: 'clean-merge-moved', observedAt: at(), source: 'poll', subject: { ...subject, baseSha: 'base-2' } })
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).not.toBeNull()
+    expect(store.listIncidents()).toEqual([])
+  })
+
   it('keeps a manually cancelled task cancelled across later polls', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Since #158 merged the pull request's real base, nuxtseo.com #725 and #746 sat in a loop: GitHub reported `CONFLICTING`, prepare merged the real base and found nothing to resolve, and the controller read that as a failure. Each pull request burned its whole Recovery budget, raised ten identical error Incidents, and stayed Failed. Both heads merge cleanly against their real base with `git merge-tree`; GitHub's state was stale.

A clean merge is now its own outcome. The Task completes with the merge as evidence, GitHub gets one GET to recompute mergeability, and one warning Incident names the stale state. Nothing requeues until the head or the base SHA moves. A merge that fails before it can conflict, such as unrelated histories, now reports the Git error instead of the same "no longer conflicts" line.

The old Failed tasks for #725 and #746 stay Failed after deploy; they clear on the next base or head change, or by cancelling them.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01D1oopZjD8zrUc1LtePHGcz