### PR TITLE
fix(github-agent): publish fork conflict merges with workflows

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -270,7 +270,12 @@ After the push, invalidate old evidence and run `adversarial-review` again again
 
 Use fenced leases and durable Publication commands for every GitHub write.
 
-Route controller credentials by Repository mapping. Use repository-scoped GitHub App tokens when installed. Use Harlan's authenticated GitHub account only for an explicitly configured maintained repository.
+Route controller credentials by Repository mapping. Use repository-scoped GitHub App tokens when installed.
+For an explicitly configured maintained repository without the App, use Harlan's authenticated GitHub account.
+
+For an approved contributor fork conflict merge containing workflow files, use Harlan's authenticated GitHub account.
+Require the contributor's current permission for maintainer edits and Approval for the exact head commit.
+The controller rechecks the saved commit and both remote branches before pushing.
 
 Mint read and write App tokens separately.
 

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -671,6 +671,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         store,
         publisher: createGitPublicationRemote({
           github,
+          forkWorkflowTokens: gatedTokens(userTokens),
           pullRequests: createGitHubPullRequestPublisher({ tokens, uploadAsset: createUserAssetUploader({ token: signal => userAccess.token(signal) }) }),
           root: controllerRoot,
           tokens,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3511,7 +3511,21 @@ function recordPublicationEvent(database: DatabaseSync, input: {
  */
 const PUBLICATION_AUTHORITY_SQL = `
   (
-    (tasks.kind = 'resolve_conflict' AND json_extract(repositories.policy_json, '$.conflictResolution') = 1)
+    (tasks.kind = 'resolve_conflict' AND json_extract(repositories.policy_json, '$.conflictResolution') = 1
+      AND (
+        EXISTS (
+          SELECT 1 FROM revisions
+          WHERE revisions.id = tasks.revision_id
+            AND lower(json_extract(revisions.payload, '$.headRepository')) = lower(repositories.github)
+        )
+        OR EXISTS (
+          SELECT 1 FROM pull_request_approvals
+          WHERE pull_request_approvals.subject_id = subjects.id
+            AND pull_request_approvals.revision_id = tasks.revision_id
+            AND pull_request_approvals.kind = 'review'
+        )
+      )
+    )
     OR (
       tasks.kind = 'review_fix'
       AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
@@ -5534,6 +5548,57 @@ const publicationDiagramMigration = `
   PRAGMA user_version = 65;
 `
 
+/**
+ * Reuses saved fork merges rejected by the App's workflow permission boundary.
+ * This runs once. The normal publisher rechecks Approval, remote branches,
+ * artifact integrity, and write authority before retrying any saved commit.
+ */
+const forkWorkflowPublicationMigration = `
+  CREATE TEMP TABLE fork_workflow_publications AS
+    SELECT publication_commands.id AS command_id, tasks.id AS task_id,
+      tasks.fence AS task_fence, publication_commands.fence AS publication_fence
+    FROM publication_commands
+    JOIN tasks ON tasks.id = publication_commands.task_id
+    JOIN subjects ON subjects.id = tasks.subject_id
+    JOIN repositories ON repositories.id = subjects.repository_id
+    JOIN revisions ON revisions.id = tasks.revision_id
+    WHERE publication_commands.state_tag = 'Failed' AND tasks.state_tag = 'Failed'
+      AND tasks.reason = publication_commands.reason
+      AND tasks.kind = 'resolve_conflict'
+      AND tasks.revision_id = subjects.current_revision_id
+      AND json_extract(revisions.payload, '$.state') = 'open'
+      AND json_extract(revisions.payload, '$.maintainerCanModify') = 1
+      AND lower(json_extract(revisions.payload, '$.headRepository')) != lower(repositories.github)
+      AND publication_commands.reason LIKE '%refusing to allow a GitHub App to create or update workflow%'
+      AND publication_commands.id = (
+        SELECT latest.id FROM publication_commands latest
+        WHERE latest.task_id = tasks.id ORDER BY latest.updated_at DESC, latest.id DESC LIMIT 1
+      )
+      AND NOT EXISTS (SELECT 1 FROM task_cancellations WHERE task_id = tasks.id)
+      AND NOT EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = subjects.id)
+      AND EXISTS (
+        SELECT 1 FROM pull_request_approvals
+        WHERE subject_id = subjects.id AND revision_id = tasks.revision_id AND kind = 'review'
+      );
+
+  INSERT INTO task_transitions (task_id, from_tag, to_tag, reason, fence, created_at)
+    SELECT task_id, 'Failed', 'Publishing', 'Retry the saved conflict merge with maintainer authentication.',
+      task_fence, strftime('%Y-%m-%dT%H:%M:%fZ', 'now') FROM fork_workflow_publications;
+  INSERT INTO publication_events (command_id, from_tag, to_tag, reason, fence, created_at)
+    SELECT command_id, 'Failed', 'Pending', 'Retry the saved conflict merge with maintainer authentication.',
+      publication_fence, strftime('%Y-%m-%dT%H:%M:%fZ', 'now') FROM fork_workflow_publications;
+
+  UPDATE tasks SET state_tag = 'Publishing', reason = NULL,
+    command_id = (SELECT command_id FROM fork_workflow_publications WHERE task_id = tasks.id),
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    WHERE id IN (SELECT task_id FROM fork_workflow_publications);
+  UPDATE publication_commands SET state_tag = 'Pending', reason = NULL, attempts = 0,
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+    WHERE id IN (SELECT command_id FROM fork_workflow_publications);
+  DROP TABLE fork_workflow_publications;
+  PRAGMA user_version = 66;
+`
+
 const batchMigration = `
   CREATE TABLE IF NOT EXISTS batches (
     id TEXT PRIMARY KEY,
@@ -5904,9 +5969,13 @@ function installSchema(database: DatabaseSync): void {
     const columns = (database.prepare('PRAGMA table_info(publication_commands)').all() as unknown as Array<{ name: string }>)
       .map(column => column.name)
     applyMigration(database, columns.includes('diagram_json') ? 'PRAGMA user_version = 65;' : publicationDiagramMigration)
+    version = 65
+  }
+  if (version === 65) {
+    applyMigration(database, forkWorkflowPublicationMigration)
     return
   }
-  if (version === 65)
+  if (version === 66)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -6519,7 +6588,7 @@ export function openJournalStore(
             SELECT 1
             FROM publication_commands
             JOIN tasks ON tasks.id = publication_commands.task_id
-            WHERE tasks.subject_id = ? AND tasks.kind = 'review_fix'
+            WHERE tasks.subject_id = ? AND tasks.kind IN ('review_fix', 'resolve_conflict')
               AND publication_commands.state_tag = 'Published'
               AND publication_commands.commit_sha = ?
               AND EXISTS (
@@ -10334,6 +10403,7 @@ export function openJournalStore(
         fence: task.task_fence,
         at: input.at,
       })
+      resolveTaskIncidents(database, task.task_id, input.at)
       database.exec('COMMIT')
       return true
     }

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -1223,6 +1223,8 @@ export interface GitPublicationRemoteOptions {
   root: string
   remoteUrl?: (repository: string) => string
   tokens: GitHubTokenProvider
+  /** Maintainer access for approved fork conflict merges containing workflow files. */
+  forkWorkflowTokens?: GitHubTokenProvider
 }
 
 function publicationRemoteUrl(repository: string): string {
@@ -1251,7 +1253,17 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
     const access = changed.stdout.split('\0').some(path => path.startsWith('.github/workflows/'))
       ? 'workflows_write'
       : 'contents_write'
-    const result = await options.tokens.getToken(command.repository, access, signal)
+    // The base repository's App installation cannot update workflow files in
+    // a contributor fork. Use the maintainer account for this exact approved
+    // conflict merge. GitHub and validateAuthority still require fork edits.
+    const forkWorkflowMerge = access === 'workflows_write'
+      && command._tag === 'UpdatePullRequest'
+      && command.taskKind === 'resolve_conflict'
+      && publicationTargetRepository(command).toLowerCase() !== command.repository.toLowerCase()
+    const source = forkWorkflowMerge ? options.forkWorkflowTokens : options.tokens
+    if (source === undefined)
+      return err('Maintainer authentication is required to merge workflow changes into this contributor branch.')
+    const result = await source.getToken(command.repository, access, signal)
     return result._tag === 'Ok' ? ok(result.value.token) : err(result.error.message)
   }
 

--- a/packages/harlan-github-agent/test/fork-publication-recovery.test.ts
+++ b/packages/harlan-github-agent/test/fork-publication-recovery.test.ts
@@ -1,0 +1,158 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, describe, expect, it } from 'vitest'
+import { openJournalStore } from '../src/store.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const directories: string[] = []
+const reason = 'Could not publish the prepared commit: refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission'
+const at = (seconds: number) => new Date(Date.parse('2026-09-07T00:00:00.000Z') + seconds * 1000).toISOString()
+
+afterEach(() => {
+  directories.splice(0).forEach(path => rmSync(path, { recursive: true, force: true }))
+})
+
+function failedForkPublication(failure = reason) {
+  const directory = mkdtempSync(join(tmpdir(), 'fork-publication-recovery-'))
+  directories.push(directory)
+  const path = join(directory, 'state.sqlite')
+  const store = openJournalStore(path)
+  const subject = pullRequestItem({ author: 'contributor', headRepository: 'contributor/example' })
+  store.syncRepositories([repositoryMapping()], at(0))
+  const observed = store.recordObservation({ externalId: 'fork', observedAt: at(1), source: 'poll', subject })
+  if (observed._tag !== 'Inserted')
+    throw new Error('Expected a pull request.')
+  store.approvePullRequest({ repository: subject.repository, pullRequestNumber: subject.number, revisionId: observed.revisionId, kind: 'review', at: at(2) })
+  store.recordObservation({ externalId: 'approved-fork', observedAt: at(3), source: 'poll', subject })
+  const task = store.claimNextConflictTask('agent', at(4), 60_000)
+  if (task === null)
+    throw new Error('Expected conflict resolution.')
+  const staged = store.stagePublication({
+    taskId: task.id,
+    workerId: 'agent',
+    fence: task.state.fence,
+    at: at(5),
+    publication: {
+      _tag: 'UpdatePullRequest',
+      taskKind: 'resolve_conflict',
+      pullRequestNumber: subject.number,
+      expectedHeadSha: subject.headSha,
+      headRef: subject.headRef,
+      baseSha: subject.baseSha,
+      baseRef: 'main',
+      commitSha: 'prepared-merge',
+      artifactRef: 'refs/harlan-github-agent/publications/saved-merge',
+      patchDigest: 'saved-patch',
+      changedFiles: 2,
+    },
+  })
+  if (staged._tag !== 'Staged')
+    throw new Error('Expected a saved merge.')
+  for (let i = 0; i < 3; i++) {
+    const command = store.claimNextPublication('publisher', at(6 + i), 60_000)
+    if (command === null)
+      throw new Error('Expected a publication retry.')
+    store.failPublication({ commandId: command.id, workerId: command.workerId, fence: command.fence, at: at(6 + i), reason: failure })
+  }
+  return { path, store, subject, task, staged }
+}
+
+function rewind(path: string) {
+  const database = new DatabaseSync(path)
+  database.exec('PRAGMA user_version = 65')
+  database.close()
+}
+
+describe('fork workflow publication recovery', () => {
+  it('retries the saved merge once without another Agent turn', () => {
+    const { path, store, staged } = failedForkPublication()
+    store.close()
+    rewind(path)
+    const recovered = openJournalStore(path)
+    expect(recovered.claimNextConflictTask('agent', at(10), 60_000)).toBeNull()
+    const command = recovered.claimNextPublication('publisher', at(10), 60_000)
+    expect(command).toMatchObject({ id: staged.commandId, commitSha: 'prepared-merge', artifactRef: 'refs/harlan-github-agent/publications/saved-merge' })
+    if (command === null)
+      throw new Error('Expected the saved merge.')
+    expect(recovered.authorizePublication({ commandId: command.id, workerId: command.workerId, fence: command.fence, at: at(11) })).toBe(true)
+    recovered.completePublication({ commandId: command.id, workerId: command.workerId, fence: command.fence, at: at(11), evidence: 'Published prepared-merge.' })
+    expect(recovered.listIncidents()).toEqual([])
+    recovered.close()
+    const restarted = openJournalStore(path)
+    expect(restarted.claimNextPublication('publisher', at(12), 60_000)).toBeNull()
+    restarted.close()
+  })
+
+  it.each(['changed head', 'dismissed', 'different failure', 'later failure'] as const)('leaves a %s untouched', (scenario) => {
+    const { path, store, subject } = failedForkPublication(scenario === 'different failure' ? 'Branch protection rejected this push.' : reason)
+    if (scenario === 'changed head')
+      store.recordObservation({ externalId: 'new-head', observedAt: at(9), source: 'poll', subject: { ...subject, headSha: 'contributor-push' } })
+    if (scenario === 'dismissed')
+      store.dismissItem({ repository: subject.repository, itemNumber: subject.number, at: at(9) })
+    store.close()
+    rewind(path)
+    if (scenario === 'later failure') {
+      const database = new DatabaseSync(path)
+      database.prepare('UPDATE tasks SET reason = ? WHERE kind = ?').run('A later repair requires a human decision.', 'resolve_conflict')
+      database.close()
+    }
+    const recovered = openJournalStore(path)
+    expect(recovered.claimNextPublication('publisher', at(10), 60_000)).toBeNull()
+    recovered.close()
+  })
+
+  it('does not renew the retry budget on another restart', () => {
+    const { path, store } = failedForkPublication()
+    store.close()
+    rewind(path)
+    const recovered = openJournalStore(path)
+    for (let i = 0; i < 3; i++) {
+      const command = recovered.claimNextPublication('publisher', at(10 + i), 60_000)
+      if (command === null)
+        throw new Error('Expected the bounded publication retry.')
+      recovered.failPublication({ commandId: command.id, workerId: command.workerId, fence: command.fence, at: at(10 + i), reason })
+    }
+    recovered.close()
+    const restarted = openJournalStore(path)
+    expect(restarted.claimNextPublication('publisher', at(15), 60_000)).toBeNull()
+    expect(restarted.claimNextConflictTask('agent', at(15), 60_000)).toBeNull()
+    restarted.close()
+  })
+
+  it('requires exact Approval when it claims a saved fork merge', () => {
+    const { path, store } = failedForkPublication()
+    store.close()
+    rewind(path)
+    const recovered = openJournalStore(path)
+    recovered.close()
+    // Represents authority revoked after migration, before the publisher runs.
+    const database = new DatabaseSync(path)
+    database.exec('DELETE FROM pull_request_approvals')
+    database.close()
+    const restarted = openJournalStore(path)
+    expect(restarted.claimNextPublication('publisher', at(15), 60_000)).toBeNull()
+    restarted.close()
+  })
+
+  it('carries Approval only to the conflict merge the controller published', () => {
+    const { path, store, subject } = failedForkPublication()
+    store.close()
+    rewind(path)
+    const recovered = openJournalStore(path)
+    const command = recovered.claimNextPublication('publisher', at(10), 60_000)
+    if (command === null)
+      throw new Error('Expected the saved merge.')
+    recovered.completePublication({ commandId: command.id, workerId: command.workerId, fence: command.fence, at: at(11), evidence: 'Published prepared-merge.' })
+    recovered.recordObservation({ externalId: 'published-head', observedAt: at(12), source: 'poll', subject: { ...subject, headSha: command.commitSha, mergeState: 'clean' } })
+    const approval = () => {
+      const item = recovered.getDashboardSnapshot(at(13)).items.find(item => item.repository === subject.repository && item.number === subject.number)
+      return item?.kind === 'pull_request' ? item.approval : undefined
+    }
+    expect(approval()).toMatchObject({ _tag: 'ReviewApproved' })
+    recovered.recordObservation({ externalId: 'unapproved-head', observedAt: at(14), source: 'poll', subject: { ...subject, headSha: 'unrelated-push', mergeState: 'clean' } })
+    expect(approval()).toMatchObject({ _tag: 'ReviewRequired' })
+    recovered.close()
+  })
+})

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -5,7 +5,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { ok } from '../src/result.ts'
+import { err, ok } from '../src/result.ts'
 import { createGitPublicationRemote } from '../src/worktree.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 
@@ -93,6 +93,74 @@ function fixture(changedPath = 'base.txt'): { bare: string, checkout: string, co
 }
 
 describe('git publication remote', () => {
+  it.each([
+    ['fork workflow merge', 'contributor/example', '.github/workflows/ci.yml', 'maintainer'],
+    ['fork source merge', 'contributor/example', 'base.txt', 'app'],
+    ['owned workflow merge', 'harlan-zw/example', '.github/workflows/ci.yml', 'app'],
+  ])('publishes a %s with the permitted account', async (_scenario, headRepository, changedPath, account) => {
+    const { bare, command, root } = fixture(changedPath)
+    const conflict = { ...command, headRepository }
+    const requested: string[] = []
+    const provider = (name: string) => ({
+      getToken: () => {
+        requested.push(name)
+        return name === account
+          ? Promise.resolve(ok({ token: 'unused', expiresAt: '2026-08-13T02:00:00.000Z' }))
+          : Promise.resolve(err({ repository: command.repository, message: 'This account cannot publish the change.' }))
+      },
+      invalidate: () => undefined,
+    })
+    const remote = createGitPublicationRemote({
+      github: {
+        getPullRequest: () => Promise.resolve(ok(pullRequestItem({
+          number: 1,
+          headSha: command.expectedHeadSha,
+          headRepository,
+          headRef: command.headRef,
+          maintainerCanModify: true,
+        }))),
+        hasOpenPullRequestForBranch: () => Promise.resolve(ok(false)),
+        isBranchProtected: () => Promise.resolve(ok(false)),
+      },
+      remoteUrl: () => bare,
+      root,
+      tokens: provider('app'),
+      forkWorkflowTokens: provider('maintainer'),
+    })
+    const signal = new AbortController().signal
+
+    expect(await remote.validateAuthority(conflict, signal)).toEqual(ok(undefined))
+    expect(await remote.push(conflict, signal)).toEqual(ok(undefined))
+    expect(git(bare, 'rev-parse', 'refs/heads/fix/conflict')).toBe(command.commitSha)
+    expect(requested).toEqual([account, account])
+  })
+
+  it('refuses a fork workflow merge after the contributor disables maintainer edits', async () => {
+    const { bare, command, root } = fixture('.github/workflows/ci.yml')
+    const conflict = { ...command, headRepository: 'contributor/example' }
+    const remote = createGitPublicationRemote({
+      github: {
+        getPullRequest: () => Promise.resolve(ok(pullRequestItem({
+          number: 1,
+          headSha: command.expectedHeadSha,
+          headRepository: conflict.headRepository,
+          headRef: command.headRef,
+          maintainerCanModify: false,
+        }))),
+        hasOpenPullRequestForBranch: () => Promise.resolve(ok(false)),
+        isBranchProtected: () => Promise.resolve(ok(false)),
+      },
+      remoteUrl: () => bare,
+      root,
+      tokens: { getToken: () => Promise.reject(new Error('No write credential is permitted.')), invalidate: () => undefined },
+      forkWorkflowTokens: { getToken: () => Promise.reject(new Error('No maintainer credential is permitted.')), invalidate: () => undefined },
+    })
+
+    expect(await remote.validateAuthority(conflict, new AbortController().signal))
+      .toEqual(err('The pull request no longer authorizes publication.'))
+    expect(git(bare, 'rev-parse', 'refs/heads/fix/conflict')).toBe(command.expectedHeadSha)
+  })
+
   it.each([
     ['a source patch', 'base.txt', 'contents_write'],
     ['a workflow patch', '.github/workflows/ci.yml', 'workflows_write'],

--- a/packages/harlan-github-agent/test/store-migration.test.ts
+++ b/packages/harlan-github-agent/test/store-migration.test.ts
@@ -635,7 +635,6 @@ describe('gitHub vocabulary migration', () => {
 
     const database = new DatabaseSync(path)
     try {
-      expect((database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version).toBe(65)
       // The old words must be gone from the rows and from the constraints.
       expect(database.prepare(`SELECT count(*) AS total FROM worker_tasks WHERE state_tag = 'NeedsAttention'`).get())
         .toEqual({ total: 0 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

GitHub rejected four mdream conflict fixes because they included workflow files in contributor forks. Approved conflict merges now use the maintainer account when they include workflow files. Saved merges retry once, and Approval follows only the published commit into fresh Review.

![Approved fork conflict merges use the maintainer account and retain Approval for fresh Review.](https://github.com/user-attachments/assets/55dfb697-95b5-43ad-bccf-b4bf78fd4ac8)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
