### PR TITLE
feat(hooks): run the Claude Code hooks in opencode sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,9 @@ Agent plugin for Nuxt/Vue/TypeScript workflows. No build step: bash hooks plus m
 check              # Parallel lint + typecheck + test (installed to ~/.local/bin)
 pnpm lint:fix      # ESLint autofix
 pnpm check:context # Verify installed Agent instructions match agent-context/
-pnpm sync:context # Install tracked Claude and Codex instructions, plus the commit-msg hook
+pnpm sync:context # Install tracked Claude and Codex instructions, the commit-msg hook, and the opencode plugin
 pnpm sync:context:hogwild # Install tracked instructions on Hogwild
+pnpm test:opencode-hooks # Run the opencode plugin against the real hook scripts
 pnpm release patch|minor|major  # Bump version, tag, push (syncs plugin.json, marketplace.json, skill frontmatter)
 ```
 
@@ -19,10 +20,14 @@ pnpm release patch|minor|major  # Bump version, tag, push (syncs plugin.json, ma
 
 **Git hook** (`agent-context/git-hooks/commit-msg`): refuses a commit subject that is not Conventional Commits, under `~/pkg` and `~/sites` only. `pnpm sync:context` installs it to `~/.config/git/hooks/` and points global `core.hooksPath` at that directory. It runs for every provider, because the GitHub agent workers use opencode or codex and never load a Claude Code plugin. A repository that sets `core.hooksPath` locally, through husky for example, overrides it.
 
+**opencode parity** (`harlan-agent-kit/plugins/opencode/harlan-hooks.ts`): the same provider gap reaches the tool hooks below. This plugin runs the same bash scripts over the same stdin and stdout contract. It denies a tool call by throwing, which opencode turns into a tool error the model reads. It rewrites a command by mutating `output.args` in place, because opencode hands that same object to the tool. A hook that fails, times out, or is missing logs to stderr and allows the call. `pnpm sync:context` installs the scripts to `~/.local/share/harlan-agent-kit/hooks/` and the plugin to `~/.config/opencode/plugins/harlan-hooks.ts`, locally and on Hogwild.
+
 **Hook lifecycle** (`harlan-agent-kit/hooks/`, wired in `.claude-plugin/plugin.json`):
 - `SessionStart`: detect project type (Nuxt module/app, UnJS, Vue, Node), show git info, warn if not pnpm
 - `PreToolUse` (Bash): block npm/yarn/npx (`pnpm-only.sh`); block raw `git worktree` mutation and `.claude/worktrees` paths (`wt-only.sh`); on `git commit` inject the commit-format rule (`pre-commit-push.sh`)
 - `PostToolUse` (Write|Edit): eslint autofix on the edited file
+
+Adding or renaming a PreToolUse Bash hook means updating `commandHooks` in the opencode plugin and `opencode_hook_files` in `scripts/sync-agent-context.sh`.
 
 **Disable hooks per-project**: `.claude/hooks.json` with `{"disabled": ["eslint", "pre-commit-push"]}`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,9 @@ pnpm release patch|minor|major  # Bump version, tag, push (syncs plugin.json, ma
 - `SessionStart`: detect project type (Nuxt module/app, UnJS, Vue, Node), show git info, warn if not pnpm
 - `PreToolUse` (Bash): block npm/yarn/npx (`pnpm-only.sh`); block raw `git worktree` mutation and `.claude/worktrees` paths (`wt-only.sh`); on `git commit` inject the commit-format rule (`pre-commit-push.sh`)
 - `PostToolUse` (Write|Edit): eslint autofix on the edited file
+- `PostToolUse` (Bash): append a `command-not-found.sh` install or BSD/GNU flag suggestion to the shell output, once per session per command
 
-Adding or renaming a PreToolUse Bash hook means updating `commandHooks` in the opencode plugin and `opencode_hook_files` in `scripts/sync-agent-context.sh`.
+Adding or renaming a PreToolUse Bash hook means updating `commandHooks` in the opencode plugin and `opencode_hook_files` in `scripts/sync-agent-context.sh`. A PostToolUse Bash hook joins `opencode_hook_files` the same way; the plugin appends its `followup_message` suggestion to the shell tool output, because opencode has no followup-message contract.
 
 **Disable hooks per-project**: `.claude/hooks.json` with `{"disabled": ["eslint", "pre-commit-push"]}`
 

--- a/harlan-agent-kit/plugins/opencode/harlan-hooks.test.ts
+++ b/harlan-agent-kit/plugins/opencode/harlan-hooks.test.ts
@@ -3,6 +3,7 @@
 // The plugin exports only its default, because opencode loads every exported
 // function in a plugin file as a plugin. So every test goes through that.
 
+import { randomUUID } from 'node:crypto'
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -20,7 +21,7 @@ afterAll(() => rmSync(workingDirectory, { recursive: true, force: true }))
 
 interface Hooks {
   'tool.execute.before': (input: { tool: string, sessionID?: string }, output: { args: any }) => Promise<void>
-  'tool.execute.after': (input: { tool: string, args: any }) => Promise<void>
+  'tool.execute.after': (input: { tool: string, sessionID?: string, args: any }, output?: { title?: string, output?: string, metadata?: any }) => Promise<void>
 }
 
 /** Loads the plugin the way opencode does, over a chosen hooks directory. */
@@ -106,5 +107,20 @@ describe('tool.execute.after', () => {
     await plugin['tool.execute.after']({ tool: 'bash', args: { command: 'ls' } })
     expect(() => readFileSync(project.log, 'utf8')).toThrow()
     rmSync(project.directory, { recursive: true, force: true })
+  })
+
+  it('appends a command-not-found suggestion to the shell output', async () => {
+    const command = `harlan-missing-${randomUUID()}`
+    const plugin = await loadPlugin(workingDirectory)
+    const output = { title: 'bash', output: `bash: ${command}: command not found`, metadata: {} }
+    await plugin['tool.execute.after']({ tool: 'bash', sessionID: randomUUID(), args: { command } }, output)
+    expect(output.output).toContain(`\`${command}\` is not installed`)
+  })
+
+  it('leaves shell output without a known failure alone', async () => {
+    const plugin = await loadPlugin(workingDirectory)
+    const output = { title: 'bash', output: 'src', metadata: {} }
+    await plugin['tool.execute.after']({ tool: 'bash', sessionID: randomUUID(), args: { command: 'ls' } }, output)
+    expect(output.output).toBe('src')
   })
 })

