### PR TITLE
chore(workflows): run lint, typecheck, build, and tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,14 @@
+name: Setup
+description: Installs Node, pnpm, and the workspace dependencies.
+
+runs:
+  using: composite
+  steps:
+    # The repository pins pnpm through `packageManager`, so this reads it.
+    - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 24
+        cache: pnpm
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,22 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
 
+      # `wt` owns every worktree in this repository, and several suites drive
+      # the real binary. Pin the version, and check the archive before it runs.
+      - name: Install Worktrunk
+        env:
+          WORKTRUNK_VERSION: v0.74.0
+          WORKTRUNK_SHA256: 28392033912ab0a9027192d9975284787b29f080b4f2fd6298c89fffecf34c1f
+        run: |
+          archive=worktrunk-x86_64-unknown-linux-musl.tar.xz
+          curl --fail --silent --show-error --location --output "$RUNNER_TEMP/$archive" \
+            "https://github.com/max-sixty/worktrunk/releases/download/$WORKTRUNK_VERSION/$archive"
+          echo "$WORKTRUNK_SHA256  $RUNNER_TEMP/$archive" | sha256sum --check
+          tar -xJf "$RUNNER_TEMP/$archive" -C "$RUNNER_TEMP" --strip-components=1 \
+            "worktrunk-x86_64-unknown-linux-musl/wt"
+          sudo install "$RUNNER_TEMP/wt" /usr/local/bin/wt
+          wt --version
+
       # `pnpm check:context` stays out of this workflow. It compares installed
       # files in a home directory against tracked sources. A runner installs
       # nothing, so it reports drift that does not exist. `pnpm test:context`
@@ -94,15 +110,15 @@ jobs:
       - name: Sentry check in
         run: pnpm test:sentry-checkin
 
-      # `pnpm test:service` chains six scripts. Three of them cannot run here.
-      # `worktrunk-config.test.sh` and `worktree-sweep.test.sh` need the `wt`
-      # binary, which a GitHub hosted runner does not install.
+      # `pnpm test:service` chains six scripts. Five of them run here.
       # `hogwild-service.test.sh` already fails on `main`, before this workflow.
-      # Repair those three in their own pull requests, then add them back.
+      # Repair it in its own pull request, then add it back.
       - name: Service scripts
         run: |
           bash scripts/service.test.sh
           bash scripts/repository-env.test.sh
+          bash scripts/worktrunk-config.test.sh
+          bash scripts/worktree-sweep.test.sh
           bash scripts/worktree-sweep-service.test.sh
 
       - name: Service package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,109 @@
+name: Test
+
+# The pull request gate for this repository.
+#
+# Runners: GitHub hosted, not the desktop. This repository is public. A self
+# hosted runner on a public repository lets a fork pull request run code on that
+# host. No self hosted runner is registered here either.
+#
+# Markdown: every event ignores `**/*.md`. Harlan pushes Markdown only changes
+# straight to `main` with no pull request, so this workflow must not block them.
+# Some tests do read tracked Markdown, so a Markdown only change can still break
+# `pnpm test`. The next non Markdown commit reports it.
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['**/*.md']
+  pull_request:
+    paths-ignore: ['**/*.md']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: pnpm typecheck
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+
+  # This job mirrors `pnpm test`, plus the hook suites that aggregate leaves out.
+  # Add a new suite here when you add one to `package.json`.
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+
+      # `pnpm check:context` stays out of this workflow. It compares installed
+      # files in a home directory against tracked sources. A runner installs
+      # nothing, so it reports drift that does not exist. `pnpm test:context`
+      # renders the same sources into a temporary home and compares them there.
+      - name: Agent instructions
+        run: pnpm test:context
+
+      - name: Git hook
+        run: pnpm test:commit-hook
+
+      - name: Himalaya read only
+        run: pnpm test:himalaya
+
+      - name: Opencode hooks
+        run: pnpm test:opencode-hooks
+
+      # These three enforce the worktree and pull request rules. `pnpm test`
+      # does not run them.
+      - name: Plugin hooks
+        run: |
+          pnpm test:wt-only
+          pnpm test:pr-skill-only
+          pnpm test:worktree-claim
+
+      - name: Sentry check in
+        run: pnpm test:sentry-checkin
+
+      # `pnpm test:service` chains six scripts. Three of them cannot run here.
+      # `worktrunk-config.test.sh` and `worktree-sweep.test.sh` need the `wt`
+      # binary, which a GitHub hosted runner does not install.
+      # `hogwild-service.test.sh` already fails on `main`, before this workflow.
+      # Repair those three in their own pull requests, then add them back.
+      - name: Service scripts
+        run: |
+          bash scripts/service.test.sh
+          bash scripts/repository-env.test.sh
+          bash scripts/worktree-sweep-service.test.sh
+
+      - name: Service package
+        run: pnpm --filter harlan-github-agent test:run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ pnpm release patch|minor|major  # Bump version, tag, push (syncs plugin.json, ma
 
 **Disable hooks per-project**: `.claude/hooks.json` with `{"disabled": ["eslint", "pre-commit-push"]}`
 
