### PR TITLE
fix(github-agent): serve the Routines page

### DIFF
--- a/packages/harlan-github-agent/package.json
+++ b/packages/harlan-github-agent/package.json
@@ -58,7 +58,7 @@
     "obuild": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "vue-tsc": "catalog:",
-    "vue": "catalog:"
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/packages/harlan-github-agent/src/app.ts
+++ b/packages/harlan-github-agent/src/app.ts
@@ -30,7 +30,7 @@ export interface AgentAppOptions {
 }
 
 /** Prerendered dashboard routes below `/`, each with its own payload. */
-const DASHBOARD_PAGES = ['history', 'watching', 'flow', 'stats'] as const
+const DASHBOARD_PAGES = ['history', 'watching', 'routines', 'flow', 'stats'] as const
 const EJECT_SETTLEMENT_TIMEOUT_MILLISECONDS = 12_000
 
 const securityHeaders = {

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -550,6 +550,13 @@ describe('dashboard HTTP app', () => {
     expect(await response.text()).toContain('How GitHub work moves through the agent')
   })
 
+  it('serves the Routines page', async () => {
+    const response = await createApp().request(`http://${allowedHost}/routines`, { headers: { authorization, host: allowedHost } })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('Scheduled checks, soonest first.')
+  })
+
   it('serves the skew protection service worker', async () => {
     const response = await createApp().request(`http://${allowedHost}/_nuxt-skew-sw.js`, { headers: { authorization, host: allowedHost } })
 

--- a/packages/harlan-github-agent/test/fixtures/dashboard/routines/index.html
+++ b/packages/harlan-github-agent/test/fixtures/dashboard/routines/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Routines | Harlan GitHub Agent</title>
+  </head>
+  <body>
+    <h1>Routines</h1>
+    <p>Scheduled checks, soonest first.</p>
+  </body>
+</html>


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

After deploying #207, `/routines` on Hogwild answered `Cannot find any route matching` even though the built page was on disk. The service lists the dashboard pages it serves and the new one was not on it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01X5NJ4nAcjsPm7PVtmdDmRS