--- a/harlan-agent-kit/plugins/opencode/harlan-hooks.test.ts
+++ b/harlan-agent-kit/plugins/opencode/harlan-hooks.test.ts
@@ -1,0 +1,110 @@
+// Drives the opencode plugin against the real hook scripts in ../../hooks.
+//
+// The plugin exports only its default, because opencode loads every exported
+// function in a plugin file as a plugin. So every test goes through that.
+
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { afterAll, describe, expect, it, vi } from 'vitest'
+import harlanHooks from './harlan-hooks.ts'
+
+const hooksDirectory = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'hooks')
+
+/** A directory with no git repository, so merged-branch-guard.sh exits early. */
+const workingDirectory = mkdtempSync(join(tmpdir(), 'harlan-hooks-'))
+
+afterAll(() => rmSync(workingDirectory, { recursive: true, force: true }))
+
+interface Hooks {
+  'tool.execute.before': (input: { tool: string, sessionID?: string }, output: { args: any }) => Promise<void>
+  'tool.execute.after': (input: { tool: string, args: any }) => Promise<void>
+}
+
+/** Loads the plugin the way opencode does, over a chosen hooks directory. */
+async function loadPlugin(directory: string, hooks = hooksDirectory): Promise<Hooks> {
+  process.env.HARLAN_AGENT_HOOKS_DIR = hooks
+  return await (harlanHooks as any)({ directory }) as Hooks
+}
+
+/** Runs the shell hook and returns the command opencode would then run. */
+async function runShellHook(command: string): Promise<string> {
+  const plugin = await loadPlugin(workingDirectory)
+  const args = { command }
+  await plugin['tool.execute.before']({ tool: 'bash' }, { args })
+  return args.command
+}
+
+/** Builds a project whose local eslint records the arguments it received. */
+function projectWithRecordingEslint(): { directory: string, log: string } {
+  const directory = mkdtempSync(join(tmpdir(), 'harlan-hooks-project-'))
+  const log = join(directory, 'eslint.log')
+  mkdirSync(join(directory, 'node_modules', '.bin'), { recursive: true })
+  const binary = join(directory, 'node_modules', '.bin', 'eslint')
+  writeFileSync(binary, `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> '${log}'\n`)
+  chmodSync(binary, 0o755)
+  return { directory, log }
+}
+
+describe('tool.execute.before', () => {
+  it('rewrites npm to pnpm', async () => {
+    await expect(runShellHook('npm install --frozen-lockfile')).resolves.toBe('pnpm install --frozen-lockfile')
+  })
+
+  it('rewrites npx to pnpm dlx', async () => {
+    await expect(runShellHook('npx tsx script.ts')).resolves.toBe('pnpm dlx tsx script.ts')
+  })
+
+  it('denies a raw git worktree add', async () => {
+    await expect(runShellHook('git worktree add ../copy feature'))
+      .rejects
+      .toThrow(/Use wt, not git worktree/)
+  })
+
+  it('denies a bare gh pr create', async () => {
+    await expect(runShellHook('gh pr create --fill')).rejects.toThrow(/PR skill/)
+  })
+
+  it('allows gh pr create from the PR skill', async () => {
+    await expect(runShellHook('HARLAN_AGENT_PR_SKILL=1 gh pr create --fill'))
+      .resolves
+      .toBe('HARLAN_AGENT_PR_SKILL=1 gh pr create --fill')
+  })
+
+  it('leaves a tool that is not the shell alone', async () => {
+    const plugin = await loadPlugin(workingDirectory)
+    const args = { command: 'npm install' }
+    await plugin['tool.execute.before']({ tool: 'read' }, { args })
+    expect(args.command).toBe('npm install')
+  })
+
+  it('allows the command and reports when the hooks are missing', async () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    const plugin = await loadPlugin(workingDirectory, join(workingDirectory, 'absent'))
+    const args = { command: 'npm install' }
+    await plugin['tool.execute.before']({ tool: 'bash' }, { args })
+    expect(args.command).toBe('npm install')
+    expect(stderr.mock.calls).toHaveLength(5)
+    stderr.mockRestore()
+  })
+})
+
+describe('tool.execute.after', () => {
+  it('lints the written file', async () => {
+    const project = projectWithRecordingEslint()
+    const plugin = await loadPlugin(project.directory)
+    await plugin['tool.execute.after']({ tool: 'write', args: { filePath: 'src/index.ts' } })
+    expect(readFileSync(project.log, 'utf8')).toMatch(/src\/index\.ts --fix/)
+    rmSync(project.directory, { recursive: true, force: true })
+  })
+
+  it('ignores a tool that wrote no file', async () => {
+    const project = projectWithRecordingEslint()
+    const plugin = await loadPlugin(project.directory)
+    await plugin['tool.execute.after']({ tool: 'bash', args: { command: 'ls' } })
+    expect(() => readFileSync(project.log, 'utf8')).toThrow()
+    rmSync(project.directory, { recursive: true, force: true })
+  })
+})