+**Workflow** (`.github/workflows/test.yml`): four jobs on GitHub hosted runners, lint, typecheck, build, and test. The test job installs a pinned `wt`, because several suites drive the real binary. Every event ignores `**/*.md`, so a Markdown only push to `main` runs nothing.
+
 **Worktrees**: `wt` (worktrunk) owns every worktree, at `<parent>/<repo>.<branch-slug>`. Full rules in `harlan-agent-kit/references/worktree-isolation.md`.
 
 ## Adding Components

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -1,5 +1,5 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import { loadGitHubAppPrivateKey, normalizeGitHubRemote, parseConfigText, validateRepositoryMappings } from '../src/config.ts'
@@ -20,7 +20,7 @@ server:
   port: 3210
   allowed_origin: https://harlan-github-agent.localhost
 storage:
-  path: /home/harlan/.local/share/harlan-github-agent/state.sqlite
+  path: ${homedir()}/.local/share/harlan-github-agent/state.sqlite
 mutations_enabled: false
 poll_interval_seconds: 60
 issue_cutoff: 2026-07-14
@@ -29,7 +29,7 @@ external_repositories:
     issues: [658]
 repositories:
   - github: harlan-zw/example
-    checkout: /home/harlan/pkg/example
+    checkout: ${homedir()}/pkg/example
     enabled: true
     ownership: owned
     default_branch: main

--- a/packages/harlan-github-agent/test/service-triggers.test.ts
+++ b/packages/harlan-github-agent/test/service-triggers.test.ts
@@ -1,3 +1,4 @@
+import { homedir } from 'node:os'
 import { describe, expect, it } from 'vitest'
 import { parseConfigText } from '../src/config.ts'
 import { dashboardSnapshotForTriggers, recordRoutineOnlyRepositoryHealth } from '../src/service.ts'
@@ -13,7 +14,7 @@ server:
   port: 3210
   allowed_origin: https://harlan-github-agent.localhost
 storage:
-  path: /home/harlan/.local/share/harlan-github-agent/state.sqlite
+  path: ${homedir()}/.local/share/harlan-github-agent/state.sqlite
 mutations_enabled: false
 max_open_pull_requests: 8
 poll_interval_seconds: 60


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Nothing ran the test suite. `.github/workflows/` did not exist, so a pull request here landed on a read of the diff alone. The bigger problem is downstream: the review contract reads an empty check set as "this repository has no gate", passes it, and lets Repair modify the Service, the Hooks, and the Skills with nothing verifying them.

Four jobs now run on a pull request and on a push to `main`: lint, typecheck, build, and test. The test job also runs `test:wt-only`, `test:pr-skill-only`, and `test:worktree-claim`, which the `pnpm test` aggregate leaves out. Those three are the ones that enforce the worktree and pull request rules, so leaving them unrun felt wrong.

Runners are GitHub hosted, not the desktop. This repository is public, and a self hosted runner on a public repository lets a fork pull request run code on the host. None is registered here anyway.

Several suites drive the real `wt` binary, so the test job installs a pinned Worktrunk release and checks its sha256 first.

Two things are out of the job:

- `hogwild-service.test.sh` already fails on clean `main` with `Hogwild received different Agent instructions`. I left it alone rather than grow this into a repair. Every other script in `pnpm test:service` runs.
- `pnpm check:context` compares files installed in a home directory against tracked sources. A runner installs nothing, so it would report drift that does not exist. `pnpm test:context` already renders the same sources into a temporary home.

The two `config` fixtures moved off a hardcoded `/home/harlan`. `parseConfigText` trusts a checkout under `~/pkg` and storage under `~/.local/share`, so those 41 tests only ever asserted anything on the desktop.

Every event carries `paths-ignore: ['**/*.md']`. Markdown only pushes go straight to `main`, so they must not wait on a check run.

Open question: is `hogwild-service.test.sh` worth repairing, or has that hash comparison outlived the deploy it guarded?

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Xf6fnPYRB2nFxHA2i8DT5h