### PR TITLE
feat(github-agent): give four more workers the repository memory

### DIFF
--- a/packages/harlan-github-agent/src/batch-worker.ts
+++ b/packages/harlan-github-agent/src/batch-worker.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { CombinedIssue, IssueWorkUnit, IssueWorkWorker } from './issue-work-worker.ts'
@@ -7,7 +8,7 @@ import type { JournalStore } from './store.ts'
 import type { ClaimedTaskResult, ClaimedTaskStore } from './task-scheduler.ts'
 import type { BatchIssue, BatchUnit, ClaimedBatch, ClaimedIssueWorkTask, PlannedBatchUnit, PullRequestBase, RepositoryMapping } from './types.ts'
 import type { AgentWorkspaceManager } from './worktree.ts'
-import { TOOLCHAIN_LINES } from './agent-context.ts'
+import { findRepositoryMemory, repositoryMemoryLine, TOOLCHAIN_LINES } from './agent-context.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { err, ok } from './result.ts'
 import { runClaimedTask } from './task-scheduler.ts'
@@ -83,16 +84,19 @@ export function parseBatchPlan(text: string): Result<BatchPlan, string> {
 export interface BatchPlanPromptInput {
   repository: string
   issues: readonly BatchIssue[]
+  /** The memory index this repository has, or null when it has none. */
+  memory?: RepositoryMemory | null
 }
 
 /** The Batch planning prompt. Exported so tests can assert its contract without an Agent. */
 export function batchPlanPrompt(input: BatchPlanPromptInput): string {
+  const memoryLines = repositoryMemoryLine(input.memory ?? null)
   return `Plan how ${input.issues.length} Ready issues in ${input.repository} become pull requests.
 
 Work as a normal local agent session inside this Git worktree, checked out at the default branch. Read code as needed to see which issues touch the same files or share one cause. Do not edit files, commit, push, or post comments.
 Every issue below was triaged Ready to implement, and each one is Routine-filed, so its target file is known.
 ${TOOLCHAIN_LINES}
-
+${memoryLines === '' ? '' : `\n${memoryLines}\n`}
 Decide units. One unit is one pull request. Rules:
 - Combine issues into one unit only when one change fixes them all, or when fixing them apart would conflict in the same lines.
 - Keep issues apart when a reviewer would want to read them apart. Small pull requests merge sooner.
@@ -119,6 +123,12 @@ export interface BatchWorkerOptions {
   activityLog?: Pick<AgentActivityLog, 'record'>
   /** Whether Issue work may claim right now, the same gate the plain scheduler uses. */
   canClaimIssueWork: () => boolean
+  /**
+   * Harlan's Claude Code home, which holds the per-repository memory.
+   *
+   * Absent means no memory reaches the turn, which is how a test runs.
+   */
+  claudeHome?: string
   github: Pick<GitHubAgentSource, 'getIssueTriageSnapshot'>
   issueWork: IssueWorkWorker
   leaseMilliseconds: number
@@ -190,6 +200,10 @@ export function createBatchWorker(options: BatchWorkerOptions): BatchWorker {
       return options.store.recordBatchPlan({ ...fenced, at: at(), units: singleUnits(batch.issues, `The planning worktree failed: ${workspace.error}`) })
     }
     const issues = await readIssueBodies(mapping, batch.issues, signal)
+    // The slug comes from the primary checkout, never from the planning worktree.
+    const memory = options.claudeHome === undefined
+      ? null
+      : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: mapping.checkout })
     const turn = await runParsedAgentTurn(
       {
         ...(options.activityLog === undefined ? {} : { activityLog: options.activityLog }),
@@ -200,9 +214,10 @@ export function createBatchWorker(options: BatchWorkerOptions): BatchWorker {
       },
       {
         freshSession: true,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         // A Batch belongs to several issues and to no single one, so no session is saved.
         number: 0,
-        prompt: batchPlanPrompt({ repository: batch.repository, issues }),
+        prompt: batchPlanPrompt({ repository: batch.repository, issues, memory }),
         repository: batch.repository,
         role: 'batch_plan',
         schema: BATCH_PLAN_SCHEMA,

--- a/packages/harlan-github-agent/src/conflict-worker.ts
+++ b/packages/harlan-github-agent/src/conflict-worker.ts
@@ -1,11 +1,12 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { GitHubSource } from './github.ts'
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedConflictResolutionTask, MutationWorkerOutcome, RepositoryMapping } from './types.ts'
 import type { ConflictWorktreeManager, PreparedConflictWorktree } from './worktree.ts'
-import { CHECK_SCOPES, checkBudgetLines, TOOLCHAIN_LINES } from './agent-context.ts'
+import { CHECK_SCOPES, checkBudgetLines, findRepositoryMemory, repositoryMemoryLine, TOOLCHAIN_LINES } from './agent-context.ts'
 import { runAgentTurn } from './agent-turn.ts'
 import { isAutomatedGitHubActor } from './github.ts'
 import { err, ok } from './result.ts'
@@ -16,6 +17,12 @@ export interface ConflictWorker {
 }
 
 export interface ConflictWorkerOptions {
+  /**
+   * Harlan's Claude Code home, which holds the per-repository memory.
+   *
+   * Absent means no memory reaches the turn, which is how a test runs.
+   */
+  claudeHome?: string
   github: Pick<GitHubSource, 'getPullRequest'>
   now: () => Date
   runtime: AgentRuntimeSource
@@ -45,9 +52,10 @@ const outputSchema = {
 }
 
 /** The conflict resolution prompt. Exported so tests can assert its contract without an Agent. */
-export function conflictResolutionPrompt(task: ClaimedConflictResolutionTask, worktree: PreparedConflictWorktree): string {
+export function conflictResolutionPrompt(task: ClaimedConflictResolutionTask, worktree: PreparedConflictWorktree, memory: RepositoryMemory | null = null): string {
   const baseRef = task.pullRequest.baseRef ?? task.repositoryMapping.defaultBranch
   const files = worktree.conflictedFiles.map(file => `- ${file}`).join('\n')
+  const memoryLines = repositoryMemoryLine(memory)
   return `Resolve the existing merge conflicts for ${task.repository}#${task.pullRequestNumber}.
 
 Work as a normal local agent session inside this Git worktree. Use the user's global agent context, installed skills, environment, and authenticated GitHub CLI.
@@ -62,6 +70,7 @@ Edit the conflicted files only. Do not change a file the merge did not touch. Th
 Leave no conflict markers in any file. Search for <<<<<<<, =======, and >>>>>>> before you return.
 Follow repository AGENTS.md and contributor instructions. Preserve the pull request intent.
 Use GitHub read commands when issue or pull request history clarifies intent. Do not post comments.
+${memoryLines === '' ? '' : `\n${memoryLines}\n`}
 
 ${checkBudgetLines(CHECK_SCOPES.conflictedFiles)}
 ${TOOLCHAIN_LINES}
@@ -148,11 +157,17 @@ export function createConflictWorker(options: ConflictWorkerOptions): ConflictWo
       if (worktreeReady._tag === 'Err')
         return worktreeReady
 
+      // The slug comes from the primary checkout, never from this worktree.
+      const memory = options.claudeHome === undefined
+        ? null
+        : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: validated.value.checkout })
+
       const turn = await runAgentTurn(options, {
         freshSession: task.state.fence > 1,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         number: task.pullRequestNumber,
         progress: { current: { percent: 35, label: 'Git worktree ready' }, report: reportProgress, work: 'conflict' },
-        prompt: conflictResolutionPrompt(currentTask, worktree),
+        prompt: conflictResolutionPrompt(currentTask, worktree, memory),
         repository: task.repository,
         role: 'conflict_resolution',
         schema: outputSchema,

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1,4 +1,5 @@
 import type { AgentActivityLog } from './agent-activity.ts'
+import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentLabelState } from './agent-label.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { AgentTokenUsage } from './agent-provider.ts'
@@ -27,7 +28,7 @@ import type {
 } from './types.ts'
 import type { AgentWorkspaceManager } from './worktree.ts'
 import { createHash, randomUUID } from 'node:crypto'
-import { TOOLCHAIN_LINES } from './agent-context.ts'
+import { findRepositoryMemory, repositoryMemoryLine, TOOLCHAIN_LINES } from './agent-context.ts'
 import { formatPhaseDuration } from './agent-progress.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { APPROVAL_LABELS } from './approval-labels.ts'
@@ -66,6 +67,12 @@ export interface IssueTriageWorker {
 
 export interface ItemAgentOptions {
   activityLog?: Pick<AgentActivityLog, 'record'>
+  /**
+   * Harlan's Claude Code home, which holds the per-repository memory.
+   *
+   * Absent means no memory reaches the turn, which is how a test runs.
+   */
+  claudeHome?: string
   github: GitHubAgentSource
   now: () => Date
   /** Called when a cosmetic status update fails, which never stops the turn. */
@@ -812,7 +819,22 @@ function repairPreflight(task: ClaimedAdversarialReviewTask, snapshot: PullReque
   return { _tag: 'Authorized' }
 }
 
-function reviewPrompt(task: ClaimedAdversarialReviewTask, snapshot: PullRequestReviewSnapshot, workspace: string, preflight: RepairPreflight, repairedHeadFindings: ReviewFinding[]): string {
+/**
+ * The memory block for a turn that must otherwise stay inside its worktree.
+ *
+ * Review reads nothing outside the worktree, and the notes live under Harlan's
+ * Claude Code home. Naming the exception here lets the turn open a note without
+ * widening any other search. The read never writes, so Review stays read only.
+ */
+function reviewMemoryBlock(memory: RepositoryMemory | null): string {
+  const lines = repositoryMemoryLine(memory)
+  return lines === ''
+    ? ''
+    : `\n${lines}\nThe memory index and its notes are the only read allowed outside the worktree.\n`
+}
+
+/** The adversarial Review prompt. Exported so tests can assert its contract without an Agent. */
+export function reviewPrompt(task: ClaimedAdversarialReviewTask, snapshot: PullRequestReviewSnapshot, workspace: string, preflight: RepairPreflight, repairedHeadFindings: ReviewFinding[], memory: RepositoryMemory | null): string {
   const repairPolicy = preflight._tag === 'Authorized'
     ? 'Repair authority preflight passed. A separate fresh Repair Agent may fix findings after this read only Review.'
     : `Repair authority preflight requires action: ${preflight.reason}`
@@ -830,7 +852,7 @@ If one of these names the same defect you find, return its identity value exactl
   return `${reviewPolicy}
 
 ${repairPolicy}
-
+${reviewMemoryBlock(memory)}
 Repository: ${task.repository}
 Pull request: #${task.pullRequestNumber}
 Workspace: ${workspace}
@@ -845,9 +867,11 @@ ${JSON.stringify(reviewConversationContext(snapshot))}
 Fetch the full GitHub conversation only if omitted history matters to a material finding.`
 }
 
-function issuePrompt(task: ClaimedIssueTriageTask, snapshot: { body: string, comments: string[] }, workspace: string): string {
+/** The Issue triage prompt. Exported so tests can assert its contract without an Agent. */
+export function issuePrompt(task: ClaimedIssueTriageTask, snapshot: { body: string, comments: string[] }, workspace: string, memory: RepositoryMemory | null): string {
+  const memoryLines = repositoryMemoryLine(memory)
   return `${issuePolicy}
-
+${memoryLines === '' ? '' : `\n${memoryLines}\n`}
 Repository: ${task.repository}
 Issue: #${task.issueNumber}
 Workspace: ${workspace}
@@ -1197,10 +1221,15 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       const reviewRuntime = options.runtime()
       const preflight = repairPreflight(task, snapshot.value, repairsBaseline, repairAccess)
       const repairedHeadFindings = options.store.getRepairedHeadFindings(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
+      // The slug comes from the primary checkout, never from this worktree.
+      const memory = options.claudeHome === undefined
+        ? null
+        : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: task.repositoryMapping.checkout })
       const turn = await runParsedAgentTurn({ ...options, parse: parseReviewResponse, runtime: () => reviewRuntime }, {
         freshSession: task.state.fence > 1 || freshReviewSession,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         number: task.pullRequestNumber,
-        prompt: reviewPrompt(task, snapshot.value, workspace.value.path, preflight, repairedHeadFindings),
+        prompt: reviewPrompt(task, snapshot.value, workspace.value.path, preflight, repairedHeadFindings, memory),
         progress: {
           current: { percent: 35, label: 'Git worktree ready' },
           report: progress => reportReviewProgress(options, task, 'review', progress, signal),
@@ -1336,10 +1365,15 @@ export function createIssueTriageWorker(options: ItemAgentOptions): IssueTriageW
       if (started._tag === 'Err')
         return started
       const scopeDigest = issueSnapshotDigest(snapshot.value)
+      // The slug comes from the primary checkout, never from this worktree.
+      const memory = options.claudeHome === undefined
+        ? null
+        : await findRepositoryMemory({ claudeHome: options.claudeHome, checkoutPath: task.repositoryMapping.checkout })
       const turn = await runParsedAgentTurn({ ...options, parse: parseIssueTriageResponse }, {
         freshSession: task.state.fence > 1,
+        ...(memory === null ? {} : { instructionPaths: [memory.indexPath] }),
         number: task.issueNumber,
-        prompt: issuePrompt(task, snapshot.value, workspace.value.path),
+        prompt: issuePrompt(task, snapshot.value, workspace.value.path, memory),
         progress: {
           current: { percent: 35, label: 'Git worktree ready' },
           report: progress => Promise.resolve(saveAgentProgress(options, task, progress)),

--- a/packages/harlan-github-agent/src/pull-request-triage.ts
+++ b/packages/harlan-github-agent/src/pull-request-triage.ts
@@ -107,7 +107,15 @@ function parseResponse(text: string): Promise<Result<PullRequestTriageResult, st
     .catch((): Result<PullRequestTriageResult, string> => err('The Agent returned malformed pull request triage JSON.'))
 }
 
-function prompt(task: ClaimedAdversarialReviewTask, changedFiles: string[]): string {
+/**
+ * The Pull request triage prompt. Exported so tests can assert its contract
+ * without an Agent.
+ *
+ * This turn gets no project memory. It runs in a service-owned directory with
+ * no repository checkout, and it may use no tools, so a memory index would name
+ * notes the turn cannot open.
+ */
+export function pullRequestTriagePrompt(task: ClaimedAdversarialReviewTask, changedFiles: string[]): string {
   return `Decide whether this pull request needs an adversarial Review.
 Every changed file is prose: Markdown, text, licence, changelog, or docs. Nothing else reached you.
 Do not use tools or inspect the repository. Use only the supplied title and changed file paths.
@@ -142,7 +150,7 @@ export function createPullRequestTriageAgent(options: PullRequestTriageAgentOpti
       const turn = await runParsedAgentTurn({ ...options, parse: parseResponse }, {
         freshSession: true,
         number: task.pullRequestNumber,
-        prompt: prompt(task, input.changedFiles),
+        prompt: pullRequestTriagePrompt(task, input.changedFiles),
         repository: task.repository,
         role: 'pull_request_triage',
         schema,

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -501,6 +501,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       source: tokens,
       worker: createConflictWorker({
         activityLog,
+        claudeHome: agentContext.value.claudeHome,
         github,
         now,
         runtime,
@@ -518,6 +519,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
     })
     const subjectWorkerOptions = {
       activityLog,
+      claudeHome: agentContext.value.claudeHome,
       github: workerGithub,
       now,
       onProgressPublishFailure: (task: ClaimedAgentTask, reason: string) => {
@@ -770,6 +772,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         worker: createBatchWorker({
           activityLog,
           canClaimIssueWork,
+          claudeHome: agentContext.value.claudeHome,
           github: workerGithub,
           issueWork: issueWorkWorker,
           leaseMilliseconds: 45 * 60_000,

--- a/packages/harlan-github-agent/test/worker-memory.test.ts
+++ b/packages/harlan-github-agent/test/worker-memory.test.ts
@@ -1,0 +1,162 @@
+import type { RepositoryMemory } from '../src/agent-context.ts'
+import type { PullRequestReviewSnapshot } from '../src/github-agent-source.ts'
+import type { ClaimedAdversarialReviewTask, ClaimedConflictResolutionTask, ClaimedIssueTriageTask } from '../src/types.ts'
+import type { PreparedConflictWorktree } from '../src/worktree.ts'
+import { describe, expect, it } from 'vitest'
+import { batchPlanPrompt } from '../src/batch-worker.ts'
+import { conflictResolutionPrompt } from '../src/conflict-worker.ts'
+import { issuePrompt, reviewPrompt } from '../src/item-agent.ts'
+import { pullRequestTriagePrompt } from '../src/pull-request-triage.ts'
+import { routineScanPrompt } from '../src/routine-worker.ts'
+import { issueItem, pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const memory: RepositoryMemory = {
+  indexPath: '/home/harlan/.claude/projects/-home-harlan-pkg-example/memory/MEMORY.md',
+}
+
+function reviewTask(): ClaimedAdversarialReviewTask {
+  const mapping = repositoryMapping()
+  const pullRequest = pullRequestItem({ mergeState: 'clean' })
+  return {
+    id: 'review-task',
+    kind: 'adversarial_review',
+    repository: mapping.github,
+    pullRequestNumber: pullRequest.number,
+    revisionId: 'revision-1',
+    state: { _tag: 'Running', workerId: 'review-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+    updatedAt: '2026-08-13T01:00:00.000Z',
+    repositoryMapping: mapping,
+    pullRequest,
+    rerun: { _tag: 'NotRequested' },
+  }
+}
+
+function reviewSnapshot(): PullRequestReviewSnapshot {
+  return {
+    baseChecks: { _tag: 'Available', checks: [] },
+    body: 'Fixes the bug.',
+    checks: { _tag: 'Available', checks: [] },
+    comments: [],
+    priorAutomatedReview: { _tag: 'None' },
+    pullRequest: pullRequestItem({ mergeState: 'clean' }),
+    requiredChecks: { _tag: 'None' },
+    reviews: [],
+  }
+}
+
+function issueTriageTask(): ClaimedIssueTriageTask {
+  const mapping = repositoryMapping()
+  const issue = issueItem()
+  return {
+    id: 'issue-triage-task',
+    kind: 'issue_triage',
+    repository: mapping.github,
+    issueNumber: issue.number,
+    revisionId: 'revision-1',
+    state: { _tag: 'Running', workerId: 'triage-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+    updatedAt: '2026-08-13T01:00:00.000Z',
+    repositoryMapping: mapping,
+    issue,
+  }
+}
+
+function conflictTask(): ClaimedConflictResolutionTask {
+  const mapping = repositoryMapping()
+  return {
+    id: 'conflict-task',
+    kind: 'resolve_conflict',
+    repository: mapping.github,
+    pullRequestNumber: 24,
+    revisionId: 'revision-1',
+    state: { _tag: 'Running', workerId: 'conflict-worker', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+    updatedAt: '2026-08-13T01:00:00.000Z',
+    repositoryMapping: mapping,
+    pullRequest: pullRequestItem({ baseSha: 'previous-base' }),
+  }
+}
+
+const conflictWorktree: PreparedConflictWorktree = {
+  path: '/tmp/conflict-worktree',
+  headSha: 'head-sha',
+  baseSha: 'current-base',
+  conflictedFiles: ['src/a.ts'],
+}
+
+const batchIssues = [{
+  taskId: 't1',
+  issueNumber: 101,
+  title: 'A',
+  body: 'Body A',
+  triageSummary: 'Summary A',
+  relatedIssues: [],
+  target: 'src/a.ts',
+}]
+
+/**
+ * Every prompt builder that may receive the project memory index.
+ *
+ * A turn that judges existing work reads Harlan's recorded decisions, so it
+ * never relitigates one. A turn that invents new work or runs without tools
+ * gets none, so the list below states both answers.
+ */
+const withMemory = {
+  adversarialReview: (value: RepositoryMemory | null) => reviewPrompt(
+    reviewTask(),
+    reviewSnapshot(),
+    '/tmp/review-worktree',
+    { _tag: 'Authorized' as const },
+    [],
+    value,
+  ),
+  issueTriage: (value: RepositoryMemory | null) => issuePrompt(
+    issueTriageTask(),
+    { body: 'Body', comments: [] },
+    '/tmp/issue-worktree',
+    value,
+  ),
+  conflictResolution: (value: RepositoryMemory | null) => conflictResolutionPrompt(conflictTask(), conflictWorktree, value),
+  batchPlan: (value: RepositoryMemory | null) => batchPlanPrompt({
+    repository: 'harlan-zw/example',
+    issues: batchIssues,
+    memory: value,
+  }),
+}
+
+describe('project memory in Agent prompts', () => {
+  for (const [name, build] of Object.entries(withMemory)) {
+    it(`names the memory index for the ${name} turn`, () => {
+      const prompt = build(memory)
+
+      expect(prompt).toContain(memory.indexPath)
+      expect(prompt).toContain('Read a linked file when its entry matters to your work.')
+      expect(prompt).toContain('Check it against the code before you rely on it.')
+    })
+
+    it(`says nothing about memory for the ${name} turn without it`, () => {
+      const prompt = build(null)
+
+      expect(prompt).not.toContain('memory')
+      expect(prompt).not.toContain('MEMORY.md')
+    })
+  }
+
+  it('lets the read only Review open the notes outside its worktree', () => {
+    expect(withMemory.adversarialReview(memory))
+      .toContain('The memory index and its notes are the only read allowed outside the worktree.')
+    expect(withMemory.adversarialReview(memory)).toContain('Keep the worktree read only.')
+  })
+
+  it('withholds memory from a Routine scan, which proposes new work', () => {
+    const prompt = routineScanPrompt({ mode: 'propose', name: 'pr-triage', rejected: [], repository: 'harlan-zw/example' })
+
+    expect(prompt).not.toContain('MEMORY.md')
+    expect(prompt).toContain('These proposals were rejected before.')
+  })
+
+  it('withholds memory from Pull request triage, which may use no tools', () => {
+    const prompt = pullRequestTriagePrompt(reviewTask(), ['README.md'])
+
+    expect(prompt).not.toContain('MEMORY.md')
+    expect(prompt).toContain('Do not use tools or inspect the repository.')
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

Memory reached three workers in #195, and the one I said was next is the one
that needed it most. Adversarial Review makes judgement calls all day against
decisions I already made and wrote down. Twice now it has flagged something the
notes explain, and I have had to say "that was deliberate" in a review comment.
It reads the index now, along with Issue triage, conflict resolution, and Batch
planning.

Two stay without it, on purpose:

- **Routine scan.** It invents proposals rather than judging existing work, and
  the prompt already carries its own rejection list. Memory records decisions
  I deferred, which have no rejection fingerprint, so the ledger could not
  catch a Routine that started filing issues for them.
- **Pull request triage.** Its prompt says not to use tools, and it runs in a
  service-owned directory with no checkout. An index naming files it cannot
  open is dead weight.

`skillDigest` hashes `reviewPolicy` only, and the memory block sits in the
per-repository part of the prompt instead, so no stored Review re-runs against
a new contract. That was the part I checked twice.

Loose end: the Review prompt says to stay inside the worktree, and the notes
live under `~/.claude`. I carved out one exception line for the memory
directory. It is the sort of hole a jailbreak walks through, though the path is
controller-supplied and the turn is read only, so I think it holds.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Xf6fnPYRB2nFxHA2i8DT5h