### PR TITLE
feat(agent): let a Routine write its own issue title

### DIFF
--- a/packages/harlan-github-agent/src/candidate-issue-controller.ts
+++ b/packages/harlan-github-agent/src/candidate-issue-controller.ts
@@ -35,6 +35,23 @@ function displayableClaim(claim: string): string {
   return claim.length <= maximumClaimLength ? claim : `${claim.slice(0, maximumClaimLength)}…`
 }
 
+// GitHub refuses a title longer than 256 characters.
+const maximumTitleLength = 256
+
+/**
+ * The issue title one Candidate gets.
+ *
+ * The title used to be the routine name joined to the whole claim, so every
+ * issue list read as truncated prose, and the name repeated the
+ * `routine:<name>` label. The Agent now writes the title, and a title that
+ * arrives blank falls back to the claim rather than filing an untitled issue.
+ */
+export function candidateIssueTitle(candidate: Pick<Candidate, 'title' | 'claim'>): string {
+  const written = candidate.title.replace(/\s+/g, ' ').trim()
+  const title = written.length > 0 ? written : candidate.claim.replace(/\s+/g, ' ').trim()
+  return title.slice(0, maximumTitleLength)
+}
+
 /**
  * Writes the issue one Candidate proposes.
  *
@@ -70,7 +87,7 @@ export function candidateIssueCommands(
       candidateId: candidate.id,
       repository: routine.repository,
       routineName: routine.name,
-      title: `${routine.name}: ${claim}`.slice(0, 256),
+      title: candidateIssueTitle(candidate),
       body: candidateIssueBody({ ...candidate, claim }, routine),
     }
   })

--- a/packages/harlan-github-agent/src/routine-worker.ts
+++ b/packages/harlan-github-agent/src/routine-worker.ts
@@ -31,11 +31,15 @@ export const CANDIDATE_SCHEMA = {
       items: {
         type: 'object',
         additionalProperties: false,
-        required: ['fingerprint', 'target', 'claim', 'verification', 'estimatedChangedFiles'],
+        required: ['fingerprint', 'title', 'target', 'claim', 'verification', 'estimatedChangedFiles'],
         properties: {
           fingerprint: {
             type: 'string',
             description: 'Stable identity for this proposal. Use a file path or a symbol path. Never a line number.',
+          },
+          title: {
+            type: 'string',
+            description: 'The issue title. Name the defect in under 70 characters. Do not add the routine name, a prefix, or a trailing period.',
           },
           target: { type: 'string', description: 'The file or symbol this proposal changes.' },
           claim: { type: 'string', description: 'One sentence saying what is wrong.' },
@@ -51,6 +55,7 @@ interface ScanResponse {
   report?: string
   candidates: Array<{
     fingerprint: string
+    title: string
     target: string
     claim: string
     verification: string
@@ -88,7 +93,7 @@ const DAILY_CHECKIN_TURN = `Apply the daily-checkin skill at .claude/skills/dail
 
 Follow its workflow completely, including running its data script and writing its report and ledger files. This worktree is disposable and nothing in it is kept, so copy the whole Markdown report, from the verdict line through the proposed actions, into \`report\`. Do not commit or push anything. Keep production access read only.
 
-Return each proposed action as one Candidate. Use the ledger fingerprint as the Candidate fingerprint when the action has one. Put the action in \`claim\`, the file or system it changes in \`target\`, and the check that proves it in \`verification\`.`
+Return each proposed action as one Candidate. Use the ledger fingerprint as the Candidate fingerprint when the action has one. Put a short issue title in \`title\`, the action in \`claim\`, the file or system it changes in \`target\`, and the check that proves it in \`verification\`.`
 
 const agentFeedbackSkillTarget = /^harlan-agent-kit\/skills\/[^/]+\/SKILL\.md$/
 
@@ -141,6 +146,10 @@ Return every proposal you would make as a Candidate. Give each one a fingerprint
 that stays the same next time you find it. Use a file path or a symbol path.
 Never use a line number, because a line number changes when anything above it
 changes.
+
+Give each one a title. A person reads it in a list of issues, so name the defect
+in under 70 characters. Write it the way you would write a commit subject. Do not
+repeat the routine name, and do not end it with a period.
 
 Estimate how many files each proposal would change. Leave out anything that
 would change more than ${DEFAULT_MAXIMUM_CHANGED_FILES} files.
@@ -292,6 +301,7 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
         runId: task.id,
         candidates: withinSize.map(candidate => ({
           fingerprint: candidate.fingerprint,
+          title: candidate.title,
           target: candidate.target,
           claim: candidate.claim,
           verification: candidate.verification,

--- a/packages/harlan-github-agent/src/routine-worker.ts
+++ b/packages/harlan-github-agent/src/routine-worker.ts
@@ -301,7 +301,7 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
         runId: task.id,
         candidates: withinSize.map(candidate => ({
           fingerprint: candidate.fingerprint,
-          title: candidate.title,
+          title: typeof candidate.title === 'string' ? candidate.title : '',
           target: candidate.target,
           claim: candidate.claim,
           verification: candidate.verification,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -5474,6 +5474,20 @@ const repairReportMigration = `
  * `publication_commands.pull_request_number` lets a unit that stacks read the
  * pull request its dependency opened without waiting for the next GitHub poll.
  */
