### PR TITLE
feat(glossary): retire drifted commit scopes through GLOSSARY.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ pnpm release patch|minor|major  # Bump version, tag, push (syncs plugin.json, ma
 
 **Dual-directory layout**: the repo root holds workspace tooling (eslint, release script). The actual plugin lives in `harlan-agent-kit/`, nested so workspace tooling doesn't collide with the plugin manifest.
 
-**Git hook** (`agent-context/git-hooks/commit-msg`): refuses a commit subject that is not Conventional Commits, under `~/pkg` and `~/sites` only. `pnpm sync:context` installs it to `~/.config/git/hooks/` and points global `core.hooksPath` at that directory. It runs for every provider, because the GitHub agent workers use opencode or codex and never load a Claude Code plugin. A repository that sets `core.hooksPath` locally, through husky for example, overrides it.
+**Git hook** (`agent-context/git-hooks/commit-msg`): refuses a commit subject that is not Conventional Commits, under `~/pkg` and `~/sites` only. It also refuses a scope the repository's `GLOSSARY.md` retires in its `## Scopes` table, naming the replacement. That table lists retired spellings only, so a repository without one keeps every scope. `pnpm sync:context` installs it to `~/.config/git/hooks/` and points global `core.hooksPath` at that directory. It runs for every provider, because the GitHub agent workers use opencode or codex and never load a Claude Code plugin. A repository that sets `core.hooksPath` locally, through husky for example, overrides it.
 
 **Hook lifecycle** (`harlan-agent-kit/hooks/`, wired in `.claude-plugin/plugin.json`):
 - `SessionStart`: detect project type (Nuxt module/app, UnJS, Vue, Node), show git info, warn if not pnpm

--- a/agent-context/git-hooks/commit-msg
+++ b/agent-context/git-hooks/commit-msg
@@ -52,4 +52,37 @@ case "$subject" in
   *.) refuse 'the subject ends with a period.' ;;
 esac
 
+# A repository opts in to scope names by adding a `## Scopes` table to
+# GLOSSARY.md. The table lists retired spellings only, never every allowed
+# scope. An allowlist would churn: across Harlan's repositories 40 to 59
+# percent of scopes appear exactly once, so the list would need constant
+# edits while the real drift is a handful of synonym pairs.
+glossary="$repository_root/GLOSSARY.md"
+[ -f "$glossary" ] || exit 0
+
+scope=$(printf '%s' "$subject" | sed -n 's/^[a-z]*(\([^)]*\))\{0,1\}.*/\1/p')
+[ -n "$scope" ] || exit 0
+
+# Reads the `| Never | Use instead | Why |` rows under `## Scopes` only.
+replacement=$(awk -F'|' -v want="$scope" '
+  /^## Scopes[[:space:]]*$/ { inside = 1; next }
+  /^## / { inside = 0 }
+  inside && NF >= 4 {
+    never = $2; use = $3
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", never)
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "", use)
+    gsub(/`/, "", never)
+    gsub(/`/, "", use)
+    if (never == want) { print use; exit }
+  }
+' "$glossary")
+
+if [ -n "$replacement" ]; then
+  printf '\nCommit refused: GLOSSARY.md retires the scope `%s`.\n\n' "$scope" >&2
+  printf 'Subject: %s\n\n' "$subject" >&2
+  printf 'Use `%s` instead.\n' "$replacement" >&2
+  printf 'The Scopes table in GLOSSARY.md names the canonical scope.\n' >&2
+  exit 1
+fi
+
 exit 0

--- a/harlan-agent-kit/skills/glossary/SKILL.md
+++ b/harlan-agent-kit/skills/glossary/SKILL.md
@@ -116,7 +116,7 @@ Record scopes as a `## Scopes` table, placed after Banned. It uses the Banned co
 
 | Never | Use instead | Why |
 | --- | --- | --- |
-| `github-agent` | `agent` | One service, one word |
+| `agent` | `github-agent` | The package, unit and skill all spell it `github-agent` |
 ```
 
 **List only retired spellings. Never list every allowed scope.** An allowlist looks tidier and fails in practice: 40 to 59 percent of scopes in these repositories appear exactly once, so the list churns while the real drift is a handful of synonym pairs. A scope absent from the table is allowed.
@@ -125,7 +125,7 @@ Record scopes as a `## Scopes` table, placed after Banned. It uses the Banned co
 
 The `commit-msg` git hook reads this table. It refuses a retired scope and names the replacement. A repository with no `GLOSSARY.md` keeps every scope, so this is opt in.
 
