### PR TITLE
fix(agent): keep a Batch alive when the store refuses a unit failure

### DIFF
--- a/packages/harlan-github-agent/src/batch-worker.ts
+++ b/packages/harlan-github-agent/src/batch-worker.ts
@@ -358,7 +358,15 @@ export function createBatchWorker(options: BatchWorkerOptions): BatchWorker {
           const execution = runUnit(batch, mapping, unit, signal)
             .catch((error: unknown) => {
               options.logger.error(error)
-              options.store.settleBatchUnit({ unitId: unit.id, at: options.now().toISOString(), state: { _tag: 'Failed', reason: error instanceof Error ? error.message : 'The unit failed unexpectedly.' } })
+              // The unit failed, and recording that can fail the same way, so
+              // this never rethrows. A Batch that loses one unit keeps its
+              // other units, and the lease expiry settles what is left.
+              try {
+                options.store.settleBatchUnit({ unitId: unit.id, at: options.now().toISOString(), state: { _tag: 'Failed', reason: error instanceof Error ? error.message : 'The unit failed unexpectedly.' } })
+              }
+              catch (settleError: unknown) {
+                options.logger.error(settleError)
+              }
             })
             .finally(() => running.delete(execution))
           running.add(execution)

--- a/packages/harlan-github-agent/test/batch-worker.test.ts
+++ b/packages/harlan-github-agent/test/batch-worker.test.ts
@@ -1,5 +1,8 @@
+import type { BatchUnit } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
-import { batchPlanPrompt, parseBatchPlan } from '../src/batch-worker.ts'
+import { batchPlanPrompt, createBatchWorker, parseBatchPlan } from '../src/batch-worker.ts'
+import { ok } from '../src/result.ts'
+import { repositoryMapping } from './fixtures.ts'
 
 describe('parseBatchPlan', () => {
   it('reads units with their stack order and cleans the prose', () => {
@@ -41,5 +44,58 @@ describe('batchPlanPrompt', () => {
     expect(prompt).toContain('"target":"src/a.ts"')
     expect(prompt).toContain('Do not edit files, commit, push, or post comments.')
     expect(prompt).toContain('Every issue appears in exactly one unit.')
+  })
+})
+
+describe('batch worker unit failures', () => {
+  it('keeps running when the store refuses the failure it is recording', async () => {
+    // The store closed under the Batch. Recording the unit failure fails the
+    // same way the unit did, and that must not take the service down with it.
+    const errors: unknown[] = []
+    const repository = repositoryMapping()
+    const unit: BatchUnit = {
+      id: 'unit-1',
+      position: 0,
+      primaryTaskId: 'task-1',
+      issueNumbers: [12],
+      dependsOnUnitId: null,
+      rationale: 'Alone.',
+      state: { _tag: 'Waiting' },
+    }
+    const worker = createBatchWorker({
+      canClaimIssueWork: () => true,
+      github: { getIssueTriageSnapshot: () => Promise.reject(new Error('The Batch reads no snapshot here.')) },
+      issueWork: { run: () => Promise.reject(new Error('No unit Task is ever claimed.')) },
+      leaseMilliseconds: 60_000,
+      logger: { info: () => undefined, error: error => errors.push(error) },
+      now: () => new Date('2026-09-04T06:03:11.000Z'),
+      runtime: {} as never,
+      store: {
+        claimBatchUnitTask: () => null,
+        completeCombinedIssueWork: () => undefined,
+        getBatchDependency: () => ({ _tag: 'Unavailable', reason: 'The unit failed.' }),
+        recordBatchPlan: () => [],
+        settleBatchUnit: () => {
+          throw new Error('database is not open')
+        },
+      } as never,
+      validateMapping: () => Promise.resolve(ok(repository)),
+      workerId: 'worker-1',
+      workspaces: { prepareBatch: () => Promise.reject(new Error('The Batch prepares no workspace here.')) },
+    })
+
+    const result = await worker.run({
+      id: 'batch-1',
+      repository: repository.github,
+      repositoryMapping: repository,
+      issues: [{ taskId: 'task-1', issueNumber: 12, title: 'Broken', body: '', triageSummary: null, relatedIssues: [], target: null }],
+      units: [unit],
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-09-04T10:03:11.000Z' },
+      createdAt: '2026-09-04T05:14:15.000Z',
+      updatedAt: '2026-09-04T05:14:15.000Z',
+    } as never, new AbortController().signal)
+
+    expect(result._tag).toBe('Ok')
+    expect(errors.map(error => error instanceof Error ? error.message : String(error))).toContain('database is not open')
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Cancelling two Batch unit Tasks on 2026-09-04 produced this, and the service went down:

```
16:03:11  ERROR  database is not open
    at Object.settleBatchUnit (src/batch-store.ts:430:21)
    at runUnit (src/batch-worker.ts:313:5)
16:03:11  ERROR  database is not open
    at Object.clearRunningLabel (src/github-agent-source.ts:521:29)
    at Object.settleTask [as onTaskSettled] (src/service.ts:473:48)
    at runUnit (src/batch-worker.ts:311:28)
systemd: Scheduled restart job, restart counter is at 11.
```

The unit failure handler recorded the failure using the same `settleBatchUnit` call that had just failed, so it threw a second time from inside the handler itself. That rejection travelled out through `Promise.race` and rejected the whole Batch. One refused write took down every other unit with it.

The handler logs a refused settle now instead of rethrowing.

What I could not pin down: why the store was closed at all. There is no shutdown line before those errors and no OOM kill in the kernel log, so I do not know who closed it, and I have not claimed the cancels caused the restart. What is certain is that a store write failing here should never be able to reject the Batch, whatever closed the database.

Left alone deliberately: a unit whose settle is refused stays `Running` in the journal until its lease expires. Settling it needs the store that just refused, so there is nothing better to do at that point.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).