### PR TITLE
fix(github-agent): retain issue approval after triage

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4500,7 +4500,7 @@ function planIssueTriage(
       && issueTriageState(existing.evidence) === 'READY_TO_IMPLEMENT'
       && subject.kind === 'issue'
       && canWorkIssues(mapping)
-      && (!requiresIssueApproval(mapping, subject.author) || issuePublicationLostBase(database, subjectId, revisionId))
+      && (!requiresIssueApproval(mapping, subject.author) || retainsIssueWorkApproval(database, subjectId, revisionId))
     ) {
       queueIssueWork(database, subjectId, revisionId, subject, mapping, observedAt)
     }
@@ -4525,6 +4525,15 @@ function issuePublicationLostBase(database: DatabaseSync, subjectId: number, rev
       AND publication_commands.state_tag = 'Superseded' AND publication_commands.reason = tasks.reason
       AND publication_commands.outcome_unknown = 0
   `).get(subjectId, revisionId) !== undefined
+}
+
+/** Controller recovery preserves Approval for the same Issue Revision. */
+function retainsIssueWorkApproval(database: DatabaseSync, subjectId: number, revisionId: string): boolean {
+  return issuePublicationLostBase(database, subjectId, revisionId) || database.prepare(`
+    SELECT 1 FROM tasks
+    WHERE subject_id = ? AND revision_id = ? AND kind = 'issue_work'
+      AND state_tag = 'Superseded' AND reason = ?
+  `).get(subjectId, revisionId, freshIssueTriageReason) !== undefined
 }
 
 function queueIssueWork(
@@ -4576,7 +4585,7 @@ function queueIssueWork(
           taskId,
           from: 'Superseded',
           to: 'Queued',
-          reason: 'Fresh issue triage was approved.',
+          reason: 'Fresh Issue triage confirmed the approved work.',
           fence: existing.fence,
           at,
         })
@@ -8780,7 +8789,7 @@ export function openJournalStore(
           if (
             subject.kind === 'issue'
             && canWorkIssues(mapping)
-            && !requiresIssueApproval(mapping, subject.author)
+            && (!requiresIssueApproval(mapping, subject.author) || retainsIssueWorkApproval(database, row.subject_id, row.revision_id))
             && issueTriageState(input.evidence) === 'READY_TO_IMPLEMENT'
           ) {
             queueIssueWork(database, row.subject_id, row.revision_id, subject, mapping, input.at)

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -4883,9 +4883,14 @@ describe('journal store', () => {
     }))
   })
 
-  it('requires fresh triage before retrying approved issue work against a changed scope', () => {
+  it.each([
+    { ownership: 'owned', route: 'READY_TO_IMPLEMENT' },
+    { ownership: 'maintained', route: 'READY_TO_IMPLEMENT' },
+    { ownership: 'owned', route: 'WAIT_TO_IMPLEMENT' },
+    { ownership: 'maintained', route: 'WAIT_TO_IMPLEMENT' },
+  ] as const)('keeps Approval after fresh triage on $ownership with route $route', ({ ownership, route }) => {
     const store = createStore()
-    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.syncRepositories([repositoryMapping({ ownership })], '2026-08-13T00:00:00.000Z')
     store.recordObservation({
       externalId: 'issue-scope-retry',
       observedAt: '2026-08-13T01:00:00.000Z',
@@ -4934,22 +4939,21 @@ describe('journal store', () => {
       workerId: retriage.state.workerId,
       fence: retriage.state.fence,
       at: '2026-08-13T01:00:09.000Z',
-      evidence: JSON.stringify({ _tag: 'READY_TO_IMPLEMENT' }),
+      evidence: JSON.stringify({ _tag: route }),
     })
-    expect(store.getDashboardSnapshot('2026-08-13T01:00:10.000Z').queue).toContainEqual(expect.objectContaining({
-      number: 12,
-      state: { _tag: 'AwaitingApproval', kind: 'issue_work' },
-    }))
-    expect(store.approveIssueWork({
-      repository: 'harlan-zw/example',
-      issueNumber: 12,
-      revisionId: retriage.revisionId,
-      at: '2026-08-13T01:00:11.000Z',
-    })).toEqual({ _tag: 'Approved', taskId: expect.any(String) })
-    expect(store.claimNextIssueWorkTask('issue-worker-4', '2026-08-13T01:00:12.000Z', 10_000)).toEqual(expect.objectContaining({
-      kind: 'issue_work',
-      issueNumber: 12,
-    }))
+    const work = store.claimNextIssueWorkTask('issue-worker-4', '2026-08-13T01:00:12.000Z', 10_000)
+    expect(work?.issueNumber ?? null).toBe(route === 'READY_TO_IMPLEMENT' ? 12 : null)
+    if (work !== null) {
+      expect(work.revisionId).toBe(triage.revisionId)
+      store.cancelTask({ taskId: work.id, at: '2026-08-13T01:00:13.000Z' })
+      store.recordObservation({
+        externalId: 'poll-after-cancellation',
+        observedAt: '2026-08-13T01:00:14.000Z',
+        source: 'poll',
+        subject: issueItem(),
+      })
+      expect(store.claimNextIssueWorkTask('issue-worker-5', '2026-08-13T01:00:15.000Z', 10_000)).toBeNull()
+    }
   })
 
   it('retries changed-scope issue work on a maintained repository', () => {
@@ -5036,8 +5040,18 @@ describe('journal store', () => {
       throw new Error('Expected changed Issue content to create a Revision.')
 
     expect(store.claimNextIssueWorkTask('issue-worker', '2026-08-13T01:00:05.000Z', 60_000)).toBeNull()
-    expect(store.claimNextIssueTriageTask('triage-2', '2026-08-13T01:00:05.000Z', 60_000))
-      .toMatchObject({ revisionId: changed.revisionId })
+    const fresh = store.claimNextIssueTriageTask('triage-2', '2026-08-13T01:00:05.000Z', 60_000)
+    if (fresh === null)
+      throw new Error('Expected Issue triage for the changed content.')
+    expect(fresh.revisionId).toBe(changed.revisionId)
+    store.completeWorkerTask({
+      taskId: fresh.id,
+      workerId: fresh.state.workerId,
+      fence: fresh.state.fence,
+      at: '2026-08-13T01:00:06.000Z',
+      evidence: JSON.stringify({ _tag: 'READY_TO_IMPLEMENT' }),
+    })
+    expect(store.claimNextIssueWorkTask('issue-worker', '2026-08-13T01:00:07.000Z', 60_000)).toBeNull()
   })
 
   it('shows repeated pull request description failures instead of the Agent fallback', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### 🔗 Linked issue

Related to nuxt-modules/og-image#677. The glyph defect remains open.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Harlan approved og-image#677, but its missing triage session triggered fresh Issue triage and another Approval prompt. Recovery now keeps Approval for the same Issue Revision when triage returns Ready to implement. Changed issue content and explicit cancellation still stop the work.

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
