### PR TITLE
fix(github-agent): resume Repair after base CI passes

### DIFF
--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -33,6 +33,7 @@ import { findRepositoryMemory, repositoryMemoryLine, TOOLCHAIN_LINES } from './a
 import { formatPhaseDuration } from './agent-progress.ts'
 import { runParsedAgentTurn } from './agent-turn.ts'
 import { APPROVAL_LABELS } from './approval-labels.ts'
+import { REVIEW_REPAIR_REFUSALS } from './failure.ts'
 import { currentGitHubChecks } from './github-agent-source.ts'
 import { isIssueTriageState } from './issue-triage.ts'
 import { repairRoundLabel } from './repair-rounds.ts'
@@ -853,11 +854,19 @@ type RepairPreflight
   = | { _tag: 'Authorized' }
     | { _tag: 'ActionRequired', reason: string }
 
-function repairPreflight(task: ClaimedAdversarialReviewTask, snapshot: PullRequestReviewSnapshot, repairsBaseline: boolean, access: Result<void, string>): RepairPreflight {
-  if (!canRepairPullRequestHead(task.repositoryMapping, task.pullRequest))
+export function repairPreflight(mapping: RepositoryMapping, snapshot: PullRequestReviewSnapshot, access: Result<void, string>): RepairPreflight {
+  if (snapshot.pullRequest.state !== 'open')
+    return { _tag: 'ActionRequired', reason: REVIEW_REPAIR_REFUSALS.closed }
+  if (snapshot.pullRequest.draft)
+    return { _tag: 'ActionRequired', reason: REVIEW_REPAIR_REFUSALS.draft }
+  if (snapshot.pullRequest.mergeState !== 'clean')
+    return { _tag: 'ActionRequired', reason: REVIEW_REPAIR_REFUSALS.conflict }
+  if (!canRepairPullRequestHead(mapping, snapshot.pullRequest))
     return { _tag: 'ActionRequired', reason: 'The controller cannot write this pull request branch.' }
   if (access._tag === 'Err')
     return { _tag: 'ActionRequired', reason: access.error }
+  const repairsBaseline = snapshot.pullRequest.purpose._tag === 'BaselineRepair'
+    || (basesDefaultBranch(snapshot.pullRequest, mapping) && headRepairsFailedBaseChecks(snapshot))
   const baseAllowsRepair = snapshot.baseChecks._tag === 'Available'
     && (snapshot.baseChecks.checks.length === 0 || checksGate(snapshot.baseChecks, 'base-ci', 'Pending').state._tag === 'Passed')
   if (!repairsBaseline && !baseAllowsRepair)
@@ -1161,14 +1170,12 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       const storedRun = task.state.fence > 1 && stored._tag === 'Current' ? stored.run : undefined
       if (storedRun !== undefined) {
         const repairAccess = await options.preflightRepair(task.repository, signal)
-        const repairsBaseline = snapshot.value.pullRequest.purpose._tag === 'BaselineRepair'
-          || (basesDefaultBranch(snapshot.value.pullRequest, task.repositoryMapping) && headRepairsFailedBaseChecks(snapshot.value))
         return projectReviewRun(
           options,
           task,
           snapshot.value,
           storedRun,
-          repairPreflight(task, snapshot.value, repairsBaseline, repairAccess),
+          repairPreflight(task.repositoryMapping, snapshot.value, repairAccess),
           signal,
         )
       }
@@ -1271,7 +1278,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
       // The Review run records which Agent provider and model answered, so the
       // runtime is read once and reused for the whole review.
       const reviewRuntime = options.runtime()
-      const preflight = repairPreflight(task, snapshot.value, repairsBaseline, repairAccess)
+      const preflight = repairPreflight(task.repositoryMapping, snapshot.value, repairAccess)
       const repairedHeadFindings = options.store.getRepairedHeadFindings(task.repository, task.pullRequestNumber, task.pullRequest.headSha)
       // The slug comes from the primary checkout, never from this worktree.
       const memory = options.claudeHome === undefined
@@ -1378,7 +1385,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         findings,
         feedback: null,
         publications: [],
-      }, preflight, signal)
+      }, repairPreflight(task.repositoryMapping, frozen.value, await options.preflightRepair(task.repository, signal)), signal)
     },
   }
 }

