### PR TITLE
fix(github-agent): accept loopback HTTP frame ancestors

### DIFF
--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -62,7 +62,7 @@ Environment files move one way from the desktop checkouts.
 Git stores only their paths.
 The sync rejects missing files, unsafe symlinks, untrusted paths, and files that Git does not ignore.
 
-The dashboard denies framing. If another HTTPS page must frame it, list that origin in `server.frame_ancestors`.
+The dashboard denies framing. If another page must frame it, list its origin in `server.frame_ancestors`: HTTPS, or `http://localhost` with a port.
 
 Save the dashboard password in `dashboard-password` beside the config file. Use at least 32 bytes and restrict the file to mode `600`.
 

--- a/packages/harlan-github-agent/config.example.yml
+++ b/packages/harlan-github-agent/config.example.yml
@@ -32,9 +32,9 @@ server:
   host: 127.0.0.1
   port: 3210
   allowed_origin: https://harlan-github-agent.localhost
-  # HTTPS origins allowed to frame the dashboard, for example a talk deck.
-  # Leave it out to deny framing.
-  # frame_ancestors: [https://deck.example.com]
+  # Origins allowed to frame the dashboard, for example a talk deck. HTTPS, or
+  # http://localhost with a port. Leave it out to deny framing.
+  # frame_ancestors: [http://localhost:3000]
 # GitHub webhooks remove most polling latency. The listener runs on its own
 # port carrying one route, so a tunnel in front of it cannot reach the
 # dashboard or the control API. Point the GitHub App webhook URL at it and set

--- a/packages/harlan-github-agent/src/app.ts
+++ b/packages/harlan-github-agent/src/app.ts
@@ -20,7 +20,7 @@ export interface AgentAppOptions {
   ejectSettlementTimeoutMilliseconds?: number
   allowedOrigin: string
   dashboardPassword: string
-  /** HTTPS origins allowed to frame the dashboard, such as a talk deck. Empty denies framing. */
+  /** Origins allowed to frame the dashboard, such as a talk deck. Empty denies framing. */
   frameAncestors?: readonly string[]
   dashboardRoot?: string
   now: () => Date

--- a/packages/harlan-github-agent/src/config.ts
+++ b/packages/harlan-github-agent/src/config.ts
@@ -228,8 +228,16 @@ function providerName(value: unknown): AgentProviderName | undefined {
 }
 
 /** Keeps the control UI on the local proxy or one private Tailscale HTTPS name. */
-function isHttpsOrigin(value: string): boolean {
-  return URL.canParse(value) && new URL(value).protocol === 'https:' && new URL(value).origin === value
+/** A frame ancestor is an HTTPS origin, or a loopback HTTP origin for a deck served from this machine. */
+function isFrameAncestorOrigin(value: string): boolean {
+  if (!URL.canParse(value))
+    return false
+  const origin = new URL(value)
+  if (origin.origin !== value)
+    return false
+  if (origin.protocol === 'https:')
+    return true
+  return origin.protocol === 'http:' && ['localhost', '127.0.0.1', '[::1]'].includes(origin.hostname)
 }
 
 function isDashboardOrigin(value: string): boolean {
@@ -597,8 +605,8 @@ export function parseConfigText(text: string): Result<AgentConfig, ConfigIssue[]
     issues.push({ path: '$.server.host', message: 'Expected a loopback address.' })
   if (allowedOrigin !== undefined && !isDashboardOrigin(allowedOrigin))
     issues.push({ path: '$.server.allowed_origin', message: 'Expected the local dashboard or an HTTPS Tailscale origin.' })
-  if (frameAncestors?.some(origin => !isHttpsOrigin(origin)))
-    issues.push({ path: '$.server.frame_ancestors', message: 'Expected HTTPS origins without a path.' })
+  if (frameAncestors?.some(origin => !isFrameAncestorOrigin(origin)))
+    issues.push({ path: '$.server.frame_ancestors', message: 'Expected HTTPS or loopback HTTP origins without a path.' })
   if (storagePath !== undefined && storagePath !== ':memory:' && !isAbsolute(storagePath))
     issues.push({ path: '$.storage.path', message: 'Expected an absolute path or :memory:.' })
   if (mutationsEnabled === true && storagePath === ':memory:')

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -101,7 +101,7 @@ export interface AgentConfig {
     host: string
     port: number
     allowedOrigin: string
-    /** HTTPS origins allowed to frame the dashboard. Empty keeps framing denied. */
+    /** HTTPS or loopback HTTP origins allowed to frame the dashboard. Empty keeps framing denied. */
     frameAncestors: readonly string[]
   }
   /** Which triggers this machine answers. Defaults to every trigger. */

--- a/packages/harlan-github-agent/test/config.test.ts
+++ b/packages/harlan-github-agent/test/config.test.ts
@@ -171,23 +171,23 @@ agent:
     })
   })
 
-  it('accepts only HTTPS origins as frame ancestors', () => {
+  it('accepts HTTPS and loopback HTTP origins as frame ancestors', () => {
     const framed = parseConfigText(configText.replace(
       'allowed_origin: https://harlan-github-agent.localhost',
-      'allowed_origin: https://harlan-github-agent.localhost\n  frame_ancestors: [https://deck.example.com]',
+      'allowed_origin: https://harlan-github-agent.localhost\n  frame_ancestors: [https://deck.example.com, http://localhost:3000]',
     ))
     const unencrypted = parseConfigText(configText.replace(
       'allowed_origin: https://harlan-github-agent.localhost',
-      'allowed_origin: https://harlan-github-agent.localhost\n  frame_ancestors: [http://deck.example.com/path]',
+      'allowed_origin: https://harlan-github-agent.localhost\n  frame_ancestors: [http://deck.example.com]',
     ))
 
     const unframed = parseConfigText(configText)
 
-    expect(framed._tag === 'Ok' && framed.value.server.frameAncestors).toEqual(['https://deck.example.com'])
+    expect(framed._tag === 'Ok' && framed.value.server.frameAncestors).toEqual(['https://deck.example.com', 'http://localhost:3000'])
     expect(unframed._tag === 'Ok' && unframed.value.server.frameAncestors).toEqual([])
     expect(unencrypted._tag === 'Err' && unencrypted.error).toContainEqual({
       path: '$.server.frame_ancestors',
-      message: 'Expected HTTPS origins without a path.',
+      message: 'Expected HTTPS or loopback HTTP origins without a path.',
     })
   })
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

#204 only accepted HTTPS frame ancestors, and the deck it was built for runs at `http://localhost:3000`. So the option could not name the one origin I needed. Loopback HTTP origins are allowed now; anything else still has to be HTTPS.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01Hexj2sFKkHe5BY3B4udJFK