### PR TITLE
fix(github-agent): recover stranded issue work

### DIFF
--- a/packages/harlan-github-agent/src/batch-store.ts
+++ b/packages/harlan-github-agent/src/batch-store.ts
@@ -27,8 +27,6 @@ export interface BatchStore {
   /** Where one unit's pull request stands, read by a unit that stacks on it. */
   getBatchDependency: (unitId: string) => BatchDependency
   settleBatchUnit: (input: { unitId: string, at: string, state: Exclude<BatchUnitState, { _tag: 'Waiting' | 'Running' }> }) => boolean
-  /** Completes a Queued Issue work Task whose issue another unit's pull request closes. */
-  completeCombinedIssueWork: (input: { taskId: string, at: string, evidence: string }) => boolean
   completeBatch: (input: { batchId: string, workerId: string, fence: number, at: string }) => boolean
   failBatch: (input: { batchId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   /** Why a reserved Issue work Task waits, keyed by Task id, for the dashboard Queue. */
@@ -38,7 +36,6 @@ export interface BatchStore {
 
 export interface BatchStoreDependencies {
   claimIssueWorkTask: (workerId: string, now: string, leaseMilliseconds: number, exactTaskId: string) => ClaimedIssueWorkTask | null
-  recordTransition: (input: { taskId: string, from: 'Queued', to: 'Completed', reason: string | null, fence: number, at: string }) => void
 }
 
 interface BatchRow {
@@ -251,6 +248,11 @@ export function createBatchStore(database: DatabaseSync, dependencies: BatchStor
         AND json_extract(repositories.policy_json, '$.issueWork') = 1
         AND NOT EXISTS (SELECT 1 FROM batch_tasks WHERE batch_tasks.task_id = tasks.id)
         AND NOT EXISTS (
+          SELECT 1 FROM combined_issue_publications AS combined
+          JOIN publication_commands AS commands ON commands.id = combined.command_id
+          WHERE combined.task_id = tasks.id AND commands.state_tag IN ('Pending', 'Running')
+        )
+        AND NOT EXISTS (
           SELECT 1 FROM batches WHERE batches.repository_id = repositories.id AND batches.state_tag IN ('Queued', 'Running')
         )
       ORDER BY repositories.github, subjects.github_number
@@ -434,18 +436,6 @@ export function createBatchStore(database: DatabaseSync, dependencies: BatchStor
     ).changes === 1
   }
 
-  const completeCombinedIssueWork: BatchStore['completeCombinedIssueWork'] = input => transaction(() => {
-    const row = database.prepare('SELECT fence FROM tasks WHERE id = ? AND state_tag = \'Queued\'').get(input.taskId) as { fence: number } | undefined
-    if (row === undefined)
-      return false
-    const result = database.prepare(`
-      UPDATE tasks SET state_tag = 'Completed', evidence = ?, reason = NULL, updated_at = ? WHERE id = ? AND state_tag = 'Queued'
-    `).run(input.evidence, input.at, input.taskId)
-    if (result.changes === 1)
-      dependencies.recordTransition({ taskId: input.taskId, from: 'Queued', to: 'Completed', reason: 'Another unit of the Batch closes this issue.', fence: row.fence, at: input.at })
-    return result.changes === 1
-  })
-
   const finishBatch = (input: { batchId: string, workerId: string, fence: number, at: string }, state: 'Completed' | 'Failed', reason: string | null): boolean => transaction(() => {
     const result = database.prepare(`
       UPDATE batches SET state_tag = ?, reason = ?, worker_id = NULL, lease_expires_at = NULL, updated_at = ? WHERE ${ownedBatchSql}
@@ -473,10 +463,21 @@ export function createBatchStore(database: DatabaseSync, dependencies: BatchStor
       numbers.push(row.github_number)
       issuesByBatch.set(row.batch_id, numbers)
     })
-    return new Map(rows.map((row) => {
+    const reasons = new Map(rows.map((row) => {
       const others = (issuesByBatch.get(row.batch_id) ?? []).filter(number => number !== row.github_number).map(number => `#${number}`)
       return [row.task_id, others.length === 0 ? 'Planned in a Batch.' : `Planned in a Batch with ${others.join(', ')}.`]
     }))
+    const publishing = database.prepare(`
+      SELECT combined.task_id, subjects.github_number
+      FROM combined_issue_publications AS combined
+      JOIN publication_commands AS commands ON commands.id = combined.command_id
+      JOIN tasks ON tasks.id = commands.task_id
+      JOIN subjects ON subjects.id = tasks.subject_id
+      WHERE commands.state_tag IN ('Pending', 'Running')
+    `).all() as Array<{ task_id: string, github_number: number }>
+    for (const row of publishing)
+      reasons.set(row.task_id, `Waiting for the combined pull request for issue #${row.github_number} to publish.`)
+    return reasons
   }
 
   const listBatches: BatchStore['listBatches'] = (limit = 20) => (database.prepare(`
@@ -493,7 +494,6 @@ export function createBatchStore(database: DatabaseSync, dependencies: BatchStor
     claimBatchUnitTask,
     getBatchDependency,
     settleBatchUnit,
-    completeCombinedIssueWork,
     completeBatch,
     failBatch,
     batchReservationReasons,

--- a/packages/harlan-github-agent/src/batch-worker.ts
+++ b/packages/harlan-github-agent/src/batch-worker.ts
@@ -138,7 +138,7 @@ export interface BatchWorkerOptions {
   onTaskSettled?: (taskId: string, task: ClaimedIssueWorkTask) => void
   onTaskStarted?: (task: ClaimedIssueWorkTask) => void
   runtime: AgentRuntimeSource
-  store: ClaimedTaskStore & Pick<JournalStore, 'claimBatchUnitTask' | 'completeCombinedIssueWork' | 'getBatchDependency' | 'recordBatchPlan' | 'settleBatchUnit'>
+  store: ClaimedTaskStore & Pick<JournalStore, 'claimBatchUnitTask' | 'getBatchDependency' | 'recordBatchPlan' | 'settleBatchUnit'>
   unitConcurrency?: number
   validateMapping: (mapping: RepositoryMapping) => Promise<Result<RepositoryMapping, string>>
   workerId: string
@@ -329,15 +329,6 @@ export function createBatchWorker(options: BatchWorkerOptions): BatchWorker {
     options.onTaskSettled?.(task.id, task)
     const at = options.now().toISOString()
     settleUnitFromTask(unit, result, at)
-    if (result._tag !== 'Publishing')
-      return
-    // The combined issues close with this pull request, so their own Tasks are done.
-    const taskByIssue = new Map(batch.issues.map(issue => [issue.issueNumber, issue.taskId]))
-    combined.forEach((issue) => {
-      const taskId = taskByIssue.get(issue.number)
-      if (taskId !== undefined)
-        options.store.completeCombinedIssueWork({ taskId, at, evidence: `Closed by the pull request for issue #${task!.issueNumber} in the same Batch.` })
-    })
   }
 
   /** Records the final state of units that published, once their pull requests exist. */

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -552,6 +552,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
           _tag: 'OpenPullRequest',
           taskKind: 'issue_work',
           issueNumber: task.issueNumber,
+          combinedIssueNumbers: combinedIssues.map(issue => issue.number),
           pullRequestTitle: response.pullRequestTitle,
           pullRequestBody: response.pullRequestBody,
           diagram: drawn._tag === 'Drawn' ? drawn.diagram : null,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -2909,8 +2909,15 @@ function dashboardQueue(
             return [{ ...base, kind: 'issue', state: { _tag: 'ActionRequired', reason } }]
           }
           case 'Failed': return [{ ...base, kind: 'issue', state: failedQueueState(work.state.reason, work.recoveryAttempts) }]
-          case 'Completed': return [{ ...base, kind: 'issue', state: { _tag: 'Pending', reason: 'Waiting for GitHub to report the pull request.' } }]
-          case 'Superseded': break
+          case 'Completed': return [{ ...base, kind: 'issue', state: { _tag: 'Pending', reason: work.state.evidence } }]
+          case 'Superseded':
+            if (work.state.reason !== freshIssueTriageReason) {
+              return [{ ...base, kind: 'issue', state: {
+                _tag: work.state.reason === 'Cancelled from the dashboard.' ? 'Pending' : 'ActionRequired',
+                reason: work.state.reason,
+              } }]
+            }
+            break
         }
       }
       const task = currentTasks.get(`${subject.repository}:${subject.number}:${subject.revisionId}:issue_triage`)
@@ -2927,6 +2934,8 @@ function dashboardQueue(
             return [{ ...base, kind: 'issue', state: { _tag: 'AwaitingApproval', kind: 'issue_work' } }]
           if (triage._tag === 'NEEDS_INFO')
             return [{ ...base, kind: 'issue', state: { _tag: 'ActionRequired', reason: typeof triage.nextAction === 'string' ? triage.nextAction : 'The issue needs more information.' } }]
+          if (triage._tag === 'READY_TO_SPEC')
+            return [{ ...base, kind: 'issue', state: { _tag: 'ActionRequired', reason: `Ready to spec. ${typeof triage.nextAction === 'string' ? triage.nextAction : 'Write the specification before implementation.'}` } }]
           return []
         }
         case 'Superseded': return []
@@ -3519,6 +3528,16 @@ function recordPublicationEvent(database: DatabaseSync, input: {
     at: input.at,
   })
 }