--- a/packages/harlan-github-agent/src/review-gate-sweep.ts
+++ b/packages/harlan-github-agent/src/review-gate-sweep.ts
@@ -5,7 +5,8 @@ import type { BaselineRepairQueueResult, JournalStore, ReviewGateRefresh } from 
 import type { RepositoryMapping, ReviewGates, ReviewOutcomeName } from './types.ts'
 import { createHash } from 'node:crypto'
 import { ciGatePendingMessage, readCiGate } from './ci-gate-pending.ts'
-import { refreshControllerGates, reviewOutcome, terminalComment } from './item-agent.ts'
+import { refreshControllerGates, repairPreflight, reviewOutcome, terminalComment } from './item-agent.ts'
+import { repairRoundLabel } from './repair-rounds.ts'
 import { err, ok } from './result.ts'
 
 /**
@@ -21,10 +22,10 @@ export type ReviewGateRefreshOutcome
 export interface ReviewGateSweepOptions {
   github: Pick<GitHubAgentSource, 'editReviewStatus' | 'getPullRequestReviewSnapshot' | 'stampAgentLabel'>
   now: () => Date
-  /** Proves the controller may push a Baseline repair branch to this repository. */
+  /** Proves the controller may publish Repair commits in this repository. */
   preflightRepair: (repository: string, signal: AbortSignal) => Promise<Result<void, string>>
   repositories: RepositoryMapping[]
