### PR TITLE
feat(github-agent): give workers the repository's project memory

### DIFF
--- a/packages/harlan-github-agent/src/agent-context.ts
+++ b/packages/harlan-github-agent/src/agent-context.ts
@@ -1,16 +1,19 @@
 import type { Result } from './result.ts'
 import { readdir, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
-import { delimiter, join, resolve } from 'node:path'
+import { delimiter, isAbsolute, join, resolve } from 'node:path'
 import process from 'node:process'
 import { err, ok } from './result.ts'
 
 export interface AgentContextPaths {
+  /** Harlan's Claude Code home, which holds the per-repository memory. */
+  claudeHome: string
   instructionsPath: string
   skillsRoot: string
 }
 
 export interface AgentContext {
+  claudeHome: string
   instructionPaths: readonly string[]
   skillDirectories: readonly string[]
 }
@@ -53,7 +56,11 @@ export function defaultAgentContextPaths(
   const codexHome = environment.CODEX_HOME === undefined
     ? join(homedir(), '.codex')
     : resolve(environment.CODEX_HOME)
+  const claudeHome = environment.CLAUDE_CONFIG_DIR === undefined
+    ? join(environment.HOME ?? homedir(), '.claude')
+    : resolve(environment.CLAUDE_CONFIG_DIR)
   return {
+    claudeHome,
     instructionsPath: join(codexHome, 'AGENTS.md'),
     skillsRoot: join(workingDirectory, 'harlan-agent-kit', 'skills'),
   }
@@ -93,7 +100,7 @@ export async function loadAgentContext(paths: AgentContextPaths): Promise<Result
   if (skillDirectories.length === 0)
     return err(`No Harlan skills exist under ${paths.skillsRoot}.`)
 
-  return ok({ instructionPaths: [paths.instructionsPath], skillDirectories })
+  return ok({ claudeHome: paths.claudeHome, instructionPaths: [paths.instructionsPath], skillDirectories })
 }
 
 function parseConfiguration(value: string | undefined): Result<OpencodeConfiguration, string> {
@@ -118,12 +125,13 @@ function stringList(value: unknown, field: string): Result<string[], string> {
     : err(`OPENCODE_CONFIG_CONTENT ${field} must contain only strings.`)
 }
 
-/** Adds the canonical context to OpenCode without dropping local configuration. */
-export function opencodeAgentEnvironment(input: {
-  context: AgentContext
-  environment: NodeJS.ProcessEnv
-}): Result<NodeJS.ProcessEnv, string> {
-  const parsed = parseConfiguration(input.environment.OPENCODE_CONFIG_CONTENT)
+/** Adds instruction files and skill directories to an OpenCode configuration. */
+function mergedConfiguration(input: {
+  configuration: string | undefined
+  instructionPaths: readonly string[]
+  skillDirectories: readonly string[]
+}): Result<string, string> {
+  const parsed = parseConfiguration(input.configuration)
   if (parsed._tag === 'Err')
     return parsed
   const configuration = parsed.value
@@ -137,18 +145,57 @@ export function opencodeAgentEnvironment(input: {
   if (paths._tag === 'Err')
     return paths
 
+  return ok(JSON.stringify({
+    ...configuration,
+    instructions: unique([...instructions.value, ...input.instructionPaths]),
+    skills: {
+      ...skills,
+      paths: unique([...paths.value, ...input.skillDirectories]),
+    },
+  }))
+}
+
+/** Adds the canonical context to OpenCode without dropping local configuration. */
+export function opencodeAgentEnvironment(input: {
+  context: AgentContext
+  environment: NodeJS.ProcessEnv
+}): Result<NodeJS.ProcessEnv, string> {
+  const merged = mergedConfiguration({
+    configuration: input.environment.OPENCODE_CONFIG_CONTENT,
+    instructionPaths: input.context.instructionPaths,
+    skillDirectories: input.context.skillDirectories,
+  })
+  if (merged._tag === 'Err')
+    return merged
   return ok({
     ...input.environment,
     PATH: opencodePath(input.environment),
-    OPENCODE_CONFIG_CONTENT: JSON.stringify({
-      ...configuration,
-      instructions: unique([...instructions.value, ...input.context.instructionPaths]),
-      skills: {
-        ...skills,
-        paths: unique([...paths.value, ...input.context.skillDirectories]),
-      },
-    }),
+    OPENCODE_CONFIG_CONTENT: merged.value,
   })
+}
+
+/**
+ * Adds one turn's own instruction files to the shared OpenCode environment.
+ *
+ * Skills are the same for every repository, so the service resolves them once.
+ * Memory belongs to one repository, so only the turn that works on that
+ * repository can name its index. The turn merges its own paths on top of the
+ * shared configuration and changes nothing else.
+ */
+export function opencodeTurnEnvironment(input: {
+  environment: NodeJS.ProcessEnv
+  instructionPaths: readonly string[]
+}): Result<NodeJS.ProcessEnv, string> {
+  if (input.instructionPaths.length === 0)
+    return ok(input.environment)
+  const merged = mergedConfiguration({
+    configuration: input.environment.OPENCODE_CONFIG_CONTENT,
+    instructionPaths: input.instructionPaths,
+    skillDirectories: [],
+  })
+  if (merged._tag === 'Err')
+    return merged
+  return ok({ ...input.environment, OPENCODE_CONFIG_CONTENT: merged.value })
 }
 
 /** Repository instruction files an Agent reads before it changes code. */
@@ -177,6 +224,91 @@ export async function listInstructionFiles(worktreePath: string): Promise<string
       throw error
     })))
   return INSTRUCTION_FILE_NAMES.filter((_, index) => present[index])
+}
+
+/**
+ * The longest project directory name Claude Code writes without a hash.
+ *
+ * A longer path is cut to this length and given a hash of the whole path. That
+ * hash comes from Claude Code's own function, so this service cannot reproduce
+ * it and refuses to guess the name.
+ */
+const MAXIMUM_PROJECT_SLUG_LENGTH = 200
+
+/**
+ * The directory name Claude Code gives one checkout under `projects`.
+ *
+ * Every character outside `a-z`, `A-Z` and `0-9` becomes one hyphen. So
+ * `/home/harlan/sites/gscdump.com` becomes `-home-harlan-sites-gscdump-com`,
+ * and a hidden directory doubles the hyphen.
+ */
+export function claudeProjectSlug(checkoutPath: string): Result<string, string> {
+  if (!isAbsolute(checkoutPath))
+    return err('The checkout path must be absolute.')
+  const slug = checkoutPath.replace(/[^a-z0-9]/gi, '-')
+  return slug.length <= MAXIMUM_PROJECT_SLUG_LENGTH
+    ? ok(slug)
+    : err(`A checkout path over ${MAXIMUM_PROJECT_SLUG_LENGTH} characters gets a hashed project name this service cannot reproduce.`)
+}
+
+/** The memory Harlan recorded on his desktop for one repository checkout. */
+export interface RepositoryMemory {
+  /** Absolute path of the index the turn loads as an instruction file. */
+  indexPath: string
+}
+
+/** The path the memory index would take for one primary checkout. */
+export function repositoryMemoryIndexPath(input: {
+  claudeHome: string
+  checkoutPath: string
+}): Result<string, string> {
+  const slug = claudeProjectSlug(input.checkoutPath)
+  if (slug._tag === 'Err')
+    return slug
+  return ok(join(input.claudeHome, 'projects', slug.value, 'memory', 'MEMORY.md'))
+}
+
+/**
+ * Names the memory index one repository has, or null when it has none.
+ *
+ * The slug must come from the primary checkout, never from the `wt` worktree a
+ * turn runs in. Harlan's desktop owns memory and this service only reads it.
+ * Nothing here writes under `claudeHome`.
+ */
+export async function findRepositoryMemory(input: {
+  claudeHome: string
+  checkoutPath: string
+}): Promise<RepositoryMemory | null> {
+  const indexPath = repositoryMemoryIndexPath(input)
+  // A path too long to name has no project directory this service can find, so
+  // the turn runs without memory instead of reading a wrong repository's notes.
+  if (indexPath._tag === 'Err')
+    return null
+  return stat(indexPath.value)
+    .then(metadata => metadata.isFile() ? { indexPath: indexPath.value } : null)
+    .catch((error: unknown) => {
+      if (isMissingPath(error))
+        return null
+      throw error
+    })
+}
+
+/**
+ * The prompt line that tells a turn what its memory index holds.
+ *
+ * The index reaches the model as an instruction file, and the notes stay on
+ * disk. Without this line the model does not know the notes exist, nor that
+ * they age. It says nothing when the repository has no memory.
+ */
+export function repositoryMemoryLine(memory: RepositoryMemory | null): string {
+  if (memory === null)
+    return ''
+  return `Your instructions include the project memory index at ${memory.indexPath}.
+Memory records decisions and context from earlier sessions on this repository.
+Each entry links to a sibling file in the same directory by name.
+Read a linked file when its entry matters to your work.
+Memory records what was true when it was written.
+Check it against the code before you rely on it.`
 }
 
 /**

--- a/packages/harlan-github-agent/src/agent-provider.ts
+++ b/packages/harlan-github-agent/src/agent-provider.ts
@@ -67,6 +67,12 @@ export function agentTextEvent(text: string): Extract<AgentEvent, { _tag: 'Messa
 }
 
 export interface AgentTurnRequest {
+  /**
+   * Absolute instruction files this turn adds to the shared Agent context.
+   *
+   * Repository memory lives here, because it belongs to one repository.
+   */
+  instructionPaths?: readonly string[]
   /** Durable Task identity used to fence one provider health canary. */
   taskId?: string
   /** Provider-specific model identifier taken from the worker profile. */