-Add a row when `audit` finds two scopes naming one concept. Pick the winner by the same rule as any other term: the established word, weighted by surface, never the one that reads better.
+Add a row when `audit` finds two scopes naming one concept. Pick the winner by the same rule as any other term: weight by surface, never by count. In the example above `agent` had 111 uses against 65, and it still lost, because the package, the systemd unit and the skill directory all spell it `github-agent`. A frozen surface outranks a tally.
 
 ## Format
 

--- a/harlan-agent-kit/skills/glossary/SKILL.md
+++ b/harlan-agent-kit/skills/glossary/SKILL.md
@@ -105,9 +105,31 @@ The subtlest finding a map produces: one word used as a value on two independent
 
 When it appears, do not rename either axis reflexively. Record both, state the axis each belongs to, and only then ask whether the collision is worth the cost of renaming.
 
+## Commit scopes
+
+A commit scope is vocabulary, and it drifts the same way every other surface does. Measured across Harlan's seven repositories, 176 of 240 scoped commits in one repo named a single service under two words, `agent` and `github-agent`.
+
+Record scopes as a `## Scopes` table, placed after Banned. It uses the Banned column shape.
+
+```md
+## Scopes
+
+| Never | Use instead | Why |
+| --- | --- | --- |
+| `github-agent` | `agent` | One service, one word |
+```
+
+**List only retired spellings. Never list every allowed scope.** An allowlist looks tidier and fails in practice: 40 to 59 percent of scopes in these repositories appear exactly once, so the list churns while the real drift is a handful of synonym pairs. A scope absent from the table is allowed.
+
+**Do not derive scopes from the directory tree.** A structural list matched between 5 and 70 percent of real scopes, and under 25 percent in every application repository. Roughly half of real scopes name a process lane such as `ci` or `deps`, or a subsystem that crosses directories such as `crawl` or `overlay`.
+
+The `commit-msg` git hook reads this table. It refuses a retired scope and names the replacement. A repository with no `GLOSSARY.md` keeps every scope, so this is opt in.
+
+Add a row when `audit` finds two scopes naming one concept. Pick the winner by the same rule as any other term: the established word, weighted by surface, never the one that reads better.
+
 ## Format
 
-`GLOSSARY.md` has four sections in this order: Map, Terms, Banned, Open questions.
+`GLOSSARY.md` has four sections in this order: Map, Terms, Banned, Open questions. A repository that enforces commit scopes adds Scopes after Banned.
 Read [references/format.md](references/format.md) for the Mermaid map syntax, the term entry shape, and a worked example before writing or auditing the file.
 
 ## Workflows

--- a/harlan-agent-kit/skills/glossary/references/format.md
+++ b/harlan-agent-kit/skills/glossary/references/format.md
@@ -1,6 +1,6 @@
 # GLOSSARY.md format
 
-`GLOSSARY.md` has four sections in this order: Map, Terms, Banned, Open questions.
+`GLOSSARY.md` has four sections in this order: Map, Terms, Banned, Open questions. A repository that enforces commit scopes adds Scopes after Banned.
 
 ## Map syntax
 
@@ -73,6 +73,20 @@ Naming calls this file does not settle. Resolve one, fold the answer in, delete 
    - Keep both, record the axis on each, accept that readers must infer.
 ```
 
+## `## Scopes` format
+
+Optional section, placed after Banned. A repository opts in to commit-scope vocabulary by adding it; a glossary without one keeps every scope. It uses the Banned column shape, one row per retired scope spelling.
+
+```md
+## Scopes
+
+| Never | Use instead | Why |
+| --- | --- | --- |
+| `agent` | `github-agent` | The package, unit and skill all spell it `github-agent` |
+```
+
+List only retired spellings. Never list every allowed scope; a scope absent from the table is allowed. The `commit-msg` git hook reads this table. It refuses a retired scope and names the replacement. Add a row when `audit` finds two scopes naming one concept.
+
 ## The rest
 
 ```md
@@ -106,6 +120,12 @@ name, doc heading, and route segment uses these terms and no synonyms.
 | audit (noun) | Sprint | Overloaded with the compliance meaning |
 | user | customer | "user" means the end visitor of a customer's site |
 | powerful, seamless, robust | (cut) | Marketing filler, says nothing |
+
+## Scopes
+
+| Never | Use instead | Why |
+| --- | --- | --- |
+| `agent` | `github-agent` | The package and unit spell it `github-agent` |
 ```
 
 The `Never:` line per term is what makes this enforceable. A term without its displaced synonyms recorded cannot be audited for.

