### PR TITLE
fix(github-agent): index review run supersession for the snapshot

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -5552,6 +5552,19 @@ const batchMigration = `
   PRAGMA user_version = 62;
 `
 
+/**
+ * The snapshot's Review agent query asks, for every Review run, whether a
+ * later run supersedes it. Without this index that is a full scan per row,
+ * about one second per snapshot on a journal with 1400 runs, and the event
+ * stream runs it every two seconds per client. That starved the controller
+ * and the poller on Hogwild on 7 September 2026.
+ */
+const reviewRunSupersedesIndexMigration = `
+  CREATE INDEX IF NOT EXISTS review_runs_supersedes ON review_runs(supersedes_review_run_id);
+
+  PRAGMA user_version = 64;
+`
+
 function applyMigration(database: DatabaseSync, migration: string): void {
   database.exec('BEGIN IMMEDIATE')
   try {
@@ -5842,9 +5855,13 @@ function installSchema(database: DatabaseSync): void {
     const columns = (database.prepare('PRAGMA table_info(candidates)').all() as unknown as Array<{ name: string }>)
       .map(column => column.name)
     applyMigration(database, columns.includes('title') ? 'PRAGMA user_version = 63;' : candidateTitleMigration)
+    version = 63
+  }
+  if (version === 63) {
+    applyMigration(database, reviewRunSupersedesIndexMigration)
     return
   }
-  if (version === 63)
+  if (version === 64)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -635,7 +635,7 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(63)
+      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(64)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

The dashboard on Hogwild stopped answering this afternoon: the main thread sat at 100% CPU, loopback requests hung, and the poller logged abandoned passes. A stack sample through the inspector landed in the Review agent query of the snapshot every time. It asks, for every Review run, whether a later run supersedes it, and that column had no index, so each snapshot did a full scan per row. The event stream builds a snapshot every two seconds per client, so two open dashboards were enough to starve everything else.

Measured on a copy of the live journal (1433 Review runs):

```
before  Run Time: real 0.963 user 0.350892 sys 0.611686
after   Run Time: real 0.005 user 0.002034 sys 0.002958
```

Migration 64 adds the index. I created the same index on the live journal by hand to end the outage, and the migration is `IF NOT EXISTS` so the deploy is a no-op there.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01X5NJ4nAcjsPm7PVtmdDmRS