-  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'queueBaselineRepairForGate' | 'recordIncident' | 'recordReviewPublication' | 'resolveIncidents' | 'stageReviewGateStatus'>
+  store: Pick<JournalStore, 'listReviewGateRefreshes' | 'queueBaselineRepairForGate' | 'queueReviewFixForGate' | 'recordIncident' | 'recordReviewPublication' | 'resolveIncidents' | 'stageReviewGateStatus'>
 }
 
 /**
@@ -39,7 +40,8 @@ const CI_GATE_OPERATION = 'ci_gate_pending'
  * Refreshes the moving gates around one completed Agent report.
  *
  * Mergeability and CI can change without a new head commit. This sweep reads
- * both again. It starts no Agent because the report still covers this diff.
+ * both again and queues deferred Repair from the stored findings.
+ * It needs no new Review Agent because the report still covers this diff.
  */
 export async function refreshReviewGates(
   options: ReviewGateSweepOptions,
@@ -69,7 +71,27 @@ export async function refreshReviewGates(
     const { gates, reportedChecks, ciCause } = refreshControllerGates(review.gates, live.value, mapping)
     const outcome = reviewOutcome(gates)
     const confidence = outcome === 'READY' ? review.confidence : undefined
-    const body = terminalComment(review.headSha, live.value.pullRequest.baseSha, gates, review.findings, confidence, reportedChecks)
+    let findings = review.findings
+    const repairable = gates.review._tag === 'Failed'
+      && findings.some(finding => finding._tag === 'Open' && finding.resolution !== 'Dismissal')
+      && !findings.some(finding => finding._tag === 'Open' && finding.resolution === 'Dismissal')
+    if (repairable) {
+      const preflight = repairPreflight(mapping, live.value, await options.preflightRepair(review.repository, signal))
+      const repair = preflight._tag === 'Authorized'
+        ? options.store.queueReviewFixForGate({
+            reviewRunId: review.reviewRunId,
+            revisionId: review.revisionId,
+            headSha: review.headSha,
+            baseSha: live.value.pullRequest.baseSha,
+            at: options.now().toISOString(),
+          })
+        : preflight
+      const firstOpen = findings.findIndex(finding => finding._tag === 'Open')
+      findings = findings.map((finding, index) => finding._tag === 'Open' && index === firstOpen
+        ? { ...finding, nextAction: repair._tag === 'Queued' ? `Repair ${repairRoundLabel(repair.rounds)} starts. ${finding.nextAction}` : repair.reason }
+        : finding)
+    }
+    const body = terminalComment(review.headSha, live.value.pullRequest.baseSha, gates, findings, confidence, reportedChecks)
     // A red default branch holds this review PENDING until someone repairs
     // it. No review lease exists here, so this is the only place that can
     // queue that repair. The store answers Existing on every later pass.
@@ -77,7 +99,7 @@ export async function refreshReviewGates(
       ? { baselineRepair: await queueBaselineRepair(options, review, live.value.pullRequest.baseSha, signal) }
       : {}
     const gatesChanged = JSON.stringify(gates) !== JSON.stringify(review.gates)
-    if (!gatesChanged) {
+    if (!gatesChanged && !(repairable && body !== review.publishedBody)) {
       // Only a gate that did not move can be overdue. A gate that changed this
       // pass rewrites its own timestamp, so the old one would report a wait
       // that has just ended.

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -12178,13 +12178,18 @@ export function openJournalStore(
             WHERE review_evidence_scopes.review_run_id = ranked.id
               AND review_evidence_scopes.policy_digest = repositories.policy_digest
           )
-          -- A finished or cancelled Repair needs an explicit new Review.
-          -- Base movement must not restore its retry budget.
+          -- A stopped Repair needs a newer Review before another round.
+          -- Base movement alone must not restore its retry budget.
           AND NOT EXISTS (
             SELECT 1 FROM tasks AS repair
             JOIN revisions AS repaired ON repaired.id = repair.revision_id
             WHERE repair.subject_id = ranked.subject_id AND repair.kind = 'review_fix'
               AND json_extract(repaired.payload, '$.headSha') = ranked.head_sha
+              AND (
+                repair.updated_at >= ranked.started_at
+                OR repair.state_tag IN ('Queued', 'Running', 'Publishing', 'Completed')
+                OR EXISTS (SELECT 1 FROM task_cancellations WHERE task_id = repair.id)
+              )
           )
         )
       )
@@ -12203,6 +12208,7 @@ export function openJournalStore(
         JOIN revisions AS cancelled_revision ON cancelled_revision.id = cancelled.revision_id
         WHERE cancelled.subject_id = ranked.subject_id AND cancelled.kind = 'adversarial_review'
           AND json_extract(cancelled_revision.payload, '$.headSha') = ranked.head_sha
+          AND task_cancellations.cancelled_at >= ranked.started_at
       )
       AND NOT EXISTS (
         SELECT 1 FROM worker_tasks AS live
@@ -12213,6 +12219,7 @@ export function openJournalStore(
         SELECT 1 FROM tasks AS repair
         WHERE repair.subject_id = ranked.subject_id AND repair.kind = 'review_fix'
           AND repair.state_tag IN ('Queued', 'ActionRequired', 'Running', 'Publishing')
+          AND (repair.state_tag != 'ActionRequired' OR repair.updated_at >= ranked.started_at)
       )
     ORDER BY repositories.github, subjects.github_number
   `).all() as unknown as ReviewGateRefreshRow[]).map(row => ({

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -732,6 +732,14 @@ export interface JournalStore extends BatchStore {
     fence: number
     at: string
   }) => ReviewFixQueueResult
+  /** Queues a completed Review's deferred Repair once its current base permits it. */
+  queueReviewFixForGate: (input: {
+    reviewRunId: string
+    revisionId: string
+    headSha: string
+    baseSha: string
+    at: string
+  }) => ReviewFixQueueResult
   /** Stores one Repair Agent's report under its fenced lease, before its commit is staged. */
   recordRepairReport: (input: { taskId: string, workerId: string, fence: number, at: string, summary: string, checks: string[] }) => boolean
   queueBaselineRepairForReview: (input: {
@@ -8263,6 +8271,47 @@ export function openJournalStore(
     }
   }
 
+  const queueReviewFixForGate: JournalStore['queueReviewFixForGate'] = (input) => {
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      // Recheck eligibility after the GitHub read. A concurrent sweep, changed
+      // head, cancellation, or Dismissal must not start another Repair.
+      const review = listReviewGateRefreshes().find(candidate =>
+        candidate.reviewRunId === input.reviewRunId
+        && candidate.revisionId === input.revisionId
+        && candidate.headSha === input.headSha)
+      const row = review === undefined
+        ? undefined
+        : database.prepare(`
+        SELECT subjects.id AS subject_id, revisions.payload, repositories.policy_json
+        FROM subjects
+        JOIN revisions ON revisions.id = subjects.current_revision_id
+        JOIN repositories ON repositories.id = subjects.repository_id
+        WHERE revisions.id = ?
+          AND json_extract(revisions.payload, '$.baseSha') = ?
+      `).get(input.revisionId, input.baseSha) as {
+          subject_id: number
+          payload: string
+          policy_json: string
+        } | undefined
+      if (row === undefined) {
+        database.exec('COMMIT')
+        return { _tag: 'ActionRequired', reason: 'The pull request changed before Repair was queued.' }
+      }
+      const subject = JSON.parse(row.payload) as GitHubPullRequestItem
+      const mapping = JSON.parse(row.policy_json) as RepositoryMapping
+      const plan = planReviewFix(database, subject, row.subject_id, input.revisionId, input.at, mapping)
+      database.exec('COMMIT')
+      return plan._tag === 'Planned'
+        ? { _tag: 'Queued', taskId: plan.taskId, rounds: plan.rounds }
+        : { _tag: 'ActionRequired', reason: plan.reason }
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
   const recordRepairReport: JournalStore['recordRepairReport'] = (input) => {
     const owned = database.prepare(`
       SELECT 1 FROM tasks
@@ -12064,7 +12113,7 @@ export function openJournalStore(
     }
   }
 
-  /** Every published clean Review whose merge or CI gate can still move. */
+  /** Published Reviews with moving gates or a Repair that has not started. */
   const listReviewGateRefreshes: JournalStore['listReviewGateRefreshes'] = () => (database.prepare(`
     WITH ranked AS (
       SELECT review_runs.*,
@@ -12110,7 +12159,35 @@ export function openJournalStore(
       LIMIT 1
     )
     WHERE ranked.run_rank = 1
-      AND json_extract(ranked.gates, '$.review._tag') = 'Passed'
+      AND (
+        json_extract(ranked.gates, '$.review._tag') = 'Passed'
+        OR (
+          json_extract(ranked.gates, '$.review._tag') = 'Failed'
+          AND EXISTS (
+            SELECT 1 FROM json_each(ranked.findings) AS finding
+            WHERE json_extract(finding.value, '$._tag') = 'Open'
+              AND COALESCE(json_extract(finding.value, '$.resolution'), 'Repair') = 'Repair'
+          )
+          AND NOT EXISTS (
+            SELECT 1 FROM json_each(ranked.findings) AS finding
+            WHERE json_extract(finding.value, '$._tag') = 'Open'
+              AND json_extract(finding.value, '$.resolution') = 'Dismissal'
+          )
+          AND EXISTS (
+            SELECT 1 FROM review_evidence_scopes
+            WHERE review_evidence_scopes.review_run_id = ranked.id
+              AND review_evidence_scopes.policy_digest = repositories.policy_digest
+          )
+          -- A finished or cancelled Repair needs an explicit new Review.
+          -- Base movement must not restore its retry budget.
+          AND NOT EXISTS (
+            SELECT 1 FROM tasks AS repair
+            JOIN revisions AS repaired ON repaired.id = repair.revision_id
+            WHERE repair.subject_id = ranked.subject_id AND repair.kind = 'review_fix'
+              AND json_extract(repaired.payload, '$.headSha') = ranked.head_sha
+          )
+        )
+      )
       AND published.result_tag = 'Published'
       AND repositories.enabled = 1
       ${repositoryWriteAuthoritySql}
@@ -12119,6 +12196,14 @@ export function openJournalStore(
       AND ranked.revision_id = subjects.current_revision_id
       AND json_extract(current_revisions.payload, '$.state') = 'open'
       AND json_extract(current_revisions.payload, '$.headSha') = ranked.head_sha
+      AND NOT EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = ranked.subject_id)
+      AND NOT EXISTS (
+        SELECT 1 FROM task_cancellations
+        JOIN worker_tasks AS cancelled ON cancelled.id = task_cancellations.task_id
+        JOIN revisions AS cancelled_revision ON cancelled_revision.id = cancelled.revision_id
+        WHERE cancelled.subject_id = ranked.subject_id AND cancelled.kind = 'adversarial_review'
+          AND json_extract(cancelled_revision.payload, '$.headSha') = ranked.head_sha
+      )
       AND NOT EXISTS (
         SELECT 1 FROM worker_tasks AS live
         WHERE live.subject_id = ranked.subject_id AND live.kind = 'adversarial_review'
@@ -13795,6 +13880,7 @@ export function openJournalStore(
     claimNextIssueWorkTask,
     claimNextReviewFixTask,
     queueReviewFixTaskForReview,
+    queueReviewFixForGate,
     recordRepairReport,
     queueBaselineRepairForReview,
     queueBaselineRepairForGate,

--- a/packages/harlan-github-agent/test/review-gate-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-gate-sweep.test.ts
@@ -114,6 +114,7 @@ function harness(options: {
     repositories: [repositoryMapping()],
     store: {
       listReviewGateRefreshes: () => [options.review ?? gateRefresh()],
+      queueReviewFixForGate: () => { throw new Error('A passing Review needs no Repair.') },
       queueBaselineRepairForGate: ({ at: _at, ...input }) => {
         recorded.baselineQueued.push(input)
         return { _tag: 'Queued', taskId: 'baseline-1' }

--- a/packages/harlan-github-agent/test/review-repair-ci.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-ci.test.ts
@@ -1,0 +1,245 @@
+import type { PullRequestReviewSnapshot } from '../src/github-agent-source.ts'
+import type { JournalStore } from '../src/store.ts'
+import type { ReviewFinding, ReviewGates } from '../src/types.ts'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { terminalComment } from '../src/item-agent.ts'
+import { ok } from '../src/result.ts'
+import { refreshReviewGates } from '../src/review-gate-sweep.ts'
+import { openJournalStore } from '../src/store.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const cleanups: Array<() => void> = []
+afterEach(() => cleanups.splice(0).reverse().forEach(cleanup => cleanup()))
+
+const finding: ReviewFinding = {
+  _tag: 'Open',
+  resolution: 'Repair',
+  summary: 'A saved name shows a false error.',
+  nextAction: 'Handle the later refresh separately.',
+}
+
+function setup(findings: ReviewFinding[] = [finding]) {
+  const directory = mkdtempSync(join(tmpdir(), 'review-repair-ci-'))
+  cleanups.push(() => rmSync(directory, { recursive: true, force: true }))
+  const path = join(directory, 'journal.sqlite')
+  const mapping = repositoryMapping()
+  const pullRequest = pullRequestItem({ mergeState: 'clean' })
+  const store = openJournalStore(path, true)
+  store.syncRepositories([mapping], '2026-09-08T04:00:00.000Z')
+  store.setRepositoryWritesEnabled(mapping.github, true)
+  const observed = store.recordObservation({
+    externalId: 'pending-repair',
+    observedAt: '2026-09-08T04:00:00.000Z',
+    source: 'poll',
+    subject: pullRequest,
+  })
+  if (observed._tag !== 'Inserted')
+    throw new Error('Expected the pull request.')
+  const task = store.claimNextAdversarialReviewTask('reviewer', '2026-09-08T04:00:01.000Z', 60_000)
+  if (task === null)
+    throw new Error('Expected Review.')
+  const gates: ReviewGates = {
+    merge: { _tag: 'Passed', evidence: [] },
+    review: { _tag: 'Failed', reason: finding.summary, evidence: [] },
+    ci: { _tag: 'Pending', reason: 'Base branch CI: code is still running.', evidence: [] },
+  }
+  store.recordReviewRun({
+    id: 'review-run',
+    repository: mapping.github,
+    pullRequestNumber: pullRequest.number,
+    revisionId: observed.revisionId,
+    headSha: pullRequest.headSha,
+    provider: 'codex',
+    sessionId: 'review-session',
+    model: 'gpt-5.6-sol',
+    agentVersion: '0.0.0',
+    skillDigest: 'a'.repeat(64),
+    startedAt: '2026-09-08T04:00:01.000Z',
+    completedAt: '2026-09-08T04:00:02.000Z',
+    gates,
+    findings,
+  })
+  store.completeReviewTask({
+    taskId: task.id,
+    workerId: task.state.workerId,
+    fence: task.state.fence,
+    at: '2026-09-08T04:00:03.000Z',
+    evidence: 'review-run',
+    resolution: { _tag: 'Reviewed', reviewRunId: 'review-run' },
+  })
+  store.recordReviewPublication({
+    id: 'review-publication',
+    reviewRunId: 'review-run',
+    at: '2026-09-08T04:00:04.000Z',
+    body: terminalComment(pullRequest.headSha, pullRequest.baseSha, gates, findings, undefined, []),
+    result: { _tag: 'Published', githubCommentId: 42, url: `${pullRequest.url}#issuecomment-42` },
+  })
+  store.close()
+  const restarted = openJournalStore(path, true)
+  cleanups.push(() => restarted.close())
+  const check = { id: 1, name: 'code', status: 'completed', conclusion: 'success', source: { _tag: 'CheckRun' as const, appId: 1 }, failure: { _tag: 'NotAsked' as const } }
+  const live: PullRequestReviewSnapshot = {
+    pullRequest,
+    baseChecks: { _tag: 'Available', checks: [check] },
+    checks: { _tag: 'Available', checks: [check] },
+    body: '',
+    comments: [],
+    reviews: [],
+    requiredChecks: { _tag: 'None' },
+    priorAutomatedReview: { _tag: 'None' },
+  }
+  const sweep = (at = '2026-09-08T04:10:00.000Z', beforeRepair = () => {}) => refreshReviewGates({
+    store: restarted,
+    repositories: [mapping],
+    now: () => new Date(at),
+    preflightRepair: () => {
+      beforeRepair()
+      return Promise.resolve(ok(undefined))
+    },
+    github: {
+      getPullRequestReviewSnapshot: () => Promise.resolve(ok(live)),
+      editReviewStatus: () => Promise.resolve(ok({ _tag: 'Edited', commentId: 42, url: pullRequest.url })),
+      stampAgentLabel: () => Promise.resolve(ok(undefined)),
+    },
+  }, new AbortController().signal)
+  return { store: restarted, sweep, live, mapping, task }
+}
+
+function publishStatus(store: JournalStore, minute = '10') {
+  const command = store.claimNextTerminalReviewStatus('publisher', `2026-09-08T04:${minute}:01.000Z`, 60_000)
+  if (command === null)
+    throw new Error('Expected the updated Review status.')
+  expect(store.completeReviewStatus({
+    commandId: command.id,
+    workerId: command.workerId,
+    fence: command.fence,
+    at: `2026-09-08T04:${minute}:02.000Z`,
+    commentId: 42,
+    url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+  })).toBe(true)
+  return command
+}
+
+describe('repair after base CI', () => {
+  it('recovers a completed BLOCKED Review after restart and queues its exact findings once', async () => {
+    const { store, sweep } = setup()
+
+    await sweep()
+    const command = publishStatus(store)
+    await sweep()
+    const repair = store.claimNextReviewFixTask('repair', '2026-09-08T04:10:03.000Z', 60_000)
+
+    expect(command.body).toContain('Repair round 1 of 3 starts.')
+    expect(repair?.kind).toBe('review_fix')
+    expect(store.getReviewFixFindings('harlan-zw/example', 24, repair!.revisionId)).toEqual([finding])
+    expect(store.claimNextReviewFixTask('another-repair', '2026-09-08T04:10:04.000Z', 60_000)).toBeNull()
+  })
+
+  it('keeps Repair pending until the base CI passes', async () => {
+    const { store, sweep, live } = setup()
+    const passing = live.baseChecks
+    live.baseChecks = { _tag: 'Unavailable', reason: 'GitHub timed out.' }
+
+    await sweep()
+    expect(store.claimNextReviewFixTask('repair', '2026-09-08T04:10:00.000Z', 60_000)).toBeNull()
+    publishStatus(store)
+    live.baseChecks = passing
+    await sweep('2026-09-08T04:11:00.000Z')
+    publishStatus(store, '11')
+
+    expect(store.claimNextReviewFixTask('repair', '2026-09-08T04:11:03.000Z', 60_000)?.kind).toBe('review_fix')
+  })
+
+  it.each(['dismissed', 'manual', 'paused', 'writes-disabled', 'new-head', 'new-base'] as const)(
+    'does not queue Repair when %s changes during the GitHub read',
+    async (change) => {
+      const { store, sweep, mapping, live } = setup()
+      await sweep(undefined, () => {
+        if (change === 'dismissed') {
+          store.dismissItem({ repository: mapping.github, itemNumber: 24, at: '2026-09-08T04:09:00.000Z' })
+        }
+        else if (change === 'manual') {
+          store.setSelectionMode('manual')
+        }
+        else if (change === 'paused') {
+          store.setRepositoryPaused(mapping.github, true)
+        }
+        else if (change === 'writes-disabled') {
+          store.setRepositoryWritesEnabled(mapping.github, false)
+        }
+        else {
+          store.recordObservation({
+            externalId: change,
+            observedAt: '2026-09-08T04:09:00.000Z',
+            source: 'poll',
+            subject: { ...live.pullRequest, ...(change === 'new-head' ? { headSha: 'new-head' } : { baseSha: 'new-base' }) },
+          })
+        }
+      })
+
+      expect(store.getDashboardSnapshot('2026-09-08T04:10:01.000Z').tasks.filter(task => task.kind === 'review_fix')).toEqual([])
+    },
+  )
+
+  it.each(['conflicting', 'unknown'] as const)('does not queue Repair while live mergeability is %s', async (mergeState) => {
+    const { store, sweep, live } = setup()
+    live.pullRequest = { ...live.pullRequest, mergeState }
+
+    await sweep()
+
+    expect(store.getDashboardSnapshot('2026-09-08T04:10:01.000Z').tasks.filter(task => task.kind === 'review_fix')).toEqual([])
+  })
+
+  it('does not repair a Review that recommends Dismissal', async () => {
+    const { store, sweep } = setup([{ ...finding, resolution: 'Dismissal' }])
+
+    await sweep()
+
+    expect(store.getDashboardSnapshot('2026-09-08T04:10:01.000Z').tasks.filter(task => task.kind === 'review_fix')).toEqual([])
+  })
+
+  it.each(['cancelled', 'action-required'] as const)('does not restart a %s Repair after the base moves', async (stop) => {
+    const { store, sweep, live } = setup()
+    await sweep()
+    publishStatus(store)
+    const repair = store.claimNextReviewFixTask('repair', '2026-09-08T04:10:03.000Z', 60_000)
+    if (repair === null)
+      throw new Error('Expected Repair.')
+    if (stop === 'cancelled') {
+      expect(store.cancelTask({ taskId: repair.id, at: '2026-09-08T04:10:04.000Z' })._tag).toBe('Cancelled')
+    }
+    else {
+      expect(store.needsAttentionTask({
+        taskId: repair.id,
+        workerId: repair.state.workerId,
+        fence: repair.state.fence,
+        at: '2026-09-08T04:10:04.000Z',
+        reason: 'The Repair needs a decision.',
+        evidence: 'blocked',
+      })).toBe(true)
+    }
+    live.pullRequest = { ...live.pullRequest, baseSha: 'new-base' }
+    store.recordObservation({ externalId: 'base-moved', observedAt: '2026-09-08T04:11:00.000Z', source: 'poll', subject: live.pullRequest })
+
+    await sweep('2026-09-08T04:12:00.000Z')
+
+    expect(store.claimNextReviewFixTask('another-repair', '2026-09-08T04:12:01.000Z', 60_000)).toBeNull()
+  })
+
+  it('recovers the same reviewed head after its base moves', async () => {
+    const { store, sweep, live } = setup()
+    live.pullRequest = { ...live.pullRequest, baseSha: 'new-base' }
+    store.recordObservation({ externalId: 'base-moved', observedAt: '2026-09-08T04:09:00.000Z', source: 'poll', subject: live.pullRequest })
+
+    await sweep()
+    publishStatus(store)
+
+    expect(store.claimNextReviewFixTask('repair', '2026-09-08T04:10:03.000Z', 60_000)?.pullRequest).toMatchObject({
+      headSha: live.pullRequest.headSha,
+      baseSha: 'new-base',
+    })
+  })
+})

--- a/packages/harlan-github-agent/test/review-repair-ci.test.ts
+++ b/packages/harlan-github-agent/test/review-repair-ci.test.ts
@@ -242,4 +242,74 @@ describe('repair after base CI', () => {
       baseSha: 'new-base',
     })
   })