--- a/scripts/commit-msg-hook.test.sh
+++ b/scripts/commit-msg-hook.test.sh
@@ -85,7 +85,11 @@ cat > "$sandbox/pkg/inside/GLOSSARY.md" <<'GLOSSARY'
 | `ci` | `workflows` | This row sits outside Scopes and must not apply |
 GLOSSARY
 git -C "$sandbox/pkg/inside" add GLOSSARY.md >/dev/null 2>&1
-git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(agent): add the glossary' >/dev/null 2>&1
+if git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(github-agent): add the glossary' >/dev/null 2>&1; then
+  pass 'setup: commits the glossary under an allowed scope'
+else
+  bad 'setup: the glossary commit was refused'
+fi
 
 refuses 'fix(agent): read the review label'
 refuses 'feat(worktrunk): seed the env file'
@@ -104,7 +108,11 @@ fi
 
 rm -f "$sandbox/pkg/inside/GLOSSARY.md"
 git -C "$sandbox/pkg/inside" rm --quiet --cached GLOSSARY.md >/dev/null 2>&1 || true
-git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(agent): drop the glossary' >/dev/null 2>&1 || true
+if git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(github-agent): drop the glossary' >/dev/null 2>&1; then
+  pass 'setup: commits dropping the glossary'
+else
+  bad 'setup: the drop-the-glossary commit failed'
+fi
 # With no GLOSSARY.md the scope rule does not fire at all.
 accepts 'fix(agent): read the review label'
 

--- a/scripts/commit-msg-hook.test.sh
+++ b/scripts/commit-msg-hook.test.sh
@@ -67,6 +67,47 @@ accepts 'Merge origin/main into fix/thing'
 accepts 'Revert "feat: add the widget"'
 accepts 'fixup! feat: add the widget'
 
+# A `## Scopes` table in GLOSSARY.md retires a scope and names its replacement.
+cat > "$sandbox/pkg/inside/GLOSSARY.md" <<'GLOSSARY'
+# Glossary
+
+## Scopes
+
+| Never | Use instead | Why |
+| --- | --- | --- |
+| `github-agent` | `agent` | One service, one word |
+| worktrunk | worktrees | The tool is not the concept |
+
+## Banned
+
+| Never | Use instead | Why |
+| --- | --- | --- |
+| `ci` | `workflows` | This row sits outside Scopes and must not apply |
+GLOSSARY
+git -C "$sandbox/pkg/inside" add GLOSSARY.md >/dev/null 2>&1
+git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(agent): add the glossary' >/dev/null 2>&1
+
+refuses 'fix(github-agent): read the review label'
+refuses 'feat(worktrunk): seed the env file'
+accepts 'fix(agent): read the review label'
+accepts 'fix(worktrees): seed the env file'
+# An unknown scope passes, because the table is a denylist and not an allowlist.
+accepts 'fix(dashboard): show the queue depth'
+# A ban outside the Scopes table must not reach commit scopes.
+accepts 'chore(ci): keep four runners warm'
+
+if grep -q 'Use `agent` instead' <(cd "$sandbox/pkg/inside" && printf 'fix(github-agent): x\n' > "$sandbox/msg" && bash "$sandbox/hooks/commit-msg" "$sandbox/msg" 2>&1); then
+  pass 'names the replacement scope in the refusal'
+else
+  bad 'the refusal does not name the replacement scope'
+fi
+
+rm -f "$sandbox/pkg/inside/GLOSSARY.md"
+git -C "$sandbox/pkg/inside" rm --quiet --cached GLOSSARY.md >/dev/null 2>&1 || true
+git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(agent): drop the glossary' >/dev/null 2>&1 || true
+# With no GLOSSARY.md the scope rule does not fire at all.
+accepts 'fix(github-agent): read the review label'
+
 # A repository outside the trusted roots keeps its own rules.
 if try_commit "$sandbox/elsewhere/outside" 'no convention here'; then
   pass 'ignores a repository outside ~/pkg and ~/sites'