--- a/harlan-agent-kit/plugins/opencode/harlan-hooks.ts
+++ b/harlan-agent-kit/plugins/opencode/harlan-hooks.ts
@@ -1,0 +1,262 @@
+// Runs the Claude Code plugin hooks inside opencode.
+//
+// The GitHub agent workers run as opencode sessions. Those sessions never load
+// a Claude Code plugin, so none of the rules in `.claude-plugin/plugin.json`
+// reach them. This plugin runs the same bash scripts over the same stdin and
+// stdout contract, so one implementation serves both providers.
+//
+// `pnpm sync:context` installs the scripts to
+// `~/.local/share/harlan-agent-kit/hooks/` and this file to
+// `~/.config/opencode/plugins/harlan-hooks.ts`.
+//
+// This file exports one value. opencode loads every exported function in a
+// plugin file as its own plugin, and calls it with the plugin input. A second
+// exported function therefore runs with the wrong arguments and breaks the
+// shell tool. Tests drive the default export.
+
+import type { Plugin } from '@opencode-ai/plugin'
+import { spawn } from 'node:child_process'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+
+/** One installed hook script and the time it may take. */
+interface HookEntry {
+  file: string
+  timeoutMilliseconds: number
+}
+
+/** What a hook decided about one tool call. */
+type Decision
+  = | { _tag: 'Allow' }
+    | { _tag: 'Deny', reason: string }
+    | { _tag: 'Rewrite', command: string }
+
+/** The result of running one hook script. */
+type HookRun
+  = | { _tag: 'Ok', stdout: string }
+    | { _tag: 'Err', reason: string }
+
+interface HarlanHookOptions {
+  /** Directory holding the installed hook scripts. */
+  hooksDirectory: string
+  /** Directory the hooks run in, so git and `.claude/hooks.json` resolve. */
+  workingDirectory: string
+  /** Session id, so `merged-branch-guard.sh` can cache its GitHub lookup. */
+  sessionId?: string
+}
+
+/**
+ * PreToolUse Bash hooks, in the order `.claude-plugin/plugin.json` lists them.
+ *
+ * `pre-commit-push.sh` only prints `additionalContext`. opencode has no place
+ * to put that, so the output is dropped. It stays in the chain for parity.
+ */
+const commandHooks: readonly HookEntry[] = [
+  { file: 'pnpm-only.sh', timeoutMilliseconds: 5000 },
+  { file: 'wt-only.sh', timeoutMilliseconds: 5000 },
+  { file: 'pr-skill-only.sh', timeoutMilliseconds: 5000 },
+  { file: 'merged-branch-guard.sh', timeoutMilliseconds: 10000 },
+  { file: 'pre-commit-push.sh', timeoutMilliseconds: 5000 },
+]
+
+/** The PostToolUse hook for a file that a tool wrote. */
+const fileHook: HookEntry = { file: 'eslint.sh', timeoutMilliseconds: 30000 }
+
+/**
+ * opencode names its shell tool `bash`.
+ * Read from `/experimental/tool/ids` on opencode 1.18.27.
+ */
+const shellTools = new Set(['bash'])
+
+/**
+ * opencode file writers. `write`, `edit` and `apply_patch` are the shipped
+ * ids. `patch` and `multiedit` cover builds that name them differently.
+ */
+const fileTools = new Set(['write', 'edit', 'apply_patch', 'patch', 'multiedit'])
+
+const defaultHooksDirectory = join(homedir(), '.local', 'share', 'harlan-agent-kit', 'hooks')
+
+/** Reports a hook that could not run. The tool call still goes ahead. */
+function reportHookFailure(reason: string): void {
+  process.stderr.write(`harlan-hooks: ${reason}\n`)
+}
+
+/** Runs one hook script over the stdin and stdout contract. */
+async function runHook(
+  scriptPath: string,
+  input: unknown,
+  entry: HookEntry,
+  options: HarlanHookOptions,
+): Promise<HookRun> {
+  return new Promise<HookRun>((resolve) => {
+    const child = spawn('bash', [scriptPath], {
+      cwd: options.workingDirectory,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: options.sessionId === undefined
+        ? process.env
+        : { ...process.env, CLAUDE_SESSION_ID: options.sessionId },
+    })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    const finish = (run: HookRun): void => {
+      if (settled)
+        return
+      settled = true
+      clearTimeout(timer)
+      resolve(run)
+    }
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL')
+      finish({ _tag: 'Err', reason: `${entry.file} timed out after ${entry.timeoutMilliseconds}ms` })
+    }, entry.timeoutMilliseconds)
+
+    child.stdout.on('data', (chunk) => {
+      stdout += String(chunk)
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+    child.on('error', (error) => {
+      finish({ _tag: 'Err', reason: `${entry.file} did not start: ${error.message}` })
+    })
+    child.on('close', (code) => {
+      if (code === 0) {
+        finish({ _tag: 'Ok', stdout })
+        return
+      }
+      finish({ _tag: 'Err', reason: `${entry.file} exited ${code}: ${stderr.trim()}` })
+    })
+    child.stdin.on('error', (error) => {
+      finish({ _tag: 'Err', reason: `${entry.file} closed stdin: ${error.message}` })
+    })
+    child.stdin.end(JSON.stringify(input))
+  })
+}
+
+/** Reads a hook decision from its stdout. Any other output allows the call. */
+function readDecision(stdout: string): Decision {
+  const trimmed = stdout.trim()
+  if (trimmed === '')
+    return { _tag: 'Allow' }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  }
+  catch {
+    // The contract treats unrecognised output as allow, so this is ignorable.
+    return { _tag: 'Allow' }
+  }
+  if (typeof parsed !== 'object' || parsed === null)
+    return { _tag: 'Allow' }
+  const specific = (parsed as { hookSpecificOutput?: unknown }).hookSpecificOutput
+  if (typeof specific !== 'object' || specific === null)
+    return { _tag: 'Allow' }
+  const output = specific as {
+    permissionDecision?: unknown
+    permissionDecisionReason?: unknown
+    updatedInput?: { command?: unknown }
+  }
+  if (output.permissionDecision === 'deny') {
+    const reason = typeof output.permissionDecisionReason === 'string'
+      ? output.permissionDecisionReason
+      : 'A Harlan Agent Kit hook denied this command.'
+    return { _tag: 'Deny', reason }
+  }
+  const rewritten = output.updatedInput?.command
+  if (output.permissionDecision === 'allow' && typeof rewritten === 'string')
+    return { _tag: 'Rewrite', command: rewritten }
+  return { _tag: 'Allow' }
+}
+
+/** Returns the first non-empty string among these keys. */
+function firstString(record: Record<string, unknown>, keys: readonly string[]): string {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value !== '')
+      return value
+  }
+  return ''
+}
+
+/**
+ * Runs every PreToolUse Bash hook over one shell command.
+ *
+ * Returns the command to run, or a deny reason. A hook that fails to run never
+ * denies. A broken enforcement layer must not stop the fleet.
+ */
+async function decideCommand(
+  command: string,
+  options: HarlanHookOptions,
+): Promise<{ _tag: 'Allow', command: string } | { _tag: 'Deny', reason: string }> {
+  let current = command
+  for (const entry of commandHooks) {
+    const run = await runHook(
+      join(options.hooksDirectory, entry.file),
+      { tool_input: { command: current } },
+      entry,
+      options,
+    )
+    if (run._tag === 'Err') {
+      reportHookFailure(run.reason)
+      continue
+    }
+    const decision = readDecision(run.stdout)
+    if (decision._tag === 'Deny')
+      return { _tag: 'Deny', reason: decision.reason }
+    if (decision._tag === 'Rewrite')
+      current = decision.command
+  }
+  return { _tag: 'Allow', command: current }
+}
+
+/** Runs the PostToolUse file hook over one written path. */
+async function lintWrittenFile(filePath: string, options: HarlanHookOptions): Promise<void> {
+  const run = await runHook(
+    join(options.hooksDirectory, fileHook.file),
+    { tool_input: { file_path: filePath } },
+    fileHook,
+    options,
+  )
+  if (run._tag === 'Err')
+    reportHookFailure(run.reason)
+}
+
+/** Builds the opencode hooks over one installed hooks directory. */
+function createHarlanHooks(options: HarlanHookOptions) {
+  return {
+    'tool.execute.before': async (input: { tool: string, sessionID?: string }, output: { args: any }) => {
+      if (!shellTools.has(input.tool))
+        return
+      const command = typeof output.args?.command === 'string' ? output.args.command : ''
+      if (command === '')
+        return
+      const verdict = await decideCommand(command, { ...options, sessionId: input.sessionID })
+      if (verdict._tag === 'Deny') {
+        // Throwing is how a plugin blocks a tool call. Verified on opencode
+        // 1.18.27: the tool never runs, the session survives, and the model
+        // reads this message.
+        throw new Error(verdict.reason)
+      }
+      // opencode hands the same args object to the tool, so mutate it in place.
+      // Assigning a new object to `output.args` changes nothing.
+      if (verdict.command !== command)
+        output.args.command = verdict.command
+    },
+    'tool.execute.after': async (input: { tool: string, args: any }) => {
+      if (!fileTools.has(input.tool))
+        return
+      const args = (input.args ?? {}) as Record<string, unknown>
+      const filePath = firstString(args, ['filePath', 'file_path', 'path', 'file'])
+      if (filePath === '')
+        return
+      await lintWrittenFile(filePath, options)
+    },
+  }
+}
+
+export default (async ({ directory }) => createHarlanHooks({
+  hooksDirectory: process.env.HARLAN_AGENT_HOOKS_DIR ?? defaultHooksDirectory,
+  workingDirectory: directory,
+})) satisfies Plugin