+/**
+ * Gives a Candidate its own issue title.
+ *
+ * The title was built as `<routine name>: <claim>`, and the claim is a whole
+ * sentence. Issue lists read as truncated prose, and the routine name repeated
+ * the `routine:<name>` label the same code already applies. The Agent now
+ * writes a short title, and this column keeps it.
+ */
+const candidateTitleMigration = `
+  ALTER TABLE candidates ADD COLUMN title TEXT;
+
+  PRAGMA user_version = 63;
+`
+
 const batchMigration = `
   CREATE TABLE IF NOT EXISTS batches (
     id TEXT PRIMARY KEY,
@@ -5811,9 +5825,17 @@ function installSchema(database: DatabaseSync): void {
     applyMigration(database, columns.includes('pull_request_number')
       ? batchMigration
       : `ALTER TABLE publication_commands ADD COLUMN pull_request_number INTEGER;\n${batchMigration}`)
+    version = 62
+  }
+  if (version === 62) {
+    // A journal rewound for replay already carries the column, and SQLite has
+    // no ADD COLUMN IF NOT EXISTS.
+    const columns = (database.prepare('PRAGMA table_info(candidates)').all() as unknown as Array<{ name: string }>)
+      .map(column => column.name)
+    applyMigration(database, columns.includes('title') ? 'PRAGMA user_version = 63;' : candidateTitleMigration)
     return
   }
-  if (version === 62)
+  if (version === 63)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -12446,6 +12468,7 @@ export function openJournalStore(
     routine_id: string
     run_id: string
     fingerprint: string
+    title: string | null
     target: string
     claim: string
     verification: string
@@ -12475,6 +12498,9 @@ export function openJournalStore(
     routineId: row.routine_id,
     runId: row.run_id,
     fingerprint: row.fingerprint,
+    // Rows written before the title column carry none. The claim was their
+    // title then, so it stays their title now.
+    title: row.title ?? row.claim,
     target: row.target,
     claim: row.claim,
     verification: row.verification,
@@ -12495,10 +12521,10 @@ export function openJournalStore(
   const recordCandidates: JournalStore['recordCandidates'] = (input) => {
     const statement = database.prepare(`
       INSERT INTO candidates (
-        id, routine_id, run_id, fingerprint, target, claim, verification,
+        id, routine_id, run_id, fingerprint, title, target, claim, verification,
         estimated_changed_files, result_tag, pull_request, created_at, updated_at
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'Proposed', NULL, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'Proposed', NULL, ?, ?)
       ON CONFLICT (routine_id, fingerprint) DO NOTHING
     `)
     const fresh: string[] = []
@@ -12511,6 +12537,7 @@ export function openJournalStore(
           input.routineId,
           input.runId,
           candidate.fingerprint,
+          candidate.title,
           candidate.target,
           candidate.claim,
           candidate.verification,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -12498,9 +12498,9 @@ export function openJournalStore(
     routineId: row.routine_id,
     runId: row.run_id,
     fingerprint: row.fingerprint,
-    // Rows written before the title column carry none. The claim was their
-    // title then, so it stays their title now.
-    title: row.title ?? row.claim,
+    // Rows written before the title column carry none, and a scan answer may
+    // leave it blank. Either way the claim was their title, so it stays it.
+    title: row.title || row.claim,
     target: row.target,
     claim: row.claim,
     verification: row.verification,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -864,6 +864,13 @@ export interface Candidate {
   runId: string
   /** Stable across runs. Never derived from a line number. */
   fingerprint: string
+  /**
+   * The issue title, written by the Agent that proposed this Candidate.
+   *
+   * The claim is a whole sentence, so it reads badly in an issue list. Older
+   * rows carry no title and fall back to the claim at read time.
+   */
+  title: string
   target: string
   claim: string
   verification: string

--- a/packages/harlan-github-agent/test/batch-store.test.ts
+++ b/packages/harlan-github-agent/test/batch-store.test.ts
@@ -37,6 +37,7 @@ async function seedReadyRoutineIssues(store: ReturnType<typeof openJournalStore>
     runId,
     candidates: numbers.map(number => ({
       fingerprint: `src/file-${number}.ts`,
+      title: 'Fixture title',
       target: `src/file-${number}.ts`,
       // The stub publisher reads the issue number it should answer from the claim.
       claim: `Issue #${number} needs a fix.`,

