### PR TITLE
docs(context): open a pull request for Markdown too

### DIFF
--- a/agent-context/context.md
+++ b/agent-context/context.md
@@ -96,16 +96,16 @@ My review rate is the bottleneck, not tool limits. Agents prove their own work (
 
 Self-hosted runners run on Hogwild. Never start `harlan-desktop-github-runner.service` on the desktop.
 
-If every task-owned changed file ends in `.md`, commit and push it directly to `origin/main`.
-This applies to repositories I own or maintain. Never create a pull request for Markdown-only work.
-If the direct push fails, stop and report it.
+Every change opens a pull request. A Markdown-only change is no exception.
+Never push to `origin/main` directly.
 Test, build, and deploy workflow events ignore `**/*.md` by default.
 A workflow opts in only when its `paths` list includes Markdown.
 Never combine `paths` and `paths-ignore` on one event.
 
 Use `harlan-agent-auto-merge` only for changes with no judgement.
-Examples include dependencies, formatting, generated files, or comments in non-Markdown files.
-The agent merges those after a READY review. Everything else waits for me.
+Examples include dependencies, formatting, generated files, comments in non-Markdown files, and Markdown that nothing executes, such as a README, docs, or a blog post.
+Never label Markdown an agent reads as instructions: Skills, `agent-context/`, `CLAUDE.md`, `AGENTS.md`, `GLOSSARY.md`, or `.github` templates.
+The agent merges labelled changes after a READY review. Everything else waits for me.
 Unsure means no label. Rules: `harlan-agent-kit/references/auto-merge.md`.
 
 ## Commits

--- a/harlan-agent-kit/references/auto-merge.md
+++ b/harlan-agent-kit/references/auto-merge.md
@@ -11,17 +11,18 @@ The label never changes whether a pull request is reviewed. Automated review run
 Add it for a change with no judgement in it:
 
 - comments or wording inside non-Markdown files, with no behaviour change
+- Markdown that nothing executes: a README, docs, or a blog post
 - dependency bump or lockfile refresh
 - formatting, lint autofix, or generated file refresh
 - changelog or version bump
 
 Never add it for a change a reviewer must judge: source behaviour, public API, configuration, CI workflow, authentication, authorization, payments, data migrations, deletes, or user-visible copy.
 
+Markdown an agent reads as instructions is source behaviour. That covers Skills, `agent-context/`, `CLAUDE.md`, `AGENTS.md`, `GLOSSARY.md`, and `.github` issue or pull request templates. A change there alters what every agent does in every repository, so Harlan merges it.
+
 When unsure, leave it off. A missing label costs one human merge. A wrong label ships an unreviewed change.
 
 Remove the label when a pull request grows past the change it was added for.
-
-Markdown-only work never reaches this policy. The `pr` skill pushes it directly to `origin/main`.
 
 ## Repository scope
 

--- a/harlan-agent-kit/skills/close-off/SKILL.md
+++ b/harlan-agent-kit/skills/close-off/SKILL.md
@@ -84,8 +84,8 @@ Check whether another open pull request uses that branch.
 
 Determine whether deployment, migration, release, smoke verification, or monitoring applies.
 
-For Markdown-only work, verify the exact commit on `origin/main`.
-Expect no CI or deployment unless a workflow event uses `paths` to include that Markdown.
+A Markdown-only pull request runs no CI unless a workflow event uses `paths` to include that Markdown.
+After its merge, verify the merge commit on `origin/main` instead of a green check.
 
 Never infer delivery from a merged pull request or unrelated green check.
 

--- a/harlan-agent-kit/skills/pr/SKILL.md
+++ b/harlan-agent-kit/skills/pr/SKILL.md
@@ -6,24 +6,11 @@ user_invocable: true
 
 Create or update a pull request for the current branch. Idempotent -- safe to run at any stage.
 
-## Markdown-only exception
+## No direct pushes
 
-If every task-owned changed path ends in `.md`, use this exception for a repository Harlan owns or maintains.
-Push the change directly to `origin/main`. Never open a pull request for Markdown-only work.
+Every change opens a pull request. Markdown is no exception: a Skill or instruction file changes agent behaviour in every repository, and a README change still earns a review. Never push to `origin/main` directly.
 
-Before editing, follow the [worktree isolation contract](../../references/worktree-isolation.md). Start from the current `origin/main`.
-
-After editing:
-
-1. Check every task-owned changed path.
-   If one path does not end in `.md`, use the normal pull request workflow below.
-2. Run any checks that cover the changed Markdown.
-3. Commit with a Conventional Commit subject.
-4. Push without force: `git push origin HEAD:main`.
-5. Verify `origin/main` points at the pushed commit.
-
-If the direct push fails, stop and report the refusal. Do not create a pull request as a fallback.
-Do not wait for CI or deployment unless its event uses `paths` to include the changed Markdown.
+A Markdown-only pull request runs no CI unless a workflow event uses `paths` to include that Markdown. Its review is the whole gate, so treat the review outcome as the check.
 
 ## When to invoke
 
@@ -32,7 +19,7 @@ Invoke on intent, not on phrasing. If the next command you are about to run is `
 None of these are reasons to skip it:
 
 - **The user never said "PR".** Once a fix is written and verified, "fix", "ship it", "land this", or a bare "yes" all mean land it. The trigger list in the description is examples, not a required wording.
-- **The change is small.** Except for Markdown-only work above, a one-line fix still needs the repo's template, the AI disclosure, a body with no verification section, and green CI. Size changes none of that.
+- **The change is small.** A one-line fix or a docs edit still needs the repo's template, the AI disclosure, a body with no verification section, and green CI. Size changes none of that.
 - **Invoking costs a turn.** Rewriting a hand-made PR body costs more, and a PR pushed without Step 4 can fail CI in front of a reviewer.
 - **You already ran the git commands.** Then a PR exists and is probably wrong. Re-enter here anyway -- Step 1 detects the existing PR and Step 5 syncs it in place.
 
@@ -246,11 +233,12 @@ Output the PR URL when done. Log to `${CLAUDE_PLUGIN_DATA}/pr-history.log`.
 `harlan-github-agent` reviews every pull request it tracks. Add `harlan-agent-auto-merge` when the change holds no judgement, and the service merges it after a `READY` review:
 
 - comments or wording inside non-Markdown files, with no behaviour change
+- Markdown that nothing executes: a README, docs, or a blog post
 - dependency bump or lockfile refresh
 - formatting, lint autofix, or generated file refresh
 - changelog or version bump
 
-Never add the label to a change a reviewer must judge: source behaviour, public API, configuration, CI workflow, authentication, authorization, payments, data handling, or user-visible copy. When unsure, leave it off. A missing label costs one human merge. A wrong label ships an unreviewed change.
+Never add the label to a change a reviewer must judge: source behaviour, public API, configuration, CI workflow, authentication, authorization, payments, data handling, or user-visible copy. Markdown an agent reads as instructions counts as source behaviour: Skills, `agent-context/`, `CLAUDE.md`, `AGENTS.md`, `GLOSSARY.md`, and `.github` templates. When unsure, leave it off. A missing label costs one human merge. A wrong label ships an unreviewed change.
 
 Read [references/auto-merge.md](../../references/auto-merge.md) for the exact conditions. A repository whose service block sets `auto_merge.pull_requests: every` needs no label; the service merges every trusted pull request there after a `READY` review at that repository's minimum confidence.
 

--- a/harlan-agent-kit/skills/take-ownership/SKILL.md
+++ b/harlan-agent-kit/skills/take-ownership/SKILL.md
@@ -34,8 +34,8 @@ Inspect local Git state and remote state. Select one exact target:
 
 Determine the intended result and applicable CI, merge, deployment, release, and smoke stages.
 
-For a Markdown-only direct push, verify the exact commit on `origin/main`.
-Expect no CI or deployment unless a workflow event uses `paths` to include that Markdown.
+A Markdown-only pull request runs no CI unless a workflow event uses `paths` to include that Markdown.
+After its merge, verify the merge commit on `origin/main` instead of a green check.
 
 Ask only when multiple targets remain plausible or the intended result materially changes the work.
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation

### 📚 Description

The Markdown-only rule let an agent push straight to `main` when every changed file ended in `.md`. It treated the extension as proof the change was inert. In this repository Markdown is the product. Earlier today `044914ba` changed the pr Skill's stacking behaviour for every repository and landed with no review and no CI.

Every change opens a pull request now. Markdown nobody executes, such as a README or a blog post, may carry `harlan-agent-auto-merge` so it still lands without waiting on me. Skills, `agent-context/`, `CLAUDE.md`, `AGENTS.md`, `GLOSSARY.md`, and `.github` templates never get the label.

After merge, `pnpm sync:context` and `pnpm sync:context:hogwild` install the new instructions.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).