### PR TITLE
feat(github-agent): allow configured dashboard frame ancestors

### DIFF
--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -62,6 +62,8 @@ Environment files move one way from the desktop checkouts.
 Git stores only their paths.
 The sync rejects missing files, unsafe symlinks, untrusted paths, and files that Git does not ignore.
 
+The dashboard denies framing. If another HTTPS page must frame it, list that origin in `server.frame_ancestors`.
+
 Save the dashboard password in `dashboard-password` beside the config file. Use at least 32 bytes and restrict the file to mode `600`.
 
 Configure your normal global Git profile before starting. The controller uses its identity and commit-signing settings for every commit it creates.

--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -32,6 +32,9 @@ server:
   host: 127.0.0.1
   port: 3210
   allowed_origin: https://harlan-github-agent.localhost
+  # HTTPS origins allowed to frame the dashboard, for example a talk deck.
+  # Leave it out to deny framing.
+  # frame_ancestors: [https://deck.example.com]
 # GitHub webhooks remove most polling latency. The listener runs on its own
 # port carrying one route, so a tunnel in front of it cannot reach the
 # dashboard or the control API. Point the GitHub App webhook URL at it and set

--- a/packages/harlan-github-agent/src/app.ts
+++ b/packages/harlan-github-agent/src/app.ts
@@ -20,6 +20,8 @@ export interface AgentAppOptions {
   ejectSettlementTimeoutMilliseconds?: number
   allowedOrigin: string
   dashboardPassword: string
+  /** HTTPS origins allowed to frame the dashboard, such as a talk deck. Empty denies framing. */
+  frameAncestors?: readonly string[]
   dashboardRoot?: string
   now: () => Date
   eventIntervalMilliseconds?: number
@@ -35,7 +37,13 @@ const securityHeaders = {
   'cache-control': 'no-store',
   'referrer-policy': 'no-referrer',
   'x-content-type-options': 'nosniff',
-  'x-frame-options': 'DENY',
+}
+
+/** Framing headers: `frame-ancestors` is the source of truth; `x-frame-options` only backs up the default deny. */
+function framingHeaders(frameAncestors: readonly string[]): { securityHeaders: Record<string, string>, frameAncestors: string } {
+  if (frameAncestors.length === 0)
+    return { securityHeaders: { ...securityHeaders, 'x-frame-options': 'DENY' }, frameAncestors: '\'none\'' }
+  return { securityHeaders, frameAncestors: ['\'self\'', ...frameAncestors].join(' ') }
 }
 
 const contentTypes: Record<string, string> = {
@@ -290,6 +298,7 @@ async function changeDismissal(options: AgentAppOptions, event: { req: Request }
 export function createAgentApp(options: AgentAppOptions): H3 {
   const dashboardRoot = options.dashboardRoot ?? defaultDashboardRoot()
   const allowedHost = new URL(options.allowedOrigin).host
+  const framing = framingHeaders(options.frameAncestors ?? [])
   const app = new H3({
     onRequest(event) {
       if (event.req.headers.get('host') !== allowedHost)
@@ -307,10 +316,10 @@ export function createAgentApp(options: AgentAppOptions): H3 {
       event.context.dashboardNonce = randomBytes(18).toString('base64')
     },
     onResponse(response, event) {
-      Object.entries(securityHeaders).forEach(([name, value]) => response.headers.set(name, value))
+      Object.entries(framing.securityHeaders).forEach(([name, value]) => response.headers.set(name, value))
       const nonce = String(event.context.dashboardNonce)
       // GitHub avatars come from github.com and redirect to avatars.githubusercontent.com.
-      response.headers.set('content-security-policy', `default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self'; frame-ancestors 'none'; img-src 'self' data: https://github.com https://avatars.githubusercontent.com; object-src 'none'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`)
+      response.headers.set('content-security-policy', `default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self'; frame-ancestors ${framing.frameAncestors}; img-src 'self' data: https://github.com https://avatars.githubusercontent.com; object-src 'none'; script-src 'self' 'nonce-${nonce}'; style-src 'self' 'unsafe-inline'`)
     },
   })
 

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -228,6 +228,10 @@ function providerName(value: unknown): AgentProviderName | undefined {
 }
 
 /** Keeps the control UI on the local proxy or one private Tailscale HTTPS name. */
+function isHttpsOrigin(value: string): boolean {
+  return URL.canParse(value) && new URL(value).protocol === 'https:' && new URL(value).origin === value
+}
+
 function isDashboardOrigin(value: string): boolean {
   if (!URL.canParse(value))
     return false
@@ -535,6 +539,9 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
   if (port === undefined)
     issues.push({ path: '$.server.port', message: 'Expected an integer from 1 to 65535.' })
   const allowedOrigin = server === undefined ? undefined : requiredString(server, 'allowed_origin', '$.server', issues)
+  const frameAncestors = server === undefined
+    ? undefined
+    : server.frame_ancestors === undefined ? [] : stringArray(server, 'frame_ancestors', '$.server', issues)
   const storagePath = storage === undefined ? undefined : requiredString(storage, 'path', '$.storage', issues)
 
   const pollValue = document.value.poll_interval_seconds
@@ -590,6 +597,8 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
     issues.push({ path: '$.server.host', message: 'Expected a loopback address.' })
   if (allowedOrigin !== undefined && !isDashboardOrigin(allowedOrigin))
     issues.push({ path: '$.server.allowed_origin', message: 'Expected the local dashboard or an HTTPS Tailscale origin.' })
+  if (frameAncestors?.some(origin => !isHttpsOrigin(origin)))
+    issues.push({ path: '$.server.frame_ancestors', message: 'Expected HTTPS origins without a path.' })
   if (storagePath !== undefined && storagePath !== ':memory:' && !isAbsolute(storagePath))
     issues.push({ path: '$.storage.path', message: 'Expected an absolute path or :memory:.' })
   if (mutationsEnabled === true && storagePath === ':memory:')
@@ -609,6 +618,7 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
     || allowedOwners === undefined
     || port === undefined
     || allowedOrigin === undefined
+    || frameAncestors === undefined
     || storagePath === undefined
     || pollIntervalSeconds === undefined
     || mutationsEnabled === undefined
@@ -625,7 +635,7 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
   return ok({
     agent,
     github: { appId, privateKeyPath, allowedOwners },
-    server: { host, port, allowedOrigin },
+    server: { host, port, allowedOrigin, frameAncestors },
     webhook,
     triggers,
     storage: { path: storagePath },

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -1159,6 +1159,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
       restoreItem: store.restoreItem,
     },
     allowedOrigin: config.server.allowedOrigin,
+    frameAncestors: config.server.frameAncestors,
     dashboardPassword: options.dashboardPassword,
     now,
     settleTask: settleAgentTask,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -101,6 +101,8 @@ export interface AgentConfig {
     host: string
     port: number
     allowedOrigin: string
+    /** HTTPS origins allowed to frame the dashboard. Empty keeps framing denied. */
+    frameAncestors: readonly string[]
   }
   /** Which triggers this machine answers. Defaults to every trigger. */
   triggers: readonly ServiceTrigger[]

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -525,6 +525,24 @@ describe('dashboard HTTP app', () => {
     expect(response.headers.get('content-security-policy')).toContain(`script-src 'self' 'nonce-${nonce}'`)
   })
 
+  it('denies framing unless frame ancestors are configured', async () => {
+    const denied = await createApp().request(`http://${allowedHost}/`, { headers: { authorization, host: allowedHost } })
+    expect(denied.headers.get('content-security-policy')).toContain('frame-ancestors \'none\'')
+    expect(denied.headers.get('x-frame-options')).toBe('DENY')
+
+    const framed = createAgentApp({
+      allowedOrigin,
+      dashboardPassword,
+      dashboardRoot,
+      frameAncestors: ['https://deck.example.com'],
+      now,
+      store: { ...agentControls, approveIssueWork: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }), approvePullRequest: () => ({ _tag: 'Rejected', reason: { _tag: 'RevisionMismatch' } }), cancelTask: () => ({ _tag: 'Rejected', reason: { _tag: 'TaskNotFound' } }), getDashboardSnapshot: () => dashboardSnapshot(), listReviewRuns: () => [], requestReviewRerun: () => ({ _tag: 'Rejected', reason: { _tag: 'ItemNotFound' } }) },
+    })
+    const allowed = await framed.request(`http://${allowedHost}/`, { headers: { authorization, host: allowedHost } })
+    expect(allowed.headers.get('content-security-policy')).toContain('frame-ancestors \'self\' https://deck.example.com')
+    expect(allowed.headers.get('x-frame-options')).toBeNull()
+  })
+
   it('serves the workflow map directly', async () => {
     const response = await createApp().request(`http://${allowedHost}/flow`, { headers: { authorization, host: allowedHost } })
 

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -171,6 +171,26 @@ agent:
     })
   })
 
+  it('accepts only HTTPS origins as frame ancestors', () => {
+    const framed = parseConfigText(configText.replace(
+      'allowed_origin: https://harlan-github-agent.localhost',
+      'allowed_origin: https://harlan-github-agent.localhost\n  frame_ancestors: [https://deck.example.com]',
+    ))
+    const unencrypted = parseConfigText(configText.replace(
+      'allowed_origin: https://harlan-github-agent.localhost',
+      'allowed_origin: https://harlan-github-agent.localhost\n  frame_ancestors: [http://deck.example.com/path]',
+    ))
+
+    const unframed = parseConfigText(configText)
+
+    expect(framed._tag === 'Ok' && framed.value.server.frameAncestors).toEqual(['https://deck.example.com'])
+    expect(unframed._tag === 'Ok' && unframed.value.server.frameAncestors).toEqual([])
+    expect(unencrypted._tag === 'Err' && unencrypted.error).toContainEqual({
+      path: '$.server.frame_ancestors',
+      message: 'Expected HTTPS origins without a path.',
+    })
+  })
+
   it('parses a precise repository policy', () => {
     const result = parseConfigText(configText)
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

I want the MelbJS deck to show the live Hogwild board inline on one slide, and the dashboard sends `frame-ancestors 'none'` plus `X-Frame-Options: DENY`, so the slide has to pop the board out into a separate window instead.

`server.frame_ancestors` now lists HTTPS origins that may frame the dashboard. Leaving it out keeps the current deny and the `X-Frame-Options` backstop.

Open question: Chrome will not show a Basic auth prompt inside a cross-origin iframe. The framed board only renders if the browser already holds the dashboard credentials from a normal tab. Fine for a talk, worth knowing before anyone relies on this elsewhere.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Hexj2sFKkHe5BY3B4udJFK