+
+/** A combined publication requires every linked issue's current authority. */
+const COMBINED_ISSUE_AUTHORITY_SQL = `NOT EXISTS (
+  SELECT 1 FROM combined_issue_publications AS combined
+  JOIN tasks AS companion ON companion.id = combined.task_id
+  JOIN subjects AS issue ON issue.id = companion.subject_id
+  WHERE combined.command_id = publication_commands.id
+    AND (companion.state_tag != 'Queued' OR companion.revision_id != issue.current_revision_id
+      OR EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = issue.id))
+)`
 
 /**
  * Which Tasks a repository still lets the controller publish.
@@ -4481,7 +4500,7 @@ function planIssueTriage(
       && issueTriageState(existing.evidence) === 'READY_TO_IMPLEMENT'
       && subject.kind === 'issue'
       && canWorkIssues(mapping)
-      && !requiresIssueApproval(mapping, subject.author)
+      && (!requiresIssueApproval(mapping, subject.author) || issuePublicationLostBase(database, subjectId, revisionId))
     ) {
       queueIssueWork(database, subjectId, revisionId, subject, mapping, observedAt)
     }
@@ -4494,6 +4513,18 @@ function planIssueTriage(
     VALUES (?, ?, ?, 'issue_triage', 'Queued', ?)
   `).run(taskId, subjectId, revisionId, observedAt)
   recordWorkerTransition(database, { taskId, from: null, to: 'Queued', reason: null, fence: 0, at: observedAt })
+}
+
+/** A staged change proves approval for this exact issue. A base update does not revoke it. */
+function issuePublicationLostBase(database: DatabaseSync, subjectId: number, revisionId: string): boolean {
+  return database.prepare(`
+    SELECT 1 FROM tasks
+    JOIN publication_commands ON publication_commands.task_id = tasks.id
+    WHERE tasks.subject_id = ? AND tasks.revision_id = ? AND tasks.kind = 'issue_work'
+      AND tasks.state_tag = 'Superseded' AND tasks.reason = 'The base branch changed before publication.'
+      AND publication_commands.state_tag = 'Superseded' AND publication_commands.reason = tasks.reason
+      AND publication_commands.outcome_unknown = 0
+  `).get(subjectId, revisionId) !== undefined
 }
 
 function queueIssueWork(
@@ -4511,6 +4542,23 @@ function queueIssueWork(
   `).run(taskId, subjectId, revisionId, at).changes === 1
   let resumed = false
   if (!inserted) {
+    if (issuePublicationLostBase(database, subjectId, revisionId)) {
+      const existing = database.prepare('SELECT fence, recovery_attempts FROM tasks WHERE id = ?')
+        .get(taskId) as { fence: number, recovery_attempts: number }
+      const exhausted = existing.recovery_attempts >= MAXIMUM_RECOVERY_ATTEMPTS
+      const reason = exhausted
+        ? 'The base branch kept changing before publication. Update the issue after checking the unpublished changes.'
+        : 'The base branch changed. Retry Issue work against its current commit.'
+      database.prepare(`
+        UPDATE tasks SET state_tag = ?, reason = ?, evidence = NULL, attempts = 0,
+          recovery_attempts = recovery_attempts + ?, progress_percent = 0, progress_label = 'Starting', updated_at = ?
+        WHERE id = ? AND state_tag = 'Superseded'
+      `).run(exhausted ? 'ActionRequired' : 'Queued', exhausted ? reason : null, exhausted ? 0 : 1, at, taskId)
+      recordTransition(database, { taskId, from: 'Superseded', to: exhausted ? 'ActionRequired' : 'Queued', reason, fence: existing.fence, at })
+      if (exhausted)
+        recordTaskIncident(database, taskId, reason, at)
+      return { inserted: !exhausted, taskId }
+    }
     const existing = database.prepare(`
       SELECT state_tag, reason, fence FROM tasks WHERE id = ? AND kind = 'issue_work'
     `).get(taskId) as { state_tag: TaskRow['state_tag'], reason: string | null, fence: number } | undefined
@@ -5720,6 +5768,50 @@ function applyForeignKeyMigration(database: DatabaseSync, migration: string): vo
   }
 }
 
+const combinedIssuePublicationMigration = `
+  CREATE TABLE IF NOT EXISTS combined_issue_publications (
+    command_id TEXT NOT NULL REFERENCES publication_commands(id),
+    task_id TEXT NOT NULL REFERENCES tasks(id),
+    PRIMARY KEY (command_id, task_id)
+  );
+  CREATE INDEX IF NOT EXISTS combined_issue_publications_task ON combined_issue_publications(task_id);
+
+  -- Old Batch Agents declared completion before the primary publication succeeded.
+  -- Match both the recorded Batch and its exact completion sentence before repairing it.
+  INSERT OR IGNORE INTO combined_issue_publications (command_id, task_id)
+    SELECT commands.id, companion.id
+    FROM batch_units AS units
+    JOIN tasks AS primary_task ON primary_task.id = units.primary_task_id
+    JOIN subjects AS primary_issue ON primary_issue.id = primary_task.subject_id
+    JOIN publication_commands AS commands ON commands.task_id = primary_task.id
+    JOIN subjects AS companion_issue ON companion_issue.repository_id = primary_issue.repository_id
+      AND companion_issue.kind = 'issue' AND companion_issue.github_number IN (SELECT value FROM json_each(units.issue_numbers))
+    JOIN tasks AS companion ON companion.subject_id = companion_issue.id AND companion.kind = 'issue_work'
+      AND companion.revision_id = companion_issue.current_revision_id
+    WHERE companion.id != primary_task.id AND companion.state_tag = 'Completed'
+      AND companion.evidence = 'Closed by the pull request for issue #' || primary_issue.github_number || ' in the same Batch.';
+
+  INSERT INTO task_transitions (task_id, from_tag, to_tag, reason, fence, created_at)
+    SELECT tasks.id, 'Completed', 'Queued', 'The combined pull request was not published.', tasks.fence, tasks.updated_at
+    FROM tasks
+    WHERE tasks.state_tag = 'Completed'
+      AND EXISTS (SELECT 1 FROM combined_issue_publications WHERE task_id = tasks.id)
+      AND NOT EXISTS (
+        SELECT 1 FROM combined_issue_publications AS combined
+        JOIN publication_commands AS commands ON commands.id = combined.command_id
+        WHERE combined.task_id = tasks.id AND commands.state_tag = 'Published'
+      );
+  UPDATE tasks SET state_tag = 'Queued', evidence = NULL, progress_percent = 0, progress_label = 'Starting'
+    WHERE state_tag = 'Completed'
+      AND EXISTS (SELECT 1 FROM combined_issue_publications WHERE task_id = tasks.id)
+      AND NOT EXISTS (
+        SELECT 1 FROM combined_issue_publications AS combined
+        JOIN publication_commands AS commands ON commands.id = combined.command_id
+        WHERE combined.task_id = tasks.id AND commands.state_tag = 'Published'
+      );
+  PRAGMA user_version = 67;
+`
+
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
@@ -6004,9 +6096,13 @@ function installSchema(database: DatabaseSync): void {
   }
   if (version === 65) {
     applyMigration(database, forkWorkflowPublicationMigration)
-    return
+    version = 66
   }
-  if (version === 66)
+  if (version === 66) {
+    applyMigration(database, combinedIssuePublicationMigration)
+    version = 67
+  }
+  if (version === 67)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -7942,6 +8038,11 @@ export function openJournalStore(
           -- A Task a Batch reserved runs under that Batch's lease. Only the
           -- exact-Task claim the Batch makes may take it.
           AND (? IS NOT NULL OR NOT EXISTS (SELECT 1 FROM batch_tasks WHERE batch_tasks.task_id = tasks.id))
+          AND NOT EXISTS (
+            SELECT 1 FROM combined_issue_publications AS combined
+            JOIN publication_commands AS commands ON commands.id = combined.command_id
+            WHERE combined.task_id = tasks.id AND commands.state_tag IN ('Pending', 'Running')
+          )
           AND tasks.revision_id = subjects.current_revision_id
           AND repositories.enabled = 1
           ${repositoryWriteAuthoritySql}
@@ -8085,7 +8186,6 @@ export function openJournalStore(
         return task
       throw new Error(`Batch unit claim returned a ${task.kind} Task.`)
     },
-    recordTransition: input => recordTransition(database, input),
   })
 
   const claimNextConflictTask: JournalStore['claimNextConflictTask'] = (workerId, now, leaseMilliseconds) => {
@@ -10119,6 +10219,9 @@ export function openJournalStore(
   const stagePublication: JournalStore['stagePublication'] = (input) => {
     database.exec('BEGIN IMMEDIATE')
     try {
+      const combinedNumbers = input.publication._tag === 'OpenPullRequest' && input.publication.taskKind === 'issue_work'
+        ? input.publication.combinedIssueNumbers ?? []
+        : []
       const existing = database.prepare(`
         SELECT id, commit_sha, base_sha, base_ref, expected_head_sha, head_ref, artifact_ref, patch_digest,
           changed_files, pull_request_title, pull_request_body
@@ -10139,7 +10242,14 @@ export function openJournalStore(
       } | undefined
       if (existing !== undefined) {
         const publication = input.publication
-        const duplicate = existing.commit_sha === publication.commitSha
+        const linkedNumbers = (database.prepare(`
+          SELECT subjects.github_number FROM combined_issue_publications
+          JOIN tasks ON tasks.id = combined_issue_publications.task_id
+          JOIN subjects ON subjects.id = tasks.subject_id
+          WHERE combined_issue_publications.command_id = ? ORDER BY subjects.github_number
+        `).all(existing.id) as Array<{ github_number: number }>).map(row => row.github_number)
+        const duplicate = JSON.stringify(linkedNumbers) === JSON.stringify([...combinedNumbers].sort((a, b) => a - b))
+          && existing.commit_sha === publication.commitSha
           && existing.base_sha === publication.baseSha
           && existing.base_ref === publication.baseRef
           && existing.expected_head_sha === publication.expectedHeadSha
@@ -10193,6 +10303,29 @@ export function openJournalStore(
         return { _tag: 'Rejected', reason: 'The publication does not match the current GitHub state.' }
       }
 
+      const combinedTasks: string[] = []
+      for (const number of combinedNumbers) {
+        const combined = database.prepare(`
+          SELECT tasks.id FROM tasks
+          JOIN subjects ON subjects.id = tasks.subject_id
+          JOIN repositories ON repositories.id = subjects.repository_id
+          WHERE repositories.github = ? AND subjects.kind = 'issue' AND subjects.github_number = ?
+            AND tasks.kind = 'issue_work' AND tasks.state_tag = 'Queued'
+            AND tasks.revision_id = subjects.current_revision_id AND tasks.id != ?
+            AND NOT EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = subjects.id)
+            AND NOT EXISTS (
+              SELECT 1 FROM combined_issue_publications AS combined
+              JOIN publication_commands AS commands ON commands.id = combined.command_id
+              WHERE combined.task_id = tasks.id AND commands.state_tag IN ('Pending', 'Running')
+            )
+        `).get(subject.repository, number, input.taskId) as { id: string } | undefined
+        if (combined === undefined || combinedTasks.includes(combined.id)) {
+          database.exec('COMMIT')
+          return { _tag: 'Rejected', reason: 'A combined issue no longer authorizes this change.' }
+        }
+        combinedTasks.push(combined.id)
+      }
+
       const commandId = digest(JSON.stringify({
         taskId: input.taskId,
         publication,
@@ -10218,6 +10351,8 @@ export function openJournalStore(
         publication._tag === 'OpenPullRequest' && publication.taskKind === 'issue_work' && publication.diagram !== null ? JSON.stringify(publication.diagram) : null,
         input.at,
       )
+      for (const taskId of combinedTasks)
+        database.prepare('INSERT INTO combined_issue_publications (command_id, task_id) VALUES (?, ?)').run(commandId, taskId)
       recordPublicationEvent(database, {
         commandId,
         from: null,
@@ -10282,6 +10417,19 @@ export function openJournalStore(
     database.exec('BEGIN IMMEDIATE')
     try {
       recoverExpiredPublications(now)
+      const invalid = database.prepare(`
+        SELECT publication_commands.id, publication_commands.fence, tasks.id AS task_id, tasks.fence AS task_fence
+        FROM publication_commands JOIN tasks ON tasks.id = publication_commands.task_id
+        WHERE publication_commands.state_tag = 'Pending' AND tasks.state_tag = 'Publishing'
+          AND NOT (${COMBINED_ISSUE_AUTHORITY_SQL})
+      `).all() as Array<{ id: string, fence: number, task_id: string, task_fence: number }>
+      for (const command of invalid) {
+        const reason = 'A combined issue changed or was cancelled before publication.'
+        database.prepare('UPDATE publication_commands SET state_tag = \'Superseded\', reason = ?, updated_at = ? WHERE id = ?').run(reason, now, command.id)
+        database.prepare('UPDATE tasks SET state_tag = \'Superseded\', reason = ?, command_id = NULL, updated_at = ? WHERE id = ?').run(reason, now, command.task_id)
+        recordPublicationEvent(database, { commandId: command.id, from: 'Pending', to: 'Superseded', reason, fence: command.fence, at: now })
+        recordTransition(database, { taskId: command.task_id, from: 'Publishing', to: 'Superseded', reason, fence: command.task_fence, at: now })
+      }
       const row = database.prepare(`
         SELECT
           publication_commands.id,
@@ -10413,6 +10561,7 @@ export function openJournalStore(
       AND repositories.enabled = 1
       ${repositoryWriteAuthoritySql}
       AND ${PUBLICATION_AUTHORITY_SQL}
+      AND ${COMBINED_ISSUE_AUTHORITY_SQL}
   `).get(input.commandId, input.workerId, input.fence, input.at) !== undefined
 
   const heartbeatPublication: JournalStore['heartbeatPublication'] = (input) => {
@@ -10471,6 +10620,20 @@ export function openJournalStore(
         at: input.at,
       })
       resolveTaskIncidents(database, task.task_id, input.at)
+      const combined = database.prepare(`
+        SELECT tasks.id, tasks.fence FROM combined_issue_publications
+        JOIN tasks ON tasks.id = combined_issue_publications.task_id
+        JOIN subjects ON subjects.id = tasks.subject_id
+        WHERE combined_issue_publications.command_id = ? AND tasks.state_tag = 'Queued'
+          AND tasks.revision_id = subjects.current_revision_id
+          AND NOT EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = subjects.id)
+      `).all(input.commandId) as Array<{ id: string, fence: number }>
+      for (const companion of combined) {
+        database.prepare(`UPDATE tasks SET state_tag = 'Completed', evidence = ?, updated_at = ? WHERE id = ?`)
+          .run(input.evidence, input.at, companion.id)
+        recordTransition(database, { taskId: companion.id, from: 'Queued', to: 'Completed', reason: 'The combined pull request was published.', fence: companion.fence, at: input.at })
+        resolveTaskIncidents(database, companion.id, input.at)
+      }
       database.exec('COMMIT')
       return true
     }

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -1090,6 +1090,8 @@ export type PublicationCommand
     _tag: 'OpenPullRequest'
     taskKind: 'issue_work'
     issueNumber: number
+    /** Additional issues covered by this exact publication. Omitted for a single issue. */
+    combinedIssueNumbers?: readonly number[]
     pullRequestTitle: string
     pullRequestBody: string
     /** The drawn PR Lens picture the description opens with, or null when the change earned none. */

--- a/packages/harlan-github-agent/test/batch-store.test.ts
+++ b/packages/harlan-github-agent/test/batch-store.test.ts
@@ -178,6 +178,7 @@ describe('batches in the journal', () => {
           _tag: 'OpenPullRequest',
           taskKind: 'issue_work',
           issueNumber: 101,
+          combinedIssueNumbers: [102],
           pullRequestTitle: 'fix: shared helper',
           pullRequestBody: 'Closes #101.\nCloses #102.',
           diagram: null,
@@ -195,12 +196,14 @@ describe('batches in the journal', () => {
       const combinedTaskId = batch.issues.find(issue => issue.issueNumber === 102)?.taskId
       if (combinedTaskId === undefined)
         throw new Error('Expected the combined Task.')
-      expect(store.completeCombinedIssueWork({ taskId: combinedTaskId, at: at(11), evidence: 'Closed by #101.' })).toBe(true)
+      expect(store.getDashboardSnapshot(at(11)).tasks.find(task => task.id === combinedTaskId)?.state).toEqual({ _tag: 'Queued' })
 
       const command = store.claimNextPublication('publisher', at(12), 600_000)
       if (command === null)
         throw new Error('Expected a publication command.')
       expect(store.completePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(13), evidence: 'Opened pull request #7.', pullRequestNumber: 7 })).toBe(true)
+      expect(store.getDashboardSnapshot(at(13)).tasks.find(task => task.id === combinedTaskId)?.state)
+        .toEqual({ _tag: 'Completed', evidence: 'Opened pull request #7.' })
       expect(store.getBatchDependency(first.id)).toEqual({ _tag: 'Published', pullRequestNumber: 7, headRef: 'fix/issue-101', headSha: 'commit-1' })
       expect(store.settleBatchUnit({ unitId: first.id, at: at(13), state: { _tag: 'Published', pullRequestNumber: 7, headRef: 'fix/issue-101', headSha: 'commit-1' } })).toBe(true)
 

--- a/packages/harlan-github-agent/test/batch-worker.test.ts
+++ b/packages/harlan-github-agent/test/batch-worker.test.ts
@@ -74,7 +74,6 @@ describe('batch worker unit failures', () => {
       runtime: {} as never,
       store: {
         claimBatchUnitTask: () => null,
-        completeCombinedIssueWork: () => undefined,
         getBatchDependency: () => ({ _tag: 'Unavailable', reason: 'The unit failed.' }),
         recordBatchPlan: () => [],
         settleBatchUnit: () => {

--- a/packages/harlan-github-agent/test/issue-work-handoffs.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-handoffs.test.ts
@@ -1,0 +1,216 @@
+import type { PreparedPublication } from '../src/types.ts'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, describe, expect, it } from 'vitest'
+import { MAXIMUM_RECOVERY_ATTEMPTS } from '../src/failure.ts'
+import { openJournalStore } from '../src/store.ts'
+import { issueItem, repositoryMapping } from './fixtures.ts'
+
+const stores: ReturnType<typeof openJournalStore>[] = []
+const directories: string[] = []
+afterEach(() => {
+  stores.splice(0).forEach(store => store.close())
+  directories.splice(0).forEach(path => rmSync(path, { recursive: true, force: true }))
+})
+const at = (second: number) => new Date(Date.parse('2026-09-08T01:00:00Z') + second * 1000).toISOString()
+
+function readyIssues(numbers = [12], path = ':memory:') {
+  const store = openJournalStore(path)
+  stores.push(store)
+  store.syncRepositories([repositoryMapping()], at(0))
+  const issues = numbers.map(number => issueItem({ number, author: 'harlan-zw' }))
+  for (const issue of issues) {
+    store.recordObservation({ externalId: `issue-${issue.number}`, observedAt: at(1), source: 'poll', subject: issue })
+    const triage = store.claimNextIssueTriageTask('triage', at(2), 600_000)!
+    store.completeWorkerTask({ taskId: triage.id, workerId: 'triage', fence: triage.state.fence, at: at(3 + numbers.indexOf(issue.number)), evidence: JSON.stringify({ _tag: 'READY_TO_IMPLEMENT' }) })
+  }
+  return { store, issues }
+}
+
+function databasePath() {
+  const directory = mkdtempSync(join(tmpdir(), 'issue-handoffs-'))
+  directories.push(directory)
+  return join(directory, 'state.sqlite')
+}
+
+function reopen(store: ReturnType<typeof openJournalStore>, path: string) {
+  stores.splice(stores.indexOf(store), 1)
+  store.close()
+  const reopened = openJournalStore(path)
+  stores.push(reopened)
+  return reopened
+}
+
+function publish(store: ReturnType<typeof openJournalStore>, second = 5, combinedIssueNumbers: number[] = []) {
+  const task = store.claimNextIssueWorkTask('implementer', at(second), 600_000)!
+  const publication: PreparedPublication & { combinedIssueNumbers: number[] } = {
+    _tag: 'OpenPullRequest',
+    taskKind: 'issue_work',
+    issueNumber: task.issueNumber,
+    pullRequestTitle: 'fix: repair the issue',
+    pullRequestBody: `Closes #${task.issueNumber}.\n${combinedIssueNumbers.map(n => `Closes #${n}.`).join('\n')}`,
+    diagram: null,
+    commitSha: `commit-${second}`,
+    baseSha: `base-${second}`,
+    baseRef: 'main',
+    expectedHeadSha: `base-${second}`,
+    headRef: `fix/issue-${task.issueNumber}`,
+    artifactRef: `refs/artifact-${second}`,
+    patchDigest: `patch-${second}`,
+    changedFiles: 1,
+    combinedIssueNumbers,
+  }
+  expect(store.stagePublication({ taskId: task.id, workerId: 'implementer', fence: task.state.fence, at: at(second + 1), publication })._tag).toBe('Staged')
+  const command = store.claimNextPublication('publisher', at(second + 2), 600_000)!
+  return { task, command }
+}
+
+describe('issue work handoffs', () => {
+  it('retries the same approved issue after the base changes before publication', () => {
+    const { store, issues: [issue] } = readyIssues()
+    const { task, command } = publish(store)
+    store.supersedePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(8), reason: 'The base branch changed before publication.' })
+
+    store.recordObservation({ externalId: 'issue-12', observedAt: at(9), source: 'poll', subject: issue! })
+
+    expect(store.claimNextIssueWorkTask('retry', at(10), 600_000)).toMatchObject({ id: task.id, state: { _tag: 'Running' } })
+    expect(store.getDashboardSnapshot(at(10)).queue[0]?.state).toEqual({ _tag: 'Active', work: 'issue_work' })
+  })
+
+  it('bounds repeated base changes and reports the actual stop reason', () => {
+    const { store, issues: [issue] } = readyIssues()
+    for (let round = 0; round <= MAXIMUM_RECOVERY_ATTEMPTS; round++) {
+      const second = 5 + round * 10
+      const { command } = publish(store, second)
+      store.supersedePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(second + 3), reason: 'The base branch changed before publication.' })
+      store.recordObservation({ externalId: 'issue-12', observedAt: at(second + 4), source: 'poll', subject: issue! })
+    }
+
+    expect(store.claimNextIssueWorkTask('retry', at(100), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at(100)).queue[0]?.state).toMatchObject({ _tag: 'ActionRequired', reason: expect.stringContaining('base branch') })
+  })
+
+  it('keeps a dashboard cancellation terminal and does not ask for approval', () => {
+    const { store, issues: [issue] } = readyIssues()
+    const task = store.getDashboardSnapshot(at(4)).tasks.find(t => t.kind === 'issue_work')!
+    store.cancelTask({ taskId: task.id, at: at(5) })
+    store.recordObservation({ externalId: 'issue-12', observedAt: at(6), source: 'poll', subject: issue! })
+
+    expect(store.claimNextIssueWorkTask('retry', at(7), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at(7)).queue[0]?.state).toEqual({ _tag: 'Pending', reason: 'Cancelled from the dashboard.' })
+  })
+
+  it('shows the confirmed pull request instead of waiting for GitHub', () => {
+    const { store } = readyIssues()
+    const { command } = publish(store)
+    const evidence = 'Opened pull request #24: https://github.com/harlan-zw/example/pull/24.'
+    store.completePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(8), evidence, pullRequestNumber: 24 })
+
+    expect(store.getDashboardSnapshot(at(9)).queue[0]?.state).toEqual({ _tag: 'Pending', reason: evidence })
+  })
+
+  it('holds related issues until the pull request is confirmed', () => {
+    const { store } = readyIssues([12, 13])
+    const { command } = publish(store, 5, [13])
+
+    expect(store.claimNextIssueWorkTask('other', at(8), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at(8)).queue.find(entry => entry.number === 13)?.state)
+      .toEqual({ _tag: 'Pending', reason: 'Waiting for the combined pull request for issue #12 to publish.' })
+    const evidence = 'Opened pull request #24: https://github.com/harlan-zw/example/pull/24.'
+    store.completePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(9), evidence, pullRequestNumber: 24 })
+    expect(store.getDashboardSnapshot(at(10)).tasks.filter(t => t.kind === 'issue_work').map(t => t.state))
+      .toEqual([{ _tag: 'Completed', evidence }, { _tag: 'Completed', evidence }])
+  })
+
+  it('retains the combined publication across a restart and prevents a second Batch claiming it', () => {
+    const path = databasePath()
+    const { store } = readyIssues([12, 13, 14], path)
+    publish(store, 5, [13, 14])
+    const restarted = reopen(store, path)
+
+    expect(restarted.planBatches(at(8))).toEqual([])
+    expect(restarted.claimNextIssueWorkTask('other', at(8), 600_000)).toBeNull()
+    const command = restarted.claimNextPublication('new-publisher', at(700), 600_000)!
+    restarted.completePublication({ commandId: command.id, workerId: 'new-publisher', fence: command.fence, at: at(701), evidence: 'Opened pull request #24.', pullRequestNumber: 24 })
+    expect(restarted.getDashboardSnapshot(at(702)).tasks.filter(t => t.kind === 'issue_work').map(t => t.state))
+      .toEqual(Array.from({ length: 3 }, () => ({ _tag: 'Completed', evidence: 'Opened pull request #24.' })))
+  })
+
+  it('revokes an unpublished change when a combined issue is cancelled', () => {
+    const { store } = readyIssues([12, 13])
+    const { command } = publish(store, 5, [13])
+    const companion = store.getDashboardSnapshot(at(8)).tasks.find(t => t.kind === 'issue_work' && t.issueNumber === 13)!
+    store.cancelTask({ taskId: companion.id, at: at(8) })
+
+    expect(store.authorizePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(9) })).toBe(false)
+    expect(store.claimNextPublication('retry', at(700), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at(701)).tasks.find(t => t.id === companion.id)?.state)
+      .toEqual({ _tag: 'Superseded', reason: 'Cancelled from the dashboard.' })
+  })
+
+  it('recovers a legacy Batch companion that was completed before publication', () => {
+    const path = databasePath()
+    const { store, issues } = readyIssues([12, 13], path)
+    const [planned] = store.planBatches(at(4))
+    const batch = store.claimNextBatch('batch', at(5), 600_000)!
+    const units = store.recordBatchPlan({ batchId: planned!.batchId, workerId: 'batch', fence: batch.state.fence, at: at(6), units: [{ issueNumbers: [12, 13], dependsOn: null, rationale: 'One repair.' }] })
+    if (units._tag === 'Err')
+      throw new Error(units.error)
+    const primary = store.claimBatchUnitTask({ unitId: units.value[0]!.id, workerId: 'batch', now: at(7), leaseMilliseconds: 600_000 })!
+    store.stagePublication({ taskId: primary.id, workerId: 'batch', fence: primary.state.fence, at: at(8), publication: {
+      _tag: 'OpenPullRequest',
+      taskKind: 'issue_work',
+      issueNumber: 12,
+      pullRequestTitle: 'fix: both issues',
+      pullRequestBody: 'Closes #12.\nCloses #13.',
+      diagram: null,
+      commitSha: 'repair',
+      baseSha: 'old-base',
+      baseRef: 'main',
+      expectedHeadSha: 'old-base',
+      headRef: 'fix/issue-12',
+      artifactRef: 'refs/repair',
+      patchDigest: 'patch',
+      changedFiles: 1,
+    } })
+    const command = store.claimNextPublication('publisher', at(9), 600_000)!
+    store.supersedePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(10), reason: 'The base branch changed before publication.' })
+    store.completeBatch({ batchId: batch.id, workerId: 'batch', fence: batch.state.fence, at: at(11) })
+    stores.splice(stores.indexOf(store), 1)
+    store.close()
+    // Reconstruct the old on-disk state as the migration's input.
+    const legacy = new DatabaseSync(path)
+    legacy.exec('UPDATE tasks SET state_tag = \'Completed\', evidence = \'Closed by the pull request for issue #12 in the same Batch.\' WHERE kind = \'issue_work\' AND state_tag = \'Queued\'; DROP TABLE combined_issue_publications; PRAGMA user_version = 66;')
+    legacy.close()
+
+    const migrated = openJournalStore(path)
+    stores.push(migrated)
+    for (const issue of issues)
+      migrated.recordObservation({ externalId: `issue-${issue.number}`, observedAt: at(12), source: 'poll', subject: issue })
+    expect(migrated.getDashboardSnapshot(at(13)).tasks.filter(t => t.kind === 'issue_work').map(t => t.state))
+      .toEqual([{ _tag: 'Queued' }, { _tag: 'Queued' }])
+    expect(migrated.claimNextIssueWorkTask('retry', at(14), 600_000)).not.toBeNull()
+  })
+
+  it('releases related issues when publication is refused', () => {
+    const { store } = readyIssues([12, 13])
+    const { command } = publish(store, 5, [13])
+    store.supersedePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(8), reason: 'The base branch changed before publication.' })
+
+    expect(store.claimNextIssueWorkTask('other', at(9), 600_000)?.issueNumber).toBe(13)
+  })
+
+  it('shows the next action for Ready to spec', () => {
+    const store = openJournalStore(':memory:')
+    stores.push(store)
+    store.syncRepositories([repositoryMapping()], at(0))
+    store.recordObservation({ externalId: 'spec', observedAt: at(1), source: 'poll', subject: issueItem() })
+    const task = store.claimNextIssueTriageTask('triage', at(2), 600_000)!
+    store.completeWorkerTask({ taskId: task.id, workerId: 'triage', fence: task.state.fence, at: at(3), evidence: JSON.stringify({ _tag: 'READY_TO_SPEC', nextAction: 'Decide the discovery spending limit.' }) })
+
+    expect(store.claimNextIssueWorkTask('implementer', at(4), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at(4)).queue[0]?.state).toEqual({ _tag: 'ActionRequired', reason: 'Ready to spec. Decide the discovery spending limit.' })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

`nuxtseo.com` issues #775, #777, and #779 stopped after a base update. Issue #782 showed completion without a published PR.
Approved Issue work now retries against the new base. Related issues complete only after GitHub confirms their PR.
The journal migration restores premature Batch completions, and the Queue shows specification steps and actual stop reasons.

![Issue work completes linked Tasks only after GitHub confirms their pull request.](https://github.com/user-attachments/assets/03b44ec7-52ab-445b-9766-05642ecbc50f)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
