### PR TITLE
fix(agent): read the manual Review label in the Review snapshot

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -5,6 +5,7 @@ import type { Result } from './result.ts'
 import type { PriorAutomatedReview } from './review-comment.ts'
 import type { GitHubPullRequestItem, GitHubRepositoryAccess, RepositoryMapping } from './types.ts'
 import { AGENT_LABELS, planAgentLabels, staleAgentLabels } from './agent-label.ts'
+import { approvalLabels } from './approval-labels.ts'
 import { hasAutoMergeLabel } from './auto-merge.ts'
 import { isControllerOwned, pullRequestPurpose } from './baseline-repair-state.ts'
 import { createAuthenticatedClient } from './github-auth.ts'
@@ -348,7 +349,10 @@ function pullRequestItem(
   const labels = pull.labels.flatMap(label => label.name === undefined ? [] : [label.name])
   return {
     kind: 'pull_request',
-    approvalLabels: [],
+    // The poller reads the same labels. An empty list here let the manual
+    // Review label survive every Review, and each new Revision then reviewed
+    // the same head commit again as a fresh manual request.
+    approvalLabels: approvalLabels(labels),
     autoMerge: hasAutoMergeLabel(labels),
     repository: repository.github,
     number: pull.number,

--- a/packages/harlan-github-agent/test/review-snapshot-approval-labels.test.ts
+++ b/packages/harlan-github-agent/test/review-snapshot-approval-labels.test.ts
@@ -1,0 +1,65 @@
+import type { Octokit } from 'octokit'
+import { describe, expect, it } from 'vitest'
+import { createGitHubAgentSource } from '../src/github-agent-source.ts'
+import { ok } from '../src/result.ts'
+import { repositoryMapping } from './fixtures.ts'
+
+const baseSha = 'b'.repeat(40)
+
+function client(labels: string[]): Octokit {
+  return {
+    paginate: () => Promise.resolve([]),
+    rest: {
+      actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')) },
+      checks: { listForRef: () => undefined },
+      issues: { listComments: () => undefined },
+      pulls: {
+        get: () => Promise.resolve({
+          data: {
+            number: 24,
+            state: 'open',
+            merged_at: null,
+            title: 'Fix the broken thing',
+            body: 'Fixes the bug.',
+            user: { login: 'harlan-zw' },
+            html_url: 'https://github.com/harlan-zw/example/pull/24',
+            created_at: '2026-08-01T00:00:00.000Z',
+            updated_at: '2026-08-13T00:00:00.000Z',
+            draft: false,
+            labels: labels.map(name => ({ name })),
+            base: { sha: baseSha, ref: 'main' },
+            head: { sha: 'c'.repeat(40), ref: 'fix/thing', repo: { full_name: 'harlan-zw/example' } },
+            maintainer_can_modify: true,
+            mergeable: true,
+          },
+        }),
+        listReviewComments: () => undefined,
+        listReviews: () => undefined,
+      },
+      repos: {
+        getBranch: () => Promise.resolve({ data: { commit: { sha: baseSha } } }),
+        getBranchRules: () => Promise.resolve({ data: [] }),
+        getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+      },
+    },
+  } as unknown as Octokit
+}
+
+describe('review snapshot approval labels', () => {
+  it('reads the manual Review label the poller reads', async () => {
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client(['harlan-agent-review', 'bug']),
+      tokens: {
+        getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T02:00:00.000Z' })),
+        invalidate: () => undefined,
+      },
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      pullRequest: expect.objectContaining({ approvalLabels: ['review'] }),
+    })))
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Follow-up to #182. mdream#216 still got three real Reviews of one head commit this week. The pull request carries `harlan-agent-review`, added by hand on 25 Aug. The poller reads that label and treats each new Revision as a manual Review request, but the Review Agent's own snapshot hardcoded an empty label list, so the Agent never noticed the request and never removed the label. Every push to `main` was a new review.

The snapshot now reads labels the same way the poller does. On the next Review the label gets consumed, and after that the head-commit reuse from #182 holds.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Ps6a9ZQEYpoZWtuLdj4WZG