--- a/harlan-agent-kit/plugins/opencode/harlan-hooks.ts
+++ b/harlan-agent-kit/plugins/opencode/harlan-hooks.ts
@@ -3,7 +3,9 @@
 // The GitHub agent workers run as opencode sessions. Those sessions never load
 // a Claude Code plugin, so none of the rules in `.claude-plugin/plugin.json`
 // reach them. This plugin runs the same bash scripts over the same stdin and
-// stdout contract, so one implementation serves both providers.
+// stdout contract, so one implementation serves both providers. PreToolUse
+// Bash hooks get their decisions from the hook stdout; `command-not-found.sh`
+// gets its `followup_message` appended to the shell tool output.
 //
 // `pnpm sync:context` installs the scripts to
 // `~/.local/share/harlan-agent-kit/hooks/` and this file to
@@ -62,6 +64,15 @@ const commandHooks: readonly HookEntry[] = [
 
 /** The PostToolUse hook for a file that a tool wrote. */
 const fileHook: HookEntry = { file: 'eslint.sh', timeoutMilliseconds: 30000 }
+
+/**
+ * The PostToolUse hook for a shell command that just failed.
+ *
+ * It answers with a `followup_message`. Claude Code shows that as a message;
+ * opencode has no such contract, so the plugin appends the suggestion to the
+ * shell tool output instead.
+ */
+const shellPostHook: HookEntry = { file: 'command-not-found.sh', timeoutMilliseconds: 5000 }
 
 /**
  * opencode names its shell tool `bash`.
@@ -180,6 +191,28 @@ function firstString(record: Record<string, unknown>, keys: readonly string[]): 
   return ''
 }
 
+/** Reads a followup message from a PostToolUse hook stdout. Empty when absent. */
+function readFollowupMessage(stdout: string): string {
+  const trimmed = stdout.trim()
+  if (trimmed === '')
+    return ''
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  }
+  catch {
+    // The contract treats unrecognised output as no message, so this is ignorable.
+    return ''
+  }
+  if (typeof parsed !== 'object' || parsed === null)
+    return ''
+  const specific = (parsed as { hookSpecificOutput?: unknown }).hookSpecificOutput
+  if (typeof specific !== 'object' || specific === null)
+    return ''
+  const message = (specific as { message?: unknown }).message
+  return typeof message === 'string' ? message : ''
+}
+
 /**
  * Runs every PreToolUse Bash hook over one shell command.
  *
@@ -223,6 +256,21 @@ async function lintWrittenFile(filePath: string, options: HarlanHookOptions): Pr
     reportHookFailure(run.reason)
 }
 
+/** Runs the PostToolUse shell hook over one finished command. Returns its suggestion, if any. */
+async function suggestForShellOutput(command: string, toolOutput: string, options: HarlanHookOptions): Promise<string> {
+  const run = await runHook(
+    join(options.hooksDirectory, shellPostHook.file),
+    { tool_input: { command }, tool_output: toolOutput },
+    shellPostHook,
+    options,
+  )
+  if (run._tag === 'Err') {
+    reportHookFailure(run.reason)
+    return ''
+  }
+  return readFollowupMessage(run.stdout)
+}
+
 /** Builds the opencode hooks over one installed hooks directory. */
 function createHarlanHooks(options: HarlanHookOptions) {
   return {
@@ -244,7 +292,17 @@ function createHarlanHooks(options: HarlanHookOptions) {
       if (verdict.command !== command)
         output.args.command = verdict.command
     },
-    'tool.execute.after': async (input: { tool: string, args: any }) => {
+    'tool.execute.after': async (input: { tool: string, sessionID?: string, args: any }, output: { output?: string }) => {
+      if (shellTools.has(input.tool)) {
+        const command = typeof input.args?.command === 'string' ? input.args.command : ''
+        const toolOutput = typeof output?.output === 'string' ? output.output : ''
+        if (command === '' || toolOutput === '')
+          return
+        const message = await suggestForShellOutput(command, toolOutput, { ...options, sessionId: input.sessionID })
+        if (message !== '')
+          output.output = `${toolOutput}\n\n${message}`
+        return
+      }
       if (!fileTools.has(input.tool))
         return
       const args = (input.args ?? {}) as Record<string, unknown>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "pnpm --filter harlan-github-agent build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "pnpm test:context && pnpm test:commit-hook && pnpm test:service && pnpm --filter harlan-github-agent test:run",
+    "test": "pnpm test:context && pnpm test:commit-hook && pnpm test:opencode-hooks && pnpm test:service && pnpm --filter harlan-github-agent test:run",
     "typecheck": "pnpm --filter harlan-github-agent typecheck",
     "check:context": "scripts/check-agent-context.sh",
     "sync:context": "bash scripts/sync-agent-context.sh local",
@@ -29,7 +29,8 @@
     "test:pr-skill-only": "bash harlan-agent-kit/hooks/pr-skill-only.test.sh",
     "test:wt-only": "bash harlan-agent-kit/hooks/wt-only.test.sh",
     "test:sentry-checkin": "python3 -m unittest discover -s harlan-agent-kit/skills/sentry-checkin/scripts -p 'test_*.py'",
-    "release": "node --experimental-strip-types scripts/release.ts"
+    "release": "node --experimental-strip-types scripts/release.ts",
+    "test:opencode-hooks": "vitest run harlan-agent-kit/plugins/opencode"
   },
   "dependencies": {
     "@antfu/eslint-config": "catalog:",
@@ -38,6 +39,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
   packages/harlan-github-agent:
     dependencies:

--- a/scripts/check-agent-context.sh
+++ b/scripts/check-agent-context.sh
@@ -8,6 +8,11 @@ CLAUDE="$TARGET_HOME/.claude/CLAUDE.md"
 CODEX="$TARGET_HOME/.codex/AGENTS.md"
 COMMIT_HOOK="$TARGET_HOME/.config/git/hooks/commit-msg"
 SOURCE_HOOK="$REPO_ROOT/agent-context/git-hooks/commit-msg"
+PLUGIN_HOOKS_DIR="$REPO_ROOT/harlan-agent-kit/hooks"
+SOURCE_PLUGIN="$REPO_ROOT/harlan-agent-kit/plugins/opencode/harlan-hooks.ts"
+INSTALLED_HOOKS_DIR="$TARGET_HOME/.local/share/harlan-agent-kit/hooks"
+INSTALLED_PLUGIN="$TARGET_HOME/.config/opencode/plugins/harlan-hooks.ts"
+OPENCODE_HOOKS=(check-config.sh pnpm-only.sh wt-only.sh pr-skill-only.sh merged-branch-guard.sh pre-commit-push.sh eslint.sh)
 SKILL="$REPO_ROOT/harlan-agent-kit/skills/ts-design-patterns/SKILL.md"
 EXPECTED_HOME=$(mktemp -d)
 trap 'rm -rf "$EXPECTED_HOME"' EXIT
@@ -36,6 +41,23 @@ else
 fi
 [ "$(HOME="$TARGET_HOME" git config --global --get core.hooksPath)" = "$TARGET_HOME/.config/git/hooks" ] \
   || bad "core.hooksPath does not point at the installed hooks. Run pnpm sync:context."
+
+# opencode reads the plugin hooks from a stable path, so drift there is silent.
+for hook_file in "${OPENCODE_HOOKS[@]}"; do
+  if [ ! -f "$INSTALLED_HOOKS_DIR/$hook_file" ]; then
+    bad "The opencode hook is not installed: $hook_file. Run pnpm sync:context."
+    continue
+  fi
+  cmp -s "$PLUGIN_HOOKS_DIR/$hook_file" "$INSTALLED_HOOKS_DIR/$hook_file" \
+    || bad "The opencode hook differs: $hook_file. Run pnpm sync:context."
+  [ -x "$INSTALLED_HOOKS_DIR/$hook_file" ] \
+    || bad "The opencode hook is not executable: $hook_file. Run pnpm sync:context."
+done
+if [ ! -f "$INSTALLED_PLUGIN" ]; then
+  bad "The opencode plugin is not installed. Run pnpm sync:context."
+else
+  cmp -s "$SOURCE_PLUGIN" "$INSTALLED_PLUGIN" || bad "The opencode plugin differs. Run pnpm sync:context."
+fi
 
 # Each principle is a bullet opening with a bold clause; compare the whole set.
 principles() { grep -E '^- \*\*(Make illegal|Errors as|No silent|Parse, don|Explicit dep|Pure core)' "$1" | sort; }

--- a/scripts/sync-agent-context.sh
+++ b/scripts/sync-agent-context.sh
@@ -8,6 +8,21 @@ shared_context="$repo_root/agent-context/context.md"
 template_claude="$repo_root/agent-context/CLAUDE.md"
 template_codex="$repo_root/agent-context/AGENTS.md"
 commit_hook="$repo_root/agent-context/git-hooks/commit-msg"
+plugin_hooks_dir="$repo_root/harlan-agent-kit/hooks"
+opencode_plugin="$repo_root/harlan-agent-kit/plugins/opencode/harlan-hooks.ts"
+# The hooks the opencode plugin runs, plus the config loader they source.
+opencode_hook_files=(
+  check-config.sh
+  pnpm-only.sh
+  wt-only.sh
+  pr-skill-only.sh
+  merged-branch-guard.sh
+  pre-commit-push.sh
+  eslint.sh
+)
+# The stable path the opencode plugin resolves the hooks from.
+hooks_install_suffix='.local/share/harlan-agent-kit/hooks'
+plugin_install_suffix='.config/opencode/plugins/harlan-hooks.ts'
 target_home="${HARLAN_AGENT_CONTEXT_HOME:-$HOME}"
 hogwild_host="${HARLAN_AGENT_CONTEXT_HOGWILD_HOST:-hogwild}"
 hogwild_home="${HARLAN_AGENT_CONTEXT_HOGWILD_HOME:-/home/harlan}"
@@ -30,6 +45,11 @@ require_sources() {
   [ -f "$template_claude" ] || fail "Claude template is missing: $template_claude"
   [ -f "$template_codex" ] || fail "Codex template is missing: $template_codex"
   [ -f "$commit_hook" ] || fail "The commit-msg hook is missing: $commit_hook"
+  [ -f "$opencode_plugin" ] || fail "The opencode plugin is missing: $opencode_plugin"
+  local hook_file
+  for hook_file in "${opencode_hook_files[@]}"; do
+    [ -f "$plugin_hooks_dir/$hook_file" ] || fail "A plugin hook is missing: $plugin_hooks_dir/$hook_file"
+  done
 }
 
 render_template() {
@@ -80,17 +100,48 @@ sync_local() {
   # HOME decides which global config git writes. The check script points
   # target_home at a sandbox, and this keeps that run out of the real config.
   HOME="$target_home" git config --global core.hooksPath "$target_home/.config/git/hooks"
+  # opencode loads no Claude Code plugin, so it reads the same hooks from here.
+  mkdir -p "$target_home/$hooks_install_suffix" "$target_home/$(dirname "$plugin_install_suffix")"
+  local hook_file
+  for hook_file in "${opencode_hook_files[@]}"; do
+    install -m 755 "$plugin_hooks_dir/$hook_file" "$target_home/$hooks_install_suffix/$hook_file"
+  done
+  install -m 644 "$opencode_plugin" "$target_home/$plugin_install_suffix"
   printf '%s\n' 'Synced local Agent instructions.'
 }
 
+# Remote paths the opencode files land on, in the order sha256sum reads them.
+opencode_remote_targets() {
+  local hook_file
+  for hook_file in "${opencode_hook_files[@]}"; do
+    printf '%s\n' "$hogwild_home/$hooks_install_suffix/$hook_file"
+  done
+  printf '%s\n' "$hogwild_home/$plugin_install_suffix"
+}
+
+# Local sources in the same order, so the two hash lists line up.
+opencode_local_sources() {
+  local hook_file
+  for hook_file in "${opencode_hook_files[@]}"; do
+    printf '%s\n' "$plugin_hooks_dir/$hook_file"
+  done
+  printf '%s\n' "$opencode_plugin"
+}
+
 cleanup_hogwild() {
+  local staged target
+  staged=''
+  while read -r target; do
+    staged="$staged '$target.next'"
+  done < <(opencode_remote_targets)
   ssh -o BatchMode=yes "$hogwild_host" \
-    "rm -f '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.codex/AGENTS.md.next' '$hogwild_home/.config/git/hooks/commit-msg.next'" \
+    "rm -f '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.codex/AGENTS.md.next' '$hogwild_home/.config/git/hooks/commit-msg.next'$staged" \
     >/dev/null 2>&1 || true
 }
 
 sync_hogwild() {
   local claude_hash codex_hash hook_hash remote_claude_hash remote_codex_hash remote_hook_hash
+  local source target mode staged_list activation opencode_hashes remote_opencode_hashes
   validate_hogwild
   local_staging=$(mktemp -d "${TMPDIR:-/tmp}/agent-context.XXXXXX")
   render_sources "$local_staging"
@@ -99,7 +150,7 @@ sync_hogwild() {
   hook_hash=$(sha256sum "$commit_hook" | cut -d' ' -f1)
 
   ssh -o BatchMode=yes "$hogwild_host" \
-    "mkdir -p '$hogwild_home/.claude' '$hogwild_home/.codex' '$hogwild_home/.config/git/hooks'"
+    "mkdir -p '$hogwild_home/.claude' '$hogwild_home/.codex' '$hogwild_home/.config/git/hooks' '$hogwild_home/$hooks_install_suffix' '$hogwild_home/$(dirname "$plugin_install_suffix")'"
   if ! scp "$local_staging/CLAUDE.md" "$hogwild_host:$hogwild_home/.claude/CLAUDE.md.next"; then
     cleanup_hogwild
     fail 'Hogwild did not receive Claude instructions.'
@@ -113,6 +164,26 @@ sync_hogwild() {
     fail 'Hogwild did not receive the commit-msg hook.'
   fi
 
+  staged_list=''
+  activation=''
+  while read -r source && read -r target <&3; do
+    if ! scp "$source" "$hogwild_host:$target.next"; then
+      cleanup_hogwild
+      fail "Hogwild did not receive $(basename "$source")."
+    fi
+    mode=755
+    if [ "$target" = "$hogwild_home/$plugin_install_suffix" ]; then
+      mode=644
+    fi
+    staged_list="$staged_list '$target.next'"
+    activation="$activation && chmod $mode '$target.next' && mv '$target.next' '$target'"
+  done < <(opencode_local_sources) 3< <(opencode_remote_targets)
+
+  opencode_hashes=$(while read -r source; do
+    sha256sum "$source" | cut -d' ' -f1
+  done < <(opencode_local_sources))
+  remote_opencode_hashes=$(ssh -o BatchMode=yes "$hogwild_host" "sha256sum$staged_list" | cut -d' ' -f1)
+
   remote_claude_hash=$(ssh -o BatchMode=yes "$hogwild_host" \
     "sha256sum '$hogwild_home/.claude/CLAUDE.md.next'" | cut -d' ' -f1)
   remote_codex_hash=$(ssh -o BatchMode=yes "$hogwild_host" \
@@ -124,9 +195,13 @@ sync_hogwild() {
     cleanup_hogwild
     fail 'Hogwild received different Agent instructions.'
   fi
+  if [ "$opencode_hashes" != "$remote_opencode_hashes" ]; then
+    cleanup_hogwild
+    fail 'Hogwild received different opencode hook files.'
+  fi
 
   ssh -o BatchMode=yes "$hogwild_host" \
-    "chmod 644 '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.codex/AGENTS.md.next' && mv '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.claude/CLAUDE.md' && mv '$hogwild_home/.codex/AGENTS.md.next' '$hogwild_home/.codex/AGENTS.md' && chmod 755 '$hogwild_home/.config/git/hooks/commit-msg.next' && mv '$hogwild_home/.config/git/hooks/commit-msg.next' '$hogwild_home/.config/git/hooks/commit-msg' && git config --global core.hooksPath '$hogwild_home/.config/git/hooks'"
+    "chmod 644 '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.codex/AGENTS.md.next' && mv '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.claude/CLAUDE.md' && mv '$hogwild_home/.codex/AGENTS.md.next' '$hogwild_home/.codex/AGENTS.md' && chmod 755 '$hogwild_home/.config/git/hooks/commit-msg.next' && mv '$hogwild_home/.config/git/hooks/commit-msg.next' '$hogwild_home/.config/git/hooks/commit-msg'$activation && git config --global core.hooksPath '$hogwild_home/.config/git/hooks'"
   printf '%s\n' 'Synced Hogwild Agent instructions.'
 }
 

--- a/scripts/sync-agent-context.sh
+++ b/scripts/sync-agent-context.sh
@@ -19,6 +19,7 @@ opencode_hook_files=(
   merged-branch-guard.sh
   pre-commit-push.sh
   eslint.sh
+  command-not-found.sh
 )
 # The stable path the opencode plugin resolves the hooks from.
 hooks_install_suffix='.local/share/harlan-agent-kit/hooks'

--- a/scripts/sync-agent-context.test.sh
+++ b/scripts/sync-agent-context.test.sh
@@ -24,6 +24,28 @@ if rg -F 'Once work turns long with no name assigned' "$test_home/.claude/CLAUDE
   exit 1
 fi
 
+opencode_hooks=(check-config.sh pnpm-only.sh wt-only.sh pr-skill-only.sh merged-branch-guard.sh pre-commit-push.sh eslint.sh)
+for hook_file in "${opencode_hooks[@]}"; do
+  cmp "$repo_root/harlan-agent-kit/hooks/$hook_file" "$test_home/.local/share/harlan-agent-kit/hooks/$hook_file"
+  if [ ! -x "$test_home/.local/share/harlan-agent-kit/hooks/$hook_file" ]; then
+    printf '%s\n' "The installed hook is not executable: $hook_file" >&2
+    exit 1
+  fi
+done
+cmp "$repo_root/harlan-agent-kit/plugins/opencode/harlan-hooks.ts" "$test_home/.config/opencode/plugins/harlan-hooks.ts"
+
+# The fake ssh answers a batched sha256sum from this basename to hash table.
+opencode_hashes="$test_root/opencode-hashes"
+: > "$opencode_hashes"
+for hook_file in "${opencode_hooks[@]}"; do
+  printf '%s %s\n' "$hook_file" \
+    "$(/usr/bin/sha256sum "$repo_root/harlan-agent-kit/hooks/$hook_file" | cut -d' ' -f1)" >> "$opencode_hashes"
+done
+printf '%s %s\n' harlan-hooks.ts \
+  "$(/usr/bin/sha256sum "$repo_root/harlan-agent-kit/plugins/opencode/harlan-hooks.ts" | cut -d' ' -f1)" >> "$opencode_hashes"
+export HARLAN_AGENT_CONTEXT_TEST_OPENCODE_HASHES="$opencode_hashes"
+export HARLAN_AGENT_CONTEXT_TEST_OPENCODE_BAD=''
+
 claude_hash=$(/usr/bin/sha256sum "$test_home/.claude/CLAUDE.md" | cut -d' ' -f1)
 codex_hash=$(/usr/bin/sha256sum "$test_home/.codex/AGENTS.md" | cut -d' ' -f1)
 hook_hash=$(/usr/bin/sha256sum "$repo_root/agent-context/git-hooks/commit-msg" | cut -d' ' -f1)
@@ -32,18 +54,34 @@ export HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH="$claude_hash"
 export HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH="$codex_hash"
 export HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH="$hook_hash"
 
-printf '%s\n' \
-  '#!/usr/bin/env bash' \
-  'printf '\''ssh %s\n'\'' "$*" >> "$HARLAN_AGENT_CONTEXT_TEST_CALLS"' \
-  'if [[ "$*" == *CLAUDE.md.next*sha256sum* || "$*" == *sha256sum*CLAUDE.md.next* ]]; then printf '\''%s  CLAUDE.md.next\n'\'' "$HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH"; fi' \
-  'if [[ "$*" == *AGENTS.md.next*sha256sum* || "$*" == *sha256sum*AGENTS.md.next* ]]; then printf '\''%s  AGENTS.md.next\n'\'' "$HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH"; fi' \
-  'if [[ "$*" == *commit-msg.next*sha256sum* || "$*" == *sha256sum*commit-msg.next* ]]; then printf '\''%s  commit-msg.next\n'\'' "$HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH"; fi' \
-  'if [[ -n "$HARLAN_AGENT_CONTEXT_TEST_SSH_FAIL" && "$*" == *core.hooksPath* ]]; then exit 42; fi' \
-  > "$test_root/bin/ssh"
-printf '%s\n' \
-  '#!/usr/bin/env bash' \
-  'printf '\''scp %s\n'\'' "$*" >> "$HARLAN_AGENT_CONTEXT_TEST_CALLS"' \
-  > "$test_root/bin/scp"
+cat > "$test_root/bin/ssh" <<'FAKE_SSH'
+#!/usr/bin/env bash
+printf 'ssh %s\n' "$*" >> "$HARLAN_AGENT_CONTEXT_TEST_CALLS"
+if [[ "$*" == *CLAUDE.md.next*sha256sum* || "$*" == *sha256sum*CLAUDE.md.next* ]]; then printf '%s  CLAUDE.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH"; fi
+if [[ "$*" == *AGENTS.md.next*sha256sum* || "$*" == *sha256sum*AGENTS.md.next* ]]; then printf '%s  AGENTS.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH"; fi
+if [[ "$*" == *commit-msg.next*sha256sum* || "$*" == *sha256sum*commit-msg.next* ]]; then printf '%s  commit-msg.next\n' "$HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH"; fi
+# The opencode files are verified in one batched sha256sum, so answer per path.
+if [[ "$*" == *"sha256sum "* && "$*" == *harlan-hooks.ts.next* ]]; then
+  for token in $*; do
+    case "$token" in
+      *.next*)
+        path=${token//\'/}
+        name=$(basename "${path%.next}")
+        if [ "$name" = "$HARLAN_AGENT_CONTEXT_TEST_OPENCODE_BAD" ]; then
+          printf 'different  %s\n' "$path"
+        else
+          printf '%s  %s\n' "$(grep -m1 "^$name " "$HARLAN_AGENT_CONTEXT_TEST_OPENCODE_HASHES" | cut -d' ' -f2)" "$path"
+        fi
+        ;;
+    esac
+  done
+fi
+if [[ -n "$HARLAN_AGENT_CONTEXT_TEST_SSH_FAIL" && "$*" == *core.hooksPath* ]]; then exit 42; fi
+FAKE_SSH
+cat > "$test_root/bin/scp" <<'FAKE_SCP'
+#!/usr/bin/env bash
+printf 'scp %s\n' "$*" >> "$HARLAN_AGENT_CONTEXT_TEST_CALLS"
+FAKE_SCP
 chmod +x "$test_root/bin/ssh" "$test_root/bin/scp"
 
 PATH="$test_root/bin:/usr/bin:/bin" \
@@ -58,6 +96,49 @@ grep -F "mv '/home/harlan/.codex/AGENTS.md.next' '/home/harlan/.codex/AGENTS.md'
 grep -F 'hogwild:/home/harlan/.config/git/hooks/commit-msg.next' "$calls" >/dev/null
 grep -F "mv '/home/harlan/.config/git/hooks/commit-msg.next' '/home/harlan/.config/git/hooks/commit-msg'" "$calls" >/dev/null
 grep -F "core.hooksPath '/home/harlan/.config/git/hooks'" "$calls" >/dev/null
+for hook_file in "${opencode_hooks[@]}"; do
+  grep -F "hogwild:/home/harlan/.local/share/harlan-agent-kit/hooks/$hook_file.next" "$calls" >/dev/null
+  grep -F "mv '/home/harlan/.local/share/harlan-agent-kit/hooks/$hook_file.next' '/home/harlan/.local/share/harlan-agent-kit/hooks/$hook_file'" "$calls" >/dev/null
+done
+grep -F 'hogwild:/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next' "$calls" >/dev/null
+grep -F "mv '/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next' '/home/harlan/.config/opencode/plugins/harlan-hooks.ts'" "$calls" >/dev/null
+grep -F "chmod 644 '/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next'" "$calls" >/dev/null
+
+# An opencode hook that arrives changed must stop the whole install.
+: > "$calls"
+export HARLAN_AGENT_CONTEXT_TEST_OPENCODE_BAD=wt-only.sh
+opencode_log="$test_root/opencode-hook.log"
+if PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/sync-agent-context.sh" hogwild >"$opencode_log" 2>&1; then
+  printf '%s\n' 'Hogwild accepted a different opencode hook.' >&2
+  exit 1
+fi
+if ! grep -F 'Hogwild received different opencode hook files.' "$opencode_log" >/dev/null; then
+  printf '%s\n' 'The opencode hook refusal named the wrong failure.' >&2
+  exit 1
+fi
+if grep -F "mv '" "$calls" >/dev/null; then
+  printf '%s\n' 'Hogwild installed an unverified opencode hook.' >&2
+  exit 1
+fi
+export HARLAN_AGENT_CONTEXT_TEST_OPENCODE_BAD=''
+
+# The plugin itself gets the same refusal.
+: > "$calls"
+export HARLAN_AGENT_CONTEXT_TEST_OPENCODE_BAD=harlan-hooks.ts
+opencode_log="$test_root/opencode-plugin.log"
+if PATH="$test_root/bin:/usr/bin:/bin" bash "$script_dir/sync-agent-context.sh" hogwild >"$opencode_log" 2>&1; then
+  printf '%s\n' 'Hogwild accepted a different opencode plugin.' >&2
+  exit 1
+fi
+if ! grep -F 'Hogwild received different opencode hook files.' "$opencode_log" >/dev/null; then
+  printf '%s\n' 'The opencode plugin refusal named the wrong failure.' >&2
+  exit 1
+fi
+if grep -F "mv '" "$calls" >/dev/null; then
+  printf '%s\n' 'Hogwild installed an unverified opencode plugin.' >&2
+  exit 1
+fi
+export HARLAN_AGENT_CONTEXT_TEST_OPENCODE_BAD=''
 
 # A hook that arrives changed must stop the install, the same as the instructions.
 : > "$calls"

--- a/scripts/sync-agent-context.test.sh
+++ b/scripts/sync-agent-context.test.sh
@@ -24,7 +24,7 @@ if rg -F 'Once work turns long with no name assigned' "$test_home/.claude/CLAUDE
   exit 1
 fi
 
-opencode_hooks=(check-config.sh pnpm-only.sh wt-only.sh pr-skill-only.sh merged-branch-guard.sh pre-commit-push.sh eslint.sh)
+opencode_hooks=(check-config.sh pnpm-only.sh wt-only.sh pr-skill-only.sh merged-branch-guard.sh pre-commit-push.sh eslint.sh command-not-found.sh)
 for hook_file in "${opencode_hooks[@]}"; do
   cmp "$repo_root/harlan-agent-kit/hooks/$hook_file" "$test_home/.local/share/harlan-agent-kit/hooks/$hook_file"
   if [ ! -x "$test_home/.local/share/harlan-agent-kit/hooks/$hook_file" ]; then


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

The GitHub agent workers run as opencode sessions on Hogwild, and Hogwild has no `~/.claude/plugins`. So none of the hooks in `.claude-plugin/plugin.json` ever reached a worker. One could run `npm`, run a raw `git worktree add`, write into `.claude/worktrees`, or call `gh pr create` straight past the PR skill, all silently.

An opencode plugin now runs those same bash scripts over the same stdin and stdout contract, and `pnpm sync:context` installs the scripts and the plugin here and on Hogwild.

![Architecture: the opencode plugin and the Claude Code manifest both reach the same hook scripts, and the context sync installs them to a stable path](https://github.com/user-attachments/assets/5a038686-a697-416d-bd3d-bf6a3f855111)

![Data flow: a worker runs npm and gets pnpm, then runs a banned worktree command and the plugin throws the hook reason before the shell sees it](https://github.com/user-attachments/assets/6ab68f05-bf3b-4ea4-939d-a677f1a514b7)

Two things I would not have guessed, both now comments in the plugin. opencode loads every exported function in a plugin file as its own plugin and calls it with the plugin input, so my first version, which exported its internals, broke the bash tool on every command with `The "paths[0]" property must be of type string, got undefined`. And a rewrite only lands if you mutate `output.args` in place, because opencode passes that same object to the tool.

Open question for you: `pre-commit-push.sh` stays in the chain, but its `additionalContext` goes nowhere, since opencode has no equivalent. Happy to drop it from the opencode chain instead if you would rather the chain only hold hooks that can act.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Xf6fnPYRB2nFxHA2i8DT5h
