### PR TITLE
fix(github-agent): recover inferred issue closures

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -6756,6 +6756,17 @@ export function openJournalStore(
           && subject.current_source === 'poll'
         if (!older && !weakerAtSameVersion)
           return false
+        // Older controllers stamped guessed issue closures with their own clock.
+        // A later GitHub poll can correct that guess even when GitHub's timestamp is older.
+        if (input.source === 'poll' && input.subject.kind === 'issue'
+          && current.kind === 'issue' && current.state === 'closed' && subject.current_source === 'poll') {
+          const inferredClosure = database.prepare(`
+            SELECT 1 FROM observations
+            WHERE subject_id = ? AND revision_id = ? AND external_id = ? AND observed_at < ?
+          `).get(subject.id, currentRevisionId, inferredClosureObservationId(current, current.updatedAt), input.observedAt)
+          if (inferredClosure !== undefined)
+            return false
+        }
         if (
           !exactPullRequest
           || input.subject.kind !== 'pull_request'

--- a/packages/harlan-github-agent/test/inferred-issue-closures.test.ts
+++ b/packages/harlan-github-agent/test/inferred-issue-closures.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { openJournalStore, reconcileRepository } from '../src/index.ts'
+import { ok } from '../src/result.ts'
+import { issueItem, repositoryMapping } from './fixtures.ts'
+
+const stores: ReturnType<typeof openJournalStore>[] = []
+afterEach(() => stores.splice(0).forEach(store => store.close()))
+
+function setup() {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  const repository = repositoryMapping({ ownership: 'maintained', authentication: 'user', issueWork: true })
+  store.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+  const issue = issueItem({ author: 'contributor' })
+  const read = (subject: typeof issue, at: string) => reconcileRepository(repository, {
+    github: {
+      listOpenItems: () => Promise.resolve(ok([subject])),
+      getIssue: () => Promise.resolve(ok(subject)),
+      getPullRequest: () => Promise.reject(new Error('No pull request exists.')),
+    },
+    store,
+    now: () => new Date(at),
+  })
+  return { store, repository, issue, read }
+}
+
+describe('inferred issue closures', () => {
+  it.each([false, true])('restores an open issue from a fresh poll when its content changed: %s', async (changed) => {
+    const { store, repository, issue, read } = setup()
+    await read(issue, '2026-08-13T02:00:00.000Z')
+    // Older controllers guessed closure from a missing list entry and stamped their own time.
+    store.closeMissingItems(repository.github, [], '2026-08-14T00:00:00.000Z')
+    const current = changed
+      ? { ...issue, contentDigest: 'updated-content', updatedAt: '2026-08-13T03:00:00.000Z' }
+      : issue
+
+    const result = await read(current, '2026-08-15T00:00:00.000Z')
+
+    expect(result).toEqual(ok(expect.objectContaining({ stale: 0 })))
+    expect(store.listOpenIssueNumbers(repository.github)).toEqual([issue.number])
+    expect(store.getDashboardSnapshot('2026-08-15T00:00:00.000Z').items)
+      .toContainEqual(expect.objectContaining({ number: issue.number, state: 'open' }))
+  })
+
+  it('restores the contributor issue without granting implementation approval', async () => {
+    const { store, repository, issue, read } = setup()
+    await read(issue, '2026-08-13T02:00:00.000Z')
+    const triage = store.claimNextIssueTriageTask('triage', '2026-08-13T02:01:00.000Z', 60_000)
+    if (triage === null)
+      throw new Error('Expected Issue triage.')
+    store.completeWorkerTask({
+      taskId: triage.id,
+      workerId: triage.state.workerId,
+      fence: triage.state.fence,
+      at: '2026-08-13T02:01:01.000Z',
+      evidence: JSON.stringify({ _tag: 'READY_TO_IMPLEMENT', difficulty: 2, impact: 4, hasReproduction: true, needsCodebaseReview: false, summary: 'Verified.', nextAction: 'Fix the issue.' }),
+    })
+    store.closeMissingItems(repository.github, [], '2026-08-14T00:00:00.000Z')
+
+    await read(issue, '2026-08-15T00:00:00.000Z')
+
+    expect(store.getDashboardSnapshot('2026-08-15T00:00:00.000Z').queue)
+      .toContainEqual(expect.objectContaining({ number: issue.number, state: { _tag: 'AwaitingApproval', kind: 'issue_work' } }))
+    expect(store.claimNextIssueWorkTask('implementation', '2026-08-15T00:01:00.000Z', 60_000)).toBeNull()
+  })
+
+  it('keeps a confirmed GitHub closure when an older open poll arrives', async () => {
+    const { store, repository, issue, read } = setup()
+    await read(issue, '2026-08-13T02:00:00.000Z')
+    store.recordObservation({
+      externalId: 'github-confirmed-closure',
+      subject: { ...issue, state: 'closed', updatedAt: '2026-08-14T00:00:00.000Z' },
+      source: 'poll',
+      observedAt: '2026-08-14T00:01:00.000Z',
+    })
+
+    const result = await read(issue, '2026-08-15T00:00:00.000Z')
+
+    expect(result).toEqual(ok(expect.objectContaining({ stale: 1 })))
+    expect(store.listOpenIssueNumbers(repository.github)).toEqual([])
+  })
+
+  it.each([
+    { source: 'webhook' as const, observedAt: '2026-08-15T00:00:00.000Z' },
+    { source: 'poll' as const, observedAt: '2026-08-13T04:00:00.000Z' },
+  ])('rejects an older issue from $source observed at $observedAt', async ({ source, observedAt }) => {
+    const { store, repository, issue, read } = setup()
+    await read(issue, '2026-08-13T02:00:00.000Z')
+    store.closeMissingItems(repository.github, [], '2026-08-14T00:00:00.000Z')
+
+    const result = store.recordObservation({ externalId: 'delayed-webhook', subject: issue, source, observedAt })
+
+    expect(result._tag).toBe('Stale')
+    expect(store.listOpenIssueNumbers(repository.github)).toEqual([])
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### 🔗 Linked issue

Related to nuxt-modules/og-image#677. This fixes Issue tracking; the glyph defect remains open.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

An older controller guessed that #677 was closed and gave that guess a newer timestamp than GitHub. Every later poll rejected the real open issue as stale. Fresh polls can now correct these recorded guesses, while confirmed closures and implementation Approval keep their existing rules.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
