### PR TITLE
feat(github-agent): report a CI Review gate that stays PENDING

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -208,6 +208,10 @@ If Review records `Repair` findings, queue all findings immediately under the ex
 
 Available empty base and head check sets with no declared required checks mean the repository has no CI. This passes the CI Review gate and permits Repair. An unavailable, running, or failed base check set does not permit Repair.
 
+Raise one `ci_gate_pending` Incident when a CI Review gate reads PENDING past its bound. Allow a check run with no conclusion 6 hours, because GitHub stops a job then. Allow a gate with nothing in flight 4 hours. Name the repository, the pull request, the cause, and when the gate last moved. Resolve the Incident when the gate moves. Report only. Never cancel, re-run, or repair a check run because of this Incident.
+
+Raise no Incident when the repository has no CI, when another Review gate holds the pull request, or when a runner lost its job. The last one raises `runner_lost` instead.
+
 If Review recommends Dismissal, queue no Repair. Use this only when the premise is wrong and Repair would replace the pull request intent. Harlan decides whether to Dismiss.
 
 If fresh Review of a Repair commit still records a Repair finding, queue the next Repair round. Give that round every earlier round's commit, report, and target findings. Never repeat a rejected approach.

--- a/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
+++ b/packages/harlan-github-agent/dashboard/app/utils/dashboard.ts
@@ -489,6 +489,7 @@ export function reviewOutcomeDetail(agent: ReviewAgent): string {
 const incidentKindLabels: Record<IncidentKind, string> = {
   agent_provider: 'Agent provider',
   agent_result: 'Agent result',
+  ci_gate_pending: 'CI gate PENDING',
   context_budget: 'Context budget',
   controller: 'Controller',
   github_access: 'GitHub access',

--- a/packages/harlan-github-agent/src/ci-gate-pending.ts
+++ b/packages/harlan-github-agent/src/ci-gate-pending.ts
@@ -1,0 +1,161 @@
+/**
+ * How long a CI Review gate may read PENDING before a person must look at it.
+ *
+ * The controller waits for CI correctly and reports nothing while it waits, so
+ * a repository whose CI never starts reads exactly like one whose CI is slow.
+ * On 2026-09-05 one repository ran no check run for ten hours, and two pull
+ * requests held a red base branch for a day. Nothing named either, so Harlan
+ * found both by asking.
+ *
+ * This module decides only whether one gate is overdue. It starts nothing,
+ * cancels nothing, and re-runs nothing. The Incident it feeds is the whole
+ * output, and Harlan decides what to do about it.
+ */
+import type { ReviewGates } from './types.ts'
+import { updatedAtLabel } from './text.ts'
+
+/**
+ * Why one CI Review gate has not settled, read from the live check sets.
+ *
+ * The gate itself carries prose, and prose cannot be classified without
+ * matching strings the controller wrote. The cause therefore travels beside
+ * the gate, from the same branch that decided it.
+ */
+export type CiGateCause
+  /** The gate reached a verdict, so nothing is outstanding. */
+  = | { _tag: 'Settled' }
+    /** The base branch is broken, so no head check run can clear the gate. */
+    | { _tag: 'BaseBranchFailed', check: string }
+    /** GitHub owes a check run it has never reported. */
+    | { _tag: 'NoCheckRun', detail: string }
+    /** A check run exists and has not reported a conclusion. */
+    | { _tag: 'CheckRunning', check: string }
+    /** The controller could not read the check runs at all. */
+    | { _tag: 'ChecksUnreadable', reason: string }
+    /** A runner stopped mid job. `runner_lost` already names this one. */
+    | { _tag: 'RunnerLost', check: string }
+
+/**
+ * How long a check run with no conclusion may hold the gate.
+ *
+ * GitHub stops any Actions job after six hours. Past that limit GitHub itself
+ * has killed the job, so a check run that still reports no conclusion will
+ * never report one. The bound is GitHub's own, not a number picked to feel
+ * right, and it never fires while a job could still finish.
+ */
+export const RUNNING_CHECK_BOUND_MILLISECONDS = 6 * 60 * 60_000
+
+/**
+ * How long a gate with nothing in flight may read PENDING.
+ *
+ * Nothing runs in these causes, so only a person or a later push changes them.
+ * The longest healthy PENDING this service ever recorded is three hours, on
+ * 2026-08-27, when a base branch deploy was still running after a Review
+ * finished. Four hours sits above that observation and far below the ten hour
+ * silence nobody saw.
+ */
+export const IDLE_GATE_BOUND_MILLISECONDS = 4 * 60 * 60_000
+
+export type CiGateReading
+  /** Not a CI Review gate this service reports on. */
+  = | { _tag: 'Ignored', reason: string }
+    | { _tag: 'Within', elapsedMilliseconds: number, boundMilliseconds: number }
+    | {
+      _tag: 'Overdue'
+      cause: CiGateCause
+      /** When the gate last moved. */
+      pendingSince: string
+      elapsedMilliseconds: number
+      boundMilliseconds: number
+    }
+
+export interface CiGateReadingInput {
+  gates: ReviewGates
+  cause: CiGateCause
+  /** When the Review gates last changed. */
+  pendingSince: string
+  now: Date
+}
+
+function boundMilliseconds(cause: CiGateCause): number {
+  return cause._tag === 'CheckRunning' ? RUNNING_CHECK_BOUND_MILLISECONDS : IDLE_GATE_BOUND_MILLISECONDS
+}
+
+/**
+ * Reads one CI Review gate as healthy, young, or overdue.
+ *
+ * Three states are deliberately excluded. A gate that passed says the
+ * repository has no CI or that CI answered, and the review contract calls both
+ * settled. A pull request whose merge or review gate is unsettled already
+ * waits for a person, so its CI Review gate is not what holds it. A lost
+ * runner raises `runner_lost`, and one fault must never fill the pane twice.
+ */
+export function readCiGate(input: CiGateReadingInput): CiGateReading {
+  if (input.gates.ci._tag !== 'Pending')
+    return { _tag: 'Ignored', reason: 'The CI Review gate is not PENDING.' }
+  if (input.gates.merge._tag !== 'Passed' || input.gates.review._tag !== 'Passed')
+    return { _tag: 'Ignored', reason: 'Another Review gate holds this pull request.' }
+  if (input.cause._tag === 'Settled' || input.cause._tag === 'RunnerLost')
+    return { _tag: 'Ignored', reason: 'This CI Review gate has its own Incident.' }
+  const since = Date.parse(input.pendingSince)
+  if (Number.isNaN(since))
+    return { _tag: 'Ignored', reason: 'The controller has no record of when the gate moved.' }
+  const bound = boundMilliseconds(input.cause)
+  const elapsedMilliseconds = input.now.getTime() - since
+  if (elapsedMilliseconds <= bound)
+    return { _tag: 'Within', elapsedMilliseconds, boundMilliseconds: bound }
+  return { _tag: 'Overdue', cause: input.cause, pendingSince: input.pendingSince, elapsedMilliseconds, boundMilliseconds: bound }
+}
+
+function causeSentence(cause: CiGateCause): string {
+  switch (cause._tag) {
+    case 'BaseBranchFailed':
+      return `Base branch check run "${cause.check}" failed.`
+    case 'NoCheckRun':
+      return cause.detail
+    case 'CheckRunning':
+      return `Check run "${cause.check}" has not reported a conclusion.`
+    case 'ChecksUnreadable':
+      return `The controller cannot read the check runs. GitHub said: ${cause.reason}`
+    default:
+      return 'The controller cannot name what holds the gate.'
+  }
+}
+
+function actionSentence(cause: CiGateCause): string {
+  switch (cause._tag) {
+    case 'BaseBranchFailed':
+      return 'If the default branch is broken, repair it and re-run the check run.'
+    case 'NoCheckRun':
+      return 'If CI never started, read the workflow triggers and the runner.'
+    case 'CheckRunning':
+      return 'GitHub stops a job after six hours, so re-run the check run.'
+    case 'ChecksUnreadable':
+      return 'If the read keeps failing, read the GitHub App installation permissions.'
+    default:
+      return 'Read the pull request checks on GitHub.'
+  }
+}
+
+/**
+ * Writes the one message this gate raises, however long it goes on.
+ *
+ * An Incident is identified by its message, so a message carrying the elapsed
+ * time would mint a new Incident on every pass and lose the first seen time
+ * that makes a long silence obvious. The bound and the moment the gate last
+ * moved say the same thing and never change, so one gate keeps one Incident
+ * and the pane counts its occurrences.
+ */
+export function ciGatePendingMessage(
+  repository: string,
+  pullRequestNumber: number,
+  reading: Extract<CiGateReading, { _tag: 'Overdue' }>,
+): string {
+  const hours = Math.round(reading.boundMilliseconds / 3_600_000)
+  return [
+    `${repository}#${pullRequestNumber}: the CI Review gate reads PENDING for more than ${hours} hours.`,
+    `The gate last moved at ${updatedAtLabel(reading.pendingSince)}.`,
+    causeSentence(reading.cause),
+    actionSentence(reading.cause),
+  ].join(' ')
+}

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -3,6 +3,7 @@ import type { RepositoryMemory } from './agent-context.ts'
 import type { AgentLabelState } from './agent-label.ts'
 import type { AgentRuntimeSource } from './agent-profile.ts'
 import type { AgentTokenUsage } from './agent-provider.ts'
+import type { CiGateCause } from './ci-gate-pending.ts'
 import type { GitHubAgentSource, GitHubCheck, GitHubChecksSnapshot, IssueTriageSnapshot, PullRequestReviewSnapshot, RequiredChecks } from './github-agent-source.ts'
 import type { IssueTriageCommentController } from './issue-triage-comment-controller.ts'
 import type { IssueTriageResult } from './issue-triage.ts'
@@ -449,23 +450,51 @@ function checksLostRunner(checks: GitHubChecksSnapshot): boolean {
   return checks._tag === 'Available' && checks.checks.some(checkRunnerLost)
 }
 
+function undecidedCause(check: GitHubCheck): CiGateCause {
+  return checkRunnerLost(check)
+    ? { _tag: 'RunnerLost', check: cleanLine(check.name) }
+    : { _tag: 'CheckRunning', check: cleanLine(check.name) }
+}
+
 function checksGate(
   checks: PullRequestReviewSnapshot['checks'],
   label: 'base-ci' | 'required-ci',
   failedTag: 'Failed' | 'Pending',
-): ReviewGateState {
+): CiGateResult {
   const checkEvidence = [evidence(label, JSON.stringify(checks))]
-  if (checks._tag === 'Unavailable')
-    return { _tag: 'Pending', reason: cleanLine(checks.reason), evidence: checkEvidence }
-  if (checks.checks.length === 0)
-    return { _tag: 'Pending', reason: label === 'base-ci' ? 'Base branch CI is unavailable.' : 'Required CI is unavailable.', evidence: checkEvidence }
+  const base = label === 'base-ci'
+  if (checks._tag === 'Unavailable') {
+    return {
+      state: { _tag: 'Pending', reason: cleanLine(checks.reason), evidence: checkEvidence },
+      reported: [],
+      cause: { _tag: 'ChecksUnreadable', reason: cleanLine(checks.reason) },
+    }
+  }
+  if (checks.checks.length === 0) {
+    return {
+      state: { _tag: 'Pending', reason: base ? 'Base branch CI is unavailable.' : 'Required CI is unavailable.', evidence: checkEvidence },
+      reported: [],
+      cause: { _tag: 'NoCheckRun', detail: base ? 'GitHub reported no check run for the base commit.' : 'GitHub reported no check run for the head commit.' },
+    }
+  }
   const failed = checks.checks.find(checkFailed)
-  if (failed !== undefined)
-    return { _tag: failedTag, reason: `${label === 'base-ci' ? 'Base branch CI: ' : ''}${cleanLine(failed.name)} failed.`, evidence: checkEvidence }
+  if (failed !== undefined) {
+    return {
+      state: { _tag: failedTag, reason: `${base ? 'Base branch CI: ' : ''}${cleanLine(failed.name)} failed.`, evidence: checkEvidence },
+      reported: [],
+      // A failed head check run is a verdict, so only a red base branch leaves
+      // the gate with nothing left to answer it.
+      cause: failedTag === 'Pending' ? { _tag: 'BaseBranchFailed', check: cleanLine(failed.name) } : { _tag: 'Settled' },
+    }
+  }
   const pending = checks.checks.find(checkUndecided)
-  return pending === undefined
-    ? { _tag: 'Passed', evidence: checkEvidence }
-    : { _tag: 'Pending', reason: `${label === 'base-ci' ? 'Base branch CI: ' : ''}${undecidedReason(pending)}`, evidence: checkEvidence }
+  if (pending === undefined)
+    return { state: { _tag: 'Passed', evidence: checkEvidence }, reported: [], cause: { _tag: 'Settled' } }
+  return {
+    state: { _tag: 'Pending', reason: `${base ? 'Base branch CI: ' : ''}${undecidedReason(pending)}`, evidence: checkEvidence },
+    reported: [],
+    cause: undecidedCause(pending),
+  }
 }
 
 /**
@@ -478,6 +507,8 @@ function checksGate(
 interface CiGateResult {
   state: ReviewGateState
   reported: string[]
+  /** Why the gate has not settled, for the Incident that names a long PENDING. */
+  cause: CiGateCause
 }
 
 /**
@@ -497,10 +528,15 @@ interface CiGateResult {
  */
 function headChecksGate(checks: PullRequestReviewSnapshot['checks'], required: RequiredChecks): CiGateResult {
   if (required._tag !== 'Declared')
-    return { state: checksGate(checks, 'required-ci', 'Failed'), reported: [] }
+    return checksGate(checks, 'required-ci', 'Failed')
   const checkEvidence = [evidence('required-ci', JSON.stringify({ checks, required }))]
-  if (checks._tag === 'Unavailable')
-    return { state: { _tag: 'Pending', reason: cleanLine(checks.reason), evidence: checkEvidence }, reported: [] }
+  if (checks._tag === 'Unavailable') {
+    return {
+      state: { _tag: 'Pending', reason: cleanLine(checks.reason), evidence: checkEvidence },
+      reported: [],
+      cause: { _tag: 'ChecksUnreadable', reason: cleanLine(checks.reason) },
+    }
+  }
   const isRequired = (check: GitHubCheck): boolean => required.contexts.includes(check.name)
   const reported = checks.checks
     .filter(check => checkFailed(check) && !isRequired(check))
@@ -508,14 +544,19 @@ function headChecksGate(checks: PullRequestReviewSnapshot['checks'], required: R
   const requiredChecks = checks.checks.filter(isRequired)
   const failed = requiredChecks.find(checkFailed)
   if (failed !== undefined)
-    return { state: { _tag: 'Failed', reason: `${cleanLine(failed.name)} failed.`, evidence: checkEvidence }, reported }
+    return { state: { _tag: 'Failed', reason: `${cleanLine(failed.name)} failed.`, evidence: checkEvidence }, reported, cause: { _tag: 'Settled' } }
   const running = requiredChecks.find(checkUndecided)
   if (running !== undefined)
-    return { state: { _tag: 'Pending', reason: undecidedReason(running), evidence: checkEvidence }, reported }
+    return { state: { _tag: 'Pending', reason: undecidedReason(running), evidence: checkEvidence }, reported, cause: undecidedCause(running) }
   const missing = required.contexts.find(context => !checks.checks.some(check => check.name === context))
-  if (missing !== undefined)
-    return { state: { _tag: 'Pending', reason: `${cleanLine(missing)} has not reported.`, evidence: checkEvidence }, reported }
-  return { state: { _tag: 'Passed', evidence: checkEvidence }, reported }
+  if (missing !== undefined) {
+    return {
+      state: { _tag: 'Pending', reason: `${cleanLine(missing)} has not reported.`, evidence: checkEvidence },
+      reported,
+      cause: { _tag: 'NoCheckRun', detail: `GitHub has not reported required check run "${cleanLine(missing)}".` },
+    }
+  }
+  return { state: { _tag: 'Passed', evidence: checkEvidence }, reported, cause: { _tag: 'Settled' } }
 }
 
 /** GitHub has no CI signal to wait for on either side of this change. */
@@ -548,13 +589,18 @@ function ciGate(snapshot: PullRequestReviewSnapshot, repairsBaseline: boolean): 
         }))],
       },
       reported: [],