+
+  it.each(['cancelled-review', 'stopped-repair'] as const)('resumes a fresh explicit Review after a %s', async (prior) => {
+    const { store, sweep, live, mapping, task } = setup()
+    const requestRerun = (revisionId: string, at: string) => store.requestReviewRerun({
+      repository: mapping.github,
+      pullRequestNumber: 24,
+      revisionId,
+      requestId: at,
+      requestedBy: 'harlan-zw',
+      source: 'dashboard',
+      at,
+    })
+    if (prior === 'cancelled-review') {
+      expect(requestRerun(task.revisionId, '2026-09-08T04:09:00.000Z')._tag).toBe('Queued')
+      const review = store.claimNextAdversarialReviewTask('reviewer', '2026-09-08T04:09:01.000Z', 60_000)
+      expect(store.cancelTask({ taskId: review!.id, at: '2026-09-08T04:09:02.000Z' })._tag).toBe('Cancelled')
+    }
+    else {
+      await sweep()
+      publishStatus(store)
+      const repair = store.claimNextReviewFixTask('repair', '2026-09-08T04:10:03.000Z', 60_000)!
+      expect(store.needsAttentionTask({
+        taskId: repair.id,
+        workerId: repair.state.workerId,
+        fence: repair.state.fence,
+        at: '2026-09-08T04:10:04.000Z',
+        reason: 'The Repair needs a decision.',
+        evidence: 'blocked',
+      })).toBe(true)
+    }
+    live.pullRequest = { ...live.pullRequest, baseSha: 'new-base' }
+    const observed = store.recordObservation({
+      externalId: 'base-before-explicit-review',
+      observedAt: '2026-09-08T04:11:00.000Z',
+      source: 'poll',
+      subject: live.pullRequest,
+    })
+    if (observed._tag !== 'Inserted')
+      throw new Error('Expected the new base.')
+    expect(requestRerun(observed.revisionId, '2026-09-08T04:12:00.000Z')._tag).toBe('Queued')
+    const review = store.claimNextAdversarialReviewTask('new-reviewer', '2026-09-08T04:12:01.000Z', 60_000)!
+    const earlier = store.listReviewRuns(mapping.github, 24)[0]!
+    expect(store.recordReviewRun({
+      ...earlier,
+      id: 'explicit-review',
+      revisionId: review.revisionId,
+      startedAt: '2026-09-08T04:12:01.000Z',
+      completedAt: '2026-09-08T04:12:02.000Z',
+    })._tag).toBe('Inserted')
+    expect(store.completeReviewTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-09-08T04:12:03.000Z',
+      evidence: 'explicit-review',
+      resolution: { _tag: 'Reviewed', reviewRunId: 'explicit-review' },
+    })).toBe(true)
+    expect(store.recordReviewPublication({
+      id: 'explicit-publication',
+      reviewRunId: 'explicit-review',
+      body: terminalComment(live.pullRequest.headSha, live.pullRequest.baseSha, earlier.gates, [finding], undefined, []),
+      at: '2026-09-08T04:12:04.000Z',
+      result: { _tag: 'Published', githubCommentId: 42, url: live.pullRequest.url },
+    })._tag).toBe('Inserted')
+
+    await sweep('2026-09-08T04:13:00.000Z')
+    publishStatus(store, '13')
+
+    expect(store.claimNextReviewFixTask('new-repair', '2026-09-08T04:13:03.000Z', 60_000)?.kind).toBe('review_fix')
+  })
 })

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -524,6 +524,29 @@ describe('review resilience', () => {
       .toBe(movedFinding?._tag === 'Open' ? movedFinding.details?.fingerprint : undefined)
   })
 
