### PR TITLE
fix(github-agent): read workflow runs with the checks token

### DIFF
--- a/packages/harlan-github-agent/package.json
+++ b/packages/harlan-github-agent/package.json
@@ -58,7 +58,7 @@
     "obuild": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "vue-tsc": "catalog:",
-    "vue": "catalog:"
+    "vue": "catalog:",
+    "vue-tsc": "catalog:"
   }
 }

--- a/packages/harlan-github-agent/src/github-auth.ts
+++ b/packages/harlan-github-agent/src/github-auth.ts
@@ -64,12 +64,16 @@ function repositoryName(repository: string): string {
  * and label call goes through GitHub's Issues API, whatever the Item is. GitHub
  * states the same requirement in its `X-Accepted-GitHub-Permissions` header for
  * those routes.
+ *
+ * `checks_read` carries `actions` because the base gate lists workflow runs
+ * to drop the suites a `workflow_run` event attached to the default branch
+ * tip. Without it GitHub answers 403 and every CI gate reads PENDING.
  */
 function permissions(access: GitHubRepositoryAccess): Record<string, PermissionLevel> {
   if (access === 'read')
     return { contents: 'read', issues: 'read', metadata: 'read', pull_requests: 'read' }
   if (access === 'checks_read')
-    return { checks: 'read', metadata: 'read', statuses: 'read' }
+    return { actions: 'read', checks: 'read', metadata: 'read', statuses: 'read' }
   if (access === 'item_write')
     return { contents: 'read', issues: 'write', metadata: 'read', pull_requests: 'write' }
   if (access === 'workflows_write')

--- a/packages/harlan-github-agent/test/github-auth.test.ts
+++ b/packages/harlan-github-agent/test/github-auth.test.ts
@@ -6,7 +6,7 @@ import { ok } from '../src/result.ts'
 describe('gitHub App authentication', () => {
   it.each([
     ['read', { contents: 'read', issues: 'read', metadata: 'read', pull_requests: 'read' }],
-    ['checks_read', { checks: 'read', metadata: 'read', statuses: 'read' }],
+    ['checks_read', { actions: 'read', checks: 'read', metadata: 'read', statuses: 'read' }],
     ['contents_write', { contents: 'write', metadata: 'read' }],
     ['item_write', { contents: 'read', issues: 'write', metadata: 'read', pull_requests: 'write' }],
     ['workflows_write', { contents: 'write', metadata: 'read', workflows: 'write' }],


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Since the #210 deploy at 09:06 UTC today every CI gate has read PENDING with `Resource not accessible by integration`. The base gate now lists workflow runs, and that route needs the `actions` permission the checks token never asked for. The App itself already holds it on both installations, so this is a token scope fix only.

On skilld.dev that left #171 and #172 stuck at PENDING with clean reviews, and #173 at Action required with a Repair finding nobody could act on. Same on nuxtseo.com and scripts.nuxt.com. The stuck gates should move on the next poll after deploy; no rerun needed.

Second commit fixes the `package.json` key order that has had lint red on `main` since #207, so this PR can go green.

https://claude.ai/code/session_01KAFkmiKfq5fM881KCpQ8bw

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).