### PR TITLE
fix(agent): keep Review work when only the base branch moves

### DIFF
--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1073,7 +1073,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
 
       const storedRun = task.state.fence > 1 && task.rerun._tag === 'NotRequested' && !manualReview
         ? options.store.listReviewRuns(task.repository, task.pullRequestNumber)
-            .find(run => run.revisionId === task.revisionId && run.headSha === task.pullRequest.headSha)
+            .find(run => run.headSha === task.pullRequest.headSha)
         : undefined
       if (storedRun !== undefined) {
         const repairAccess = await options.preflightRepair(task.repository, signal)

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3843,6 +3843,145 @@ function planReviewFix(
   return { _tag: 'Refused', reason: REVIEW_REPAIR_REFUSALS.owned }
 }
 
+/**
+ * The Revision a Review write lands on.
+ *
+ * A Review answers a head commit. The Revision an Agent claimed can be replaced
+ * while it works, when the base branch moves or GitHub recomputes mergeability,
+ * and the Review rows follow the subject's current Revision. A write that names
+ * the claimed Revision lands on the current one while both share the head
+ * commit. A different head commit keeps the claimed id, and the caller's own
+ * checks refuse it.
+ */
+function currentSameHeadRevision(database: DatabaseSync, revisionId: string): string {
+  const row = database.prepare(`
+    SELECT subjects.current_revision_id AS current_id
+    FROM revisions AS claimed
+    JOIN subjects ON subjects.id = claimed.subject_id
+    JOIN revisions AS current ON current.id = subjects.current_revision_id
+    WHERE claimed.id = ? AND subjects.kind = 'pull_request'
+      AND json_extract(current.payload, '$.state') = 'open'
+      AND json_extract(current.payload, '$.headSha') = json_extract(claimed.payload, '$.headSha')
+  `).get(revisionId) as { current_id: string } | undefined
+  return row?.current_id ?? revisionId
+}
+
+/**
+ * Moves Review work to the Revision that now carries the same head commit.
+ *
+ * A Review answers a head commit. The base branch moving, or GitHub
+ * recomputing mergeability, makes a new Revision of the same head, and every
+ * Review row keyed by Revision read as stale: the running Review was
+ * superseded, a READY verdict stopped refreshing, and a Repair lost its
+ * findings. 208 Reviews died that way in one fortnight. Rows follow the head.
+ *
+ * Conflict resolution and Baseline repair answer a base commit, so they stay.
+ */
+function followHeadCommit(database: DatabaseSync, subjectId: number, revisionId: string, headSha: string): void {
+  const sameHead = `
+    SELECT id FROM revisions
+    WHERE subject_id = ? AND id != ? AND json_extract(payload, '$.headSha') = ?
+  `
+  const sameHeadArgs = [subjectId, revisionId, headSha]
+  database.prepare(`
+    UPDATE review_runs SET revision_id = ?
+    WHERE subject_id = ? AND head_sha = ? AND revision_id != ?
+  `).run(revisionId, subjectId, headSha, revisionId)
+  // A Review that queued a Baseline repair answers that base commit. It stays,
+  // and the moved base gets a fresh Review that can read the repaired base.
+  const waitsOnBaseline = `
+    SELECT revision_id FROM tasks WHERE subject_id = ? AND kind = 'baseline_repair'
+  `
+  database.prepare(`
+    UPDATE worker_tasks SET revision_id = ?
+    WHERE subject_id = ? AND kind = 'adversarial_review' AND state_tag != 'Superseded'
+      AND revision_id IN (${sameHead})
+      AND revision_id NOT IN (${waitsOnBaseline})
+  `).run(revisionId, subjectId, ...sameHeadArgs, subjectId)
+  database.prepare(`
+    UPDATE tasks SET revision_id = ?
+    WHERE subject_id = ? AND kind = 'review_fix' AND state_tag != 'Superseded'
+      AND revision_id IN (${sameHead})
+  `).run(revisionId, subjectId, ...sameHeadArgs)
+  database.prepare(`
+    UPDATE review_status_commands SET revision_id = ?
+    WHERE revision_id IN (${sameHead})
+      AND (
+        (task_kind = 'adversarial_review' AND task_id IN (SELECT id FROM worker_tasks WHERE subject_id = ? AND revision_id = ?))
+        OR (task_kind = 'review_fix' AND task_id IN (SELECT id FROM tasks WHERE subject_id = ? AND revision_id = ?))
+      )
+  `).run(revisionId, ...sameHeadArgs, subjectId, revisionId, subjectId, revisionId)
+  // One row per subject and Revision. The row a Task recorded outranks one a
+  // poll derived, then the newest wins.
+  database.prepare(`
+    DELETE FROM review_resolutions
+    WHERE subject_id = ? AND (revision_id = ? OR revision_id IN (${sameHead}))
+      AND resolution_tag != 'WaitingForBaselineRepair'
+      AND rowid != (
+        SELECT rowid FROM review_resolutions
+        WHERE subject_id = ? AND (revision_id = ? OR revision_id IN (${sameHead}))
+          AND resolution_tag != 'WaitingForBaselineRepair'
+        ORDER BY (task_id IS NOT NULL) DESC, created_at DESC, rowid DESC
+        LIMIT 1
+      )
+  `).run(subjectId, revisionId, ...sameHeadArgs, subjectId, revisionId, ...sameHeadArgs)
+  database.prepare(`
+    UPDATE review_resolutions SET revision_id = ?
+    WHERE subject_id = ? AND revision_id IN (${sameHead})
+      AND resolution_tag != 'WaitingForBaselineRepair'
+      AND NOT EXISTS (SELECT 1 FROM review_resolutions AS held WHERE held.subject_id = ? AND held.revision_id = ?)
+  `).run(revisionId, subjectId, ...sameHeadArgs, subjectId, revisionId)
+  database.prepare(`
+    DELETE FROM pull_request_triage_runs
+    WHERE subject_id = ? AND (revision_id = ? OR revision_id IN (${sameHead}))
+      AND rowid != (
+        SELECT rowid FROM pull_request_triage_runs
+        WHERE subject_id = ? AND (revision_id = ? OR revision_id IN (${sameHead}))
+        ORDER BY completed_at DESC, rowid DESC
+        LIMIT 1
+      )
+  `).run(subjectId, revisionId, ...sameHeadArgs, subjectId, revisionId, ...sameHeadArgs)
+  database.prepare(`
+    UPDATE pull_request_triage_runs SET revision_id = ?
+    WHERE subject_id = ? AND revision_id IN (${sameHead})
+  `).run(revisionId, subjectId, ...sameHeadArgs)
+  database.prepare(`
+    DELETE FROM approval_prompt_comments
+    WHERE subject_id = ? AND (revision_id = ? OR revision_id IN (${sameHead}))
+      AND rowid != (
+        SELECT rowid FROM approval_prompt_comments
+        WHERE subject_id = ? AND (revision_id = ? OR revision_id IN (${sameHead}))
+        ORDER BY updated_at DESC, rowid DESC
+        LIMIT 1
+      )
+  `).run(subjectId, revisionId, ...sameHeadArgs, subjectId, revisionId, ...sameHeadArgs)
+  database.prepare(`
+    UPDATE approval_prompt_comments SET revision_id = ?
+    WHERE subject_id = ? AND revision_id IN (${sameHead})
+  `).run(revisionId, subjectId, ...sameHeadArgs)
+  // A person approved this head commit, whatever the base was at the time.
+  database.prepare(`
+    INSERT OR IGNORE INTO pull_request_approvals (subject_id, revision_id, kind, approved_at)
+    SELECT subject_id, ?, kind, MIN(approved_at)
+    FROM pull_request_approvals
+    WHERE subject_id = ? AND revision_id IN (${sameHead})
+    GROUP BY kind
+  `).run(revisionId, subjectId, ...sameHeadArgs)
+}
+
+/**
+ * A Review Task id no other row holds.
+ *
+ * Review Tasks follow the head commit across Revisions, and a Superseded one
+ * keeps the id of the Revision it started on. A later visit to that Revision
+ * must not reuse it.
+ */
+function unusedWorkerTaskId(database: DatabaseSync, taskId: string, at: string): string {
+  return database.prepare('SELECT 1 FROM worker_tasks WHERE id = ?').get(taskId) === undefined
+    ? taskId
+    : digest(`${taskId}:${at}`)
+}
+
 function supersedeWorkerTasks(
   database: DatabaseSync,
   subjectId: number,
@@ -4028,7 +4167,37 @@ function planAdversarialReview(
 
   const eligible = reviewable && subject.mergeState === 'clean'
 
-  if (alreadyReviewed && subject.kind === 'pull_request' && subject.priorAutomatedReview._tag === 'Found') {
+  // This service's own Review run outranks a comment it finds on GitHub, which
+  // is usually that same run. Read the other way round, a base branch move
+  // filed every verdict as someone else's review.
+  if (alreadyReviewed && localAttempt.head_review_run_id !== null) {
+    const stored = database.prepare(`
+      INSERT INTO review_resolutions (
+        subject_id, revision_id, task_id, task_fence, resolution_tag,
+        review_run_id, baseline_task_id, github_url, reason, created_at
+      ) VALUES (?, ?, NULL, 0, 'Reviewed', ?, NULL, NULL, NULL, ?)
+      ON CONFLICT(subject_id, revision_id) DO UPDATE SET
+        task_id = NULL, task_fence = 0, resolution_tag = 'Reviewed',
+        review_run_id = excluded.review_run_id, baseline_task_id = NULL, github_url = NULL,
+        reason = NULL, created_at = excluded.created_at
+      WHERE review_resolutions.task_id IS NULL
+        AND review_resolutions.resolution_tag IN ('UnknownNeedsReconciliation', 'ExistingReview')
+    `).run(subjectId, revisionId, localAttempt.head_review_run_id, observedAt)
+    if (stored.changes === 1) {
+      recordWorkflowEvent(database, {
+        stream: 'review_resolution',
+        event: 'Reused',
+        entityId: `${subjectId}:${revisionId}`,
+        repository: mapping.github,
+        itemNumber: subject.number,
+        revisionId,
+        from: null,
+        to: 'Reviewed',
+        at: observedAt,
+      })
+    }
+  }
+  else if (alreadyReviewed && subject.kind === 'pull_request' && subject.priorAutomatedReview._tag === 'Found') {
     const stored = database.prepare(`
       INSERT INTO review_resolutions (
         subject_id, revision_id, task_id, task_fence, resolution_tag,
@@ -4054,28 +4223,6 @@ function planAdversarialReview(
       })
     }
   }
-  else if (alreadyReviewed && localAttempt.head_review_run_id !== null) {
-    const stored = database.prepare(`
-      INSERT INTO review_resolutions (
-        subject_id, revision_id, task_id, task_fence, resolution_tag,
-        review_run_id, baseline_task_id, github_url, reason, created_at
-      ) VALUES (?, ?, NULL, 0, 'Reviewed', ?, NULL, NULL, NULL, ?)
-      ON CONFLICT(subject_id, revision_id) DO NOTHING
-    `).run(subjectId, revisionId, localAttempt.head_review_run_id, observedAt)
-    if (stored.changes === 1) {
-      recordWorkflowEvent(database, {
-        stream: 'review_resolution',
-        event: 'Reused',
-        entityId: `${subjectId}:${revisionId}`,
-        repository: mapping.github,
-        itemNumber: subject.number,
-        revisionId,
-        from: null,
-        to: 'Reviewed',
-        at: observedAt,
-      })
-    }
-  }
 
   if (!eligible) {
     supersedeWorkerTasks(
@@ -4091,9 +4238,18 @@ function planAdversarialReview(
   }
 
   supersedeWorkerTasks(database, subjectId, 'adversarial_review', observedAt, 'A newer pull request head commit replaced this review.', revisionId)
+  // Review Tasks follow the head commit, so one Revision can hold several.
+  // The live one answers, then the last one that ran.
   const existing = database.prepare(`
     SELECT id, state_tag, reason, fence, recovery_attempts FROM worker_tasks
     WHERE subject_id = ? AND kind = 'adversarial_review' AND revision_id = ?
+    ORDER BY
+      CASE state_tag
+        WHEN 'Running' THEN 0 WHEN 'Queued' THEN 0 WHEN 'ActionRequired' THEN 0
+        WHEN 'Completed' THEN 1 WHEN 'Failed' THEN 2 ELSE 3
+      END,
+      updated_at DESC, id DESC
+    LIMIT 1
   `).get(subjectId, revisionId) as { id: string, state_tag: TaskRow['state_tag'], reason: string | null, fence: number, recovery_attempts: number } | undefined
   // The failure taxonomy decides, never a list of exact wordings. The list this
   // replaces was collected from past incidents, so rewording any one of those
@@ -4190,7 +4346,7 @@ function planAdversarialReview(
   if (existing !== undefined)
     return
 
-  const taskId = digest(`${mapping.github}:pull_request:${subject.number}:${revisionId}:adversarial_review`)
+  const taskId = unusedWorkerTaskId(database, digest(`${mapping.github}:pull_request:${subject.number}:${revisionId}:adversarial_review`), observedAt)
   database.prepare(`
     INSERT INTO worker_tasks (id, subject_id, revision_id, kind, state_tag, updated_at)
     VALUES (?, ?, ?, 'adversarial_review', 'Queued', ?)
@@ -5966,6 +6122,7 @@ export function openJournalStore(
   }
 
   const requestReviewRerun: JournalStore['requestReviewRerun'] = (input) => {
+    const revisionId = currentSameHeadRevision(database, input.revisionId)
     database.exec('BEGIN IMMEDIATE')
     try {
       const duplicate = database.prepare(`
@@ -6006,7 +6163,7 @@ export function openJournalStore(
         database.exec('COMMIT')
         return { _tag: 'Rejected', reason: { _tag: 'ItemNotFound' } }
       }
-      if (row.current_revision_id !== input.revisionId) {
+      if (row.current_revision_id !== revisionId) {
         database.exec('COMMIT')
         return { _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }
       }
@@ -6022,7 +6179,7 @@ export function openJournalStore(
             AND worker_tasks.subject_id = ?
             AND worker_tasks.revision_id = ?
           LIMIT 1
-        `).get(row.subject_id, input.revisionId) !== undefined
+        `).get(row.subject_id, revisionId) !== undefined
         if (priorDispute) {
           database.exec('COMMIT')
           return { _tag: 'Rejected', reason: { _tag: 'DisputeCapReached' } }
@@ -6042,7 +6199,7 @@ export function openJournalStore(
         || database.prepare(`
           SELECT 1 FROM pull_request_approvals
           WHERE subject_id = ? AND revision_id = ? AND kind = 'review'
-        `).get(row.subject_id, input.revisionId) !== undefined
+        `).get(row.subject_id, revisionId) !== undefined
       if (
         pullRequest.state !== 'open'
         || pullRequest.draft
@@ -6054,12 +6211,12 @@ export function openJournalStore(
         return { _tag: 'Rejected', reason: { _tag: 'ReviewNotReady' } }
       }
 
-      const taskId = row.task_id ?? digest(`${mapping.github}:pull_request:${pullRequest.number}:${input.revisionId}:adversarial_review`)
+      const taskId = row.task_id ?? unusedWorkerTaskId(database, digest(`${mapping.github}:pull_request:${pullRequest.number}:${revisionId}:adversarial_review`), input.at)
       if (row.task_id === null) {
         database.prepare(`
           INSERT INTO worker_tasks (id, subject_id, revision_id, kind, state_tag, updated_at)
           VALUES (?, ?, ?, 'adversarial_review', 'Queued', ?)
-        `).run(taskId, row.subject_id, input.revisionId, input.at)
+        `).run(taskId, row.subject_id, revisionId, input.at)
         recordWorkerTransition(database, { taskId, from: null, to: 'Queued', reason: 'Review rerun requested.', fence: 0, at: input.at })
       }
       else if (row.state_tag !== 'Queued' && row.state_tag !== 'Running') {
@@ -6151,6 +6308,8 @@ export function openJournalStore(
           return
         }
         if (input.subject.kind === 'pull_request') {
+          if (subject.current_revision_id !== revisionId)
+            followHeadCommit(database, subject.id, revisionId, input.subject.headSha)
           // Every mutation Task is claimable only on the subject's current
           // Revision, so one left on an older Revision can never run again. It
           // still holds the one active Task slot for its kind, which blocked
@@ -6752,6 +6911,7 @@ export function openJournalStore(
   }
 
   const recordPullRequestTriageRun: JournalStore['recordPullRequestTriageRun'] = (input) => {
+    const revisionId = currentSameHeadRevision(database, input.revisionId)
     const revision = database.prepare(`
       SELECT worker_tasks.subject_id, revisions.payload
       FROM worker_tasks
@@ -6765,8 +6925,8 @@ export function openJournalStore(
       input.taskId,
       input.repository,
       input.pullRequestNumber,
-      input.revisionId,
-      input.revisionId,
+      revisionId,
+      revisionId,
     ) as { subject_id: number, payload: string } | undefined
     const subject = revision === undefined ? undefined : JSON.parse(revision.payload) as GitHubItem
     if (revision === undefined || subject?.kind !== 'pull_request' || subject.headSha !== input.headSha)
@@ -6778,7 +6938,7 @@ export function openJournalStore(
       const existing = database.prepare(`
         SELECT head_sha, outcome_tag FROM pull_request_triage_runs
         WHERE task_id = ? OR (subject_id = ? AND revision_id = ?)
-      `).get(input.taskId, revision.subject_id, input.revisionId) as {
+      `).get(input.taskId, revision.subject_id, revisionId) as {
         head_sha: string
         outcome_tag: 'ReviewRequired' | 'ReviewSkipped' | 'ReviewRequiredAfterFailure'
       } | undefined
@@ -6799,7 +6959,7 @@ export function openJournalStore(
       `).run(
         input.taskId,
         revision.subject_id,
-        input.revisionId,
+        revisionId,
         input.headSha,
         input.startedAt,
         input.completedAt,
@@ -6841,6 +7001,7 @@ export function openJournalStore(
   }
 
   const recordReviewRun: JournalStore['recordReviewRun'] = (input) => {
+    const revisionId = currentSameHeadRevision(database, input.revisionId)
     const outcome = reviewOutcome(input)
     if (outcome._tag === 'Rejected')
       return outcome
@@ -6872,7 +7033,7 @@ export function openJournalStore(
       WHERE repositories.github = ? AND subjects.github_number = ?
         AND subjects.kind = 'pull_request' AND revisions.id = ?
         AND subjects.current_revision_id = revisions.id
-    `).get(input.repository, input.pullRequestNumber, input.revisionId) as {
+    `).get(input.repository, input.pullRequestNumber, revisionId) as {
       subject_id: number
       payload: string
       policy_json: string
@@ -6891,6 +7052,8 @@ export function openJournalStore(
     const gates = JSON.stringify(input.gates)
     const findings = JSON.stringify(input.findings)
     const usage = JSON.stringify(runUsage)
+    // The digest names the Revision the Agent claimed, so a retry after the
+    // base branch moved still reads as the same run.
     const contentDigest = digest(JSON.stringify({
       repository: input.repository,
       pullRequestNumber: input.pullRequestNumber,
@@ -6928,7 +7091,7 @@ export function openJournalStore(
       `).run(
         input.id,
         revision.subject_id,
-        input.revisionId,
+        revisionId,
         input.provider,
         input.sessionId,
         input.model,
@@ -6959,7 +7122,7 @@ export function openJournalStore(
         entityId: input.id,
         repository: input.repository,
         itemNumber: input.pullRequestNumber,
-        revisionId: input.revisionId,
+        revisionId,
         taskId: revision.review_task_id,
         from: 'Running',
         to: 'Completed',
@@ -6988,6 +7151,7 @@ export function openJournalStore(
   }
 
   const supersedeReviewRun: JournalStore['supersedeReviewRun'] = (input) => {
+    const revisionId = currentSameHeadRevision(database, input.revisionId)
     const outcome = reviewOutcome(input)
     if (outcome._tag === 'Rejected')
       return outcome
@@ -7004,7 +7168,7 @@ export function openJournalStore(
       WHERE repositories.github = ? AND subjects.github_number = ?
         AND subjects.kind = 'pull_request' AND revisions.id = ?
         AND subjects.current_revision_id = revisions.id
-    `).get(input.repository, input.pullRequestNumber, input.revisionId) as {
+    `).get(input.repository, input.pullRequestNumber, revisionId) as {
       subject_id: number
       payload: string
       policy_json: string
@@ -7065,7 +7229,7 @@ export function openJournalStore(
       `).get(
         input.supersedesReviewRunId,
         revision.subject_id,
-        input.revisionId,
+        revisionId,
         input.headSha,
       )
       if (parent === undefined) {
@@ -7084,7 +7248,7 @@ export function openJournalStore(
       `).run(
         input.id,
         revision.subject_id,
-        input.revisionId,
+        revisionId,
         input.provider,
         input.sessionId,
         input.model,
@@ -7355,17 +7519,21 @@ export function openJournalStore(
   }
 
   const getReviewFixFindings: JournalStore['getReviewFixFindings'] = (repository, pullRequestNumber, revisionId) => {
+    // The Review answers the head commit the Revision names, whichever
+    // Revision of that head the run sits on now.
     const row = database.prepare(`
       SELECT review_runs.findings
       FROM review_runs
       JOIN subjects ON subjects.id = review_runs.subject_id
       JOIN repositories ON repositories.id = subjects.repository_id
+      JOIN revisions ON revisions.id = ? AND revisions.subject_id = subjects.id
       WHERE repositories.github = ? AND subjects.github_number = ?
-        AND subjects.kind = 'pull_request' AND review_runs.revision_id = ?
+        AND subjects.kind = 'pull_request'
+        AND review_runs.head_sha = json_extract(revisions.payload, '$.headSha')
         AND review_runs.kind = 'adversarial_review'
       ORDER BY review_runs.completed_at DESC, review_runs.id DESC
       LIMIT 1
-    `).get(repository, pullRequestNumber, revisionId) as { findings: string } | undefined
+    `).get(revisionId, repository, pullRequestNumber) as { findings: string } | undefined
     return row === undefined
       ? []
       : (JSON.parse(row.findings) as ReviewFinding[]).filter(finding => finding._tag === 'Open' && finding.resolution !== 'Dismissal')
@@ -8770,6 +8938,7 @@ export function openJournalStore(
   }
 
   const stageReviewStatus: JournalStore['stageReviewStatus'] = (input) => {
+    const revisionId = currentSameHeadRevision(database, input.revisionId)
     const bodySha256 = digest(input.body)
     const desiredOutcome = input.desiredOutcome ?? reviewDesiredOutcomeFromBody(input.body)
     const commandId = digest(`${input.taskKind}:${input.taskId}:${input.fence}:${input.phase}:${input.reviewRunId ?? ''}:${desiredOutcome ?? ''}:${bodySha256}`)
@@ -8796,8 +8965,8 @@ export function openJournalStore(
         input.workerId,
         input.fence,
         input.at,
-        input.revisionId,
-        input.revisionId,
+        revisionId,
+        revisionId,
         input.expectedHeadSha,
       )
       if (authorized === undefined) {
@@ -8840,7 +9009,7 @@ export function openJournalStore(
         input.taskKind,
         input.taskId,
         input.fence,
-        input.revisionId,
+        revisionId,
         input.expectedHeadSha,
         input.phase,
         input.body,

--- a/packages/harlan-github-agent/test/review-follows-head.test.ts
+++ b/packages/harlan-github-agent/test/review-follows-head.test.ts
@@ -1,0 +1,243 @@
+import type { ReviewGates } from '../src/types.ts'
+import { afterEach, describe, expect, it } from 'vitest'
+import { openJournalStore } from '../src/store.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const stores: Array<ReturnType<typeof openJournalStore>> = []
+
+afterEach(() => stores.splice(0).forEach(store => store.close()))
+
+function createStore() {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  return store
+}
+
+function passedReviewGates(): ReviewGates {
+  return {
+    merge: { _tag: 'Passed', evidence: [{ label: 'mergeability', sha256: 'b'.repeat(64) }] },
+    review: { _tag: 'Passed', evidence: [{ label: 'review', sha256: 'c'.repeat(64) }] },
+    ci: { _tag: 'Passed', evidence: [{ label: 'required-ci', sha256: 'e'.repeat(64) }] },
+  }
+}
+
+const reviewRun = {
+  repository: 'harlan-zw/example',
+  pullRequestNumber: 24,
+  headSha: 'abc123',
+  provider: 'codex' as const,
+  sessionId: 'session-1',
+  model: 'gpt-5.6',
+  agentVersion: '1.2.3',
+  skillDigest: 'f'.repeat(64),
+  startedAt: '2026-08-13T01:01:00.000Z',
+  completedAt: '2026-08-13T01:02:00.000Z',
+}
+
+/** The same head commit observed again after the base branch moved. */
+function baseMoved(store: ReturnType<typeof openJournalStore>, at: string, overrides: Parameters<typeof pullRequestItem>[0] = {}) {
+  const observed = store.recordObservation({
+    externalId: `base-moved-${at}`,
+    observedAt: at,
+    source: 'poll',
+    subject: pullRequestItem({ mergeState: 'clean', baseSha: 'base456', ...overrides }),
+  })
+  if (observed._tag === 'Stale' || observed._tag === 'Conflict')
+    throw new Error(`Expected the moved base to be recorded, not ${observed._tag}.`)
+  return observed.revisionId
+}
+
+describe('review work follows the head commit', () => {
+  it('keeps a running Review when only the base branch moves', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'running-review',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (task === null)
+      throw new Error('Expected the queued Review Task.')
+
+    baseMoved(store, '2026-08-13T01:00:45.000Z')
+
+    expect(store.heartbeatWorkerTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:00:50.000Z',
+      leaseMilliseconds: 60 * 60_000,
+    })).toBe(true)
+    expect(store.recordReviewRun({
+      ...reviewRun,
+      id: 'run-after-base-move',
+      revisionId: task.revisionId,
+      gates: passedReviewGates(),
+      confidence: 91,
+      findings: [],
+    })).toEqual({ _tag: 'Inserted', reviewRunId: 'run-after-base-move' })
+    expect(store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:02:30.000Z',
+      revisionId: task.revisionId,
+      expectedHeadSha: 'abc123',
+      body: '### 🤖 READY',
+      desiredOutcome: 'READY',
+      reviewRunId: 'run-after-base-move',
+    })._tag).toBe('Staged')
+    expect(store.completeReviewTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:03:00.000Z',
+      evidence: 'run-after-base-move',
+      resolution: { _tag: 'Reviewed', reviewRunId: 'run-after-base-move' },
+    })).toBe(true)
+
+    const snapshot = store.getDashboardSnapshot('2026-08-13T01:03:30.000Z')
+    expect(snapshot.tasks.filter(item => item.kind === 'adversarial_review').map(item => item.state._tag)).toEqual(['Completed'])
+    expect(snapshot.queue).toEqual([])
+  })
+
+  it('keeps a READY verdict refreshing after the base branch moves', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'ready-review',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (task === null)
+      throw new Error('Expected the queued Review Task.')
+    store.recordReviewRun({
+      ...reviewRun,
+      id: 'ready-run',
+      revisionId: observed.revisionId,
+      gates: passedReviewGates(),
+      confidence: 91,
+      findings: [],
+    })
+    store.completeReviewTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:02:30.000Z',
+      evidence: 'ready-run',
+      resolution: { _tag: 'Reviewed', reviewRunId: 'ready-run' },
+    })
+    store.recordReviewPublication({
+      id: 'ready-publication',
+      reviewRunId: 'ready-run',
+      body: '### 🤖 READY',
+      at: '2026-08-13T01:03:00.000Z',
+      result: { _tag: 'Published', githubCommentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' },
+    })
+    expect(store.listReviewGateRefreshes()).toHaveLength(1)
+
+    const movedRevisionId = baseMoved(store, '2026-08-13T02:00:00.000Z')
+
+    expect(store.listReviewGateRefreshes()).toEqual([expect.objectContaining({
+      reviewRunId: 'ready-run',
+      revisionId: movedRevisionId,
+      headSha: 'abc123',
+      commentId: 42,
+    })])
+    const snapshot = store.getDashboardSnapshot('2026-08-13T02:00:30.000Z')
+    expect(snapshot.tasks.filter(item => item.kind === 'adversarial_review').map(item => item.state._tag)).toEqual(['Completed'])
+    expect(snapshot.queue).toEqual([])
+  })
+
+  it('keeps a Repair and its findings after the base branch moves', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'blocked-review',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    const review = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (review === null)
+      throw new Error('Expected the queued Review Task.')
+    const gates = passedReviewGates()
+    gates.review = { _tag: 'Failed', reason: 'Unsafe input reached a command boundary.', evidence: [] }
+    store.recordReviewRun({
+      ...reviewRun,
+      id: 'blocked-run',
+      revisionId: observed.revisionId,
+      gates,
+      findings: [{ _tag: 'Open', summary: 'Unsafe command input.', nextAction: 'Apply the guarded fix.' }],
+    })
+    const queued = store.queueReviewFixTaskForReview({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:03:00.000Z',
+    })
+    if (queued._tag !== 'Queued')
+      throw new Error(`Expected the Repair Task, not ${queued._tag}.`)
+    const repair = store.claimNextReviewFixTask('repair-1', '2026-08-13T01:03:30.000Z', 60 * 60_000)
+    if (repair === null)
+      throw new Error('Expected the queued Repair Task.')
+
+    baseMoved(store, '2026-08-13T01:04:00.000Z')
+
+    expect(store.getReviewFixFindings('harlan-zw/example', 24, repair.revisionId)).toEqual([
+      { _tag: 'Open', summary: 'Unsafe command input.', nextAction: 'Apply the guarded fix.' },
+    ])
+    const snapshot = store.getDashboardSnapshot('2026-08-13T01:04:30.000Z')
+    expect(snapshot.tasks.find(item => item.id === repair.id)?.state._tag).toBe('Running')
+  })
+
+  it('leaves one Review Task when mergeability flaps after the base branch moves', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'flapping-review',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (task === null)
+      throw new Error('Expected the queued Review Task.')
+    store.recordReviewRun({
+      ...reviewRun,
+      id: 'flapping-run',
+      revisionId: observed.revisionId,
+      gates: passedReviewGates(),
+      confidence: 91,
+      findings: [],
+    })
+    store.completeReviewTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:02:30.000Z',
+      evidence: 'flapping-run',
+      resolution: { _tag: 'Reviewed', reviewRunId: 'flapping-run' },
+    })
+
+    baseMoved(store, '2026-08-13T02:00:00.000Z')
+    baseMoved(store, '2026-08-13T02:01:00.000Z', { mergeState: 'unknown' })
+    baseMoved(store, '2026-08-13T02:02:00.000Z')
+
+    const snapshot = store.getDashboardSnapshot('2026-08-13T02:03:00.000Z')
+    expect(snapshot.tasks.filter(item => item.kind === 'adversarial_review').map(item => item.state._tag)).toEqual(['Completed'])
+    expect(snapshot.queue).toEqual([])
+  })
+})

--- a/packages/harlan-github-agent/test/review-repair-claim.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-claim.test.ts
@@ -175,50 +175,6 @@ describe('review Repair queue', () => {
     })._tag).toBe('Staged')
   })
 
-  it('stops an active Repair when the pull request base commit changes', () => {
-    const store = createStore()
-    const { review, revisionId } = runningReview(store, 'fix/base-moved')
-    recordOpenFinding(store, revisionId, review.pullRequest.headSha)
-    const queued = store.queueReviewFixTaskForReview({
-      taskId: review.id,
-      workerId: review.state.workerId,
-      fence: review.state.fence,
-      at: '2026-08-13T01:00:04.000Z',
-    })
-    if (queued._tag !== 'Queued')
-      throw new Error(queued.reason)
-    const repair = store.claimNextReviewFixTask('repair-agent', '2026-08-13T01:00:05.000Z', 600_000)
-    if (repair === null)
-      throw new Error('Expected the Repair Task.')
-
-    const moved = store.recordObservation({
-      externalId: 'repair-base-moved',
-      observedAt: '2026-08-13T01:00:06.000Z',
-      source: 'poll',
-      subject: pullRequestItem({
-        headRef: repair.pullRequest.headRef,
-        headSha: repair.pullRequest.headSha,
-        baseSha: 'new-base-commit',
-        mergeState: 'clean',
-        updatedAt: '2026-08-13T01:00:06.000Z',
-      }),
-    })
-    if (moved._tag !== 'Inserted')
-      throw new Error('Expected the base move to create a new Revision.')
-
-    expect(store.heartbeatTask({
-      taskId: repair.id,
-      workerId: repair.state.workerId,
-      fence: repair.state.fence,
-      at: '2026-08-13T01:00:07.000Z',
-      leaseMilliseconds: 600_000,
-    })).toBe(false)
-    expect(store.getDashboardSnapshot('2026-08-13T01:00:07.000Z').tasks.find(task => task.id === repair.id)?.state).toEqual({
-      _tag: 'Superseded',
-      reason: 'A newer pull request Revision replaced this Repair.',
-    })
-  })
-
   it('retires a disputed Repair after a fresh Review finds no defect', () => {
     const store = createStore()
     const { review, revisionId } = runningReview(store, 'fix/disputed-finding')

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -3886,9 +3886,12 @@ describe('journal store', () => {
       throw new Error('Expected the new base revision.')
 
     expect(store.claimNextAdversarialReviewTask('reviewer-2', '2026-08-13T02:01:00.000Z', 10_000)).toBeNull()
-    expect(store.listWorkflowEvents({ stream: 'review_resolution', limit: 10 })).toContainEqual(expect.objectContaining({
-      event: 'Recorded',
+    // The run answers the head commit, so it follows the head to the new base.
+    expect(store.listReviewRuns('harlan-zw/example', 24)).toEqual([expect.objectContaining({
+      id: 'old-base-attempt',
       revisionId: secondObservation.revisionId,
+    })])
+    expect(store.listWorkflowEvents({ stream: 'review_resolution', limit: 10 })).not.toContainEqual(expect.objectContaining({
       to: 'ExistingReview',
     }))
   })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

A Revision hashes the base SHA, so every push to `main` minted a new Revision of every open pull request. On harlan-agent-kit#154 one READY Review sits under 18 later Revisions, each resolved as "existing review" by someone else, with gate refresh stopped. Across the fleet, 208 Reviews were superseded since 2026-08-20 with the reason "a newer head commit replaced this review" while the head had not changed.

Review rows now follow the head commit to the new Revision, and a write from a Task claimed on the old Revision lands on the current one while both share the head. Conflict resolution and Baseline repair answer a base commit, so they stay put.

Not sure about one thing: a Review that is Queued when the pull request turns `conflicting` is still superseded, and the revisited clean Revision now gets a fresh Task instead of silently never reviewing again. That looks like the right behaviour but it is a change.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Ps6a9ZQEYpoZWtuLdj4WZG