+  it.each([
+    { initial: 'in_progress', final: 'completed', repairs: 1 },
+    { initial: 'completed', final: 'in_progress', repairs: 0 },
+  ])('uses final base CI for Repair when it changes from $initial to $final', async ({ initial, final, repairs }) => {
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    const snapshots = [initial, final].map((status) => {
+      const snapshot = reviewSnapshot(pullRequest)
+      if (snapshot.baseChecks._tag === 'Available')
+        snapshot.baseChecks.checks = snapshot.baseChecks.checks.map(check => ({ ...check, status, conclusion: status === 'completed' ? 'success' : null }))
+      return snapshot
+    })
+    const test = harness({
+      pullRequest,
+      snapshots,
+      response: { findings: [materialFinding()], confidence: 90 },
+    })
+
+    await createReviewWorker(test.options).run(reviewTask(pullRequest), new AbortController().signal)
+
+    expect(test.queued).toBe(repairs)
+    expect(test.comments.at(-1)).toContain(repairs === 1 ? 'Repair round 1 of 3 starts.' : 'The base branch must pass CI before Repair starts.')
+  })
+
   it('queues Repair when the base branch has no CI', async () => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     const snapshot = reviewSnapshot(pullRequest)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

[nuxtseo.com#871](https://github.com/harlan-zw/nuxtseo.com/pull/871) stayed BLOCKED after base CI passed because Repair never started.
Recheck Repair eligibility when Review finishes and when later CI results arrive, using the saved findings.

![Completed Reviews resume Repair after base CI passes](https://github.com/user-attachments/assets/652f5d23-c618-43f0-8d1c-f6f060e2ff9d)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
