### PR TITLE
fix(github-agent): retry changed-scope issue work on maintained repos

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -8541,9 +8541,12 @@ export function openJournalStore(
               AND newer.scheduled_for > routine_runs.scheduled_for
           )
       `).all() as unknown as RecoveryCandidateRow[]).filter(row => isRecoverable(row, at))
-      const issueScopeRows = database.prepare(`
+      // The capability that claims Issue work decides the retry, so a
+      // maintained repository never strands a changed-scope failure.
+      const issueScopeRows = (database.prepare(`
         SELECT tasks.id AS task_id, tasks.fence AS task_fence,
-          worker_tasks.id AS triage_id, worker_tasks.fence AS triage_fence
+          worker_tasks.id AS triage_id, worker_tasks.fence AS triage_fence,
+          repositories.policy_json AS policy_json
         FROM tasks
         JOIN subjects ON subjects.id = tasks.subject_id
         JOIN repositories ON repositories.id = subjects.repository_id
@@ -8555,15 +8558,13 @@ export function openJournalStore(
           AND tasks.reason = 'The issue changed before work started.'
           AND tasks.revision_id = subjects.current_revision_id
           AND worker_tasks.state_tag = 'Completed'
-          AND repositories.enabled = 1
-          AND repositories.ownership = 'owned'
-          AND json_extract(repositories.policy_json, '$.issueWork') = 1
       `).all() as unknown as Array<{
         task_id: string
         task_fence: number
         triage_id: string
         triage_fence: number
-      }>
+        policy_json: string
+      }>).filter(row => canWorkIssues(JSON.parse(row.policy_json) as RepositoryMapping))
       const retry = database.prepare(`
         UPDATE worker_tasks
         SET state_tag = 'Queued', reason = NULL, attempts = 0, worker_id = NULL,

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4643,6 +4643,52 @@ describe('journal store', () => {
     }))
   })
 
+  it('retries changed-scope issue work on a maintained repository', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping({ ownership: 'maintained' })], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'issue-scope-retry-maintained',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: issueItem(),
+    })
+    const triage = store.claimNextIssueTriageTask('triage-worker', '2026-08-13T01:00:01.000Z', 10_000)
+    if (triage === null)
+      throw new Error('Expected issue triage.')
+    store.completeWorkerTask({
+      taskId: triage.id,
+      workerId: triage.state.workerId,
+      fence: triage.state.fence,
+      at: '2026-08-13T01:00:02.000Z',
+      evidence: JSON.stringify({ _tag: 'READY_TO_IMPLEMENT' }),
+    })
+    expect(store.approveIssueWork({
+      repository: 'harlan-zw/example',
+      issueNumber: 12,
+      revisionId: triage.revisionId,
+      at: '2026-08-13T01:00:03.000Z',
+    })).toEqual({ _tag: 'Approved', taskId: expect.any(String) })
+    for (const attempt of [1, 2, 3]) {
+      const at = `2026-08-13T01:00:0${attempt + 3}.000Z`
+      const task = store.claimNextIssueWorkTask(`issue-worker-${attempt}`, at, 10_000)
+      if (task === null)
+        throw new Error(`Expected issue work attempt ${attempt}.`)
+      store.failTask({
+        taskId: task.id,
+        workerId: task.state.workerId,
+        fence: task.state.fence,
+        at,
+        reason: 'The issue changed before work started.',
+      })
+    }
+
+    // The same capability that claims the work decides the retry. Maintained
+    // repositories may work issues, so their changed-scope failures retriage.
+    expect(store.retryRecoverableWorkerFailures('2026-08-13T01:00:07.000Z')).toBe(1)
+    const retriage = store.claimNextIssueTriageTask('triage-worker-2', '2026-08-13T01:00:08.000Z', 10_000)
+    expect(retriage?.state.fence).toBe(2)
+  })
+
   it('invalidates triage and Approval when human Issue content changes', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Seven skilld.dev issues have sat since 4 Sep at three failed "The issue changed before work started" attempts. The dashboard says "The controller will retry" and the Incident says `Retrying`, but the recovery query only re-queued that failure for `owned` repositories, and skilld-dev/skilld.dev is `maintained`. The claim side already lets maintained repositories work issues, so the retry now uses the same capability instead of an inline ownership check.

Not touched here: why those attempts failed in the first place. The GitHub timeline shows the controller adding and removing `harlan-agent-running` four seconds apart on each try, which points at the triage session digest no longer matching once the triage comment exists. Worth a separate look.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_018YZRTAXUYRb1y7rJf9iqNz