### PR TITLE
fix(github-agent): queue Baseline repair from the gate refresh

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -208,6 +208,10 @@ If Review records `Repair` findings, queue all findings immediately under the ex
 
 Available empty base and head check sets with no declared required checks mean the repository has no CI. This passes the CI Review gate and permits Repair. An unavailable, running, or failed base check set does not permit Repair.
 
+Ignore a base check run that a `workflow_run` event attached to the base commit. It reports on another commit's workflow, not on the base commit.
+
+When the gate refresh of a settled review finds the default branch failed, queue one Baseline repair for that exact base commit. Report Existing on every later pass.
+
 Raise one `ci_gate_pending` Incident when a CI Review gate reads PENDING past its bound. Allow a check run with no conclusion 6 hours, because GitHub stops a job then. Allow a gate with nothing in flight 4 hours. Name the repository, the pull request, the cause, and when the gate last moved. Resolve the Incident when the gate moves. Report only. Never cancel, re-run, or repair a check run because of this Incident.
 
 Raise no Incident when the repository has no CI, when another Review gate holds the pull request, or when a runner lost its job. The last one raises `runner_lost` instead.

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -87,6 +87,19 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
   return [...current.values()]
 }
 
+/**
+ * The check suites of workflow runs a `workflow_run` event started.
+ *
+ * GitHub attaches such a run to the default branch tip, not to the commit
+ * whose workflow finished. A bundle-size comment job on `main` therefore
+ * appears as a running base check every time any pull request's CI ends, and
+ * the base gate read that as "the default branch has not passed" while Repair
+ * waited. Those suites answer for another commit, so they are dropped.
+ */
+export function derivedCheckSuiteIds(runs: ReadonlyArray<{ event: string, check_suite_id?: number | null }>): Set<number> {
+  return new Set(runs.flatMap(run => run.event === 'workflow_run' && typeof run.check_suite_id === 'number' ? [run.check_suite_id] : []))
+}
+
 export function chronologicalPullRequestComments(entries: Array<{ body: string, createdAt: string }>): string[] {
   return [...entries]
     .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
@@ -718,7 +731,10 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
           : Promise.all([
               checksClient.value.paginate(checksClient.value.rest.checks.listForRef, { owner, repo, ref, per_page: 100, request: { signal } }),
               checksClient.value.rest.repos.getCombinedStatusForRef({ owner, repo, ref, per_page: 100, request: { signal } }),
-            ]).then(async ([runs, statuses]): Promise<GitHubChecksSnapshot> => {
+              checksClient.value.paginate(checksClient.value.rest.actions.listWorkflowRunsForRepo, { owner, repo, head_sha: ref, per_page: 100, request: { signal } }),
+            ]).then(async ([allRuns, statuses, workflowRuns]): Promise<GitHubChecksSnapshot> => {
+              const derivedSuites = derivedCheckSuiteIds(workflowRuns)
+              const runs = allRuns.filter(check => check.check_suite?.id === undefined || check.check_suite.id === null || !derivedSuites.has(check.check_suite.id))
               const current = currentGitHubChecks([
                 ...runs.map(check => ({
                   id: check.id,

--- a/packages/harlan-github-agent/src/review-gate-sweep.ts
+++ b/packages/harlan-github-agent/src/review-gate-sweep.ts
@@ -1,24 +1,30 @@
 import type { CiGateCause } from './ci-gate-pending.ts'
 import type { GitHubAgentSource } from './github-agent-source.ts'
 import type { Result } from './result.ts'
-import type { JournalStore, ReviewGateRefresh } from './store.ts'
+import type { BaselineRepairQueueResult, JournalStore, ReviewGateRefresh } from './store.ts'
 import type { RepositoryMapping, ReviewGates, ReviewOutcomeName } from './types.ts'
 import { createHash } from 'node:crypto'
 import { ciGatePendingMessage, readCiGate } from './ci-gate-pending.ts'
 import { refreshControllerGates, reviewOutcome, terminalComment } from './item-agent.ts'
 import { err, ok } from './result.ts'
 
+/**
+ * `baselineRepair` is present only when the default branch failed under this
+ * review. It says what the sweep did about that red base.
+ */
 export type ReviewGateRefreshOutcome
-  = | { _tag: 'PublicationQueued', repository: string, pullRequestNumber: number, outcome: ReviewOutcomeName }
-    | { _tag: 'Unchanged', repository: string, pullRequestNumber: number, outcome: ReviewOutcomeName, reason: string }
+  = | { _tag: 'PublicationQueued', repository: string, pullRequestNumber: number, outcome: ReviewOutcomeName, baselineRepair?: BaselineRepairQueueResult }
+    | { _tag: 'Unchanged', repository: string, pullRequestNumber: number, outcome: ReviewOutcomeName, reason: string, baselineRepair?: BaselineRepairQueueResult }
     | { _tag: 'Superseded', repository: string, pullRequestNumber: number }
     | { _tag: 'Retired', repository: string, pullRequestNumber: number, reason: string }
 
 export interface ReviewGateSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot' | 'stampAgentLabel'>
   now: () => Date
+  /** Proves the controller may push a Baseline repair branch to this repository. */
+  preflightRepair: (repository: string, signal: AbortSignal) => Promise<Result<void, string>>
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'recordIncident' | 'recordReviewPublication' | 'resolveIncidents' | 'stageReviewGateStatus'>
+  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'queueBaselineRepairForGate' | 'recordIncident' | 'recordReviewPublication' | 'resolveIncidents' | 'stageReviewGateStatus'>
 }
 
 /**
@@ -64,6 +70,12 @@ export async function refreshReviewGates(
     const outcome = reviewOutcome(gates)
     const confidence = outcome === 'READY' ? review.confidence : undefined
     const body = terminalComment(review.headSha, live.value.pullRequest.baseSha, gates, review.findings, confidence, reportedChecks)
+    // A red default branch holds this review PENDING until someone repairs
+    // it. No review lease exists here, so this is the only place that can
+    // queue that repair. The store answers Existing on every later pass.
+    const baselineRepair = ciCause._tag === 'BaseBranchFailed'
+      ? { baselineRepair: await queueBaselineRepair(options, review, live.value.pullRequest.baseSha, signal) }
+      : {}
     const gatesChanged = JSON.stringify(gates) !== JSON.stringify(review.gates)
     if (!gatesChanged) {
       // Only a gate that did not move can be overdue. A gate that changed this
@@ -113,7 +125,7 @@ export async function refreshReviewGates(
         })
         if (staged._tag === 'Rejected')
           return err(`${review.repository}#${review.pullRequestNumber}: ${staged.reason}`)
-        return ok({ _tag: 'PublicationQueued', repository: review.repository, pullRequestNumber: review.pullRequestNumber, outcome })
+        return ok({ _tag: 'PublicationQueued', repository: review.repository, pullRequestNumber: review.pullRequestNumber, outcome, ...baselineRepair })
       }
       const stamped = await options.github.stampAgentLabel(mapping, review.pullRequestNumber, outcome, signal)
       if (stamped._tag === 'Err')
@@ -125,6 +137,7 @@ export async function refreshReviewGates(
         pullRequestNumber: review.pullRequestNumber,
         outcome,
         reason: unsettled === undefined ? 'The controller gates did not change.' : unsettled.reason,
+        ...baselineRepair,
       })
     }
 
@@ -142,7 +155,7 @@ export async function refreshReviewGates(
     })
     if (staged._tag === 'Rejected')
       return err(`${review.repository}#${review.pullRequestNumber}: ${staged.reason}`)
-    return ok({ _tag: 'PublicationQueued', repository: review.repository, pullRequestNumber: review.pullRequestNumber, outcome })
+    return ok({ _tag: 'PublicationQueued', repository: review.repository, pullRequestNumber: review.pullRequestNumber, outcome, ...baselineRepair })
   }
 
   const results: Array<Result<ReviewGateRefreshOutcome, string>> = []
@@ -150,6 +163,31 @@ export async function refreshReviewGates(
     results.push(await settle(review))
   resolveSettledCiGates(options, signal, unread, stalled)
   return results
+}
+
+/**
+ * Queues the Baseline repair for the red base commit under one review.
+ *
+ * Write access is proved first, because a repository Harlan only watches can
+ * never take a repair branch. The store then binds the repair to the reviewed
+ * Revision and refuses a stack, a moved base, or a policy that forbids it.
+ */
+async function queueBaselineRepair(
+  options: ReviewGateSweepOptions,
+  review: ReviewGateRefresh,
+  baseSha: string,
+  signal: AbortSignal,
+): Promise<BaselineRepairQueueResult> {
+  const access = await options.preflightRepair(review.repository, signal)
+  if (access._tag === 'Err')
+    return { _tag: 'NotAuthorized', reason: access.error }
+  return options.store.queueBaselineRepairForGate({
+    repository: review.repository,
+    pullRequestNumber: review.pullRequestNumber,
+    revisionId: review.revisionId,
+    baseSha,
+    at: options.now().toISOString(),
+  })
 }
 
 /**

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -1009,11 +1009,21 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         const settled = await guarded('Review gate refresh', () => refreshReviewGates({
           github: workerGithub,
           now,
+          preflightRepair: (repository, refreshSignal) => preflightGitHubWriteAccess(tokens, repository, ['contents_write'], refreshSignal),
           repositories: config.repositories,
           store,
         }, signal), [])
         settled.forEach((result) => {
           if (result._tag === 'Ok') {
+            if ((result.value._tag === 'PublicationQueued' || result.value._tag === 'Unchanged') && result.value.baselineRepair !== undefined) {
+              const repair = result.value.baselineRepair
+              const detail = 'reason' in repair
+                ? `no Baseline repair for the red default branch: ${repair.reason}`
+                : repair._tag === 'Queued'
+                  ? `queued Baseline repair ${repair.taskId} for the red default branch.`
+                  : `Baseline repair ${repair.taskId} already covers the red default branch.`
+              options.logger.info(`${result.value.repository}#${result.value.pullRequestNumber}: ${detail}`)
+            }
             if (result.value._tag === 'PublicationQueued')
               options.logger.info(`${result.value.repository}#${result.value.pullRequestNumber}: queued the ${result.value.outcome} Review status.`)
             else if (result.value._tag === 'Superseded')

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -501,6 +501,20 @@ export interface StoppedReview {
 }
 
 /** A published clean Review whose moving controller gates need another read. */
+export type BaselineRepairQueueResult
+  = | { _tag: 'Queued' | 'Existing', taskId: string }
+    | { _tag: 'Rejected', reason: string }
+    | { _tag: 'NotAuthorized', reason: string }
+
+/** The pull request Revision one Baseline repair is queued for. */
+interface BaselineRepairSubjectRow {
+  subject_id: number
+  revision_id: string
+  payload: string
+  policy_json: string
+  github: string
+}
+
 export interface ReviewGateRefresh {
   reviewRunId: string
   repository: string
@@ -725,9 +739,23 @@ export interface JournalStore extends BatchStore {
     fence: number
     baseSha: string
     at: string
-  }) => { _tag: 'Queued' | 'Existing', taskId: string }
-    | { _tag: 'Rejected', reason: string }
-    | { _tag: 'NotAuthorized', reason: string }
+  }) => BaselineRepairQueueResult
+  /**
+   * Queues one Baseline repair from a completed review's gate refresh.
+   *
+   * A review that ended READY keeps its CI gate refreshed without an Agent.
+   * When the default branch turns red under it, nothing held a review lease,
+   * so the review path above could never queue the repair. This path binds
+   * the repair to the reviewed Revision instead, and refuses once that
+   * Revision is no longer the pull request's current one.
+   */
+  queueBaselineRepairForGate: (input: {
+    repository: string
+    pullRequestNumber: number
+    revisionId: string
+    baseSha: string
+    at: string
+  }) => BaselineRepairQueueResult
   /**
    * Retires a dead Baseline repair once a review proves the base is healthy.
    *
@@ -8040,30 +8068,25 @@ export function openJournalStore(
     }, 0)
   }
 
-  const queueBaselineRepairForReview: JournalStore['queueBaselineRepairForReview'] = (input) => {
+  /**
+   * Queues one Baseline repair for the red base commit of one pull request.
+   *
+   * `lookup` names the pull request Revision that authorizes the repair. The
+   * review path binds it to a live review lease; the gate refresh path binds it
+   * to the reviewed Revision that is still current. `missing` is the reason
+   * when the lookup finds nothing.
+   */
+  const queueBaselineRepairForSubject = (
+    lookup: () => BaselineRepairSubjectRow | undefined,
+    missing: string,
+    input: { baseSha: string, at: string },
+  ): BaselineRepairQueueResult => {
     database.exec('BEGIN IMMEDIATE')
     try {
-      const row = database.prepare(`
-        SELECT worker_tasks.subject_id, worker_tasks.revision_id, revisions.payload,
-          repositories.policy_json, repositories.github
-        FROM worker_tasks
-        JOIN subjects ON subjects.id = worker_tasks.subject_id
-        JOIN revisions ON revisions.id = worker_tasks.revision_id
-        JOIN repositories ON repositories.id = subjects.repository_id
-        WHERE worker_tasks.id = ? AND worker_tasks.kind = 'adversarial_review'
-          AND worker_tasks.state_tag = 'Running' AND worker_tasks.worker_id = ?
-          AND worker_tasks.fence = ? AND worker_tasks.lease_expires_at > ?
-          AND repositories.enabled = 1
-      `).get(input.taskId, input.workerId, input.fence, input.at) as {
-        subject_id: number
-        revision_id: string
-        payload: string
-        policy_json: string
-        github: string
-      } | undefined
+      const row = lookup()
       if (row === undefined) {
         database.exec('COMMIT')
-        return { _tag: 'Rejected', reason: 'The active review no longer authorizes Baseline repair.' }
+        return { _tag: 'Rejected', reason: missing }
       }
       const subject = JSON.parse(row.payload) as GitHubItem
       const mapping = JSON.parse(row.policy_json) as RepositoryMapping
@@ -8157,6 +8180,38 @@ export function openJournalStore(
       throw error
     }
   }
+
+  const queueBaselineRepairForReview: JournalStore['queueBaselineRepairForReview'] = input => queueBaselineRepairForSubject(
+    () => database.prepare(`
+      SELECT worker_tasks.subject_id, worker_tasks.revision_id, revisions.payload,
+        repositories.policy_json, repositories.github
+      FROM worker_tasks
+      JOIN subjects ON subjects.id = worker_tasks.subject_id
+      JOIN revisions ON revisions.id = worker_tasks.revision_id
+      JOIN repositories ON repositories.id = subjects.repository_id
+      WHERE worker_tasks.id = ? AND worker_tasks.kind = 'adversarial_review'
+        AND worker_tasks.state_tag = 'Running' AND worker_tasks.worker_id = ?
+        AND worker_tasks.fence = ? AND worker_tasks.lease_expires_at > ?
+        AND repositories.enabled = 1
+    `).get(input.taskId, input.workerId, input.fence, input.at) as BaselineRepairSubjectRow | undefined,
+    'The active review no longer authorizes Baseline repair.',
+    input,
+  )
+
+  const queueBaselineRepairForGate: JournalStore['queueBaselineRepairForGate'] = input => queueBaselineRepairForSubject(
+    () => database.prepare(`
+      SELECT subjects.id AS subject_id, revisions.id AS revision_id, revisions.payload,
+        repositories.policy_json, repositories.github
+      FROM subjects
+      JOIN repositories ON repositories.id = subjects.repository_id
+      JOIN revisions ON revisions.id = subjects.current_revision_id
+      WHERE repositories.github = ? AND subjects.kind = 'pull_request'
+        AND subjects.github_number = ? AND revisions.id = ?
+        AND repositories.enabled = 1
+    `).get(input.repository, input.pullRequestNumber, input.revisionId) as BaselineRepairSubjectRow | undefined,
+    'The reviewed pull request Revision is no longer current.',
+    input,
+  )
 
   const claimNextIssueWorkTask: JournalStore['claimNextIssueWorkTask'] = (workerId, now, leaseMilliseconds) => {
     const task = claimMutationTask('issue_work', workerId, now, leaseMilliseconds)
@@ -13426,6 +13481,7 @@ export function openJournalStore(
     queueReviewFixTaskForReview,
     recordRepairReport,
     queueBaselineRepairForReview,
+    queueBaselineRepairForGate,
     retireBaselineRepairForReview,
     claimNextPublication,
     claimIssueTriageComment,

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -125,4 +125,55 @@ describe('live pull request base', () => {
     expect(checkedRefs).toContain(liveBaseSha)
     expect(checkedRefs).not.toContain(historicBaseSha)
   })
+
+  it('drops base check runs that a workflow_run event attached to the base commit', async () => {
+    const listForRef = () => undefined
+    const listWorkflowRunsForRepo = () => undefined
+    const client = {
+      paginate: (method: unknown, input: { ref?: string, head_sha?: string }) => {
+        if (method === listForRef && input.ref === liveBaseSha) {
+          return Promise.resolve([
+            { id: 1, name: 'comment', status: 'in_progress', conclusion: null, app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 7 } },
+            { id: 2, name: 'test', status: 'completed', conclusion: 'success', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } },
+          ])
+        }
+        if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
+          return Promise.resolve([
+            { id: 70, event: 'workflow_run', check_suite_id: 7 },
+            { id: 80, event: 'push', check_suite_id: 8 },
+          ])
+        }
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'test', status: 'completed', conclusion: 'success' })],
+      },
+    })))
+  })
 })