--- a/packages/harlan-github-agent/src/agent-turn.ts
+++ b/packages/harlan-github-agent/src/agent-turn.ts
@@ -33,6 +33,8 @@ export interface AgentTurnOptions {
 export interface AgentTurnInput {
   /** Start without prior session context, while still saving the new session for Eject. */
   freshSession?: boolean
+  /** Absolute instruction files this turn adds, such as the memory index. */
+  instructionPaths?: readonly string[]
   /** Issue or pull request number the session belongs to. */
   number: number
   progress?: {
@@ -133,6 +135,7 @@ export async function runAgentTurn(
   const runtime = options.runtime()
   const profile = roleProfile(runtime.profile, input.role)
   const events = runtime.provider.runTurn({
+    ...(input.instructionPaths === undefined ? {} : { instructionPaths: input.instructionPaths }),
     taskId: input.taskId,
     model: profile.model,
     ...(profile.reasoningEffort === undefined ? {} : { reasoningEffort: profile.reasoningEffort }),

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { FailedJobContext, GitHubAgentSource, GitHubCheck, PullRequestReviewSnapshot, PullRequestTemplate } from './github-agent-source.ts'
 import type { Result } from './result.ts'
@@ -8,7 +9,7 @@ import type { BaselineRepairWorktreeManager } from './worktree.ts'
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { redactSecrets, truncateOutput } from './agent-activity.ts'
-import { CHECK_SCOPES, checkBudgetLines, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
+import { CHECK_SCOPES, checkBudgetLines, findRepositoryMemory, repositoryMemoryLine, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { withBaselineRepairMarker } from './baseline-repair-state.ts'
 import { classifyCheckFailure } from './failure.ts'
@@ -59,6 +60,12 @@ export interface WorkspaceFile {
 const GITHUB_ACTIONS_APP_ID = 15368
 
 export interface BaselineRepairWorkerOptions {
+  /**
+   * Harlan's Claude Code home, which holds the per-repository memory.
+   *
+   * Absent means no memory reaches the turn, which is how a test runs.
+   */
+  claudeHome?: string
   github: Pick<GitHubAgentSource, 'findOpenPullRequestForBranch' | 'getFailedJobContext' | 'getPullRequestReviewSnapshot' | 'getPullRequestTemplate'>
   /** Reads the prepared worktree. `inspectWorkspaceFiles` reads it from disk. */
   inspectWorkspace: (path: string) => Promise<WorkspaceFacts>
@@ -226,6 +233,8 @@ export interface BaselineRepairPromptInput {
   repairable: FailedCheckContext[]
   infrastructure: Array<{ check: GitHubCheck, reason: string }>
   workspace: WorkspaceFacts
+  /** The memory index this repository has, or null when it has none. */
+  memory?: RepositoryMemory | null
 }
 
 /** Pure. Everything the Agent needs, in the order it needs it. */
@@ -244,7 +253,8 @@ export function baselineRepairPrompt(input: BaselineRepairPromptInput): string {
 Own the work end to end. Find the root cause, implement the complete fix, and verify it.
 Work as a normal local agent session. Use the user's global agent context and installed skills.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before you return a result.
-${agents}${UNIT_TEST_LINES}
+${agents}${repositoryMemoryLine(input.memory ?? null)}
+${UNIT_TEST_LINES}
 
 Failing checks:
 ${input.repairable.map(checkBlock).join('\n')}
@@ -343,8 +353,13 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
       if (ready._tag === 'Err')
         return ready
       const workspace = await options.inspectWorkspace(prepared.value.path)
+      // The slug comes from the primary checkout, never from this worktree.
+      const memory = options.claudeHome === undefined
+        ? null
+        : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: validated.value.checkout })
       const turn = await runAgentTurn(options, {
         freshSession: task.state.fence > 1,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         number: task.pullRequestNumber,
         progress: { current: { percent: 35, label: 'Git worktree ready' }, report: progress, work: 'baseline' },
         prompt: baselineRepairPrompt({
@@ -353,6 +368,7 @@ export function createBaselineRepairWorker(options: BaselineRepairWorkerOptions)
           repairable,
           infrastructure,
           workspace,
+          memory,
         }),
         repository: task.repository,
         role: 'baseline_repair',

--- a/packages/harlan-github-agent/src/baseline-repair-worker.ts
+++ b/packages/harlan-github-agent/src/baseline-repair-worker.ts
@@ -242,6 +242,8 @@ export function baselineRepairPrompt(input: BaselineRepairPromptInput): string {
   const agents = input.workspace.hasAgentsFile
     ? 'Read AGENTS.md in this worktree before you change code.\n'
     : ''
+  const memory = repositoryMemoryLine(input.memory ?? null)
+  const memoryBlock = memory === '' ? '' : `${memory}\n`
   const nodeOptions = input.workspace.nodeOptions === null
     ? ''
     : `The workflow sets NODE_OPTIONS=${input.workspace.nodeOptions}. Use the same value for every local command.\n`
@@ -253,8 +255,7 @@ export function baselineRepairPrompt(input: BaselineRepairPromptInput): string {
 Own the work end to end. Find the root cause, implement the complete fix, and verify it.
 Work as a normal local agent session. Use the user's global agent context and installed skills.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before you return a result.
-${agents}${repositoryMemoryLine(input.memory ?? null)}
-${UNIT_TEST_LINES}
+${agents}${memoryBlock}${UNIT_TEST_LINES}
 
 Failing checks:
 ${input.repairable.map(checkBlock).join('\n')}

--- a/packages/harlan-github-agent/src/codex-provider.ts
+++ b/packages/harlan-github-agent/src/codex-provider.ts
@@ -107,6 +107,9 @@ export function createCodexProvider(options: CodexProviderOptions = {}): AgentPr
     runTurn: (request: AgentTurnRequest) => (async function* () {
       // The SDK replaces the inherited environment when `env` is set, so the
       // whole service environment goes with the worktree's seeded .env on top.
+      // Codex takes no per-turn instruction file, so it ignores
+      // `request.instructionPaths`. The prompt names the memory index path, and
+      // the turn opens it as a file instead.
       const client = factory({ env: definedEntries(workspaceEnvironment(process.env, request.workspace)) })
       const baseOptions = {
         model: request.model,

--- a/packages/harlan-github-agent/src/index.ts
+++ b/packages/harlan-github-agent/src/index.ts
@@ -1,5 +1,5 @@
-export { defaultAgentContextPaths, loadAgentContext, opencodeAgentEnvironment } from './agent-context.ts'
-export type { AgentContext, AgentContextPaths } from './agent-context.ts'
+export { claudeProjectSlug, defaultAgentContextPaths, findRepositoryMemory, loadAgentContext, opencodeAgentEnvironment, opencodeTurnEnvironment, repositoryMemoryIndexPath, repositoryMemoryLine } from './agent-context.ts'
+export type { AgentContext, AgentContextPaths, RepositoryMemory } from './agent-context.ts'
 export { createAgentPermitPool } from './agent-permit-pool.ts'
 export { AGENT_MODELS, AGENT_PROVIDER_NAMES, AGENT_ROLES, agentProfile, CODEX_AGENT_PROFILE, createAgentRuntimeSource, OPENCODE_AGENT_PROFILE, parseAgentSelection, providerAgentSelection, REASONING_EFFORTS, resolveAgentProfile, resolveAgentSelection, roleProfile } from './agent-profile.ts'
 export type { AgentRuntime, AgentRuntimeSource } from './agent-profile.ts'

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -262,6 +262,8 @@ ${JSON.stringify(combined.map(issue => ({ number: issue.number, title: issue.tit
 /** The Issue work prompt. Exported so tests can assert its contract without an Agent. */
 export function issueWorkPrompt(input: IssueWorkPromptInput): string {
   const { task, routineSource } = input
+  const memory = repositoryMemoryLine(input.memory ?? null)
+  const memoryBlock = memory === '' ? '' : `${memory}\n`
   return `Continue working on the approved GitHub issue ${task.repository}#${task.issueNumber}.
 
 ${storedTriageLines(input.triage)}
@@ -269,8 +271,7 @@ Plan, implement, and verify the complete fix.
 Work as a normal local agent session inside this Git worktree. Use the user's global agent context and installed skills.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before returning a result.
 ${instructionFilesLine(input.instructionFiles)}
-${repositoryMemoryLine(input.memory ?? null)}
-Select every installed code-domain skill whose trigger matches the affected implementation. Do not load workflow skills such as pr, unit-tests, or humanize-writing. Their rules are inlined below.
+${memoryBlock}Select every installed code-domain skill whose trigger matches the affected implementation. Do not load workflow skills such as pr, unit-tests, or humanize-writing. Their rules are inlined below.
 ${UNIT_TEST_LINES}
 ${checkBudgetLines(CHECK_SCOPES.changedFiles)}
 ${TOOLCHAIN_LINES}

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { GitHubAgentSource, PullRequestTemplate } from './github-agent-source.ts'
 import type { IssueTriageResult } from './issue-triage.ts'
@@ -7,7 +8,7 @@ import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedIssueWorkTask, MutationWorkerOutcome, OpenAgentPullRequest, PullRequestBase, RepositoryMapping, RoutineIssueSource } from './types.ts'
 import type { IssueWorktreeManager, PreparedWorkerWorkspace, VerifiedIssuePatch } from './worktree.ts'
 import { redactSecrets, truncateOutput } from './agent-activity.ts'
-import { CHECK_SCOPES, checkBudgetLines, instructionFilesLine, listInstructionFiles, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
+import { CHECK_SCOPES, checkBudgetLines, findRepositoryMemory, instructionFilesLine, listInstructionFiles, repositoryMemoryLine, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { parseStoredIssueTriage } from './issue-triage.ts'
 import { issueSnapshotDigest } from './item-agent.ts'
@@ -67,6 +68,12 @@ export interface IssueWorkWorker {
 }
 
 export interface IssueWorkWorkerOptions {
+  /**
+   * Harlan's Claude Code home, which holds the per-repository memory.
+   *
+   * Absent means no memory reaches the turn, which is how a test runs.
+   */
+  claudeHome?: string
   github: Pick<GitHubAgentSource, 'getIssueTriageSnapshot' | 'getPullRequestTemplate' | 'listPullRequestFiles'>
   now: () => Date
   runtime: AgentRuntimeSource
@@ -238,6 +245,8 @@ export interface IssueWorkPromptInput {
   instructionFiles: readonly string[]
   /** Other issues the same pull request closes, when a Batch combined them. */
   combinedIssues?: readonly CombinedIssue[]
+  /** The memory index this repository has, or null when it has none. */
+  memory?: RepositoryMemory | null
 }
 
 function combinedIssueLines(combined: readonly CombinedIssue[]): string {
@@ -260,6 +269,7 @@ Plan, implement, and verify the complete fix.
 Work as a normal local agent session inside this Git worktree. Use the user's global agent context and installed skills.
 This worktree was prepared fresh for this turn. No work from an earlier turn of this session is present in it. Redo the whole change here before returning a result.
 ${instructionFilesLine(input.instructionFiles)}
+${repositoryMemoryLine(input.memory ?? null)}
 Select every installed code-domain skill whose trigger matches the affected implementation. Do not load workflow skills such as pr, unit-tests, or humanize-writing. Their rules are inlined below.
 ${UNIT_TEST_LINES}
 ${checkBudgetLines(CHECK_SCOPES.changedFiles)}
@@ -371,6 +381,10 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       if (ready._tag === 'Err')
         return ready
       const instructionFiles = await listInstructionFiles(prepared.value.path)
+      // The slug comes from the primary checkout, never from this worktree.
+      const memory = options.claudeHome === undefined
+        ? null
+        : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: validated.value.checkout })
       const triage = parseStoredIssueTriage(options.store.getIssueTriageEvidence(task.repository, task.issueNumber, task.revisionId))
 
       // The triage session is keyed on the issue alone, so neither stacking nor
@@ -381,6 +395,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
         return err('The issue changed before work started.')
       const turn = await runAgentTurn(options, {
         freshSession: task.state.fence > 1,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         number: task.issueNumber,
         progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'fix' },
         prompt: issueWorkPrompt({
@@ -392,6 +407,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
           triage,
           instructionFiles,
           combinedIssues,
+          memory,
         }),
         repository: task.repository,
         role: 'issue_work',

--- a/packages/harlan-github-agent/src/opencode-provider.ts
+++ b/packages/harlan-github-agent/src/opencode-provider.ts
@@ -4,6 +4,7 @@ import type { AgentEvent, AgentProvider, AgentTokenUsage, AgentTurnRequest } fro
 import { spawn } from 'node:child_process'
 import process from 'node:process'
 import { createInterface } from 'node:readline'
+import { opencodeTurnEnvironment } from './agent-context.ts'
 import { agentProviderFailureReason, agentTextEvent, DEFAULT_CACHED_CONTEXT_BUDGET, extractJsonObject, jsonOutputInstruction } from './agent-provider.ts'
 import { workspaceEnvironment } from './workspace-environment.ts'
 
@@ -185,7 +186,17 @@ export function createOpencodeProvider(options: OpencodeProviderOptions = {}): A
 
   async function* runOnce(request: AgentTurnRequest, prompt: string): AsyncGenerator<AgentEvent> {
     // The worktree's seeded .env carries the tokens its own scripts read.
-    const child = spawnOpencode(opencodeArguments(request, prompt), request.workspace, workspaceEnvironment(environment, request.workspace))
+    // This turn's own instruction files, such as the repository memory index,
+    // merge on top of the shared OpenCode configuration.
+    const turnEnvironment = opencodeTurnEnvironment({
+      environment: workspaceEnvironment(environment, request.workspace),
+      instructionPaths: request.instructionPaths ?? [],
+    })
+    if (turnEnvironment._tag === 'Err') {
+      yield { _tag: 'Failed', reason: turnEnvironment.error }
+      return
+    }
+    const child = spawnOpencode(opencodeArguments(request, prompt), request.workspace, turnEnvironment.value)
     const abort = () => child.kill('SIGTERM')
     request.signal.addEventListener('abort', abort, { once: true })
     let standardError = ''

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -111,12 +111,13 @@ export interface ReviewFixPromptInput {
 /** The Repair prompt. Exported so tests can assert its contract without an Agent. */
 export function reviewFixPrompt(input: ReviewFixPromptInput): string {
   const { task, findings } = input
+  const memory = repositoryMemoryLine(input.memory ?? null)
+  const memoryBlock = memory === '' ? '' : `${memory}\n`
   return `Repair the exact material Review findings for ${task.repository}#${task.pullRequestNumber}.
 
 Work as a fresh local Agent session inside this prepared Git worktree.
 ${instructionFilesLine(input.instructionFiles)}
-${repositoryMemoryLine(input.memory ?? null)}
-Treat the findings below as the complete Repair scope.
+${memoryBlock}Treat the findings below as the complete Repair scope.
 ${repairRoundHistory(task.rounds)}
 ${UNIT_TEST_LINES}
 For each finding, write the named failing regression test first. Confirm it fails for the stated reason.

--- a/packages/harlan-github-agent/src/review-fix-worker.ts
+++ b/packages/harlan-github-agent/src/review-fix-worker.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
@@ -7,7 +8,7 @@ import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedReviewFixTask, MutationWorkerOutcome, RepositoryMapping, ReviewFinding } from './types.ts'
 import type { ReviewFixWorktreeManager } from './worktree.ts'
 import { createHash } from 'node:crypto'
-import { CHECK_SCOPES, checkBudgetLines, instructionFilesLine, listInstructionFiles, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
+import { CHECK_SCOPES, checkBudgetLines, findRepositoryMemory, instructionFilesLine, listInstructionFiles, repositoryMemoryLine, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { repairRoundHistory } from './repair-rounds.ts'
 import { canRepairPullRequestHead } from './repository-policy.ts'
@@ -44,6 +45,12 @@ interface AgentResponsePayload {
 
 export interface ReviewFixWorkerOptions {
   activityLog?: Pick<AgentActivityLog, 'record'>
+  /**
+   * Harlan's Claude Code home, which holds the per-repository memory.
+   *
+   * Absent means no memory reaches the turn, which is how a test runs.
+   */
+  claudeHome?: string
   github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot'>
   now: () => Date
   onProgressPublishFailure?: (task: ClaimedReviewFixTask, reason: string) => void
@@ -97,6 +104,8 @@ export interface ReviewFixPromptInput {
   findings: readonly ReviewFinding[]
   /** Instruction file names that exist in the prepared worktree. */
   instructionFiles: readonly string[]
+  /** The memory index this repository has, or null when it has none. */
+  memory?: RepositoryMemory | null
 }
 
 /** The Repair prompt. Exported so tests can assert its contract without an Agent. */
@@ -106,6 +115,7 @@ export function reviewFixPrompt(input: ReviewFixPromptInput): string {
 
 Work as a fresh local Agent session inside this prepared Git worktree.
 ${instructionFilesLine(input.instructionFiles)}
+${repositoryMemoryLine(input.memory ?? null)}
 Treat the findings below as the complete Repair scope.
 ${repairRoundHistory(task.rounds)}
 ${UNIT_TEST_LINES}
@@ -190,12 +200,17 @@ export function createReviewFixWorker(options: ReviewFixWorkerOptions): ReviewFi
       if (ready._tag === 'Err')
         return ready
       const instructionFiles = await listInstructionFiles(prepared.value.path)
+      // The slug comes from the primary checkout, never from this worktree.
+      const memory = options.claudeHome === undefined
+        ? null
+        : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: validated.value.checkout })
 
       const turn = await runParsedAgentTurn({ ...options, parse: parseResponse }, {
         freshSession: true,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         number: task.pullRequestNumber,
         progress: { current: { percent: 35, label: 'Repair worktree ready' }, report: progress, work: 'fix' },
-        prompt: reviewFixPrompt({ task, findings, instructionFiles }),
+        prompt: reviewFixPrompt({ task, findings, instructionFiles, memory }),
         repository: task.repository,
         role: 'review_fix',
         schema: outputSchema,

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -487,6 +487,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       worker: createIssueWorkWorker({
         github: workerGithub,
         activityLog,
+        claudeHome: agentContext.value.claudeHome,
         now,
         runtime,
         store,
@@ -596,6 +597,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           source: tokens,
           worker: createBaselineRepairWorker({
             activityLog,
+            claudeHome: agentContext.value.claudeHome,
             github: workerGithub,
             inspectWorkspace: inspectWorkspaceFiles,
             now,
@@ -704,6 +706,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
           source: tokens,
           worker: createReviewFixWorker({
             activityLog,
+            claudeHome: agentContext.value.claudeHome,
             github: workerGithub,
             now,
             onProgressPublishFailure: subjectWorkerOptions.onProgressPublishFailure,

--- a/packages/harlan-github-agent/test/agent-context.test.ts
+++ b/packages/harlan-github-agent/test/agent-context.test.ts
@@ -2,11 +2,12 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { defaultAgentContextPaths, instructionFilesLine, listInstructionFiles, loadAgentContext, opencodeAgentEnvironment } from '../src/agent-context.ts'
+import { claudeProjectSlug, defaultAgentContextPaths, findRepositoryMemory, instructionFilesLine, listInstructionFiles, loadAgentContext, opencodeAgentEnvironment, opencodeTurnEnvironment, repositoryMemoryIndexPath, repositoryMemoryLine } from '../src/agent-context.ts'
 
 describe('defaultAgentContextPaths', () => {
   it('resolves the copied service context from its working directory', () => {
-    expect(defaultAgentContextPaths({ CODEX_HOME: '/agent-home' }, '/service')).toEqual({
+    expect(defaultAgentContextPaths({ CODEX_HOME: '/agent-home', HOME: '/agent-home' }, '/service')).toEqual({
+      claudeHome: '/agent-home/.claude',
       instructionsPath: '/agent-home/AGENTS.md',
       skillsRoot: '/service/harlan-agent-kit/skills',
     })
@@ -26,9 +27,10 @@ describe('loadAgentContext', () => {
     }))
 
     try {
-      await expect(loadAgentContext({ instructionsPath, skillsRoot })).resolves.toEqual({
+      await expect(loadAgentContext({ claudeHome: join(root, '.claude'), instructionsPath, skillsRoot })).resolves.toEqual({
         _tag: 'Ok',
         value: {
+          claudeHome: join(root, '.claude'),
           instructionPaths: [instructionsPath],
           skillDirectories: [join(skillsRoot, 'pr'), join(skillsRoot, 'unit-tests')],
         },
@@ -44,6 +46,7 @@ describe('loadAgentContext', () => {
 
     try {
       await expect(loadAgentContext({
+        claudeHome: join(root, '.claude'),
         instructionsPath: join(root, 'missing.md'),
         skillsRoot: join(root, 'skills'),
       })).resolves.toEqual({
@@ -60,7 +63,7 @@ describe('loadAgentContext', () => {
 describe('opencodeAgentEnvironment', () => {
   it('keeps the standard OpenCode install reachable with a restricted service PATH', () => {
     const result = opencodeAgentEnvironment({
-      context: { instructionPaths: ['/global/AGENTS.md'], skillDirectories: ['/skills/pr'] },
+      context: { claudeHome: '/agent-home/.claude', instructionPaths: ['/global/AGENTS.md'], skillDirectories: ['/skills/pr'] },
       environment: { HOME: '/agent-home', PATH: '/usr/bin:/bin' },
     })
 
@@ -73,6 +76,7 @@ describe('opencodeAgentEnvironment', () => {
   it('adds global instructions and every skill without dropping existing configuration', () => {
     const result = opencodeAgentEnvironment({
       context: {
+        claudeHome: '/home/harlan/.claude',
         instructionPaths: ['/home/harlan/.codex/AGENTS.md'],
         skillDirectories: ['/kit/skills/pr', '/kit/skills/unit-tests'],
       },
@@ -103,7 +107,7 @@ describe('opencodeAgentEnvironment', () => {
 
   it('rejects malformed existing OpenCode configuration', () => {
     expect(opencodeAgentEnvironment({
-      context: { instructionPaths: ['/global/AGENTS.md'], skillDirectories: ['/skills/pr'] },
+      context: { claudeHome: '/agent-home/.claude', instructionPaths: ['/global/AGENTS.md'], skillDirectories: ['/skills/pr'] },
       environment: { OPENCODE_CONFIG_CONTENT: '{' },
     })).toEqual({
       _tag: 'Err',
@@ -141,5 +145,157 @@ describe('listInstructionFiles', () => {
 
   it('reports nothing for a worktree that does not exist', async () => {
     await expect(listInstructionFiles(join(tmpdir(), 'harlan-missing-worktree'))).resolves.toEqual([])
+  })
+})
+
+describe('claudeProjectSlug', () => {
+  it('names the project directory Claude Code writes for a real checkout', () => {
+    expect(claudeProjectSlug('/home/harlan/pkg/harlan-agent-kit'))
+      .toEqual({ _tag: 'Ok', value: '-home-harlan-pkg-harlan-agent-kit' })
+  })
+
+  it('turns every dot in a site checkout into one hyphen', () => {
+    expect(claudeProjectSlug('/home/harlan/sites/gscdump.com'))
+      .toEqual({ _tag: 'Ok', value: '-home-harlan-sites-gscdump-com' })
+    expect(claudeProjectSlug('/home/harlan/sites/scripts.nuxt.com'))
+      .toEqual({ _tag: 'Ok', value: '-home-harlan-sites-scripts-nuxt-com' })
+  })
+
+  it('doubles the hyphen for a hidden directory', () => {
+    expect(claudeProjectSlug('/home/harlan/.claude/skills/vue-skilld/.skilld'))
+      .toEqual({ _tag: 'Ok', value: '-home-harlan--claude-skills-vue-skilld--skilld' })
+  })
+
+  it('names a worktree sibling separately from its primary checkout', () => {
+    expect(claudeProjectSlug('/home/harlan/pkg/nuxt-pr-36208-control.fix-pr-36208-layer-scan'))
+      .toEqual({ _tag: 'Ok', value: '-home-harlan-pkg-nuxt-pr-36208-control-fix-pr-36208-layer-scan' })
+  })
+
+  it('refuses a relative path', () => {
+    expect(claudeProjectSlug('pkg/harlan-agent-kit'))
+      .toEqual({ _tag: 'Err', error: 'The checkout path must be absolute.' })
+  })
+
+  it('refuses a path whose project name Claude Code shortens with a hash', () => {
+    const result = claudeProjectSlug(`/home/harlan/pkg/${'a'.repeat(200)}`)
+
+    expect(result._tag).toBe('Err')
+  })
+})
+
+describe('repositoryMemoryIndexPath', () => {
+  it('points at the index inside the project memory directory', () => {
+    expect(repositoryMemoryIndexPath({
+      claudeHome: '/home/harlan/.claude',
+      checkoutPath: '/home/harlan/pkg/harlan-agent-kit',
+    })).toEqual({
+      _tag: 'Ok',
+      value: '/home/harlan/.claude/projects/-home-harlan-pkg-harlan-agent-kit/memory/MEMORY.md',
+    })
+  })
+})
+
+describe('findRepositoryMemory', () => {
+  it('names the index the desktop recorded for a primary checkout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'harlan-agent-memory-'))
+    const claudeHome = join(root, '.claude')
+    const memory = join(claudeHome, 'projects', '-home-harlan-pkg-harlan-agent-kit', 'memory')
+    await mkdir(memory, { recursive: true })
+    await writeFile(join(memory, 'MEMORY.md'), '- [Deployment](deployment.md)\n')
+
+    try {
+      await expect(findRepositoryMemory({ claudeHome, checkoutPath: '/home/harlan/pkg/harlan-agent-kit' }))
+        .resolves
+        .toEqual({ indexPath: join(memory, 'MEMORY.md') })
+    }
+    finally {
+      await rm(root, { recursive: true })
+    }
+  })
+
+  it('answers null when the repository has no memory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'harlan-agent-memory-'))
+
+    try {
+      await expect(findRepositoryMemory({ claudeHome: join(root, '.claude'), checkoutPath: '/home/harlan/pkg/unwritten' }))
+        .resolves
+        .toBeNull()
+    }
+    finally {
+      await rm(root, { recursive: true })
+    }
+  })
+
+  it('answers null for a worktree whose primary checkout holds the memory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'harlan-agent-memory-'))
+    const claudeHome = join(root, '.claude')
+    const memory = join(claudeHome, 'projects', '-home-harlan-pkg-harlan-agent-kit', 'memory')
+    await mkdir(memory, { recursive: true })
+    await writeFile(join(memory, 'MEMORY.md'), '- [Deployment](deployment.md)\n')
+
+    try {
+      await expect(findRepositoryMemory({ claudeHome, checkoutPath: '/home/harlan/pkg/harlan-agent-kit.feat-thing' }))
+        .resolves
+        .toBeNull()
+    }
+    finally {
+      await rm(root, { recursive: true })
+    }
+  })
+})
+
+describe('repositoryMemoryLine', () => {
+  it('says nothing when the repository has no memory', () => {
+    expect(repositoryMemoryLine(null)).toBe('')
+  })
+
+  it('names the index, the sibling files, and the age of what it records', () => {
+    const line = repositoryMemoryLine({ indexPath: '/home/harlan/.claude/projects/-home-harlan-pkg-unhead/memory/MEMORY.md' })
+
+    expect(line).toContain('/home/harlan/.claude/projects/-home-harlan-pkg-unhead/memory/MEMORY.md')
+    expect(line).toContain('links to a sibling file in the same directory by name')
+    expect(line).toContain('Check it against the code before you rely on it.')
+  })
+})
+
+describe('opencodeTurnEnvironment', () => {
+  it('adds one turn instruction file without dropping the shared context', () => {
+    const result = opencodeTurnEnvironment({
+      environment: {
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          instructions: ['/home/harlan/.codex/AGENTS.md'],
+          skills: { paths: ['/kit/skills/pr'] },
+        }),
+      },
+      instructionPaths: ['/home/harlan/.claude/projects/-home-harlan-pkg-unhead/memory/MEMORY.md'],
+    })
+
+    expect(result._tag).toBe('Ok')
+    if (result._tag === 'Err')
+      return
+    expect(JSON.parse(result.value.OPENCODE_CONFIG_CONTENT ?? '')).toEqual({
+      instructions: [
+        '/home/harlan/.codex/AGENTS.md',
+        '/home/harlan/.claude/projects/-home-harlan-pkg-unhead/memory/MEMORY.md',
+      ],
+      skills: { paths: ['/kit/skills/pr'] },
+    })
+  })
+
+  it('answers the same environment when the turn adds nothing', () => {
+    const environment = { OPENCODE_CONFIG_CONTENT: '{"instructions":["/a.md"]}' }
+
+    expect(opencodeTurnEnvironment({ environment, instructionPaths: [] }))
+      .toEqual({ _tag: 'Ok', value: environment })
+  })
+
+  it('rejects malformed existing OpenCode configuration', () => {
+    expect(opencodeTurnEnvironment({
+      environment: { OPENCODE_CONFIG_CONTENT: '{' },
+      instructionPaths: ['/memory/MEMORY.md'],
+    })).toEqual({
+      _tag: 'Err',
+      error: 'OPENCODE_CONFIG_CONTENT must contain one JSON object.',
+    })
   })
 })

--- a/packages/harlan-github-agent/test/issue-work-prompt.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-prompt.test.ts
@@ -93,3 +93,36 @@ describe('parseStoredIssueTriage', () => {
     expect(parseStoredIssueTriage(evidence)).toBeNull()
   })
 })
+
+describe('issueWorkPrompt memory', () => {
+  it('names the memory index and how to treat it', () => {
+    const prompt = issueWorkPrompt({
+      task: task(),
+      body: 'Body',
+      comments: [],
+      template: { _tag: 'Missing' },
+      routineSource: null,
+      triage: parseStoredIssueTriage(null),
+      instructionFiles: [],
+      memory: { indexPath: '/home/harlan/.claude/projects/-home-harlan-pkg-unhead/memory/MEMORY.md' },
+    })
+
+    expect(prompt).toContain('project memory index at /home/harlan/.claude/projects/-home-harlan-pkg-unhead/memory/MEMORY.md')
+    expect(prompt).toContain('Check it against the code before you rely on it.')
+  })
+
+  it('says nothing about memory when the repository has none', () => {
+    const prompt = issueWorkPrompt({
+      task: task(),
+      body: 'Body',
+      comments: [],
+      template: { _tag: 'Missing' },
+      routineSource: null,
+      triage: parseStoredIssueTriage(null),
+      instructionFiles: [],
+      memory: null,
+    })
+
+    expect(prompt).not.toContain('project memory index')
+  })
+})

--- a/scripts/check-agent-context.sh
+++ b/scripts/check-agent-context.sh
@@ -28,7 +28,12 @@ for f in "$REPO_ROOT/agent-context/context.md" "$REPO_ROOT/agent-context/CLAUDE.
 done
 [ "$fail" -eq 0 ] || exit 1
 
-HARLAN_AGENT_CONTEXT_HOME="$EXPECTED_HOME" bash "$REPO_ROOT/scripts/sync-agent-context.sh" local >/dev/null
+# Project memory is out of scope for this check. It compares installed files
+# against tracked sources in this repository. Memory has no tracked source: it
+# is Harlan's, it changes every session, so a difference is normal and reporting
+# it as drift would make the check meaningless. The sandbox run skips it.
+HARLAN_AGENT_CONTEXT_HOME="$EXPECTED_HOME" HARLAN_AGENT_CONTEXT_SKIP_MEMORY=1 \
+  bash "$REPO_ROOT/scripts/sync-agent-context.sh" local >/dev/null
 
 cmp -s "$EXPECTED_CLAUDE" "$CLAUDE" || bad "Claude instructions differ. Run pnpm sync:context."
 cmp -s "$EXPECTED_CODEX" "$CODEX" || bad "Codex instructions differ. Run pnpm sync:context."

--- a/scripts/sync-agent-context.sh
+++ b/scripts/sync-agent-context.sh
@@ -206,18 +206,132 @@ sync_hogwild() {
   printf '%s\n' 'Synced Hogwild Agent instructions.'
 }
 
+# ---------------------------------------------------------------------------
+# Project memory
+#
+# Harlan's desktop records per-repository memory under ~/.claude/projects. A
+# worker on Hogwild starts cold without it. This section copies it out.
+#
+# One direction only. The desktop owns memory. Workers read it and never write
+# it back, and nothing here ever copies from Hogwild to the desktop.
+#
+# Integrity: every single file above is verified by sha256 before its mv. A
+# directory sync cannot do that per file. rsync checks a digest of each file it
+# transfers and retries a mismatch, so a transferred file is whole or the run
+# fails. The tar fallback relies on tar's own exit status. Neither is atomic, so
+# a worker reading memory mid-sync can see a partly updated tree. Memory is
+# reference material a turn checks against the code, so a stale or missing note
+# costs context and never correctness.
+# ---------------------------------------------------------------------------
+memory_root="${HARLAN_AGENT_CONTEXT_MEMORY_ROOT:-$HOME/.claude/projects}"
+memory_checkout_roots="${HARLAN_AGENT_CONTEXT_CHECKOUT_ROOTS:-$HOME/pkg:$HOME/sites}"
+
+# Claude Code names a project directory after the checkout path. Every
+# character outside a-z, A-Z and 0-9 becomes one hyphen.
+project_slug() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9' '-'
+}
+
+# Prints the slug of every primary checkout that has memory, one per line.
+# A wt worktree carries a .git file, not a directory, so it never matches. A
+# project directory with no matching checkout is never copied.
+memory_slugs() {
+  local root checkout slug
+  [ -d "$memory_root" ] || return 0
+  while IFS= read -r root; do
+    [ -n "$root" ] && [ -d "$root" ] || continue
+    for checkout in "$root"/*; do
+      [ -d "$checkout/.git" ] || continue
+      slug=$(project_slug "$checkout")
+      [ -d "$memory_root/$slug/memory" ] || continue
+      printf '%s\n' "$slug"
+    done
+  done < <(printf '%s\n' "$memory_checkout_roots" | tr ':' '\n')
+}
+
+memory_enabled() {
+  [ "${HARLAN_AGENT_CONTEXT_SKIP_MEMORY:-0}" != 1 ]
+}
+
+# Mirrors one memory directory onto a local path.
+copy_memory_tree() {
+  local source=$1 destination=$2
+  mkdir -p "$destination"
+  if command -v rsync >/dev/null 2>&1; then
+    rsync -a --delete "$source/" "$destination/"
+    return
+  fi
+  # tar has no delete, so the destination starts empty. Every slug matches
+  # [A-Za-z0-9-], so the path this removes is always inside the memory tree.
+  rm -rf "${destination:?}"
+  mkdir -p "$destination"
+  tar -C "$source" -cf - . | tar -C "$destination" -xf -
+}
+
+sync_local_memory() {
+  local destination_root slug count
+  memory_enabled || return 0
+  validate_local_home
+  destination_root="$target_home/.claude/projects"
+  if [ "$memory_root" = "$destination_root" ]; then
+    printf '%s\n' 'Local project memory is already the source. Nothing to copy.'
+    return 0
+  fi
+  count=0
+  while IFS= read -r slug; do
+    mkdir -p "$destination_root/$slug"
+    copy_memory_tree "$memory_root/$slug/memory" "$destination_root/$slug/memory"
+    count=$((count + 1))
+  done < <(memory_slugs)
+  printf 'Synced project memory for %s repositories.\n' "$count"
+}
+
+sync_hogwild_memory() {
+  local slug source remote count remote_rsync
+  memory_enabled || return 0
+  validate_hogwild
+  count=0
+  remote_rsync=''
+  if command -v rsync >/dev/null 2>&1; then
+    remote_rsync=$(ssh -o BatchMode=yes "$hogwild_host" 'command -v rsync' 2>/dev/null || true)
+  fi
+  while IFS= read -r slug; do
+    source="$memory_root/$slug/memory"
+    remote="$hogwild_home/.claude/projects/$slug/memory"
+    if [ -n "$remote_rsync" ]; then
+      ssh -o BatchMode=yes "$hogwild_host" "mkdir -p '$remote'" \
+        || fail "Hogwild did not accept the memory directory for $slug."
+      rsync -a --delete -e 'ssh -o BatchMode=yes' "$source/" "$hogwild_host:$remote/" \
+        || fail "Hogwild did not receive the project memory for $slug."
+    else
+      # tar has no delete, so the remote directory starts empty. Every slug
+      # matches [A-Za-z0-9-], so this removes a path inside the memory tree.
+      ssh -o BatchMode=yes "$hogwild_host" "rm -rf '$remote' && mkdir -p '$remote'" \
+        || fail "Hogwild did not accept the memory directory for $slug."
+      tar -C "$source" -czf - . | ssh -o BatchMode=yes "$hogwild_host" "tar -C '$remote' -xzf -" \
+        || fail "Hogwild did not receive the project memory for $slug."
+    fi
+    count=$((count + 1))
+  done < <(memory_slugs)
+  printf 'Synced project memory for %s repositories to Hogwild.\n' "$count"
+}
+
 require_sources
 
 case "${1:-local}" in
   local)
     sync_local
+    sync_local_memory
     ;;
   hogwild)
     sync_hogwild
+    sync_hogwild_memory
     ;;
   all)
     sync_local
+    sync_local_memory
     sync_hogwild
+    sync_hogwild_memory
     ;;
   *)
     fail 'Use local, hogwild, or all.'

--- a/scripts/sync-agent-context.test.sh
+++ b/scripts/sync-agent-context.test.sh
@@ -11,7 +11,42 @@ test_home="$test_root/home"
 calls="$test_root/calls"
 mkdir -p "$test_home" "$test_root/bin"
 
+# Project memory fixtures: one primary checkout, one wt worktree sibling, and
+# one project directory that no checkout matches.
+memory_root="$test_root/projects"
+checkout_root="$test_root/pkg"
+mkdir -p "$checkout_root/demo-pkg/.git" "$checkout_root/demo-pkg.feat-thing"
+printf '%s\n' 'gitdir: /elsewhere' > "$checkout_root/demo-pkg.feat-thing/.git"
+primary_slug=$(printf '%s' "$checkout_root/demo-pkg" | tr -c 'A-Za-z0-9' '-')
+worktree_slug=$(printf '%s' "$checkout_root/demo-pkg.feat-thing" | tr -c 'A-Za-z0-9' '-')
+mkdir -p "$memory_root/$primary_slug/memory" "$memory_root/$worktree_slug/memory" "$memory_root/-unrelated/memory"
+printf '%s\n' '- [Deployment](deployment.md)' > "$memory_root/$primary_slug/memory/MEMORY.md"
+printf '%s\n' '# Deployment' > "$memory_root/$primary_slug/memory/deployment.md"
+printf '%s\n' '- [Worktree](worktree.md)' > "$memory_root/$worktree_slug/memory/MEMORY.md"
+printf '%s\n' '- [Unrelated](unrelated.md)' > "$memory_root/-unrelated/memory/MEMORY.md"
+export HARLAN_AGENT_CONTEXT_MEMORY_ROOT="$memory_root"
+export HARLAN_AGENT_CONTEXT_CHECKOUT_ROOTS="$checkout_root"
+
 HARLAN_AGENT_CONTEXT_HOME="$test_home" bash "$script_dir/sync-agent-context.sh" local >/dev/null
+
+cmp "$memory_root/$primary_slug/memory/MEMORY.md" "$test_home/.claude/projects/$primary_slug/memory/MEMORY.md"
+cmp "$memory_root/$primary_slug/memory/deployment.md" "$test_home/.claude/projects/$primary_slug/memory/deployment.md"
+if [ -e "$test_home/.claude/projects/$worktree_slug" ]; then
+  printf '%s\n' 'The sync copied memory for a wt worktree sibling.' >&2
+  exit 1
+fi
+if [ -e "$test_home/.claude/projects/-unrelated" ]; then
+  printf '%s\n' 'The sync copied memory for a project with no checkout.' >&2
+  exit 1
+fi
+
+# A note the desktop deleted must not survive on the worker host.
+printf '%s\n' '# Stale' > "$test_home/.claude/projects/$primary_slug/memory/stale.md"
+HARLAN_AGENT_CONTEXT_HOME="$test_home" bash "$script_dir/sync-agent-context.sh" local >/dev/null
+if [ -e "$test_home/.claude/projects/$primary_slug/memory/stale.md" ]; then
+  printf '%s\n' 'The sync kept a note the desktop no longer has.' >&2
+  exit 1
+fi
 
 cmp "$repo_root/agent-context/context.md" "$test_home/.claude/CLAUDE.md"
 cmp "$repo_root/agent-context/context.md" "$test_home/.codex/AGENTS.md"
@@ -57,6 +92,9 @@ export HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH="$hook_hash"
 cat > "$test_root/bin/ssh" <<'FAKE_SSH'
 #!/usr/bin/env bash
 printf 'ssh %s\n' "$*" >> "$HARLAN_AGENT_CONTEXT_TEST_CALLS"
+# Real ssh reads the piped stream. The memory tar fallback would take SIGPIPE
+# without this.
+if [[ "$*" == *"tar -C"* ]]; then cat >/dev/null; fi
 if [[ "$*" == *CLAUDE.md.next*sha256sum* || "$*" == *sha256sum*CLAUDE.md.next* ]]; then printf '%s  CLAUDE.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH"; fi
 if [[ "$*" == *AGENTS.md.next*sha256sum* || "$*" == *sha256sum*AGENTS.md.next* ]]; then printf '%s  AGENTS.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH"; fi
 if [[ "$*" == *commit-msg.next*sha256sum* || "$*" == *sha256sum*commit-msg.next* ]]; then printf '%s  commit-msg.next\n' "$HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH"; fi
@@ -101,6 +139,18 @@ for hook_file in "${opencode_hooks[@]}"; do
   grep -F "mv '/home/harlan/.local/share/harlan-agent-kit/hooks/$hook_file.next' '/home/harlan/.local/share/harlan-agent-kit/hooks/$hook_file'" "$calls" >/dev/null
 done
 grep -F 'hogwild:/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next' "$calls" >/dev/null
+
+# Memory reaches Hogwild for the primary checkout only, over the tar fallback
+# because the fake ssh reports no remote rsync.
+grep -F "tar -C '/home/harlan/.claude/projects/$primary_slug/memory' -xzf -" "$calls" >/dev/null
+if grep -F "/home/harlan/.claude/projects/$worktree_slug" "$calls" >/dev/null; then
+  printf '%s\n' 'Hogwild received memory for a wt worktree sibling.' >&2
+  exit 1
+fi
+if grep -F '/home/harlan/.claude/projects/-unrelated' "$calls" >/dev/null; then
+  printf '%s\n' 'Hogwild received memory for a project with no checkout.' >&2
+  exit 1
+fi
 grep -F "mv '/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next' '/home/harlan/.config/opencode/plugins/harlan-hooks.ts'" "$calls" >/dev/null
 grep -F "chmod 644 '/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next'" "$calls" >/dev/null
 


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

42 of my projects carry per-project memory on the desktop, and none of it
reached the service. Workers kept re-deriving how the service deploys, how to
triage an Incident, why a Baseline repair stalls a stack. Sometimes they got it
wrong and I found out in review.

A turn now loads that repository's `MEMORY.md` as one of its own instruction
files, and the prompt says what memory is and that it can be stale. The
individual notes stay on disk, the way they work for me.

Two things I am unsure about:

- Only Issue work, Repair, and Baseline repair get it. Adversarial review,
  conflict resolution, and Routine scans do not. I did not want to touch six
  prompt builders in one go, but Review is probably the next one worth it.
- Codex takes no per-turn instruction file, so it only sees the prompt line
  naming the path. It has to open the file itself. OpenCode gets the index
  loaded properly.

I left memory out of `check:context`. That check compares installed files with
tracked sources, and memory has no tracked source: it changes every session, so
a difference is the normal state and reporting it as drift would make the check
noise.

The sync mirrors primary checkouts only. A `wt` worktree carries a `.git` file
rather than a directory, which is what separates them.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Xf6fnPYRB2nFxHA2i8DT5h