### PR TITLE
fix(github-agent): settle shared baseline reviews

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -8615,10 +8615,12 @@ export function openJournalStore(
     try {
       const task = database.prepare(`
         SELECT worker_tasks.subject_id, worker_tasks.revision_id,
-          repositories.github AS repository, subjects.github_number
+          repositories.github AS repository, subjects.github_number,
+          json_extract(revisions.payload, '$.baseSha') AS base_sha
         FROM worker_tasks
         JOIN subjects ON subjects.id = worker_tasks.subject_id
         JOIN repositories ON repositories.id = subjects.repository_id
+        JOIN revisions ON revisions.id = worker_tasks.revision_id
         WHERE worker_tasks.id = ? AND worker_tasks.kind = 'adversarial_review'
           AND worker_tasks.state_tag = 'Running' AND worker_tasks.worker_id = ?
           AND worker_tasks.fence = ? AND worker_tasks.lease_expires_at > ?
@@ -8628,6 +8630,7 @@ export function openJournalStore(
         revision_id: string
         repository: string
         github_number: number
+        base_sha: string
       } | undefined
       if (task === undefined) {
         database.exec('COMMIT')
@@ -8646,11 +8649,13 @@ export function openJournalStore(
             return { reviewRunId: input.resolution.reviewRunId, baselineTaskId: null, githubUrl: null, reason: null }
           }
           case 'WaitingForBaselineRepair': {
+            // All reviews of this repository's base commit share one repair.
+            const expectedTaskId = digest(`${task.repository}:baseline:${task.base_sha}`)
             const baseline = database.prepare(`
               SELECT 1 FROM tasks
-              WHERE id = ? AND subject_id = ? AND revision_id = ? AND kind = 'baseline_repair'
-            `).get(input.resolution.taskId, task.subject_id, task.revision_id)
-            if (baseline === undefined)
+              WHERE id = ? AND kind = 'baseline_repair'
+            `).get(input.resolution.taskId)
+            if (input.resolution.taskId !== expectedTaskId || baseline === undefined)
               throw new Error('The Review resolution references a different Baseline repair Task.')
             return { reviewRunId: null, baselineTaskId: input.resolution.taskId, githubUrl: null, reason: null }
           }

--- a/packages/harlan-github-agent/src/worker-task-scheduler.ts
+++ b/packages/harlan-github-agent/src/worker-task-scheduler.ts
@@ -1,7 +1,7 @@
 import type { AgentPermitPool } from './agent-permit-pool.ts'
 import type { AgentTokenUsage } from './agent-provider.ts'
 import type { Result } from './result.ts'
-import { err } from './result.ts'
+import { err, ok } from './result.ts'
 /**
  * The least a scheduler needs to lease one unit of work.
  *
@@ -95,21 +95,25 @@ export function createWorkerTaskScheduler<Task extends LeasedWork, Success exten
       if (executionController.signal.aborted)
         return
       if (result._tag === 'Ok') {
-        const completed = options.complete({
+        // A completion error must release the owned lease before this worker moves on.
+        const completion = await Promise.resolve().then(() => options.complete({
           ...result.value,
           taskId: task.id,
           workerId: options.workerId,
           fence: task.state.fence,
           at: options.now().toISOString(),
+        })).then(completed => completed ? ok(undefined) : err('The Task lease changed before completion.')).catch((error: unknown) => {
+          options.onError(error)
+          return err(error instanceof Error ? error.message : 'Task completion failed unexpectedly.')
         })
-        if (completed)
+        if (completion._tag === 'Ok')
           return
         options.fail({
           taskId: task.id,
           workerId: options.workerId,
           fence: task.state.fence,
           at: options.now().toISOString(),
-          reason: 'The Task lease changed before completion.',
+          reason: completion.error,
         })
         return
       }

--- a/packages/harlan-github-agent/test/shared-baseline-review.test.ts
+++ b/packages/harlan-github-agent/test/shared-baseline-review.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createAgentPermitPool } from '../src/agent-permit-pool.ts'
+import { ok } from '../src/result.ts'
+import { openJournalStore } from '../src/store.ts'
+import { createWorkerTaskScheduler } from '../src/worker-task-scheduler.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const stores: ReturnType<typeof openJournalStore>[] = []
+afterEach(() => stores.splice(0).forEach(store => store.close()))
+const at = (second: number) => new Date(Date.parse('2026-09-08T04:00:00Z') + second * 1000).toISOString()
+
+function setup() {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  store.syncRepositories([repositoryMapping(), repositoryMapping({ github: 'harlan-zw/other' })], at(0))
+  return store
+}
+
+function review(store: ReturnType<typeof openJournalStore>, number: number, baseSha = 'base123', repository = 'harlan-zw/example') {
+  store.recordObservation({ externalId: `${repository}-${number}-${baseSha}`, observedAt: at(1), source: 'poll', subject: pullRequestItem({ number, repository, baseSha, mergeState: 'clean' }) })
+  const task = store.claimNextAdversarialReviewTask('reviewer', at(2), 600_000)!
+  const baseline = store.queueBaselineRepairForReview({ taskId: task.id, workerId: 'reviewer', fence: task.state.fence, at: at(3), baseSha })
+  if (baseline._tag !== 'Queued' && baseline._tag !== 'Existing')
+    throw new Error('Expected Baseline repair.')
+  return { task, baseline }
+}
+
+describe('shared Baseline repair completion', () => {
+  it('lets two pull requests wait for one repair of the same repository and base commit', () => {
+    const store = setup()
+    const first = review(store, 24)
+    const second = review(store, 25)
+    expect(second.baseline).toEqual({ _tag: 'Existing', taskId: first.baseline.taskId })
+
+    for (const { task, baseline } of [first, second]) {
+      expect(store.completeReviewTask({ taskId: task.id, workerId: 'reviewer', fence: task.state.fence, at: at(4), evidence: 'Waiting for Baseline repair.', resolution: { _tag: 'WaitingForBaselineRepair', taskId: baseline.taskId } })).toBe(true)
+    }
+    expect(store.getDashboardSnapshot(at(5)).tasks.filter(task => task.kind === 'adversarial_review').map(task => task.state._tag)).toEqual(['Completed', 'Completed'])
+    expect(store.isSafeToRestart(at(5))).toBe(true)
+  })
+
+  it.each([
+    ['another repository', 'base123', 'harlan-zw/other'],
+    ['another base commit', 'changed-base', 'harlan-zw/example'],
+  ])('rejects a repair for %s', (_label, baseSha, repository) => {
+    const store = setup()
+    const first = review(store, 24)
+    const second = review(store, 25, baseSha, repository)
+
+    expect(() => store.completeReviewTask({ taskId: second.task.id, workerId: 'reviewer', fence: second.task.state.fence, at: at(4), evidence: 'Waiting for Baseline repair.', resolution: { _tag: 'WaitingForBaselineRepair', taskId: first.baseline.taskId } })).toThrow('different Baseline repair Task')
+  })
+
+  it('settles the owned lease when completion throws so a restart can proceed', async () => {
+    const store = setup()
+    store.recordObservation({ externalId: 'review', observedAt: at(1), source: 'poll', subject: pullRequestItem({ mergeState: 'clean' }) })
+    const error = new Error('The Review resolution references a different Baseline repair Task.')
+    const errors: unknown[] = []
+    const scheduler = createWorkerTaskScheduler({
+      claim: store.claimNextAdversarialReviewTask,
+      complete: () => { throw error },
+      fail: store.failWorkerTask,
+      heartbeat: store.heartbeatWorkerTask,
+      intervalMilliseconds: 60_000,
+      leaseMilliseconds: 45 * 60_000,
+      now: () => new Date(at(2)),
+      onError: error => errors.push(error),
+      permits: createAgentPermitPool(1),
+      worker: { run: async () => ok({ evidence: 'Waiting for Baseline repair.' }) },
+      workerId: 'reviewer',
+    })
+
+    await scheduler.runNow()
+
+    expect(errors).toEqual([error])
+    expect(store.isSafeToRestart(at(3))).toBe(true)
+    expect(store.getDashboardSnapshot(at(3)).tasks[0]?.state._tag).not.toBe('Running')
+    await scheduler.stop()
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Four NuxtSEO reviews stopped with “The Review resolution references a different Baseline repair Task.”
The scheduler moved on, but Running leases delayed a Service update.

Reviews now share repairs by repository and base commit. If completion throws, the scheduler records the failure and releases its lease.

![Reviews share a Baseline repair and release their leases before a safe restart.](https://github.com/user-attachments/assets/d32da95e-a181-452d-92c0-9583b5f0fbaf)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