--- a/packages/harlan-github-agent/test/review-gate-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-gate-sweep.test.ts
@@ -3,7 +3,7 @@ import type { RecordIncidentInput, ReviewGateRefresh } from '../src/store.ts'
 import type { Incident, ReviewGates } from '../src/types.ts'
 import { afterEach, describe, expect, it } from 'vitest'
 import { refreshControllerGates } from '../src/item-agent.ts'
-import { ok } from '../src/result.ts'
+import { err, ok } from '../src/result.ts'
 import { refreshReviewGates } from '../src/review-gate-sweep.ts'
 import { openJournalStore } from '../src/store.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
@@ -83,15 +83,18 @@ interface Recorded {
   failed: Array<{ reviewRunId: string, reason: string }>
   staged: Array<{ reviewRunId: string, outcome: string, ci: string, reconciliationId?: string, body: string }>
   stamped: string[]
+  baselineQueued: Array<{ repository: string, pullRequestNumber: number, revisionId: string, baseSha: string }>
 }
 
 function harness(options: {
   review?: ReviewGateRefresh
   live?: ReturnType<typeof snapshot>
   edit?: () => Promise<any>
+  repairAccess?: string
 }) {
-  const recorded: Recorded = { failed: [], incidents: [], resolved: [], staged: [], stamped: [] }
+  const recorded: Recorded = { baselineQueued: [], failed: [], incidents: [], resolved: [], staged: [], stamped: [] }
   const run = async () => refreshReviewGates({
+    preflightRepair: () => Promise.resolve(options.repairAccess === undefined ? ok(undefined) : err(options.repairAccess)),
     github: {
       getPullRequestReviewSnapshot: () => Promise.resolve(options.live ?? snapshot([check()])),
       editReviewStatus: (_repository, _number, commentId, expectedBody, body) => {
@@ -111,6 +114,10 @@ function harness(options: {
     repositories: [repositoryMapping()],
     store: {
       listReviewGateRefreshes: () => [options.review ?? gateRefresh()],
+      queueBaselineRepairForGate: ({ at: _at, ...input }) => {
+        recorded.baselineQueued.push(input)
+        return { _tag: 'Queued', taskId: 'baseline-1' }
+      },
       recordIncident: (incident) => {
         recorded.incidents.push(incident)
         return { ...incident, id: 'incident-1', occurrences: 1, firstSeenAt: incident.at, lastSeenAt: incident.at } satisfies Incident
@@ -141,6 +148,70 @@ function harness(options: {
 }
 
 describe('refreshReviewGates', () => {
+  it('queues a Baseline repair once the default branch fails under a settled review', async () => {
+    const live = snapshot([check({ name: 'Fuzz fuzz_options', conclusion: 'failure' })])
+    const { recorded, run } = harness({ live })
+
+    const results = await run()
+
+    expect(recorded.baselineQueued).toEqual([{
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: 'revision-1',
+      baseSha: 'base123',
+    }])
+    expect(results).toEqual([ok({
+      _tag: 'PublicationQueued',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      outcome: 'PENDING',
+      baselineRepair: { _tag: 'Queued', taskId: 'baseline-1' },
+    })])
+  })
+
+  it('keeps asking for the Baseline repair while the default branch stays red', async () => {
+    const live = snapshot([check({ name: 'Fuzz fuzz_options', conclusion: 'failure' })])
+    if (live._tag !== 'Ok')
+      throw new Error('Expected a Review snapshot.')
+    const { recorded, run } = harness({
+      live,
+      review: gateRefresh({
+        gates: refreshControllerGates(pendingControllerGates(), live.value, repositoryMapping()).gates,
+      }),
+    })
+
+    const results = await run()
+
+    expect(recorded.baselineQueued).toHaveLength(1)
+    expect(results).toEqual([ok(expect.objectContaining({
+      _tag: 'Unchanged',
+      outcome: 'PENDING',
+      baselineRepair: { _tag: 'Queued', taskId: 'baseline-1' },
+    }))])
+  })
+
+  it('queues no Baseline repair when the controller cannot push to the repository', async () => {
+    const live = snapshot([check({ name: 'Fuzz fuzz_options', conclusion: 'failure' })])
+    const { recorded, run } = harness({ live, repairAccess: 'The installation lacks contents write.' })
+
+    const results = await run()
+
+    expect(recorded.baselineQueued).toEqual([])
+    expect(results).toEqual([ok(expect.objectContaining({
+      baselineRepair: { _tag: 'NotAuthorized', reason: 'The installation lacks contents write.' },
+    }))])
+  })
+
+  it('queues no Baseline repair while the default branch is still running', async () => {
+    const live = snapshot([check({ status: 'in_progress', conclusion: null })])
+    const { recorded, run } = harness({ live })
+
+    const results = await run()
+
+    expect(recorded.baselineQueued).toEqual([])
+    expect(results[0]).toEqual(ok(expect.not.objectContaining({ baselineRepair: expect.anything() })))
+  })
+
   it('turns a review waiting on base branch CI into READY once CI passes', async () => {
     const { recorded, run } = harness({})
 
@@ -426,6 +497,7 @@ describe('refreshReviewGates against the journal store', () => {
 
     const stamped: string[] = []
     const results = await refreshReviewGates({
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot([check()])),
         editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
@@ -525,6 +597,7 @@ describe('refreshReviewGates against the journal store', () => {
     })).toEqual({ _tag: 'Inserted', publicationId: 'publication-pending' })
 
     const results = await refreshReviewGates({
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(snapshot([check()])),
         editReviewStatus: () => Promise.resolve(ok({ _tag: 'Changed' })),
@@ -604,6 +677,7 @@ describe('refreshReviewGates against the journal store', () => {
     expect(store.listReviewGateRefreshes()[0]?.gatesUpdatedAt).toBe('2026-08-26T08:20:00.000Z')
 
     await refreshReviewGates({
+      preflightRepair: () => Promise.resolve(ok(undefined)),
       github: {
         getPullRequestReviewSnapshot: () => Promise.resolve(red),
         editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -2828,6 +2828,70 @@ describe('journal store', () => {
     expect(queued._tag).toBe('Queued')
   })
 
+  it('queues a Baseline repair from a gate refresh of the current pull request Revision', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'baseline-gate-pr',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the pull request Revision.')
+
+    const queued = store.queueBaselineRepairForGate({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      baseSha: 'base123',
+      at: '2026-08-13T01:02:00.000Z',
+    })
+    const again = store.queueBaselineRepairForGate({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      baseSha: 'base123',
+      at: '2026-08-13T01:03:00.000Z',
+    })
+    const repair = store.claimNextBaselineRepairTask('baseline-agent', '2026-08-13T01:04:00.000Z', 600_000)
+
+    expect(queued._tag).toBe('Queued')
+    expect(again).toEqual({ _tag: 'Existing', taskId: queued._tag === 'Queued' ? queued.taskId : '' })
+    expect(repair).toEqual(expect.objectContaining({ kind: 'baseline_repair', pullRequestNumber: 24 }))
+    expect(repair?.pullRequest.baseSha).toBe('base123')
+  })
+
+  it('refuses a gate refresh Baseline repair for a superseded pull request Revision', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const observed = store.recordObservation({
+      externalId: 'baseline-gate-stale-pr',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the pull request Revision.')
+    store.recordObservation({
+      externalId: 'baseline-gate-stale-pr-moved',
+      observedAt: '2026-08-13T01:01:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean', headSha: 'moved-head-commit', updatedAt: '2026-08-13T01:01:00.000Z' }),
+    })
+
+    const queued = store.queueBaselineRepairForGate({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: observed.revisionId,
+      baseSha: 'base123',
+      at: '2026-08-13T01:02:00.000Z',
+    })
+
+    expect(queued).toEqual({ _tag: 'Rejected', reason: 'The reviewed pull request Revision is no longer current.' })
+    expect(store.claimNextBaselineRepairTask('baseline-agent', '2026-08-13T01:04:00.000Z', 600_000)).toBeNull()
+  })
+
   it('reports an external repository as unauthorized rather than rejected', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping({ ownership: 'external' })], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Two stalls on mdream last week had the same root: the agent only queues a Baseline repair from inside a review session.

mdream#227 passed review on 4 Sept. The Monday fuzz schedule then failed on `main`, the gate sweep flipped the PR to PENDING, and nothing queued a repair because no review lease existed. It sat there until I merged the fix by hand.

mdream#226 had a Repair finding, but Repair refused with "The base branch must pass CI before Repair starts" while `main` was green. The base commit's check runs included a `comment` job from the bundle-size workflow. A `workflow_run` event attaches that job to the default branch tip, and it was in progress at snapshot time, so the base gate read running.

The gate sweep now queues one Baseline repair for the exact red base commit, bound to the reviewed Revision. Base checks drop every suite a `workflow_run` event started.

Loose end I did not take: a real in-flight push CI on `main` at Repair preflight still ends the review BLOCKED instead of waiting. The skill says a running base check set refuses Repair, so I left that rule alone.

![Architecture: the gate sweep now queues into the same Baseline repair Task the review path uses, with workflow_run suites filtered before the base gate](https://github.com/user-attachments/assets/88c6e5eb-bdfc-40ec-9602-b9a322c7422a)

![Data flow: a scheduled failure on main under a settled review now ends in a Baseline repair pull request](https://github.com/user-attachments/assets/504adef5-178f-4431-ae44-2b9a18d3d6e8)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01JqqNStmPNiipFpeYeboLUS
