### PR TITLE
fix(github-agent): keep a Running review whose own run just landed

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4053,13 +4053,15 @@ function supersedeWorkerTasks(
   at: string,
   reason: string,
   exceptRevisionId?: string,
+  keepRunningRevisionId?: string,
 ): void {
   const rows = database.prepare(`
     SELECT id, state_tag, fence FROM worker_tasks
     WHERE subject_id = ? AND kind = ?
       AND state_tag IN ('Queued', 'ActionRequired', 'Running', 'Failed')
       AND (? IS NULL OR revision_id != ?)
-  `).all(subjectId, kind, exceptRevisionId ?? null, exceptRevisionId ?? null) as unknown as Array<{
+      AND NOT (? IS NOT NULL AND state_tag = 'Running' AND revision_id = ? AND lease_expires_at > ?)
+  `).all(subjectId, kind, exceptRevisionId ?? null, exceptRevisionId ?? null, keepRunningRevisionId ?? null, keepRunningRevisionId ?? null, at) as unknown as Array<{
     id: string
     state_tag: 'Queued' | 'ActionRequired' | 'Running' | 'Failed'
     fence: number
@@ -4289,6 +4291,11 @@ function planAdversarialReview(
   }
 
   if (!eligible) {
+    // A worker records its run, then publishes the comment. A poll between
+    // the two reads the head as reviewed because of that very run, so the
+    // Running Task on this revision keeps its worker and completes itself,
+    // while its lease is live. Anything else waiting on the head is done for.
+    const ownRunLanded = alreadyReviewed && localAttempt.head_review_run_id !== null
     supersedeWorkerTasks(
       database,
       subjectId,
@@ -4297,6 +4304,8 @@ function planAdversarialReview(
       alreadyReviewed
         ? 'The current head commit already has an automated review.'
         : 'The pull request is not ready for review.',
+      undefined,
+      ownRunLanded ? revisionId : undefined,
     )
     return
   }

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4069,6 +4069,55 @@ describe('journal store', () => {
     expect(store.findCurrentPolicyReviewRun(first.repository, first.pullRequestNumber, first.pullRequest.headSha)).toBeNull()
   })
 
+  it('keeps a Running Review whose own run just landed through the next poll', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.recordObservation({
+      externalId: 'running-review-first',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    const task = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:01:00.000Z', 3_600_000)
+    if (task === null)
+      throw new Error('Expected the Review Task.')
+    store.recordReviewRun({
+      id: 'landed-run',
+      repository: task.repository,
+      pullRequestNumber: task.pullRequestNumber,
+      revisionId: task.revisionId,
+      headSha: task.pullRequest.headSha,
+      provider: 'codex',
+      sessionId: 'landed-session',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:01:00.000Z',
+      completedAt: '2026-08-13T01:10:00.000Z',
+      gates: passedReviewGates(),
+      confidence: 95,
+      findings: [],
+    })
+
+    // The worker records its run, then publishes. A poll between the two
+    // reads the head as reviewed and must not take the Task from that worker.
+    store.recordObservation({
+      externalId: 'running-review-poll',
+      observedAt: '2026-08-13T01:10:01.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+
+    expect(store.completeWorkerTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:10:02.000Z',
+      evidence: 'landed-run',
+    })).toBe(true)
+  })
+
   it('releases a review after its completed Baseline repair becomes stale', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

A review worker records its run, then publishes the comment. When a poll lands in that one-second window it reads the head as already reviewed, because of that very run, and supersedes the Running task before it publishes. The findings are stored but never posted, the comment stays at `REVIEWING`, and no Repair queues. skilld.dev#173 hit it today; the Hogwild journal shows 44 such losses since 14 Aug.

```
10:10:14.190  review run 3d934a38 completed   outcome Blocked, 1 Repair finding
10:10:15.563  task 6dbd6f17 Running → Superseded  The current head commit already has an automated review.
```

The planner now leaves a Running task on the current revision alone while its lease is live. A task whose worker has died still gets superseded, as before.

https://claude.ai/code/session_01KAFkmiKfq5fM881KCpQ8bw

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).