### PR TITLE
fix(agent): key the issue triage session on the issue alone

### DIFF
--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -373,9 +373,9 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       const instructionFiles = await listInstructionFiles(prepared.value.path)
       const triage = parseStoredIssueTriage(options.store.getIssueTriageEvidence(task.repository, task.issueNumber, task.revisionId))
 
-      // The triage session is keyed on the default branch tip, whatever the pull
-      // request stacks on, so stacking never loses the session that triaged it.
-      const scopeDigest = issueSnapshotDigest({ ...snapshot.value, baseSha: prepared.value.defaultBranchSha })
+      // The triage session is keyed on the issue alone, so neither stacking nor
+      // a moved default branch loses the session that triaged it.
+      const scopeDigest = issueSnapshotDigest(snapshot.value)
       const sessionId = options.store.getWorkerSession(task.repository, task.issueNumber, 'issue_triage', scopeDigest)
       if (sessionId === null)
         return err('The issue changed before work started.')
@@ -452,7 +452,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       const frozen = await options.github.getIssueTriageSnapshot(validated.value, task.issueNumber, signal)
       if (frozen._tag === 'Err')
         return frozen
-      if (issueSnapshotDigest({ ...frozen.value, baseSha: prepared.value.defaultBranchSha }) !== scopeDigest)
+      if (issueSnapshotDigest(frozen.value) !== scopeDigest)
         return err('The issue changed before the controller committed the fix.')
 
       const committed = await options.worktrees.commit(task, stacked.value.workspace, stacked.value.patch, response.commitMessage, signal)

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -298,7 +298,10 @@ export function reviewSnapshotDigest(snapshot: PullRequestReviewSnapshot): strin
   return createHash('sha256').update(JSON.stringify({ ...reviewed, pullRequest })).digest('hex')
 }
 
-export function issueSnapshotDigest(snapshot: { baseSha: string, body: string, comments: string[], state: string, title: string, updatedAt: string }): string {
+// The digest keys an issue's triage session, so it carries the issue and
+// nothing else. A branch tip here would retire every stored session each time
+// the default branch moved, and no issue triaged before that commit could run.
+export function issueSnapshotDigest(snapshot: { body: string, comments: string[], state: string, title: string, updatedAt: string }): string {
   const { updatedAt: _githubActivityAt, ...issue } = snapshot
   return createHash('sha256').update(JSON.stringify(issue)).digest('hex')
 }
@@ -1329,7 +1332,7 @@ export function createIssueTriageWorker(options: ItemAgentOptions): IssueTriageW
       const started = saveAgentProgress(options, task, { percent: 35, label: 'Git worktree ready' })
       if (started._tag === 'Err')
         return started
-      const scopeDigest = issueSnapshotDigest({ ...snapshot.value, baseSha: workspace.value.baseSha })
+      const scopeDigest = issueSnapshotDigest(snapshot.value)
       const turn = await runParsedAgentTurn({ ...options, parse: parseIssueTriageResponse }, {
         freshSession: task.state.fence > 1,
         number: task.issueNumber,

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -4,6 +4,7 @@ import type { ProviderCapture } from './fixtures.ts'
 import { describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { createIssueWorkWorker } from '../src/issue-work-worker.ts'
+import { issueSnapshotDigest } from '../src/item-agent.ts'
 import { ok } from '../src/result.ts'
 import { agentRuntime, issueItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
@@ -612,5 +613,64 @@ Closes #12.`,
 
     expect(workspaceCreated).toBe(true)
     expect(result).toEqual({ _tag: 'Err', error: 'The issue changed before work started.' })
+  })
+  it('keeps the triage session when only the default branch moves', async () => {
+    const repository = repositoryMapping()
+    const issue = issueItem()
+    // The issue itself never changed. Only the default branch tip advanced
+    // between the triage turn and this Batch unit claiming its Task.
+    const snapshot = { body: 'Body', comments: [], state: 'open' as const, title: issue.title, updatedAt: '2026-08-13T01:00:00.000Z' }
+    const triageDigest = issueSnapshotDigest(snapshot)
+    const asked: Array<string | undefined> = []
+    const worker = createIssueWorkWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider(turnEvents({
+        outcome: 'implemented',
+        summary: 'Fixed.',
+        checks: ['pnpm test'],
+        commitMessage: 'fix: helper',
+        pullRequestTitle: 'fix: helper',
+        pullRequestBody: '### Description\n\nFixed.\n\n### Linked Issues\n\nCloses #12.',
+      }))),
+      github: {
+        getIssueTriageSnapshot: () => Promise.resolve(ok(snapshot)),
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Found', body: '### Description\n\n### Linked Issues' })),
+        listPullRequestFiles: () => Promise.resolve(ok([])),
+      },
+      now: () => new Date('2026-08-13T01:06:00.000Z'),
+      store: {
+        getIssueTriageEvidence: () => null,
+        getWorkerSession: (_repository, _itemNumber, _role, scopeDigest) => {
+          asked.push(scopeDigest)
+          return scopeDigest === triageDigest ? 'triage-session' : null
+        },
+        listOpenAgentPullRequests: () => [],
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+      },
+      validateMapping: () => Promise.resolve(ok(repository)),
+      worktrees: {
+        // Triage ran on `main-sha-1`. This worktree stands on `main-sha-2`.
+        prepare: () => Promise.resolve(ok({ path: '/tmp/issue-work', headSha: 'main-sha-2', baseSha: 'main-sha-2', defaultBranchSha: 'main-sha-2' })),
+        verify: () => Promise.resolve(ok({ digest: 'patch-digest', changedFiles: 1, changedPaths: ['src/helper.ts'] })),
+        restack: () => Promise.reject(new Error('Issue work must not restack.')),
+        commit: () => Promise.resolve(ok({ commitSha: 'commit-sha', baseSha: 'main-sha-2', artifactRef: 'artifact-ref', digest: 'patch-digest', changedFiles: 1 })),
+      },
+    })
+
+    const result = await worker.run({
+      id: 'issue-work-task',
+      kind: 'issue_work',
+      repository: repository.github,
+      issueNumber: issue.number,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T01:10:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: repository,
+      issue,
+    }, new AbortController().signal)
+
+    expect(new Set(asked)).toEqual(new Set([triageDigest]))
+    if (result._tag !== 'Ok' || result.value._tag !== 'Publish' || result.value.publication._tag !== 'OpenPullRequest')
+      throw new Error('Expected a pull request publication.')
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

An issue triaged before the newest commit on the default branch could not be worked at all. Issue work rebuilt the triage session key from the current default branch tip, triage had stored it from the tip as it stood during triage, so the key drifted the moment anything merged. The unit then died with `The issue changed before work started.` while the issue sat there open, same title, same body.

Batches turned that from a rare race into the normal case. A Batch reserves every Task up front and its planning turn ran between 4 and 31 minutes in today's first live run, so the branch had almost always moved before a unit claimed anything. 18 of 22 units failed this way. The recovery pass re-triages a Task that failed with this exact reason, so the same issues opened a fresh Batch and went round again about every 29 minutes.

The digest covers the issue now: body, comments, state, title. Stacking never depended on it.

One thing to know before deploying: every stored session digest was built with the old key, so each pending issue fails its lookup once, re-triages, and is stable after that. Same cost the service was already paying on every commit to a default branch.

Loose end I did not chase: unlighthouse.dev #26 and #34 published because their triage landed minutes before their unit ran, so they won the race the others lost. Nothing in the code makes that ordering explicit, it just happened to hold.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).