--- a/packages/harlan-github-agent/test/candidate-issue.test.ts
+++ b/packages/harlan-github-agent/test/candidate-issue.test.ts
@@ -1,7 +1,7 @@
 import type { GitHubIssuePublisher } from '../src/github.ts'
 import type { Candidate, ClaimedRoutineRun } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
-import { candidateIssueBody, candidateIssueCommands, createCandidateIssueController, routineIssueLabel } from '../src/candidate-issue-controller.ts'
+import { candidateIssueBody, candidateIssueCommands, candidateIssueTitle, createCandidateIssueController, routineIssueLabel } from '../src/candidate-issue-controller.ts'
 import { err, ok } from '../src/result.ts'
 import { openJournalStore } from '../src/store.ts'
 import { repositoryMapping } from './fixtures.ts'
@@ -26,6 +26,7 @@ const candidate: Candidate = {
   routineId: routine.routineId,
   runId: routine.id,
   fingerprint: 'src/store.ts#openRoutineRun',
+  title: 'Fixture title',
   target: 'src/store.ts',
   claim: 'This helper is never called.',
   verification: 'pnpm test',
@@ -55,6 +56,7 @@ function seed(store: ReturnType<typeof openJournalStore>): void {
     runId: routine.id,
     candidates: [{
       fingerprint: candidate.fingerprint,
+      title: 'Fixture title',
       target: candidate.target,
       claim: candidate.claim,
       verification: candidate.verification,
@@ -175,6 +177,7 @@ describe('filing the issues Candidates propose', () => {
         runId: routine.id,
         candidates: Array.from({ length: 8 }, (_unused, index) => ({
           fingerprint: `src/file-${index}.ts`,
+          title: 'Fixture title',
           target: `src/file-${index}.ts`,
           claim: 'unused',
           verification: 'pnpm test',
@@ -315,7 +318,7 @@ describe('filing the issues Candidates propose', () => {
 
       const claimed = store.claimNextCandidateIssue('controller-2', now().toISOString(), 60_000)
 
-      expect(claimed?.title).toBe('pr-triage: This helper is never called.')
+      expect(claimed?.title).toBe('Fixture title')
       expect(claimed?.reason).toBe('GitHub returned 502.')
     }
     finally {
@@ -375,7 +378,7 @@ describe('filing the issues Candidates propose', () => {
       await createCandidateIssueController({ github: publisher(calls), now: () => new Date('2026-08-28T07:10:00.000Z'), store, workerId: 'controller-3' })
         .publishPending(new AbortController().signal)
 
-      expect(calls.map(call => call.title)).toEqual(['pr-triage: This helper is never called.'])
+      expect(calls.map(call => call.title)).toEqual(['Fixture title'])
     }
     finally {
       store.close()
@@ -449,5 +452,41 @@ describe('filing the issues Candidates propose', () => {
     finally {
       store.close()
     }
+  })
+})
+
+describe('the title one Candidate gets', () => {
+  it('uses the title the Agent wrote, not the claim, and adds no routine prefix', () => {
+    const [command] = candidateIssueCommands([{
+      ...candidate,
+      title: 'Cache the skill detail response',
+      claim: 'Every TTL expiry re-runs six D1 queries at once, so the route sheds load.',
+    }], routine)
+
+    expect(command?.title).toBe('Cache the skill detail response')
+  })
+
+  it('falls back to the claim when the Agent leaves the title blank', () => {
+    expect(candidateIssueTitle({ title: '   ', claim: 'The deploy gate cannot run the binary.' }))
+      .toBe('The deploy gate cannot run the binary.')
+  })
+
+  it('collapses a title written across several lines', () => {
+    expect(candidateIssueTitle({ title: 'Cache the skill\n  detail response', claim: 'unused' }))
+      .toBe('Cache the skill detail response')
+  })
+
+  it('caps a title at the 256 characters GitHub accepts', () => {
+    expect(candidateIssueTitle({ title: 'a'.repeat(300), claim: 'unused' })).toHaveLength(256)
+  })
+
+  it('keeps the claim in the body when the title is shorter', () => {
+    const [command] = candidateIssueCommands([{
+      ...candidate,
+      title: 'Cache the skill detail response',
+      claim: 'Every TTL expiry re-runs six D1 queries at once.',
+    }], routine)
+
+    expect(command?.body).toContain('Every TTL expiry re-runs six D1 queries at once.')
   })
 })

--- a/packages/harlan-github-agent/test/routine-controller.test.ts
+++ b/packages/harlan-github-agent/test/routine-controller.test.ts
@@ -172,6 +172,7 @@ describe('syncing one repository Routine spec', () => {
         runId: run.id,
         candidates: [{
           fingerprint: 'src/cache.ts#stale-fallback',
+          title: 'Fixture title',
           target: 'src/cache.ts',
           claim: 'The stale fallback differs between cache readers.',
           verification: 'pnpm test',

--- a/packages/harlan-github-agent/test/routine-report.test.ts
+++ b/packages/harlan-github-agent/test/routine-report.test.ts
@@ -88,6 +88,7 @@ describe('writing what one run did', () => {
       routineId,
       runId,
       fingerprint: 'src/store.ts#openRoutineRun',
+      title: 'Fixture title',
       target: 'src/store.ts',
       claim: 'The scheduler can open the same run twice.',
       verification: 'pnpm vitest run test/routine-controller.test.ts',
@@ -139,6 +140,7 @@ describe('publishing the run log', () => {
         runId,
         candidates: [{
           fingerprint: 'src/store.ts#openRoutineRun',
+          title: 'Fixture title',
           target: 'src/store.ts',
           claim: 'The scheduler can open the same run twice.',
           verification: 'pnpm vitest run test/routine-controller.test.ts',

--- a/packages/harlan-github-agent/test/routine-spec.test.ts
+++ b/packages/harlan-github-agent/test/routine-spec.test.ts
@@ -414,6 +414,7 @@ describe('the Candidate ledger', () => {
 
   const candidate = {
     fingerprint: 'src/store.ts#openRoutineRun',
+    title: 'Fixture title',
     target: 'src/store.ts',
     claim: 'This helper is never called.',
     verification: 'pnpm test',

--- a/packages/harlan-github-agent/test/routine-worker.test.ts
+++ b/packages/harlan-github-agent/test/routine-worker.test.ts
@@ -66,6 +66,7 @@ function seed(store: ReturnType<typeof openJournalStore>): void {
 
 const candidate = {
   fingerprint: 'src/store.ts#openRoutineRun',
+  title: 'Fixture title',
   target: 'src/store.ts',
   claim: 'This helper is never called.',
   verification: 'pnpm test',
@@ -136,6 +137,7 @@ describe('building the scan prompt', () => {
         routineId: 'r1',
         runId: 'run-1',
         fingerprint: 'src/old.ts',
+        title: 'Fixture title',
         target: 'src/old.ts',
         claim: 'unused',
         verification: 'pnpm test',
@@ -159,6 +161,7 @@ describe('building the scan prompt', () => {
         routineId: 'r1',
         runId: 'run-1',
         fingerprint: 'src/open.ts',
+        title: 'Fixture title',
         target: 'src/open.ts',
         claim: 'unused',
         verification: 'pnpm test',

--- a/packages/harlan-github-agent/test/routine-worker.test.ts
+++ b/packages/harlan-github-agent/test/routine-worker.test.ts
@@ -294,6 +294,33 @@ describe('running one scan', () => {
     }
   })
 
+  it('keeps the run alive when a Candidate arrives without a usable title', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store)
+      const untitled = {
+        fingerprint: candidate.fingerprint,
+        target: candidate.target,
+        claim: candidate.claim,
+        verification: candidate.verification,
+        estimatedChangedFiles: candidate.estimatedChangedFiles,
+      }
+      const numbered = { ...candidate, fingerprint: 'src/answer.ts#main', title: 42 }
+
+      const result = await workerFor(store, scanning({ candidates: [untitled, numbered] }))
+        .run(claimStoredRun(store), new AbortController().signal)
+
+      expect(result).toMatchObject({ _tag: 'Ok' })
+      expect(store.listCandidates('harlan-zw/example:pr-triage')).toMatchObject([
+        { fingerprint: untitled.fingerprint, title: untitled.claim },
+        { fingerprint: numbered.fingerprint, title: numbered.claim },
+      ])
+    }
+    finally {
+      store.close()
+    }
+  })
+
   it('drops a proposal larger than the file limit before it reaches the ledger', async () => {
     const store = openJournalStore(':memory:')
     try {

--- a/packages/harlan-github-agent/test/service-state.test.ts
+++ b/packages/harlan-github-agent/test/service-state.test.ts
@@ -77,6 +77,7 @@ function seedRoutineState(path: string): void {
       runId: run.id,
       candidates: [{
         fingerprint: 'src/store.ts#openRoutineRun',
+        title: 'Fixture title',
         target: 'src/store.ts',
         claim: 'One Routine result belongs on Hogwild.',
         verification: 'pnpm test',

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -635,7 +635,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(62)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(63)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })
@@ -708,6 +708,55 @@ describe('agent selection migration', () => {
 
       expect(store.getAgentSelection()).toEqual({ _tag: 'FollowsConfiguration' })
       expect(store.getDashboardSnapshot('2026-08-18T01:00:01.000Z').agentProfile.provider).toBe('codex')
+    }
+    finally {
+      store.close()
+    }
+  })
+})
+
+describe('candidate title migration', () => {
+  it('reads the claim as the title for a Candidate recorded before titles existed', () => {
+    const path = join(directory, 'state.sqlite')
+    const seeded = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    seeded.syncRepositories([repositoryMapping()], '2026-09-05T00:00:00.000Z')
+    seeded.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'daily-checkin', crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+      at: '2026-09-05T00:00:00.000Z',
+    })
+    seeded.openRoutineRun({
+      routineId: 'harlan-zw/example:daily-checkin',
+      scheduledFor: '2026-09-05T07:00:00.000Z',
+      specSha: 'abc123',
+      at: '2026-09-05T07:00:05.000Z',
+    })
+    seeded.recordCandidates({
+      routineId: 'harlan-zw/example:daily-checkin',
+      runId: 'harlan-zw/example:daily-checkin:2026-09-05T07:00:00.000Z',
+      candidates: [{
+        fingerprint: 'server/utils/cache.ts#cached',
+        title: 'Written after the column existed',
+        target: 'server/utils/cache.ts',
+        claim: 'The deploy gate cannot run the published binary.',
+        verification: 'pnpm test',
+        estimatedChangedFiles: 1,
+      }],
+      at: '2026-09-05T07:05:00.000Z',
+    })
+    seeded.close()
+
+    // Rewind the journal to the shape a service running version 62 wrote.
+    const database = new DatabaseSync(path)
+    database.exec('ALTER TABLE candidates DROP COLUMN title')
+    database.exec('PRAGMA user_version = 62')
+    database.close()
+
+    const store = openJournalStore(path, true, CODEX_AGENT_PROFILE)
+    try {
+      const [candidate] = store.listCandidates('harlan-zw/example:daily-checkin')
+      expect(candidate?.title).toBe('The deploy gate cannot run the published binary.')
     }
     finally {
       store.close()


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

Routine-filed issues are unreadable in a list. The title is `<routine name>: <claim>`, and the claim is a whole sentence, so GitHub truncates mid-thought. This morning's four check-ins filed eight issues that all look like this:

```
daily-checkin: The deploy gate cannot run skilld@3.0.0-beta.4 because the published bin…
daily-checkin: completedState counts `skipped` conclusions as complete, so a skipped gu…
daily-checkin: A Search Engine binding that stopped producing rows still reports health…
```

The routine name is dead weight too. The same code already stamps a `routine:<name>` label, and the body already says which Routine filed it.

The scan Agent now writes a short title of its own, and the Candidate carries it through to the issue.

![PR Lens diagram of the Candidate title path, from the Agent answer through schema validation and the candidates table to the GitHub issue](https://github.com/user-attachments/assets/8f71a853-9b4c-4a07-8a74-275d8f799383)

Two things I want a second opinion on:

- The 70 character limit lives in the prompt, not the schema. I did not want a hard reject that throws away a whole scan over a long title, so a long one is capped at GitHub's 256 instead. That may be too lenient.
- Candidates recorded before this read their claim back as their title, so old rows keep the titles they have. I chose that over a backfill because the claim is genuinely all we stored. If you would rather the old rows get retitled, that is a separate pass.

### 📝 Migration

This adds schema version 63, a nullable `title` column on `candidates`. `pnpm service:hogwild:update` alone is not enough. Pause agents, snapshot `state.sqlite`, update, then resume:

```
POST /api/agents/pause
# poll /api/state until agentControl.safeToRestart
cp ~/.local/share/harlan-github-agent/state.sqlite ~/state.sqlite.bak
pnpm service:hogwild:update
POST /api/agents/resume
```

Rolling back past 63 needs the snapshot. The migration itself does not drop anything, but an older binary refuses a version it does not know.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
