### PR TITLE
fix(hooks): stop ssh eating the memory slug list

### DIFF
--- a/scripts/sync-agent-context.sh
+++ b/scripts/sync-agent-context.sh
@@ -301,20 +301,23 @@ sync_hogwild_memory() {
   count=0
   remote_rsync=''
   if command -v rsync >/dev/null 2>&1; then
-    remote_rsync=$(ssh -o BatchMode=yes "$hogwild_host" 'command -v rsync' 2>/dev/null || true)
+    remote_rsync=$(ssh -n -o BatchMode=yes "$hogwild_host" 'command -v rsync' 2>/dev/null || true)
   fi
+
+  # Every ssh below runs with -n. Without it the first one reads the rest of
+  # the slug list from stdin, and the loop copies exactly one repository.
   while IFS= read -r slug; do
     source="$memory_root/$slug/memory"
     remote="$hogwild_home/.claude/projects/$slug/memory"
     if [ -n "$remote_rsync" ]; then
-      ssh -o BatchMode=yes "$hogwild_host" "mkdir -p '$remote'" \
+      ssh -n -o BatchMode=yes "$hogwild_host" "mkdir -p '$remote'" \
         || fail "Hogwild did not accept the memory directory for $slug."
       rsync -a --delete -e 'ssh -o BatchMode=yes' "$source/" "$hogwild_host:$remote/" \
         || fail "Hogwild did not receive the project memory for $slug."
     else
       # tar has no delete, so the remote directory starts empty. Every slug
       # matches [A-Za-z0-9-], so this removes a path inside the memory tree.
-      ssh -o BatchMode=yes "$hogwild_host" "rm -rf '$remote' && mkdir -p '$remote'" \
+      ssh -n -o BatchMode=yes "$hogwild_host" "rm -rf '$remote' && mkdir -p '$remote'" \
         || fail "Hogwild did not accept the memory directory for $slug."
       tar -C "$source" -czf - . | ssh -o BatchMode=yes "$hogwild_host" "tar -C '$remote' -xzf -" \
         || fail "Hogwild did not receive the project memory for $slug."

--- a/scripts/sync-agent-context.test.sh
+++ b/scripts/sync-agent-context.test.sh
@@ -99,9 +99,11 @@ export HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH="$hook_hash"
 cat > "$test_root/bin/ssh" <<'FAKE_SSH'
 #!/usr/bin/env bash
 printf 'ssh %s\n' "$*" >> "$HARLAN_AGENT_CONTEXT_TEST_CALLS"
-# Real ssh reads the piped stream. The memory tar fallback would take SIGPIPE
-# without this.
-if [[ "$*" == *"tar -C"* ]]; then cat >/dev/null; fi
+# Real ssh reads stdin unless it is given -n, and that is exactly how the
+# memory loop lost every slug after the first. Copy that for the memory calls
+# only. Draining every call would hang the ones made in command substitution,
+# because their stdin is the caller's and nothing closes it.
+if [[ "$1" != '-n' && ( "$*" == *"tar -C"* || "$*" == *"/memory'"* ) ]]; then cat >/dev/null; fi
 if [[ "$*" == *CLAUDE.md.next*sha256sum* || "$*" == *sha256sum*CLAUDE.md.next* ]]; then printf '%s  CLAUDE.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH"; fi
 if [[ "$*" == *AGENTS.md.next*sha256sum* || "$*" == *sha256sum*AGENTS.md.next* ]]; then printf '%s  AGENTS.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH"; fi
 if [[ "$*" == *commit-msg.next*sha256sum* || "$*" == *sha256sum*commit-msg.next* ]]; then printf '%s  commit-msg.next\n' "$HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH"; fi
@@ -150,6 +152,23 @@ grep -F 'hogwild:/home/harlan/.config/opencode/plugins/harlan-hooks.ts.next' "$c
 # Memory reaches Hogwild for the primary checkout only, over the tar fallback
 # because the fake ssh reports no remote rsync.
 grep -F "tar -C '/home/harlan/.claude/projects/$primary_slug/memory' -xzf -" "$calls" >/dev/null
+
+# A second primary checkout proves the loop survives its own ssh calls. Without
+# -n the first ssh eats the slug list and only one repository ever syncs.
+second_slug=$(printf '%s' "$test_root/pkg/second" | tr -c 'A-Za-z0-9' '-')
+mkdir -p "$test_root/pkg/second/.git" "$memory_root/$second_slug/memory"
+printf '%s\n' '- [Second](second.md)' > "$memory_root/$second_slug/memory/MEMORY.md"
+: > "$calls"
+PATH="$test_root/bin:/usr/bin:/bin" \
+  HARLAN_AGENT_CONTEXT_HOGWILD_HOST=hogwild \
+  HARLAN_AGENT_CONTEXT_HOGWILD_HOME=/home/harlan \
+  bash "$script_dir/sync-agent-context.sh" hogwild >/dev/null
+for slug in "$primary_slug" "$second_slug"; do
+  if ! grep -F "tar -C '/home/harlan/.claude/projects/$slug/memory' -xzf -" "$calls" >/dev/null; then
+    printf '%s\n' "Hogwild memory sync stopped before $slug. An ssh call read the slug list." >&2
+    exit 1
+  fi
+done
 if grep -F "/home/harlan/.claude/projects/$worktree_slug" "$calls" >/dev/null; then
   printf '%s\n' 'Hogwild received memory for a wt worktree sibling.' >&2
   exit 1


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

The memory sync from #195 reported success and copied one repository out of 33. Hogwild ended up with a single project directory, 32K instead of 5.1 MB.

`ssh` reads standard input. Inside the sync loop standard input is the slug list feeding the `while read`, so the first `ssh` swallowed every remaining slug and the loop ended after one pass. The count printed 1 and nothing failed, which is why it looked fine.

Every `ssh` in that loop now runs with `-n`.

The test did not catch this because its fake `ssh` drained standard input unconditionally, which is the behaviour the fix produces. The fake now drains only when `-n` is absent, matching real `ssh`, and a second primary checkout fixture proves the loop reaches both. I checked it fails without the fix: it stops at the second slug and names it.

The fake still drains only for the memory calls. Draining every call hangs the ones made in command substitution, because their standard input is the caller's and nothing closes it. That cost me a wedged test run before I narrowed it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
