### PR TITLE
fix(github-agent): review afresh past its own stale comment

### DIFF
--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -90,7 +90,7 @@ export interface ItemAgentOptions {
 export interface ReviewWorkerOptions extends Omit<ItemAgentOptions, 'workspaces'> {
   preflightRepair: (repository: string, signal: AbortSignal) => Promise<Result<void, string>>
   pullRequestTriage?: PullRequestTriageAgent
-  store: Pick<JournalStore, 'getRepairedHeadFindings' | 'getWorkerSession' | 'findCurrentPolicyReviewRun' | 'queueReviewFixTaskForReview' | 'recordIncident' | 'recordPullRequestTriageRun' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'supersedeReviewRun' | 'updateAgentProgress'>
+  store: Pick<JournalStore, 'getRepairedHeadFindings' | 'getWorkerSession' | 'storedReviewForHead' | 'queueReviewFixTaskForReview' | 'recordIncident' | 'recordPullRequestTriageRun' | 'recordReviewRun' | 'recordReviewPublication' | 'saveWorkerSession' | 'queueBaselineRepairForReview' | 'retireBaselineRepairForReview' | 'supersedeReviewRun' | 'updateAgentProgress'>
   workspaces: Pick<AgentWorkspaceManager, 'prepareIssue' | 'prepareReview' | 'verifyReview'>
 }
 
@@ -1152,12 +1152,13 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       if (checksLostRunner(snapshot.value.checks) || checksLostRunner(snapshot.value.baseChecks))
         recordRunnerLostIncident(options, task.repository)
 
+      const stored = task.rerun._tag === 'NotRequested' && !manualReview
+        ? options.store.storedReviewForHead(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
+        : { _tag: 'None' as const }
       // A later fence resumes the stored run, unless repository policy moved
       // since it ran: then the planner asked for a fresh Review, and resuming
       // would only requeue the same run on every poll.
-      const storedRun = task.state.fence > 1 && task.rerun._tag === 'NotRequested' && !manualReview
-        ? options.store.findCurrentPolicyReviewRun(task.repository, task.pullRequestNumber, task.pullRequest.headSha) ?? undefined
-        : undefined
+      const storedRun = task.state.fence > 1 && stored._tag === 'Current' ? stored.run : undefined
       if (storedRun !== undefined) {
         const repairAccess = await options.preflightRepair(task.repository, signal)
         const repairsBaseline = snapshot.value.pullRequest.purpose._tag === 'BaselineRepair'
@@ -1172,7 +1173,10 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         )
       }
 
-      if (snapshot.value.priorAutomatedReview._tag === 'Found' && snapshot.value.priorAutomatedReview.state === 'complete' && task.rerun._tag === 'NotRequested' && !manualReview) {
+      // A complete comment stands in for a Review only when this service never
+      // reviewed the head. Its own comment under an older policy is what the
+      // planner queued this fresh Review to replace.
+      if (stored._tag === 'None' && snapshot.value.priorAutomatedReview._tag === 'Found' && snapshot.value.priorAutomatedReview.state === 'complete' && task.rerun._tag === 'NotRequested' && !manualReview) {
         return ok({
           evidence: `Existing automated review by @${snapshot.value.priorAutomatedReview.authorLogin}: ${snapshot.value.priorAutomatedReview.url}`,
           resolution: { _tag: 'ExistingReview', url: snapshot.value.priorAutomatedReview.url },

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -93,6 +93,7 @@ import type {
   SelectionMode,
   ServiceUpdateStatus,
   StoredAgentControl,
+  StoredReviewForHead,
   SupersedeReviewRunInput,
   SupersedeReviewRunResult,
   TaskState,
@@ -1003,11 +1004,8 @@ export interface JournalStore extends BatchStore {
     at: string
   }) => boolean
   listReviewRuns: (repository: string, pullRequestNumber: number) => ReviewRun[]
-  /**
-   * The newest Review run for one head commit whose evidence was recorded
-   * under the repository's current policy, or null when policy moved since.
-   */
-  findCurrentPolicyReviewRun: (repository: string, pullRequestNumber: number, headSha: string) => ReviewRun | null
+  /** What this service already holds for one head commit. */
+  storedReviewForHead: (repository: string, pullRequestNumber: number, headSha: string) => StoredReviewForHead
   /** Replaces one person's explicit judgment about one Review run. */
   recordAgentFeedback: (input: { reviewRunId: string, feedback: AgentFeedbackInput, at: string }) => RecordAgentFeedbackResult
   /** Newest explicit judgments with the Review evidence needed by the feedback Routine. */
@@ -7717,26 +7715,33 @@ export function openJournalStore(
   }
 
   // The planner requeues a reviewed head when no evidence scope carries the
-  // repository's current policy digest. A worker that then resumed the old run
-  // completed with no new scope, and the planner requeued it on every poll.
-  // Only a run recorded under the current policy is worth resuming.
-  const findCurrentPolicyReviewRun: JournalStore['findCurrentPolicyReviewRun'] = (repository, pullRequestNumber, headSha) => {
+  // repository's current policy digest. A worker that then resumed the old
+  // run, or accepted its comment on GitHub as an existing review, completed
+  // with no new scope, and the planner requeued it on every poll. Only a run
+  // recorded under the current policy is worth resuming, and only a head this
+  // service never reviewed may lean on another actor's comment.
+  const storedReviewForHead: JournalStore['storedReviewForHead'] = (repository, pullRequestNumber, headSha) => {
     const row = database.prepare(`
-      SELECT review_runs.id
+      SELECT
+        review_runs.id,
+        EXISTS (
+          SELECT 1 FROM review_evidence_scopes
+          WHERE review_evidence_scopes.review_run_id = review_runs.id
+            AND review_evidence_scopes.policy_digest = repositories.policy_digest
+        ) AS current
       FROM review_runs
       JOIN subjects ON subjects.id = review_runs.subject_id
       JOIN repositories ON repositories.id = subjects.repository_id
-      JOIN review_evidence_scopes ON review_evidence_scopes.review_run_id = review_runs.id
       WHERE repositories.github = ? AND subjects.github_number = ?
         AND subjects.kind = 'pull_request' AND review_runs.kind = 'adversarial_review'
         AND review_runs.head_sha = ?
-        AND review_evidence_scopes.policy_digest = repositories.policy_digest
-      ORDER BY review_runs.completed_at DESC, review_runs.id DESC
+      ORDER BY current DESC, review_runs.completed_at DESC, review_runs.id DESC
       LIMIT 1
-    `).get(repository, pullRequestNumber, headSha) as { id: string } | undefined
+    `).get(repository, pullRequestNumber, headSha) as { id: string, current: number } | undefined
     if (row === undefined)
-      return null
-    return listReviewRuns(repository, pullRequestNumber).find(run => run.id === row.id) ?? null
+      return { _tag: 'None' }
+    const run = row.current === 1 ? listReviewRuns(repository, pullRequestNumber).find(candidate => candidate.id === row.id) : undefined
+    return run === undefined ? { _tag: 'Stale' } : { _tag: 'Current', run }
   }
 
   const listReviewRuns: JournalStore['listReviewRuns'] = (repository, pullRequestNumber) => {
@@ -13622,7 +13627,7 @@ export function openJournalStore(
     getRepairedHeadFindings,
     listAgentFeedback,
     listReviewRuns,
-    findCurrentPolicyReviewRun,
+    storedReviewForHead,
     recordAgentFeedback,
     needsAttentionTask,
     requestRestart,

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -395,6 +395,20 @@ export interface ReviewRun {
 }
 
 /** One explicit answer for every successfully completed Review Task. */
+/**
+ * What this service already holds for one head commit, from a worker's view.
+ *
+ * `Current` was recorded under the repository's current policy and may be
+ * resumed. `Stale` predates that policy: the planner queued a fresh Review to
+ * replace it, so neither it nor its comment on GitHub may stand in. `None`
+ * means this service never reviewed the head, so a complete comment from
+ * another actor may.
+ */
+export type StoredReviewForHead
+  = | { _tag: 'Current', run: ReviewRun }
+    | { _tag: 'Stale' }
+    | { _tag: 'None' }
+
 export type ReviewResolution
   = | { _tag: 'Reviewed', reviewRunId: string }
     | { _tag: 'ReviewSkipped', reason: string }

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -89,7 +89,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A clean review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -249,7 +249,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A clean Review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: (run) => {
@@ -461,7 +461,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A second review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -508,6 +508,95 @@ describe('subject Workers', () => {
     })
     expect(capture.requests).toEqual([])
     expect(workspaceCreated).toBe(false)
+  })
+
+  it('reviews afresh when its own comment predates the current policy', async () => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    let workspaceCreated = false
+    const capture: ProviderCapture = { requests: [] }
+    const worker = createReviewWorker({
+      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([], capture)),
+      github: {
+        consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
+        ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
+        clearAgentLabels: () => Promise.reject(new Error('Unexpected label clear.')),
+        clearRunningLabel: () => Promise.reject(new Error('Unexpected Running label clear.')),
+        listRunningLabelledItems: () => Promise.reject(new Error('Unexpected Running label read.')),
+        stampAgentLabel: () => Promise.resolve(ok(undefined)),
+        findOpenPullRequestForBranch: () => Promise.reject(new Error('Unexpected pull request lookup.')),
+        getFailedJobContext: () => Promise.reject(new Error('Unexpected job log read.')),
+        getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
+        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
+        listPullRequestFiles: () => Promise.resolve(ok([])),
+        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
+          body: 'Fixes the bug.',
+          checks: { _tag: 'Available', checks: [] },
+          comments: [],
+          priorAutomatedReview: {
+            _tag: 'Found',
+            authorLogin: 'harlan-zw',
+            state: 'complete',
+            url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+          },
+          pullRequest,
+          requiredChecks: { _tag: 'None' as const },
+          reviews: [],
+        })),
+        upsertIssueTriageComment: () => Promise.reject(new Error('Review must not post issue triage.')),
+        upsertReviewStatus: () => Promise.reject(new Error('A second comment must not be posted.')),
+      },
+      now: () => new Date('2026-08-13T01:00:00.000Z'),
+      preflightRepair: () => Promise.resolve(ok(undefined)),
+      store: {
+        queueReviewFixTaskForReview: () => { throw new Error('A second review must not queue Repair work.') },
+        getRepairedHeadFindings: () => [],
+        getWorkerSession: () => null,
+        storedReviewForHead: () => ({ _tag: 'Stale' }),
+        supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
+        recordIncident: () => { throw new Error('Unexpected Incident.') },
+        recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
+        queueBaselineRepairForReview: () => { throw new Error('A second review must not queue Baseline repair.') },
+        retireBaselineRepairForReview: () => 0,
+        saveWorkerSession: () => undefined,
+        updateAgentProgress: () => true,
+        recordReviewRun: () => { throw new Error('A second review must not be recorded.') },
+        recordReviewPublication: () => { throw new Error('A second comment must not be recorded.') },
+      },
+      status: {
+        publish: () => Promise.resolve(ok({ commentId: 42, url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' })),
+      },
+      triageStatus: { publish: () => Promise.reject(new Error('Review must not publish issue triage.')) },
+      workspaces: {
+        prepareIssue: () => Promise.reject(new Error('Unexpected issue workspace.')),
+        prepareReview: () => {
+          workspaceCreated = true
+          return Promise.resolve(err('Stopped at the worktree on purpose.'))
+        },
+        verifyReview: () => Promise.reject(new Error('A second Review must not verify a worktree.')),
+      },
+    })
+
+    const result = await worker.run({
+      id: 'review-task',
+      kind: 'adversarial_review',
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: 'revision-1',
+      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
+      updatedAt: '2026-08-13T01:00:00.000Z',
+      repositoryMapping: repositoryMapping(),
+      pullRequest,
+      rerun: { _tag: 'NotRequested' },
+    }, new AbortController().signal)
+
+    // The complete comment on GitHub is this service's own, written under an
+    // older policy. The planner queued a fresh Review to replace it, so the
+    // worker must head for a worktree instead of resolving ExistingReview.
+    expect(result).toEqual(err('Stopped at the worktree on purpose.'))
+    expect(capture.requests).toEqual([])
+    expect(workspaceCreated).toBe(true)
   })
 
   it('queues every structured finding without changing the Review worktree', async () => {
@@ -566,7 +655,7 @@ describe('subject Workers', () => {
         },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -684,7 +773,7 @@ describe('subject Workers', () => {
         },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -789,7 +878,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A wrong premise must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -907,7 +996,7 @@ describe('subject Workers', () => {
           }]
         },
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -990,7 +1079,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('Base CI failure must prevent Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -1084,7 +1173,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -1175,7 +1264,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
@@ -1262,7 +1351,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('No Repair is needed.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        findCurrentPolicyReviewRun: () => null,
+        storedReviewForHead: () => ({ _tag: 'None' }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },

--- a/packages/harlan-github-agent/test/required-checks.test.ts
+++ b/packages/harlan-github-agent/test/required-checks.test.ts
@@ -79,7 +79,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], requiredChecks: Required
       queueReviewFixTaskForReview: () => { throw new Error('Unexpected Repair queue.') },
       getRepairedHeadFindings: () => [],
       getWorkerSession: () => null,
-      findCurrentPolicyReviewRun: () => null,
+      storedReviewForHead: () => ({ _tag: 'None' }),
       supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
       recordIncident: () => { throw new Error('Unexpected Incident.') },
       recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -120,7 +120,10 @@ function harness(input: {
         return { _tag: 'Queued', taskId: 'repair-task', rounds: { number: 1, limit: 3 } }
       }),
       getRepairedHeadFindings: () => [],
-      findCurrentPolicyReviewRun: (_repository, _pullRequestNumber, headSha) => (input.reviewRuns ?? []).find(run => run.headSha === headSha) ?? null,
+      storedReviewForHead: (_repository, _pullRequestNumber, headSha) => {
+        const run = (input.reviewRuns ?? []).find(candidate => candidate.headSha === headSha)
+        return run === undefined ? { _tag: 'None' } : { _tag: 'Current', run }
+      },
       getWorkerSession: () => null,
       recordIncident: () => { throw new Error('Unexpected Incident.') },
       recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },

--- a/packages/harlan-github-agent/test/runner-lost.test.ts
+++ b/packages/harlan-github-agent/test/runner-lost.test.ts
@@ -87,7 +87,7 @@ function reviewWith(input: { headChecks: GitHubCheck[], baseChecks?: GitHubCheck
       queueReviewFixTaskForReview: () => { throw new Error('Unexpected Repair queue.') },
       getRepairedHeadFindings: () => [],
       getWorkerSession: () => null,
-      findCurrentPolicyReviewRun: () => null,
+      storedReviewForHead: () => ({ _tag: 'None' }),
       supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
       recordIncident: (incident) => {
         incidents.push(incident)

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4058,15 +4058,16 @@ describe('journal store', () => {
       at: '2026-08-13T01:02:00.000Z',
       evidence: 'policy-scope-review',
     })
-    expect(store.findCurrentPolicyReviewRun(first.repository, first.pullRequestNumber, first.pullRequest.headSha))
-      .toEqual(expect.objectContaining({ id: 'policy-scope-review' }))
+    expect(store.storedReviewForHead(first.repository, first.pullRequestNumber, first.pullRequest.headSha))
+      .toEqual({ _tag: 'Current', run: expect.objectContaining({ id: 'policy-scope-review' }) })
 
     store.syncRepositories([{ ...initialPolicy, autoMerge: { _tag: 'Every', minimumConfidence: 90 } }], '2026-08-13T02:00:00.000Z')
 
     // The planner requeues this head for a fresh Review. A worker that still
     // resumed the stored run would complete without new evidence, and the
     // planner would requeue it on every poll.
-    expect(store.findCurrentPolicyReviewRun(first.repository, first.pullRequestNumber, first.pullRequest.headSha)).toBeNull()
+    expect(store.storedReviewForHead(first.repository, first.pullRequestNumber, first.pullRequest.headSha)).toEqual({ _tag: 'Stale' })
+    expect(store.storedReviewForHead(first.repository, first.pullRequestNumber, 'unreviewed-head')).toEqual({ _tag: 'None' })
   })
 
   it('releases a review after its completed Baseline repair becomes stale', () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

#215 closed one of two shortcuts a requeued review could take. Straight after its deploy the ten requeued tasks took the other: the service's own READY comment on GitHub counted as an existing review, so each task completed in two seconds with no new evidence and the planner requeued it on the next poll.

```
14:21:44  b224ddf5  Running → Completed   resolution ExistingReview
14:22:45  b224ddf5  Completed → Queued    Trusted Review policy changed.
```

The store now answers what it holds for a head as `Current`, `Stale`, or `None`. A worker resumes only `Current`, and accepts a complete comment only for `None`, which is the planner's own rule: another actor's review counts only when this service never reviewed the head. `Stale` goes to a fresh Agent review, as the planner asked.

Stacked in spirit on #218, which stops mapping additions from making every review `Stale` in the first place; the two merge independently.

https://claude.ai/code/session_01KAFkmiKfq5fM881KCpQ8bw

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).