### PR TITLE
fix(github-agent): preserve issue work inputs and results

### DIFF
--- a/packages/harlan-github-agent/src/agent-provider.ts
+++ b/packages/harlan-github-agent/src/agent-provider.ts
@@ -122,9 +122,19 @@ ${JSON.stringify(schema)}`
  * Falls back to the raw text so the caller reports one parse failure.
  */
 export function extractJsonObject(text: string): string {
-  const fenced = /```(?:json)?\n?([\s\S]*?)```/i.exec(text)
-  const candidate = (fenced?.[1] ?? text).trim()
-  const start = candidate.indexOf('{')
-  const end = candidate.lastIndexOf('}')
-  return start === -1 || end <= start ? candidate : candidate.slice(start, end + 1)
+  // Code fences can belong to a JSON string, such as a pull request body.
+  // Extract the outer object before interpreting anything inside its strings.
+  const start = text.indexOf('{')
+  const end = text.lastIndexOf('}')
+  if (start === -1 || end <= start)
+    return text
+  const candidate = text.slice(start, end + 1)
+  try {
+    JSON.parse(candidate)
+    return candidate
+  }
+  catch {
+    // Braces in prose are not JSON. Keep the full answer for parsing or repair.
+    return text
+  }
 }

--- a/packages/harlan-github-agent/src/github-write-gate.ts
+++ b/packages/harlan-github-agent/src/github-write-gate.ts
@@ -60,20 +60,20 @@ export async function preflightGitHubWriteAccess(
   return ok(undefined)
 }
 
-interface RepositoryWorker<Task extends { repository: string }, Value> {
-  run: (task: Task, signal: AbortSignal) => Promise<Result<Value, string>>
+interface RepositoryWorker<Task extends { repository: string }, Value, Context extends unknown[]> {
+  run: (task: Task, signal: AbortSignal, ...context: Context) => Promise<Result<Value, string>>
 }
 
 /** Refuses work before an Agent turn when its required GitHub access is absent. */
-export function withGitHubWritePreflight<Task extends { repository: string }, Value>(options: {
+export function withGitHubWritePreflight<Task extends { repository: string }, Value, Context extends unknown[]>(options: {
   accesses: readonly GitHubRepositoryAccess[]
   source: GitHubTokenProvider
-  worker: RepositoryWorker<Task, Value>
-}): RepositoryWorker<Task, Value> {
+  worker: RepositoryWorker<Task, Value, Context>
+}): RepositoryWorker<Task, Value, Context> {
   return {
-    async run(task, signal) {
+    async run(task, signal, ...context) {
       const access = await preflightGitHubWriteAccess(options.source, task.repository, options.accesses, signal)
-      return access._tag === 'Err' ? access : options.worker.run(task, signal)
+      return access._tag === 'Err' ? access : options.worker.run(task, signal, ...context)
     },
   }
 }

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -9,13 +9,14 @@ import { join } from 'node:path'
 import { SCHEMA_VERSION } from '@coldtea/pr-lens-schema'
 import { afterEach, describe, expect, it } from 'vitest'
 import { CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
+import { withGitHubWritePreflight } from '../src/github-write-gate.ts'
 import { createIssueWorkWorker } from '../src/issue-work-worker.ts'
 import { issueSnapshotDigest } from '../src/item-agent.ts'
 import { ok } from '../src/result.ts'
 import { agentRuntime, issueItem, repositoryMapping, stubProvider, turnEvents } from './fixtures.ts'
 
 describe('issue work worker', () => {
-  it('closes every combined issue and stacks on the base a Batch chose', async () => {
+  it('keeps combined issues and the planned base through the GitHub write preflight', async () => {
     const repository = repositoryMapping()
     const issue = issueItem()
     const bases: PullRequestBase[] = []
@@ -54,7 +55,15 @@ describe('issue work worker', () => {
       },
     })
 
-    const result = await worker.run({
+    const guarded = withGitHubWritePreflight({
+      accesses: ['item_write', 'contents_write'],
+      source: {
+        getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2126-01-01T00:00:00.000Z' })),
+        invalidate: () => undefined,
+      },
+      worker,
+    })
+    const result = await guarded.run({
       id: 'issue-work-task',
       kind: 'issue_work',
       repository: repository.github,
@@ -70,8 +79,9 @@ describe('issue work worker', () => {
     })
 
     expect(bases).toEqual([{ _tag: 'Stacked', ref: 'fix/issue-9', pullRequestNumber: 9, headSha: 'stack-head' }])
-    if (result._tag !== 'Ok' || result.value._tag !== 'Publish' || result.value.publication._tag !== 'OpenPullRequest')
+    if (result._tag !== 'Ok' || result.value._tag !== 'Publish' || result.value.publication._tag !== 'OpenPullRequest' || result.value.publication.taskKind !== 'issue_work')
       throw new Error('Expected a pull request publication.')
+    expect(result.value.publication.combinedIssueNumbers).toEqual([13])
     expect(result.value.publication.baseRef).toBe('fix/issue-9')
     expect(result.value.publication.pullRequestBody).toContain('Closes #12.')
     expect(result.value.publication.pullRequestBody).toContain('Closes #13.')

--- a/packages/harlan-github-agent/test/opencode-provider.test.ts
+++ b/packages/harlan-github-agent/test/opencode-provider.test.ts
@@ -116,6 +116,17 @@ describe('opencodeAgentEvent', () => {
     })).toEqual({ _tag: 'FileChanged', changes: [{ path: 'src/parser.ts', kind: 'update' }] })
   })
 
+  it.each(['', 'All green. Work complete.\n\n'])('keeps code fences inside an implemented result with prefix %j', (prefix) => {
+    const response = JSON.stringify({
+      outcome: 'implemented',
+      summary: 'The regression failed before the fix and passed afterwards.',
+      pullRequestBody: 'Before:\n```\ncurl -w \'%{http_code} %{redirect_url}\'\n```\nAfter:\n```\n301 /docs/intro\n```',
+    })
+
+    expect(opencodeAgentEvent({ type: 'text', part: { text: `${prefix}${response}` } }))
+      .toEqual({ _tag: 'Message', text: response })
+  })
+
   it('strips the code fence from the final message', () => {
     expect(opencodeAgentEvent(textLine)).toEqual({ _tag: 'Message', text: '{"outcome":"resolved"}' })
   })
@@ -287,6 +298,11 @@ describe('extractJsonObject', () => {
 
   it('takes the object out of surrounding prose', () => {
     expect(extractJsonObject('Here is the result: {"a":1} Done.')).toBe('{"a":1}')
+  })
+
+  it('keeps the complete explanation when braces do not contain JSON', () => {
+    const response = 'The command was curl -w \'%{http_code} %{redirect_url}\'. No response arrived.'
+    expect(extractJsonObject(response)).toBe(response)
   })
 
   it('returns the text unchanged when it holds no object', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

NuxtSEO agents completed #775 and #779, but code examples inside their result JSON became the entire result. Both changes were then reported as blocked. The Batch for #777 and #782 also lost its combined issue list at the permission check, so its pull request covered only #777.

Preserve the complete result JSON and pass every Batch instruction through permission checks.

![Issue work keeps its combined issues, planned base, and complete Agent result](https://github.com/user-attachments/assets/c52ee7b1-4b47-4357-accc-f76ec66fada7)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
