### PR TITLE
test(github-agent): call the renamed stored review lookup

### DIFF
--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4070,8 +4070,8 @@ describe('journal store', () => {
     })
 
     expect(store.claimNextAdversarialReviewTask('reviewer-2', '2026-08-13T02:01:00.000Z', 10_000)).toBeNull()
-    expect(store.findCurrentPolicyReviewRun(first.repository, first.pullRequestNumber, first.pullRequest.headSha))
-      .toEqual(expect.objectContaining({ id: 'auto-merge-scope-review' }))
+    expect(store.storedReviewForHead(first.repository, first.pullRequestNumber, first.pullRequest.headSha))
+      .toEqual({ _tag: 'Current', run: expect.objectContaining({ id: 'auto-merge-scope-review' }) })
   })
 
   it('stops counting a stored Review run once trusted repository policy changes', () => {


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

#218 and #219 merged independently. #218 added a test against the lookup that #219 renamed, so `main` fails typecheck and the store suite. One call site renamed, nothing else.

https://claude.ai/code/session_01KAFkmiKfq5fM881KCpQ8bw

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).