+      cause: { _tag: 'Settled' },
     }
   }
   const base = checksGate(snapshot.baseChecks, 'base-ci', 'Pending')
-  if (base._tag !== 'Passed')
-    return { state: base, reported: [] }
+  if (base.state._tag !== 'Passed')
+    return base
   const head = headChecksGate(snapshot.checks, snapshot.requiredChecks)
-  return { state: { ...head.state, evidence: [...base.evidence, ...head.state.evidence] }, reported: head.reported }
+  return {
+    state: { ...head.state, evidence: [...base.state.evidence, ...head.state.evidence] },
+    reported: head.reported,
+    cause: head.cause,
+  }
 }
 
 /**
@@ -647,12 +693,12 @@ export function refreshControllerGates(
   gates: ReviewGates,
   snapshot: PullRequestReviewSnapshot,
   mapping: RepositoryMapping,
-): { gates: ReviewGates, reportedChecks: string[] } {
+): { gates: ReviewGates, reportedChecks: string[], ciCause: CiGateCause } {
   const repairsBaseline = snapshot.pullRequest.purpose._tag === 'BaselineRepair'
     || (basesDefaultBranch(snapshot.pullRequest, mapping) && headRepairsFailedBaseChecks(snapshot))
   const ci = ciGate(snapshot, repairsBaseline)
   const merge = mergeGate(snapshot.pullRequest)
-  return { gates: { ...gates, ci: ci.state, merge }, reportedChecks: ci.reported }
+  return { gates: { ...gates, ci: ci.state, merge }, reportedChecks: ci.reported, ciCause: ci.cause }
 }
 
 /**
@@ -813,7 +859,7 @@ function repairPreflight(task: ClaimedAdversarialReviewTask, snapshot: PullReque
   if (access._tag === 'Err')
     return { _tag: 'ActionRequired', reason: access.error }
   const baseAllowsRepair = snapshot.baseChecks._tag === 'Available'
-    && (snapshot.baseChecks.checks.length === 0 || checksGate(snapshot.baseChecks, 'base-ci', 'Pending')._tag === 'Passed')
+    && (snapshot.baseChecks.checks.length === 0 || checksGate(snapshot.baseChecks, 'base-ci', 'Pending').state._tag === 'Passed')
   if (!repairsBaseline && !baseAllowsRepair)
     return { _tag: 'ActionRequired', reason: 'The base branch must pass CI before Repair starts.' }
   return { _tag: 'Authorized' }

--- a/packages/harlan-github-agent/src/review-gate-sweep.ts
+++ b/packages/harlan-github-agent/src/review-gate-sweep.ts
@@ -1,8 +1,10 @@
+import type { CiGateCause } from './ci-gate-pending.ts'
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
 import type { JournalStore, ReviewGateRefresh } from './store.ts'
-import type { RepositoryMapping, ReviewOutcomeName } from './types.ts'
+import type { RepositoryMapping, ReviewGates, ReviewOutcomeName } from './types.ts'
 import { createHash } from 'node:crypto'
+import { ciGatePendingMessage, readCiGate } from './ci-gate-pending.ts'
 import { refreshControllerGates, reviewOutcome, terminalComment } from './item-agent.ts'
 import { err, ok } from './result.ts'
 
@@ -16,8 +18,16 @@ export interface ReviewGateSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot' | 'stampAgentLabel'>
   now: () => Date
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'recordReviewPublication' | 'stageReviewGateStatus'>
+  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'recordIncident' | 'recordReviewPublication' | 'resolveIncidents' | 'stageReviewGateStatus'>
 }
+
+/**
+ * The operation every long PENDING CI Review gate reports under.
+ *
+ * The sweep resolves this operation alone, so a repository keeps its other
+ * Incidents while its gates clear.
+ */
+const CI_GATE_OPERATION = 'ci_gate_pending'
 
 /**
  * Refreshes the moving gates around one completed Agent report.
@@ -31,25 +41,35 @@ export async function refreshReviewGates(
 ): Promise<Array<Result<ReviewGateRefreshOutcome, string>>> {
   const mappings = new Map(options.repositories.map(mapping => [mapping.github.toLowerCase(), mapping]))
   const reviews = options.store.listReviewGateRefreshes()
+  /** Every overdue CI Review gate message this pass raised, by repository. */
+  const stalled = new Map<string, string[]>()
+  /** Repositories whose live state this pass could not read. */
+  const unread = new Set<string>()
 
   const settle = async (review: ReviewGateRefresh): Promise<Result<ReviewGateRefreshOutcome, string>> => {
     const mapping = mappings.get(review.repository.toLowerCase())
     if (mapping === undefined)
       return err(`${review.repository}: the repository is no longer configured.`)
     const live = await options.github.getPullRequestReviewSnapshot(mapping, review.pullRequestNumber, signal)
-    if (live._tag === 'Err')
+    if (live._tag === 'Err') {
+      unread.add(review.repository.toLowerCase())
       return err(`${review.repository}#${review.pullRequestNumber}: ${live.error}`)
+    }
     // A moved head commit gets its own Review. Restating this verdict against it
     // would answer for a diff nothing read.
     if (live.value.pullRequest.state !== 'open' || live.value.pullRequest.headSha !== review.headSha)
       return ok({ _tag: 'Superseded', repository: review.repository, pullRequestNumber: review.pullRequestNumber })
 
-    const { gates, reportedChecks } = refreshControllerGates(review.gates, live.value, mapping)
+    const { gates, reportedChecks, ciCause } = refreshControllerGates(review.gates, live.value, mapping)
     const outcome = reviewOutcome(gates)
     const confidence = outcome === 'READY' ? review.confidence : undefined
     const body = terminalComment(review.headSha, live.value.pullRequest.baseSha, gates, review.findings, confidence, reportedChecks)
     const gatesChanged = JSON.stringify(gates) !== JSON.stringify(review.gates)
     if (!gatesChanged) {
+      // Only a gate that did not move can be overdue. A gate that changed this
+      // pass rewrites its own timestamp, so the old one would report a wait
+      // that has just ended.
+      reportOverdueCiGate(options, review, gates, ciCause, stalled)
       const confirmed = await options.github.editReviewStatus(
         mapping,
         review.pullRequestNumber,
@@ -128,5 +148,63 @@ export async function refreshReviewGates(
   const results: Array<Result<ReviewGateRefreshOutcome, string>> = []
   for (const review of reviews)
     results.push(await settle(review))
+  resolveSettledCiGates(options, signal, unread, stalled)
   return results
+}
+
+/**
+ * Records one Incident for a CI Review gate that has read PENDING too long.
+ *
+ * The controller keeps waiting. It cancels nothing, re-runs nothing, and
+ * queues nothing here, because every one of those decisions belongs to Harlan.
+ * The Recovery therefore reads Action required, which is what the pane must
+ * say about work that only a person moves.
+ */
+function reportOverdueCiGate(
+  options: ReviewGateSweepOptions,
+  review: ReviewGateRefresh,
+  gates: ReviewGates,
+  ciCause: CiGateCause,
+  stalled: Map<string, string[]>,
+): void {
+  const reading = readCiGate({ gates, cause: ciCause, pendingSince: review.gatesUpdatedAt, now: options.now() })
+  if (reading._tag !== 'Overdue')
+    return
+  const message = ciGatePendingMessage(review.repository, review.pullRequestNumber, reading)
+  stalled.set(review.repository, [...(stalled.get(review.repository) ?? []), message])
+  options.store.recordIncident({
+    scope: { _tag: 'Repository', repository: review.repository },
+    kind: 'ci_gate_pending',
+    severity: 'warning',
+    operation: CI_GATE_OPERATION,
+    message,
+    recovery: { _tag: 'ActionRequired' },
+    at: options.now().toISOString(),
+  })
+}
+
+/**
+ * Closes the Incident of every gate that moved since the last pass.
+ *
+ * An Incident nobody clears trains the reader to skip the pane, so the sweep
+ * that raises these also owns closing them. A repository whose snapshot could
+ * not be read is skipped, because silence there says nothing about its gates.
+ */
+function resolveSettledCiGates(
+  options: ReviewGateSweepOptions,
+  signal: AbortSignal,
+  unread: Set<string>,
+  stalled: Map<string, string[]>,
+): void {
+  if (signal.aborted)
+    return
+  const at = options.now().toISOString()
+  options.repositories
+    .filter(mapping => !unread.has(mapping.github.toLowerCase()))
+    .forEach(mapping => options.store.resolveIncidents(
+      { _tag: 'Repository', repository: mapping.github },
+      at,
+      CI_GATE_OPERATION,
+      stalled.get(mapping.github) ?? [],
+    ))
 }

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -515,6 +515,14 @@ export interface ReviewGateRefresh {
   completedAt: string
   usage: AgentTokenUsage
   gates: ReviewGates
+  /**
+   * When these gates last changed.
+   *
+   * The projection is written only when the gates or the outcome move, so this
+   * is how long the current answer has stood. A CI Review gate that reads
+   * PENDING from here to now has held one repository still for that long.
+   */
+  gatesUpdatedAt: string
   findings: ReviewFinding[]
   /** The agent's own score, kept whatever the gates said. */
   confidence: number | undefined
@@ -538,6 +546,7 @@ interface ReviewGateRefreshRow {
   completed_at: string
   usage: string
   gates: string
+  gates_updated_at: string
   findings: string
   confidence: number | null
   github_comment_id: number
@@ -6913,7 +6922,16 @@ export function openJournalStore(
     database.prepare(`
       UPDATE repositories SET last_attempt_at = ?, last_success_at = ?, last_error = NULL WHERE github = ?
     `).run(at, at, github)
-    resolveIncidents({ _tag: 'Repository', repository: github }, at)
+    // A healthy poll proves GitHub answers for this repository, so it clears
+    // every Incident a failed read raised. It proves nothing about a Review
+    // gate that never moved, and the sweep that raises `ci_gate_pending` closes
+    // it when the gate moves. Clearing it here would hide a real stall for as
+    // long as GitHub kept answering.
+    database.prepare(`
+      UPDATE incidents SET resolved_at = ?
+      WHERE resolved_at IS NULL AND scope_tag = 'Repository' AND repository = ?
+        AND kind != 'ci_gate_pending'
+    `).run(at, github)
     // Edge triggered, on the poll that recovers. A long GitHub outage spends the
     // whole recovery budget of every Task it touches, and those Tasks would then
     // stay dead after GitHub came back. Checking `last_error` first keeps this
@@ -11667,6 +11685,7 @@ export function openJournalStore(
       ranked.completed_at,
       ranked.usage,
       COALESCE(projection.gates, ranked.gates) AS gates,
+      COALESCE(projection.updated_at, ranked.completed_at) AS gates_updated_at,
       ranked.findings,
       COALESCE(projection.confidence, ranked.confidence) AS confidence,
       published.github_comment_id,
@@ -11718,6 +11737,7 @@ export function openJournalStore(
     completedAt: row.completed_at,
     usage: agentTokenUsageFromJson(row.usage),
     gates: JSON.parse(row.gates) as ReviewGates,
+    gatesUpdatedAt: row.gates_updated_at,
     findings: JSON.parse(row.findings) as ReviewFinding[],
     confidence: row.confidence ?? undefined,
     commentId: row.github_comment_id,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -1340,9 +1340,10 @@ export type IncidentScope
 /**
  * What one Incident is about.
  *
- * Every kind except `runner_lost` comes from `classifyFailure`, which reads a
- * failure message. `runner_lost` comes from GitHub's own job steps instead, so
- * it is raised where the checks snapshot is built.
+ * Most kinds come from `classifyFailure`, which reads a failure message.
+ * `runner_lost` comes from GitHub's own job steps instead, so it is raised
+ * where the checks snapshot is built. `ci_gate_pending` comes from a clock
+ * reading against a gate that never moved, so no message exists to classify.
  */
 export type IncidentKind
   = | 'github_unavailable'
@@ -1363,6 +1364,15 @@ export type IncidentKind
      * under review is not broken, so its check runs read as PENDING.
      */
     | 'runner_lost'
+    /**
+     * A CI Review gate has read PENDING far longer than any healthy one does.
+     *
+     * No failure message exists, because nothing failed. The controller waits
+     * correctly, and that is the problem: a repository whose CI never starts
+     * used to read exactly like one whose CI is slow. The bounds and the
+     * wording live in `ci-gate-pending.ts`.
+     */
+    | 'ci_gate_pending'
     | 'unknown'
 
 /** What the controller will do about an Incident without being asked. */

--- a/packages/harlan-github-agent/test/ci-gate-pending.test.ts
+++ b/packages/harlan-github-agent/test/ci-gate-pending.test.ts
@@ -1,0 +1,134 @@
+import type { CiGateCause } from '../src/ci-gate-pending.ts'
+import type { ReviewGates } from '../src/types.ts'
+import { describe, expect, it } from 'vitest'
+import {
+  ciGatePendingMessage,
+  IDLE_GATE_BOUND_MILLISECONDS,
+  readCiGate,
+  RUNNING_CHECK_BOUND_MILLISECONDS,
+} from '../src/ci-gate-pending.ts'
+
+const pendingSince = '2026-09-05T00:00:00.000Z'
+
+function at(milliseconds: number): Date {
+  return new Date(Date.parse(pendingSince) + milliseconds)
+}
+
+function passed(label: string) {
+  return { _tag: 'Passed' as const, evidence: [{ label, sha256: 'a'.repeat(64) }] }
+}
+
+function gates(overrides: Partial<ReviewGates> = {}): ReviewGates {
+  return {
+    merge: passed('mergeability'),
+    review: passed('agent-report'),
+    ci: { _tag: 'Pending', reason: 'Base branch CI: build failed.', evidence: [{ label: 'base-ci', sha256: 'b'.repeat(64) }] },
+    ...overrides,
+  }
+}
+
+const baseFailed: CiGateCause = { _tag: 'BaseBranchFailed', check: 'build' }
+const running: CiGateCause = { _tag: 'CheckRunning', check: 'ci / test' }
+
+describe('readCiGate', () => {
+  it('reports a base branch failure the pull request cannot resolve as overdue', () => {
+    const reading = readCiGate({ gates: gates(), cause: baseFailed, pendingSince, now: at(IDLE_GATE_BOUND_MILLISECONDS + 60_000) })
+
+    expect(reading).toEqual({
+      _tag: 'Overdue',
+      cause: baseFailed,
+      pendingSince,
+      elapsedMilliseconds: IDLE_GATE_BOUND_MILLISECONDS + 60_000,
+      boundMilliseconds: IDLE_GATE_BOUND_MILLISECONDS,
+    })
+  })
+
+  it('keeps the three hour wait this service recorded as healthy inside the bound', () => {
+    const reading = readCiGate({ gates: gates(), cause: baseFailed, pendingSince, now: at(3 * 60 * 60_000) })
+
+    expect(reading).toEqual({
+      _tag: 'Within',
+      elapsedMilliseconds: 3 * 60 * 60_000,
+      boundMilliseconds: IDLE_GATE_BOUND_MILLISECONDS,
+    })
+  })
+
+  it('gives a running check run the whole time GitHub allows one job', () => {
+    const input = { gates: gates(), cause: running, pendingSince }
+
+    expect(readCiGate({ ...input, now: at(RUNNING_CHECK_BOUND_MILLISECONDS - 60_000) })._tag).toBe('Within')
+    expect(readCiGate({ ...input, now: at(RUNNING_CHECK_BOUND_MILLISECONDS + 60_000) })).toEqual({
+      _tag: 'Overdue',
+      cause: running,
+      pendingSince,
+      elapsedMilliseconds: RUNNING_CHECK_BOUND_MILLISECONDS + 60_000,
+      boundMilliseconds: RUNNING_CHECK_BOUND_MILLISECONDS,
+    })
+  })
+
+  it('ignores a repository with no CI, because its gate passed', () => {
+    const reading = readCiGate({
+      gates: gates({ ci: passed('github-ci') }),
+      cause: { _tag: 'Settled' },
+      pendingSince,
+      now: at(5 * 24 * 60 * 60_000),
+    })
+
+    expect(reading._tag).toBe('Ignored')
+  })
+
+  it('ignores a pull request another Review gate already holds', () => {
+    const reading = readCiGate({
+      gates: gates({ merge: { _tag: 'Failed', reason: 'The pull request has merge conflicts.', evidence: [] } }),
+      cause: baseFailed,
+      pendingSince,
+      now: at(2 * 24 * 60 * 60_000),
+    })
+
+    expect(reading._tag).toBe('Ignored')
+  })
+
+  it('ignores a lost runner, because that failure has its own Incident', () => {
+    const reading = readCiGate({
+      gates: gates(),
+      cause: { _tag: 'RunnerLost', check: 'ci / test' },
+      pendingSince,
+      now: at(2 * 24 * 60 * 60_000),
+    })
+
+    expect(reading._tag).toBe('Ignored')
+  })
+
+  it('ignores a clock that runs backwards', () => {
+    const reading = readCiGate({ gates: gates(), cause: baseFailed, pendingSince, now: at(-60_000) })
+
+    expect(reading._tag).toBe('Within')
+  })
+})
+
+describe('ciGatePendingMessage', () => {
+  it('names the repository, the pull request, the gate state, and the wait', () => {
+    const reading = readCiGate({ gates: gates(), cause: baseFailed, pendingSince, now: at(26 * 60 * 60_000) })
+    if (reading._tag !== 'Overdue')
+      throw new Error('Expected an overdue CI Review gate.')
+
+    const message = ciGatePendingMessage('harlan-zw/gscdump.com', 213, reading)
+
+    expect(message).toBe([
+      'harlan-zw/gscdump.com#213: the CI Review gate reads PENDING for more than 4 hours.',
+      'The gate last moved at 2026-09-05 00:00 UTC.',
+      'Base branch check run "build" failed.',
+      'If the default branch is broken, repair it and re-run the check run.',
+    ].join(' '))
+  })
+
+  it('writes one message whatever the wait grows to, so one gate keeps one Incident', () => {
+    const early = readCiGate({ gates: gates(), cause: running, pendingSince, now: at(7 * 60 * 60_000) })
+    const late = readCiGate({ gates: gates(), cause: running, pendingSince, now: at(70 * 60 * 60_000) })
+    if (early._tag !== 'Overdue' || late._tag !== 'Overdue')
+      throw new Error('Expected two overdue CI Review gates.')
+
+    expect(ciGatePendingMessage('harlan-zw/example', 24, early)).toBe(ciGatePendingMessage('harlan-zw/example', 24, late))
+    expect(ciGatePendingMessage('harlan-zw/example', 24, early)).toContain('Check run "ci / test" has not reported a conclusion.')
+  })
+})

--- a/packages/harlan-github-agent/test/review-gate-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-gate-sweep.test.ts
@@ -1,6 +1,6 @@
 import type { GitHubCheck } from '../src/github-agent-source.ts'
-import type { ReviewGateRefresh } from '../src/store.ts'
-import type { ReviewGates } from '../src/types.ts'
+import type { RecordIncidentInput, ReviewGateRefresh } from '../src/store.ts'
+import type { Incident, ReviewGates } from '../src/types.ts'
 import { afterEach, describe, expect, it } from 'vitest'
 import { refreshControllerGates } from '../src/item-agent.ts'
 import { ok } from '../src/result.ts'
@@ -44,6 +44,7 @@ function gateRefresh(overrides: Partial<ReviewGateRefresh> = {}): ReviewGateRefr
     gates: pendingControllerGates(),
     findings: [],
     confidence: 88,
+    gatesUpdatedAt: '2026-08-27T08:20:00.000Z',
     commentId: 42,
     publishedBody: '### 🤖 PENDING',
     ...overrides,
@@ -77,6 +78,8 @@ function snapshot(baseChecks: GitHubCheck[], headChecks: GitHubCheck[] = [check(
 
 interface Recorded {
   edited?: { commentId: number, expectedBody: string, body: string }
+  incidents: RecordIncidentInput[]
+  resolved: Array<{ repository: string, operation: string | undefined, exceptMessages: readonly string[] }>
   failed: Array<{ reviewRunId: string, reason: string }>
   staged: Array<{ reviewRunId: string, outcome: string, ci: string, reconciliationId?: string, body: string }>
   stamped: string[]
@@ -87,7 +90,7 @@ function harness(options: {
   live?: ReturnType<typeof snapshot>
   edit?: () => Promise<any>
 }) {
-  const recorded: Recorded = { failed: [], staged: [], stamped: [] }
+  const recorded: Recorded = { failed: [], incidents: [], resolved: [], staged: [], stamped: [] }
   const run = async () => refreshReviewGates({
     github: {
       getPullRequestReviewSnapshot: () => Promise.resolve(options.live ?? snapshot([check()])),
@@ -108,6 +111,15 @@ function harness(options: {
     repositories: [repositoryMapping()],
     store: {
       listReviewGateRefreshes: () => [options.review ?? gateRefresh()],
+      recordIncident: (incident) => {
+        recorded.incidents.push(incident)
+        return { ...incident, id: 'incident-1', occurrences: 1, firstSeenAt: incident.at, lastSeenAt: incident.at } satisfies Incident
+      },
+      resolveIncidents: (scope, _at, operation, exceptMessages = []) => {
+        if (scope._tag === 'Repository')
+          recorded.resolved.push({ repository: scope.repository, operation, exceptMessages })
+        return 0
+      },
       recordReviewPublication: (input) => {
         if (input.result._tag === 'Failed')
           recorded.failed.push({ reviewRunId: input.reviewRunId, reason: input.result.reason })
@@ -269,6 +281,69 @@ describe('refreshReviewGates', () => {
     })])
     expect(recorded.stamped).toEqual([])
     expect(recorded.staged[0]?.reconciliationId).toContain('Missing:42:')
+  })
+
+  it('raises one Incident when the CI Review gate has read PENDING for a day', async () => {
+    const live = snapshot([check({ conclusion: 'failure' })])
+    if (live._tag !== 'Ok')
+      throw new Error('Expected a Review snapshot.')
+    const { recorded, run } = harness({
+      live,
+      review: gateRefresh({
+        gates: refreshControllerGates(pendingControllerGates(), live.value, repositoryMapping()).gates,
+        gatesUpdatedAt: '2026-08-26T11:15:00.000Z',
+      }),
+    })
+
+    await run()
+
+    const message = 'harlan-zw/example#24: the CI Review gate reads PENDING for more than 4 hours. '
+      + 'The gate last moved at 2026-08-26 11:15 UTC. '
+      + 'Base branch check run "deploy (pro-admin)" failed. '
+      + 'If the default branch is broken, repair it and re-run the check run.'
+    expect(recorded.incidents).toEqual([{
+      scope: { _tag: 'Repository', repository: 'harlan-zw/example' },
+      kind: 'ci_gate_pending',
+      severity: 'warning',
+      operation: 'ci_gate_pending',
+      message,
+      recovery: { _tag: 'ActionRequired' },
+      at: '2026-08-27T11:15:00.000Z',
+    }])
+    expect(recorded.resolved).toEqual([{
+      repository: 'harlan-zw/example',
+      operation: 'ci_gate_pending',
+      exceptMessages: [message],
+    }])
+  })
+
+  it('raises no Incident while the CI Review gate is inside its bound', async () => {
+    const live = snapshot([check({ status: 'in_progress', conclusion: null })])
+    if (live._tag !== 'Ok')
+      throw new Error('Expected a Review snapshot.')
+    const { recorded, run } = harness({
+      live,
+      review: gateRefresh({
+        gates: refreshControllerGates(pendingControllerGates(), live.value, repositoryMapping()).gates,
+      }),
+    })
+
+    await run()
+
+    expect(recorded.incidents).toEqual([])
+  })
+
+  it('resolves the Incident once the CI Review gate moves', async () => {
+    const { recorded, run } = harness({})
+
+    await run()
+
+    expect(recorded.incidents).toEqual([])
+    expect(recorded.resolved).toEqual([{
+      repository: 'harlan-zw/example',
+      operation: 'ci_gate_pending',
+      exceptMessages: [],
+    }])
   })
 
   it('retires the Review instead of staging a status when another actor owns the comment', async () => {
@@ -479,5 +554,80 @@ describe('refreshReviewGates against the journal store', () => {
     expect(settledRun.outcome).toEqual({ _tag: 'Ready', confidence: 88 })
     expect(settledRun.gates.ci._tag).toBe('Passed')
     expect(settledRun.usage).toEqual({ _tag: 'Available', input: 10, cachedInput: 0, cacheWrite: 0, output: 5, reasoning: 0 })
+  })
+
+  it('names the pull request whose CI Review gate has not moved for a day', async () => {
+    const store = openJournalStore(':memory:')
+    stores.push(store)
+    store.syncRepositories([repositoryMapping()], '2026-08-26T08:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'stalled-ci-pr',
+      observedAt: '2026-08-26T08:01:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected a new pull request revision.')
+    const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-26T08:01:30.000Z', 60_000)
+    if (task === null)
+      throw new Error('Expected the queued Review Task.')
+    store.completeWorkerTask({ taskId: task.id, workerId: task.state.workerId, fence: task.state.fence, at: '2026-08-26T08:02:00.000Z', evidence: 'review-run' })
+
+    const red = snapshot([check({ conclusion: 'failure' })])
+    if (red._tag !== 'Ok')
+      throw new Error('Expected a Review snapshot.')
+    expect(store.recordReviewRun({
+      id: 'run-stalled',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      headSha: 'abc123',
+      provider: 'codex',
+      sessionId: 'session-1',
+      model: 'gpt-5.6-sol',
+      agentVersion: '0.0.0',
+      skillDigest: 'c'.repeat(64),
+      startedAt: '2026-08-26T08:11:00.000Z',
+      completedAt: '2026-08-26T08:20:00.000Z',
+      usage: { _tag: 'Unavailable' },
+      gates: refreshControllerGates(pendingControllerGates(), red.value, repositoryMapping()).gates,
+      confidence: 88,
+      findings: [],
+    })).toEqual({ _tag: 'Inserted', reviewRunId: 'run-stalled' })
+    expect(store.recordReviewPublication({
+      id: 'publication-stalled',
+      reviewRunId: 'run-stalled',
+      body: '### 🤖 PENDING',
+      at: '2026-08-26T08:21:00.000Z',
+      result: { _tag: 'Published', githubCommentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' },
+    })).toEqual({ _tag: 'Inserted', publicationId: 'publication-stalled' })
+    expect(store.listReviewGateRefreshes()[0]?.gatesUpdatedAt).toBe('2026-08-26T08:20:00.000Z')
+
+    await refreshReviewGates({
+      github: {
+        getPullRequestReviewSnapshot: () => Promise.resolve(red),
+        editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+        stampAgentLabel: () => Promise.resolve(ok(undefined)),
+      },
+      now: () => new Date('2026-08-27T11:15:00.000Z'),
+      repositories: [repositoryMapping()],
+      store,
+    }, new AbortController().signal)
+
+    expect(store.listIncidents()).toEqual([expect.objectContaining({
+      scope: { _tag: 'Repository', repository: 'harlan-zw/example' },
+      kind: 'ci_gate_pending',
+      occurrences: 1,
+      firstSeenAt: '2026-08-27T11:15:00.000Z',
+      message: 'harlan-zw/example#24: the CI Review gate reads PENDING for more than 4 hours. '
+        + 'The gate last moved at 2026-08-26 08:20 UTC. '
+        + 'Base branch check run "deploy (pro-admin)" failed. '
+        + 'If the default branch is broken, repair it and re-run the check run.',
+    })])
+
+    // A poll answers for GitHub, never for a gate that never moved.
+    store.recordPollSuccess('harlan-zw/example', '2026-08-27T11:20:00.000Z')
+
+    expect(store.listIncidents()).toHaveLength(1)
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature

### 📚 Description

skilld.dev ran no check run for ten hours yesterday, and gscdump.com #213 and #218 sat on a red base branch for a whole day. The controller waited correctly in all three, so nothing surfaced, and I only found them because I went looking. A pull request whose checks never start reads exactly like one whose checks are slow.

The review gate sweep now reads how long a CI Review gate has held its answer and raises one `ci_gate_pending` Incident once it passes its bound. A check run with no conclusion gets six hours, which is when GitHub stops the job anyway. A gate with nothing in flight gets four hours, an hour past the longest healthy PENDING this service has on record (three hours on 27 Aug, a base branch deploy still running after a Review finished). The Incident names the repository, the pull request, the cause, and when the gate last moved. The same sweep closes it when the gate moves.

It reports and stops there. Nothing is cancelled, re-run, or repaired, and the Recovery reads Action required.

A repository with no CI still passes the gate, so it raises nothing. A pull request another gate already holds raises nothing. A lost runner keeps `runner_lost` and does not raise a second Incident for the same fault.

Two loose ends. I kept the bound fixed instead of deriving it from each repository's own check durations, because the checks snapshot carries no timing at all and adding it costs new GitHub reads on every pass; if four hours reads noisy on the slower sites that is the next thing to try. And I stopped a successful poll from clearing this one Incident kind, since a poll proves GitHub answers and proves nothing about a gate that never moved. `runner_lost` still clears on poll, because nothing else would ever close it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Xf6fnPYRB2nFxHA2i8DT5h
