### PR TITLE
fix(github-agent): digest only the policy a Review verdict depends on

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -2459,6 +2459,25 @@ function digest(value: string): string {
   return createHash('sha256').update(value).digest('hex')
 }
 
+/**
+ * The repository policy a stored Review verdict depends on.
+ *
+ * A change here starts a fresh Review of every open pull request, so this
+ * names only the fields the Review gates and Repair authority read. Digesting
+ * the whole mapping sent the fleet back through Review whenever a field was
+ * added for something else, as Auto merge scope did.
+ */
+export function reviewPolicyDigest(mapping: RepositoryMapping): string {
+  return digest(JSON.stringify({
+    github: mapping.github,
+    authentication: mapping.authentication,
+    ownership: mapping.ownership,
+    defaultBranch: mapping.defaultBranch,
+    writablePullRequestAuthors: mapping.writablePullRequestAuthors,
+    writablePullRequestHeadPrefixes: mapping.writablePullRequestHeadPrefixes,
+  }))
+}
+
 function inferredClosureObservationId(subject: Pick<GitHubItem, 'repository' | 'kind' | 'number'>, observedAt: string): string {
   return digest(`poll-closure:${subject.repository}:${subject.kind}:${subject.number}:${observedAt}`)
 }
@@ -4200,7 +4219,7 @@ function planAdversarialReview(
     revisionId,
     subjectId,
     subject.kind === 'pull_request' ? subject.headSha : '',
-    digest(JSON.stringify(mapping)),
+    reviewPolicyDigest(mapping),
   ) as {
     any_attempt: number
     revision_attempt: number
@@ -6304,8 +6323,7 @@ export function openJournalStore(
     try {
       database.prepare('UPDATE repositories SET enabled = 0').run()
       repositories.forEach((mapping) => {
-        const policy = JSON.stringify(mapping)
-        statement.run(mapping.github, policy, digest(policy), mapping.enabled ? 1 : 0, mapping.ownership)
+        statement.run(mapping.github, JSON.stringify(mapping), reviewPolicyDigest(mapping), mapping.enabled ? 1 : 0, mapping.ownership)
       })
       const unauthorized = database.prepare(`
         SELECT tasks.id, tasks.kind, tasks.state_tag, tasks.fence, tasks.subject_id
@@ -7306,7 +7324,7 @@ export function openJournalStore(
       return { _tag: 'Rejected', reason: { _tag: 'ReviewApprovalRequired' } }
 
     const runUsage: AgentTokenUsage = input.usage ?? { _tag: 'Unavailable' }
-    const policyDigest = input.policyDigest ?? digest(revision.policy_json)
+    const policyDigest = input.policyDigest ?? reviewPolicyDigest(JSON.parse(revision.policy_json) as RepositoryMapping)
     const gates = JSON.stringify(input.gates)
     const findings = JSON.stringify(input.findings)
     const usage = JSON.stringify(runUsage)
@@ -7440,7 +7458,7 @@ export function openJournalStore(
       return { _tag: 'Rejected', reason: { _tag: 'ReviewApprovalRequired' } }
 
     const runUsage: AgentTokenUsage = input.usage ?? { _tag: 'Unavailable' }
-    const policyDigest = input.policyDigest ?? digest(revision.policy_json)
+    const policyDigest = input.policyDigest ?? reviewPolicyDigest(JSON.parse(revision.policy_json) as RepositoryMapping)
     const gates = JSON.stringify(input.gates)
     const findings = JSON.stringify(input.findings)
     const usage = JSON.stringify(runUsage)

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4021,6 +4021,59 @@ describe('journal store', () => {
       .toEqual(expect.objectContaining({ id: first.id }))
   })
 
+  it('keeps the stored Review when only Auto merge scope changes', () => {
+    const store = createStore()
+    const initialPolicy = repositoryMapping()
+    store.syncRepositories([initialPolicy], '2026-08-13T00:00:00.000Z')
+    store.recordObservation({
+      externalId: 'review-before-auto-merge-change',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+    const first = store.claimNextAdversarialReviewTask('reviewer-1', '2026-08-13T01:01:00.000Z', 3_600_000)
+    if (first === null)
+      throw new Error('Expected the first Review.')
+    store.recordReviewRun({
+      id: 'auto-merge-scope-review',
+      repository: first.repository,
+      pullRequestNumber: first.pullRequestNumber,
+      revisionId: first.revisionId,
+      headSha: first.pullRequest.headSha,
+      provider: 'codex',
+      sessionId: 'auto-merge-scope-session',
+      model: 'gpt-5.6',
+      agentVersion: '1.2.3',
+      skillDigest: 'f'.repeat(64),
+      startedAt: '2026-08-13T01:01:00.000Z',
+      completedAt: '2026-08-13T01:02:00.000Z',
+      gates: passedReviewGates(),
+      confidence: 95,
+      findings: [],
+    })
+    store.completeWorkerTask({
+      taskId: first.id,
+      workerId: first.state.workerId,
+      fence: first.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      evidence: 'auto-merge-scope-review',
+    })
+
+    // Auto merge reads a verdict; it does not change one. A wider scope must
+    // not send every open pull request back through Review.
+    store.syncRepositories([{ ...initialPolicy, autoMerge: { _tag: 'Every', minimumConfidence: 90 } }], '2026-08-13T02:00:00.000Z')
+    store.recordObservation({
+      externalId: 'review-after-auto-merge-change',
+      observedAt: '2026-08-13T02:00:01.000Z',
+      source: 'poll',
+      subject: pullRequestItem({ mergeState: 'clean' }),
+    })
+
+    expect(store.claimNextAdversarialReviewTask('reviewer-2', '2026-08-13T02:01:00.000Z', 10_000)).toBeNull()
+    expect(store.findCurrentPolicyReviewRun(first.repository, first.pullRequestNumber, first.pullRequest.headSha))
+      .toEqual(expect.objectContaining({ id: 'auto-merge-scope-review' }))
+  })
+
   it('stops counting a stored Review run once trusted repository policy changes', () => {
     const store = createStore()
     const initialPolicy = repositoryMapping()
@@ -4061,7 +4114,10 @@ describe('journal store', () => {
     expect(store.findCurrentPolicyReviewRun(first.repository, first.pullRequestNumber, first.pullRequest.headSha))
       .toEqual(expect.objectContaining({ id: 'policy-scope-review' }))
 
-    store.syncRepositories([{ ...initialPolicy, autoMerge: { _tag: 'Every', minimumConfidence: 90 } }], '2026-08-13T02:00:00.000Z')
+    store.syncRepositories([{
+      ...initialPolicy,
+      writablePullRequestHeadPrefixes: [...initialPolicy.writablePullRequestHeadPrefixes, 'refactor/'],
+    }], '2026-08-13T02:00:00.000Z')
 
     // The planner requeues this head for a fresh Review. A worker that still
     // resumed the stored run would complete without new evidence, and the


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

A stored Review counts only while its policy digest matches the repository's. That digest covered the whole mapping, so adding a field for anything else, as #211 did with Auto merge scope, invalidated every stored review and sent the fleet back through Review at the next restart. #215 stopped the requeue loop that followed; this stops the cause.

The digest now covers the fields a verdict and its Repair authority actually depend on: repository identity, authentication, ownership, default branch, writable authors, and writable head prefixes. Toggling `enabled` or `pullRequestReview` is checked on every poll already, so neither belongs in it.

One-off cost: existing scopes miss the new digest once, so expect one fresh review per open pull request after deploy. After that, only a change to one of those six fields re-reviews.

https://claude.ai/code/session_01KAFkmiKfq5fM881KCpQ8bw

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).