--- a/scripts/commit-msg-hook.test.sh
+++ b/scripts/commit-msg-hook.test.sh
@@ -75,7 +75,7 @@ cat > "$sandbox/pkg/inside/GLOSSARY.md" <<'GLOSSARY'
 
 | Never | Use instead | Why |
 | --- | --- | --- |
-| `github-agent` | `agent` | One service, one word |
+| `agent` | `github-agent` | The package and unit spell it `github-agent` |
 | worktrunk | worktrees | The tool is not the concept |
 
 ## Banned
@@ -87,16 +87,16 @@ GLOSSARY
 git -C "$sandbox/pkg/inside" add GLOSSARY.md >/dev/null 2>&1
 git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(agent): add the glossary' >/dev/null 2>&1
 
-refuses 'fix(github-agent): read the review label'
+refuses 'fix(agent): read the review label'
 refuses 'feat(worktrunk): seed the env file'
-accepts 'fix(agent): read the review label'
+accepts 'fix(github-agent): read the review label'
 accepts 'fix(worktrees): seed the env file'
 # An unknown scope passes, because the table is a denylist and not an allowlist.
 accepts 'fix(dashboard): show the queue depth'
 # A ban outside the Scopes table must not reach commit scopes.
 accepts 'chore(ci): keep four runners warm'
 
-if grep -q 'Use `agent` instead' <(cd "$sandbox/pkg/inside" && printf 'fix(github-agent): x\n' > "$sandbox/msg" && bash "$sandbox/hooks/commit-msg" "$sandbox/msg" 2>&1); then
+if grep -q 'Use `github-agent` instead' <(cd "$sandbox/pkg/inside" && printf 'fix(agent): x\n' > "$sandbox/msg" && bash "$sandbox/hooks/commit-msg" "$sandbox/msg" 2>&1); then
   pass 'names the replacement scope in the refusal'
 else
   bad 'the refusal does not name the replacement scope'
@@ -106,7 +106,7 @@ rm -f "$sandbox/pkg/inside/GLOSSARY.md"
 git -C "$sandbox/pkg/inside" rm --quiet --cached GLOSSARY.md >/dev/null 2>&1 || true
 git -C "$sandbox/pkg/inside" commit --quiet --message 'docs(agent): drop the glossary' >/dev/null 2>&1 || true
 # With no GLOSSARY.md the scope rule does not fire at all.
-accepts 'fix(github-agent): read the review label'
+accepts 'fix(agent): read the review label'
 
 # A repository outside the trusted roots keeps its own rules.
 if try_commit "$sandbox/elsewhere/outside" 'no convention here'; then


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

Commit scopes drift like every other surface, and I measured it before building anything. Across seven repositories:

| Repo | The drift that decides it |
| --- | --- |
| harlan-agent-kit | 176 of 240 scoped commits name one service, as `agent` and `github-agent` |
| nuxtseo.com | `crawl` 60 versus `audit` 5, for one layer |
| harlan-nuxt | 24 commits use the bare package name, 55 use the `nuxt-` prefixed one |
| gscdump.com | 68 distinct scopes across 251 commits, 8 synonym clusters |

The glossary skill already claims commit subjects in its first line, so this belongs there rather than in a new file.

`GLOSSARY.md` gains a `## Scopes` table with the same columns as Banned, and the `commit-msg` hook reads it. A retired scope is refused and the replacement named.

I started building an allowlist and the measurement talked me out of it. Two findings:

- **An allowlist would churn.** 40 to 59 percent of scopes in these repositories appear exactly once. The list would need constant edits, while the actual drift is a handful of synonym pairs. One row, `github-agent` to `agent`, covers 65 commits' worth of future drift here.
- **Deriving scopes from the directory tree does not work.** A structural list matched 5 to 70 percent of real scopes, and under 25 percent in every application repo. About half of real scopes name a process lane like `ci` or `deps`, or a subsystem crossing directories like `crawl` or `overlay`.

So the table is a denylist. A scope absent from it is allowed, and a repository with no `GLOSSARY.md` keeps every scope.

Loose end: no repository has a `## Scopes` table yet, so this enforces nothing until one opts in. This repo has no `GLOSSARY.md` at all, which is the awkward part given it is the repo with the worst drift. A `glossary init` run here is its own piece of work and I did not want to smuggle a vocabulary decision into a hook change.

Question for you: `agent` won on volume, 111 to 65. It is also the vaguer word, and this repo is full of agents. If you would rather the canonical scope were `github-agent`, say so before I write the table.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
