### PR TITLE
fix(github-agent): restore labels for existing reviews

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -218,6 +218,15 @@ export interface FailedJobContext {
 
 export const FAILED_JOB_LOG_TAIL_LINES = 80
 
+export interface ExistingReviewLabel extends PublishedReviewStatus {
+  label: 'READY' | 'PENDING' | 'BLOCKED' | 'ADVERSARIAL_REVIEW_SKIPPED'
+}
+
+export interface ExistingReviewLabelSource {
+  /** Reads the latest trusted review for the pinned head without editing its comment. */
+  readExistingReviewLabel: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, headSha: string, signal: AbortSignal) => Promise<Result<ExistingReviewLabel, string>>
+}
+
 export interface GitHubAgentSource {
   /** Finds the open pull request whose head is `headRef`, if one exists. */
   findOpenPullRequestForBranch: (repository: RepositoryMapping, headRef: string, signal: AbortSignal) => Promise<Result<OpenPullRequestReference | null, string>>
@@ -398,7 +407,7 @@ function pullRequestItem(
   }
 }
 
-export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitHubAgentSource {
+export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitHubAgentSource & ExistingReviewLabelSource {
   const clientWith = async (tokens: GitHubTokenProvider, repository: string, access: GitHubRepositoryAccess, signal: AbortSignal): Promise<Result<Octokit, string>> => {
     const token = await tokens.getToken(repository, access, signal)
     return token._tag === 'Err'
@@ -544,6 +553,48 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
       return octokit.value.rest.issues.removeLabel({ ...request, name: AGENT_LABELS.RUNNING.name })
         .then((): Result<void, string> => ok(undefined))
         .catch((error: unknown): Result<void, string> => errorStatus(error) === 404 ? ok(undefined) : err(message(error)))
+    },
+
+    async readExistingReviewLabel(repository, pullRequestNumber, commentId, headSha, signal) {
+      const octokit = await client(repository.github, 'read', signal)
+      if (octokit._tag === 'Err')
+        return octokit
+      const { owner, repo } = repositoryParts(repository.github)
+      return octokit.value.paginate(octokit.value.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: pullRequestNumber,
+        per_page: 100,
+        request: { signal },
+      }).then(async (comments): Promise<Result<ExistingReviewLabel, string>> => {
+        const prior = priorAutomatedReviewForHead(comments.flatMap(comment =>
+          comment.body == null || comment.user?.login === undefined
+            ? []
+            : [{
+                authorAssociation: comment.author_association,
+                authorLogin: comment.user.login,
+                body: comment.body,
+                url: comment.html_url,
+              }]), headSha, options.actorLogin(repository))
+        const comment = comments.find(comment => comment.id === commentId)
+        if (prior._tag !== 'Found' || prior.state !== 'complete' || comment?.html_url !== prior.url)
+          return err('The completed review changed before its label was restored.')
+        const body = comment.body ?? ''
+        const outcome = body.match(/^### 🤖 (READY|BLOCKED|REVIEW SKIPPED)\b/m)?.[1]
+          ?? body.match(/^\*\*(PASS|PENDING|BLOCKED)\b/m)?.[1]
+        const label = outcome === 'PASS' || outcome === 'READY'
+          ? 'READY'
+          : outcome === 'REVIEW SKIPPED'
+            ? 'ADVERSARIAL_REVIEW_SKIPPED'
+            : outcome === 'PENDING' || outcome === 'BLOCKED' ? outcome : null
+        if (label === null)
+          return err('The completed review has no recognized outcome.')
+        // Read the head after the comments, immediately before the label write.
+        const pull = await octokit.value.rest.pulls.get({ owner, repo, pull_number: pullRequestNumber, request: { signal } })
+        if (pull.data.state !== 'open' || pull.data.head.sha !== headSha)
+          return err('The pull request changed before its review label was restored.')
+        return ok({ commentId: comment.id, url: comment.html_url, label })
+      }).catch((error: unknown): Result<ExistingReviewLabel, string> => err(message(error)))
     },
 
     async stampAgentLabel(repository, itemNumber, state, signal) {

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -222,9 +222,22 @@ export interface ExistingReviewLabel extends PublishedReviewStatus {
   label: 'READY' | 'PENDING' | 'BLOCKED' | 'ADVERSARIAL_REVIEW_SKIPPED'
 }
 
+/**
+ * Why the trusted comment stopped yielding its outcome label.
+ *
+ * `Permanent` says the comment no longer carries the review its command is
+ * pinned to: it was deleted or edited past recognition, or the pull request
+ * moved off the pinned head. No retry restores it, so the caller retires the
+ * command instead of asking GitHub the same question every pass. `Transient`
+ * covers transport trouble a retry can outlive.
+ */
+export type ExistingReviewLabelFailure
+  = | { _tag: 'Permanent', message: string }
+    | { _tag: 'Transient', message: string }
+
 export interface ExistingReviewLabelSource {
   /** Reads the latest trusted review for the pinned head without editing its comment. */
-  readExistingReviewLabel: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, headSha: string, signal: AbortSignal) => Promise<Result<ExistingReviewLabel, string>>
+  readExistingReviewLabel: (repository: RepositoryMapping, pullRequestNumber: number, commentId: number, headSha: string, signal: AbortSignal) => Promise<Result<ExistingReviewLabel, ExistingReviewLabelFailure>>
 }
 
 export interface GitHubAgentSource {
@@ -558,7 +571,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
     async readExistingReviewLabel(repository, pullRequestNumber, commentId, headSha, signal) {
       const octokit = await client(repository.github, 'read', signal)
       if (octokit._tag === 'Err')
-        return octokit
+        return err({ _tag: 'Transient', message: octokit.error })
       const { owner, repo } = repositoryParts(repository.github)
       return octokit.value.paginate(octokit.value.rest.issues.listComments, {
         owner,
@@ -566,7 +579,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
         issue_number: pullRequestNumber,
         per_page: 100,
         request: { signal },
-      }).then(async (comments): Promise<Result<ExistingReviewLabel, string>> => {
+      }).then(async (comments): Promise<Result<ExistingReviewLabel, ExistingReviewLabelFailure>> => {
         const prior = priorAutomatedReviewForHead(comments.flatMap(comment =>
           comment.body == null || comment.user?.login === undefined
             ? []
@@ -578,7 +591,7 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
               }]), headSha, options.actorLogin(repository))
         const comment = comments.find(comment => comment.id === commentId)
         if (prior._tag !== 'Found' || prior.state !== 'complete' || comment?.html_url !== prior.url)
-          return err('The completed review changed before its label was restored.')
+          return err({ _tag: 'Permanent', message: 'The completed review changed before its label was restored.' })
         const body = comment.body ?? ''
         const outcome = body.match(/^### 🤖 (READY|BLOCKED|REVIEW SKIPPED)\b/m)?.[1]
           ?? body.match(/^\*\*(PASS|PENDING|BLOCKED)\b/m)?.[1]
@@ -588,13 +601,13 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
             ? 'ADVERSARIAL_REVIEW_SKIPPED'
             : outcome === 'PENDING' || outcome === 'BLOCKED' ? outcome : null
         if (label === null)
-          return err('The completed review has no recognized outcome.')
+          return err({ _tag: 'Permanent', message: 'The completed review has no recognized outcome.' })
         // Read the head after the comments, immediately before the label write.
         const pull = await octokit.value.rest.pulls.get({ owner, repo, pull_number: pullRequestNumber, request: { signal } })
         if (pull.data.state !== 'open' || pull.data.head.sha !== headSha)
-          return err('The pull request changed before its review label was restored.')
+          return err({ _tag: 'Permanent', message: 'The pull request changed before its review label was restored.' })
         return ok({ commentId: comment.id, url: comment.html_url, label })
-      }).catch((error: unknown): Result<ExistingReviewLabel, string> => err(message(error)))
+      }).catch((error: unknown): Result<ExistingReviewLabel, ExistingReviewLabelFailure> => err({ _tag: 'Transient', message: message(error) }))
     },
 
     async stampAgentLabel(repository, itemNumber, state, signal) {

--- a/packages/harlan-github-agent/src/review-status-controller.ts
+++ b/packages/harlan-github-agent/src/review-status-controller.ts
@@ -1,4 +1,4 @@
-import type { ExistingReviewLabelSource, GitHubAgentSource, PublishedReviewStatus } from './github-agent-source.ts'
+import type { ExistingReviewLabelFailure, ExistingReviewLabelSource, GitHubAgentSource, PublishedReviewStatus } from './github-agent-source.ts'
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedAdversarialReviewTask, ClaimedReviewFixTask, ClaimedReviewStatusCommand, ReviewDesiredOutcome, ReviewStatusTaskPhase } from './types.ts'
@@ -18,14 +18,92 @@ export interface ReviewStatusControllerOptions {
   github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'> & ExistingReviewLabelSource
   leaseMilliseconds: number
   now: () => Date
-  store: Pick<JournalStore, 'claimReviewStatus' | 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt' | 'stageReviewStatus'>
+  store: Pick<JournalStore, 'claimReviewStatus' | 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt' | 'stageReviewStatus' | 'supersedeReviewStatus'>
   workerId: string
 }
 
 export interface ReviewStatusPublicationOptions {
   github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'> & ExistingReviewLabelSource
   now: () => Date
-  store: Pick<JournalStore, 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt'>
+  store: Pick<JournalStore, 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt' | 'supersedeReviewStatus'>
+}
+
+/** Files one failure with the store that answers for it: defer or retire. */
+function settleUnpublished(
+  options: ReviewStatusPublicationOptions,
+  command: ClaimedReviewStatusCommand,
+  failure: ExistingReviewLabelFailure,
+): void {
+  const input = {
+    commandId: command.id,
+    workerId: command.workerId,
+    fence: command.fence,
+    at: options.now().toISOString(),
+    reason: failure.message,
+  }
+  if (failure._tag === 'Transient')
+    options.store.deferReviewStatus(input)
+  else
+    options.store.supersedeReviewStatus(input)
+}
+
+/** Restores one outcome label for a trusted review comment this service must not edit. */
+async function publishExistingReviewLabel(
+  options: ReviewStatusPublicationOptions,
+  command: ClaimedReviewStatusCommand,
+  signal: AbortSignal,
+): Promise<Result<PublishedReviewStatus, string>> {
+  // The read re-validates the state and the head itself, so the heavier review
+  // snapshot would spend GitHub calls re-reading the same truth.
+  const existing = command.commentId === null
+    ? err({ _tag: 'Permanent' as const, message: 'The existing review has no comment identifier.' })
+    : await options.github.readExistingReviewLabel(
+        command.repositoryMapping,
+        command.pullRequestNumber,
+        command.commentId,
+        command.expectedHeadSha,
+        signal,
+      )
+  if (existing._tag === 'Err') {
+    settleUnpublished(options, command, existing.error)
+    return err(existing.error.message)
+  }
+  const stamped = await options.github.stampAgentLabel(
+    command.repositoryMapping,
+    command.pullRequestNumber,
+    existing.value.label,
+    signal,
+  )
+  if (stamped._tag === 'Err') {
+    options.store.deferReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: options.now().toISOString(),
+      reason: stamped.error,
+    })
+    return stamped
+  }
+  const labelConfirmed = options.store.recordReviewStatusReceipt({
+    commandId: command.id,
+    workerId: command.workerId,
+    fence: command.fence,
+    at: options.now().toISOString(),
+    sink: 'outcome_label',
+  })
+  if (!labelConfirmed)
+    return err('GitHub accepted the Review label, but its receipt lost the Publication lease.')
+  const completed = options.store.completeReviewStatus({
+    commandId: command.id,
+    workerId: command.workerId,
+    fence: command.fence,
+    at: options.now().toISOString(),
+    commentId: existing.value.commentId,
+    url: existing.value.url,
+  })
+  return completed
+    ? ok(existing.value)
+    : err('GitHub accepted the review comment, but the local review changed. Refresh before retrying.')
 }
 
 /** Publishes one already fenced command. Terminal commands may outlive their Agent Task. */
@@ -35,6 +113,9 @@ export async function publishClaimedReviewStatus(
   replacePriorReview: boolean,
   signal: AbortSignal,
 ): Promise<Result<PublishedReviewStatus, string>> {
+  if (command.taskKind === 'existing_review')
+    return publishExistingReviewLabel(options, command, signal)
+
   const current = await options.github.getPullRequestReviewSnapshot(command.repositoryMapping, command.pullRequestNumber, signal)
   if (current._tag === 'Err') {
     options.store.deferReviewStatus({
@@ -58,18 +139,7 @@ export async function publishClaimedReviewStatus(
     return err(reason)
   }
 
-  const existing = command.taskKind === 'existing_review'
-    ? command.commentId === null
-      ? err('The existing review has no comment identifier.')
-      : await options.github.readExistingReviewLabel(
-          command.repositoryMapping,
-          command.pullRequestNumber,
-          command.commentId,
-          command.expectedHeadSha,
-          signal,
-        )
-    : null
-  const published = existing ?? await options.github.upsertReviewStatus(
+  const published = await options.github.upsertReviewStatus(
     command.repositoryMapping,
     command.pullRequestNumber,
     command.commentId,
@@ -99,15 +169,13 @@ export async function publishClaimedReviewStatus(
   if (!commentConfirmed)
     return err('GitHub accepted the review comment, but its receipt lost the Publication lease.')
 
-  const label = existing?._tag === 'Ok'
-    ? existing.value.label
-    : command.phase !== 'terminal'
-      ? null
-      : command.desiredOutcome === 'READY' || command.desiredOutcome === 'BLOCKED' || command.desiredOutcome === 'PENDING'
-        ? command.desiredOutcome
-        : command.desiredOutcome === 'WAITING'
-          ? 'PENDING'
-          : null
+  const label = command.phase !== 'terminal'
+    ? null
+    : command.desiredOutcome === 'READY' || command.desiredOutcome === 'BLOCKED' || command.desiredOutcome === 'PENDING'
+      ? command.desiredOutcome
+      : command.desiredOutcome === 'WAITING'
+        ? 'PENDING'
+        : null
   if (label !== null) {
     const stamped = await options.github.stampAgentLabel(
       command.repositoryMapping,

--- a/packages/harlan-github-agent/src/review-status-controller.ts
+++ b/packages/harlan-github-agent/src/review-status-controller.ts
@@ -1,4 +1,4 @@
-import type { GitHubAgentSource, PublishedReviewStatus } from './github-agent-source.ts'
+import type { ExistingReviewLabelSource, GitHubAgentSource, PublishedReviewStatus } from './github-agent-source.ts'
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
 import type { AgentProgress, ClaimedAdversarialReviewTask, ClaimedReviewFixTask, ClaimedReviewStatusCommand, ReviewDesiredOutcome, ReviewStatusTaskPhase } from './types.ts'
@@ -15,7 +15,7 @@ export interface ReviewStatusController {
 }
 
 export interface ReviewStatusControllerOptions {
-  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'>
+  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'> & ExistingReviewLabelSource
   leaseMilliseconds: number
   now: () => Date
   store: Pick<JournalStore, 'claimReviewStatus' | 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt' | 'stageReviewStatus'>
@@ -23,7 +23,7 @@ export interface ReviewStatusControllerOptions {
 }
 
 export interface ReviewStatusPublicationOptions {
-  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'>
+  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'> & ExistingReviewLabelSource
   now: () => Date
   store: Pick<JournalStore, 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt'>
 }
@@ -58,7 +58,18 @@ export async function publishClaimedReviewStatus(
     return err(reason)
   }
 
-  const published = await options.github.upsertReviewStatus(
+  const existing = command.taskKind === 'existing_review'
+    ? command.commentId === null
+      ? err('The existing review has no comment identifier.')
+      : await options.github.readExistingReviewLabel(
+          command.repositoryMapping,
+          command.pullRequestNumber,
+          command.commentId,
+          command.expectedHeadSha,
+          signal,
+        )
+    : null
+  const published = existing ?? await options.github.upsertReviewStatus(
     command.repositoryMapping,
     command.pullRequestNumber,
     command.commentId,
@@ -88,13 +99,15 @@ export async function publishClaimedReviewStatus(
   if (!commentConfirmed)
     return err('GitHub accepted the review comment, but its receipt lost the Publication lease.')
 
-  const label = command.phase !== 'terminal'
-    ? null
-    : command.desiredOutcome === 'READY' || command.desiredOutcome === 'BLOCKED' || command.desiredOutcome === 'PENDING'
-      ? command.desiredOutcome
-      : command.desiredOutcome === 'WAITING'
-        ? 'PENDING'
-        : null
+  const label = existing?._tag === 'Ok'
+    ? existing.value.label
+    : command.phase !== 'terminal'
+      ? null
+      : command.desiredOutcome === 'READY' || command.desiredOutcome === 'BLOCKED' || command.desiredOutcome === 'PENDING'
+        ? command.desiredOutcome
+        : command.desiredOutcome === 'WAITING'
+          ? 'PENDING'
+          : null
   if (label !== null) {
     const stamped = await options.github.stampAgentLabel(
       command.repositoryMapping,

--- a/packages/harlan-github-agent/src/review-status-scheduler.ts
+++ b/packages/harlan-github-agent/src/review-status-scheduler.ts
@@ -1,4 +1,4 @@
-import type { GitHubAgentSource } from './github-agent-source.ts'
+import type { ExistingReviewLabelSource, GitHubAgentSource } from './github-agent-source.ts'
 import type { JournalStore } from './store.ts'
 import { publishClaimedReviewStatus } from './review-status-controller.ts'
 
@@ -9,7 +9,7 @@ export interface ReviewStatusScheduler {
 }
 
 export interface ReviewStatusSchedulerOptions {
-  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'>
+  github: Pick<GitHubAgentSource, 'getPullRequestReviewSnapshot' | 'stampAgentLabel' | 'upsertReviewStatus'> & ExistingReviewLabelSource
   intervalMilliseconds: number
   leaseMilliseconds: number
   now: () => Date

--- a/packages/harlan-github-agent/src/review-status-scheduler.ts
+++ b/packages/harlan-github-agent/src/review-status-scheduler.ts
@@ -23,7 +23,7 @@ export interface ReviewStatusSchedulerOptions {
    * after the defect behind it was fixed.
    */
   onPublished: (repository: string, pullRequestNumber: number) => void
-  store: Pick<JournalStore, 'claimNextTerminalReviewStatus' | 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt'>
+  store: Pick<JournalStore, 'claimNextTerminalReviewStatus' | 'completeReviewStatus' | 'deferReviewStatus' | 'recordReviewStatusReceipt' | 'supersedeReviewStatus'>
   workerId: string
 }
 

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -862,6 +862,7 @@ export interface JournalStore extends BatchStore {
   failTask: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
   failWorkerTask: (input: { taskId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
   deferReviewStatus: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
+  supersedeReviewStatus: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   deferIssueTriageComment: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => boolean
   failPublication: (input: { commandId: string, workerId: string, fence: number, at: string, reason: string }) => 'Retrying' | 'Failed' | 'Rejected'
   getDashboardSnapshot: (generatedAt: string) => DashboardSnapshot
@@ -4248,8 +4249,13 @@ function stageExistingReviewLabel(database: DatabaseSync, subject: GitHubPullReq
       id, task_kind, task_id, task_fence, revision_id, expected_head_sha, phase, body, body_sha256,
       desired_outcome, state_tag, github_comment_id, github_url, created_at, updated_at
     ) VALUES (?, 'existing_review', ?, 0, ?, ?, 'terminal', '', ?, 'EXISTING', 'Pending', ?, ?, ?, ?)
+    -- The id pins one revision to one comment, so an unchanged observation names
+    -- a Published command whose label is already on the pull request. Restaging
+    -- it would republish through GitHub on every poll and never converge. Only a
+    -- Superseded command yields again, so retired work can return when the
+    -- observation that retired it goes away.
     ON CONFLICT(id) DO UPDATE SET state_tag = 'Pending', updated_at = excluded.updated_at
-    WHERE review_status_commands.state_tag IN ('Published', 'Superseded')
+    WHERE review_status_commands.state_tag = 'Superseded'
   `).run(commandId, commandId, revisionId, subject.headSha, digest(''), commentId, prior.url, at, at)
   if (staged.changes === 1)
     recordReviewStatusEvent(database, { commandId, event: 'Staged', from: null, to: 'Pending', at })
@@ -10256,6 +10262,36 @@ export function openJournalStore(
     }
   }
 
+  /** Retires one Running command whose failure no retry can answer. */
+  const supersedeReviewStatus: JournalStore['supersedeReviewStatus'] = (input) => {
+    database.exec('BEGIN IMMEDIATE')
+    try {
+      const changed = database.prepare(`
+        UPDATE review_status_commands
+        SET state_tag = 'Superseded', reason = ?, worker_id = NULL,
+          lease_expires_at = NULL, updated_at = ?
+        WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
+      `).run(input.reason, input.at, input.commandId, input.workerId, input.fence).changes === 1
+      if (changed) {
+        recordReviewStatusEvent(database, {
+          commandId: input.commandId,
+          event: 'Superseded',
+          from: 'Running',
+          to: 'Superseded',
+          reason: input.reason,
+          fence: input.fence,
+          at: input.at,
+        })
+      }
+      database.exec('COMMIT')
+      return changed
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
   const heartbeatTask: JournalStore['heartbeatTask'] = (input) => {
     const leaseExpiresAt = new Date(new Date(input.at).getTime() + input.leaseMilliseconds).toISOString()
     return database.prepare(`
@@ -14034,6 +14070,7 @@ export function openJournalStore(
     deferPublication,
     deferIssueTriageComment,
     deferReviewStatus,
+    supersedeReviewStatus,
     failPublication,
     failTask,
     failWorkerTask,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -12444,7 +12444,9 @@ export function openJournalStore(
         0 AS source_rank
       FROM review_status_commands AS status
       JOIN revisions AS status_revision ON status_revision.id = status.revision_id
-      WHERE status.state_tag = 'Published'
+      -- An existing_review publication edits nothing: its body is empty and its
+      -- comment belongs to a trusted actor, so a closure must never target it.
+      WHERE status.state_tag = 'Published' AND status.task_kind != 'existing_review'
       UNION ALL
       SELECT
         'review:' || publication.id AS publication_id,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3280,7 +3280,9 @@ function reviewStatusWorkflowScope(database: DatabaseSync, commandId: string): W
     LEFT JOIN tasks
       ON review_status_commands.task_kind = 'review_fix'
       AND tasks.id = review_status_commands.task_id
-    JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id)
+    JOIN revisions AS status_revision ON status_revision.id = review_status_commands.revision_id
+    JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id,
+      CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.subject_id END)
     JOIN repositories ON repositories.id = subjects.repository_id
     WHERE review_status_commands.id = ?
   `).get(commandId) as unknown as WorkflowScope
@@ -3324,7 +3326,9 @@ function supersedeUnauthorizedReviewStatuses(database: DatabaseSync, at: string)
     LEFT JOIN tasks
       ON review_status_commands.task_kind = 'review_fix'
       AND tasks.id = review_status_commands.task_id
-    JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id)
+    JOIN revisions AS status_revision ON status_revision.id = review_status_commands.revision_id
+    JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id,
+      CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.subject_id END)
     JOIN repositories ON repositories.id = subjects.repository_id
     WHERE review_status_commands.state_tag = 'Pending'
       AND (
@@ -4208,6 +4212,49 @@ function cancelSubjectTasks(database: DatabaseSync, subjectId: number, at: strin
   taskIds.forEach(task => cancelStoredTask(database, task.id, at, reason))
 }
 
+/** The existing comment yields to current work, Dismissal, and Approval policy. */
+const existingReviewLabelClaimSql = `(review_status_commands.task_kind = 'existing_review'
+      AND EXISTS (SELECT 1 FROM review_resolutions AS resolution
+        WHERE resolution.subject_id = subjects.id AND resolution.revision_id = subjects.current_revision_id
+          AND resolution.resolution_tag = 'ExistingReview' AND resolution.github_url = review_status_commands.github_url)
+      AND NOT EXISTS (SELECT 1 FROM worker_tasks AS active
+        WHERE active.subject_id = subjects.id AND active.state_tag IN ('Queued', 'Running'))
+      AND NOT EXISTS (SELECT 1 FROM tasks AS active
+        WHERE active.subject_id = subjects.id AND active.state_tag IN ('Queued', 'Running', 'Publishing'))
+      AND json_extract(status_revision.payload, '$.state') = 'open'
+      AND NOT EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = subjects.id)
+      AND (
+        EXISTS (SELECT 1 FROM pull_request_approvals
+          WHERE subject_id = subjects.id AND revision_id = subjects.current_revision_id AND kind = 'review')
+        OR ((SELECT selection_mode FROM agent_control WHERE singleton = 1) = 'auto'
+          AND EXISTS (SELECT 1 FROM json_each(repositories.policy_json, '$.writablePullRequestAuthors')
+            WHERE lower(value) = lower(json_extract(status_revision.payload, '$.author'))))
+      ))`
+
+/** Restores the label omitted by a completed review from another trusted actor. */
+function stageExistingReviewLabel(database: DatabaseSync, subject: GitHubPullRequestItem, revisionId: string, at: string): void {
+  const prior = subject.priorAutomatedReview
+  if (prior._tag !== 'Found' || prior.state !== 'complete')
+    return
+  const prefix = `${subject.url}#issuecomment-`
+  if (!prior.url.startsWith(prefix))
+    return
+  const commentId = Number(prior.url.slice(prefix.length))
+  if (!Number.isSafeInteger(commentId) || commentId <= 0)
+    return
+  const commandId = digest(`existing-review-label:${revisionId}:${commentId}`)
+  const staged = database.prepare(`
+    INSERT INTO review_status_commands (
+      id, task_kind, task_id, task_fence, revision_id, expected_head_sha, phase, body, body_sha256,
+      desired_outcome, state_tag, github_comment_id, github_url, created_at, updated_at
+    ) VALUES (?, 'existing_review', ?, 0, ?, ?, 'terminal', '', ?, 'EXISTING', 'Pending', ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET state_tag = 'Pending', updated_at = excluded.updated_at
+    WHERE review_status_commands.state_tag = 'Published'
+  `).run(commandId, commandId, revisionId, subject.headSha, digest(''), commentId, prior.url, at, at)
+  if (staged.changes === 1)
+    recordReviewStatusEvent(database, { commandId, event: 'Staged', from: null, to: 'Pending', at })
+}
+
 function planAdversarialReview(
   database: DatabaseSync,
   subject: GitHubItem,
@@ -4313,7 +4360,7 @@ function planAdversarialReview(
         task_id = NULL, task_fence = 0, resolution_tag = 'ExistingReview',
         review_run_id = NULL, baseline_task_id = NULL, github_url = excluded.github_url,
         reason = NULL, created_at = excluded.created_at
-      WHERE review_resolutions.resolution_tag = 'UnknownNeedsReconciliation'
+      WHERE review_resolutions.resolution_tag IN ('UnknownNeedsReconciliation', 'ExistingReview')
     `).run(subjectId, revisionId, subject.priorAutomatedReview.url, observedAt)
     if (stored.changes === 1) {
       recordWorkflowEvent(database, {
@@ -4347,6 +4394,11 @@ function planAdversarialReview(
       undefined,
       ownRunLanded ? revisionId : undefined,
     )
+    if (alreadyReviewed && localAttempt.head_review_run_id === null && subject.kind === 'pull_request'
+      && subject.state === 'open' && mapping.enabled && mapping.pullRequestReview
+      && (!approvalRequired || reviewApproved) && !manualReviewRequested) {
+      stageExistingReviewLabel(database, subject, revisionId, observedAt)
+    }
     return
   }
 
@@ -5825,6 +5877,53 @@ const combinedIssuePublicationMigration = `
   PRAGMA user_version = 67;
 `
 
+/** Publishes labels for trusted reviews without creating an Agent Task. */
+const existingReviewLabelMigration = `
+  DROP INDEX review_status_commands_state;
+  CREATE TABLE review_status_commands_v68 (
+    id TEXT PRIMARY KEY,
+    task_kind TEXT NOT NULL CHECK (task_kind IN ('adversarial_review', 'review_fix', 'existing_review')),
+    task_id TEXT NOT NULL,
+    task_fence INTEGER NOT NULL,
+    revision_id TEXT NOT NULL REFERENCES revisions(id),
+    expected_head_sha TEXT NOT NULL,
+    phase TEXT NOT NULL CHECK (phase IN ('snapshot', 'review', 'repair', 'terminal', 'queued')),
+    body TEXT NOT NULL,
+    body_sha256 TEXT NOT NULL CHECK (length(body_sha256) = 64),
+    state_tag TEXT NOT NULL CHECK (state_tag IN ('Pending', 'Running', 'Published', 'Superseded')),
+    outcome_unknown INTEGER NOT NULL DEFAULT 0 CHECK (outcome_unknown IN (0, 1)),
+    reason TEXT,
+    github_comment_id INTEGER,
+    github_url TEXT,
+    worker_id TEXT,
+    fence INTEGER NOT NULL DEFAULT 0,
+    lease_expires_at TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    review_run_id TEXT REFERENCES review_runs(id),
+    desired_outcome TEXT CHECK (desired_outcome IN ('READY', 'PENDING', 'BLOCKED', 'WAITING', 'EXISTING', 'SKIPPED')),
+    UNIQUE (task_kind, task_id, task_fence, phase, body_sha256),
+    CHECK (
+      (task_kind = 'adversarial_review' AND phase IN ('snapshot', 'review', 'terminal', 'queued'))
+      OR (task_kind = 'review_fix' AND phase IN ('repair', 'terminal', 'queued'))
+      OR (task_kind = 'existing_review' AND phase = 'terminal')
+    ),
+    CHECK (
+      (state_tag = 'Running' AND worker_id IS NOT NULL AND lease_expires_at IS NOT NULL)
+      OR (state_tag != 'Running' AND worker_id IS NULL AND lease_expires_at IS NULL)
+    ),
+    CHECK (
+      (state_tag = 'Published' AND github_comment_id IS NOT NULL AND github_url IS NOT NULL)
+      OR state_tag != 'Published'
+    )
+  );
+  INSERT INTO review_status_commands_v68 SELECT * FROM review_status_commands;
+  DROP TABLE review_status_commands;
+  ALTER TABLE review_status_commands_v68 RENAME TO review_status_commands;
+  CREATE INDEX review_status_commands_state ON review_status_commands(state_tag, updated_at);
+  PRAGMA user_version = 68;
+`
+
 function installSchema(database: DatabaseSync): void {
   database.exec('PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL; PRAGMA synchronous = NORMAL; PRAGMA busy_timeout = 5000;')
   let version = (database.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
@@ -6115,7 +6214,11 @@ function installSchema(database: DatabaseSync): void {
     applyMigration(database, combinedIssuePublicationMigration)
     version = 67
   }
-  if (version === 67)
+  if (version === 67) {
+    applyMigration(database, existingReviewLabelMigration)
+    version = 68
+  }
+  if (version === 68)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -9786,14 +9889,17 @@ export function openJournalStore(
         LEFT JOIN tasks
           ON review_status_commands.task_kind = 'review_fix'
           AND tasks.id = review_status_commands.task_id
-        JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id)
+        JOIN revisions AS status_revision ON status_revision.id = review_status_commands.revision_id
+        JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id,
+          CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.subject_id END)
         JOIN repositories ON repositories.id = subjects.repository_id
         WHERE review_status_commands.id = ? AND review_status_commands.state_tag = 'Pending'
           AND (
             (
               review_status_commands.phase = 'terminal'
               AND (
-                (review_status_commands.task_kind = 'adversarial_review' AND worker_tasks.kind = 'adversarial_review')
+                ${existingReviewLabelClaimSql}
+                OR (review_status_commands.task_kind = 'adversarial_review' AND worker_tasks.kind = 'adversarial_review')
                 OR (review_status_commands.task_kind = 'review_fix' AND tasks.kind = 'review_fix')
               )
             )
@@ -9813,14 +9919,15 @@ export function openJournalStore(
               AND tasks.lease_expires_at > ?
             )
           )
-          AND COALESCE(worker_tasks.revision_id, tasks.revision_id) = subjects.current_revision_id
+          AND COALESCE(worker_tasks.revision_id, tasks.revision_id,
+          CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.id END) = subjects.current_revision_id
           AND review_status_commands.revision_id = subjects.current_revision_id
           AND repositories.enabled = 1
           ${repositoryWriteAuthoritySql}
           AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
       `).get(commandId, now, now) as {
             id: string
-            task_kind: 'adversarial_review' | 'review_fix'
+            task_kind: 'adversarial_review' | 'review_fix' | 'existing_review'
             task_id: string
             repository: string
             github_number: number
@@ -9857,9 +9964,11 @@ export function openJournalStore(
         at: now,
       })
       database.exec('COMMIT')
-      const taskPhase: ReviewStatusTaskPhase = row.task_kind === 'review_fix'
-        ? { taskKind: 'review_fix', phase: row.phase as 'repair' | 'terminal' }
-        : { taskKind: 'adversarial_review', phase: row.phase as 'snapshot' | 'review' | 'terminal' }
+      const taskPhase: ReviewStatusTaskPhase = row.task_kind === 'existing_review'
+        ? { taskKind: 'existing_review', phase: 'terminal' }
+        : row.task_kind === 'review_fix'
+          ? { taskKind: 'review_fix', phase: row.phase as 'repair' | 'terminal' }
+          : { taskKind: 'adversarial_review', phase: row.phase as 'snapshot' | 'review' | 'terminal' }
       return {
         id: row.id,
         taskId: row.task_id,
@@ -9898,7 +10007,9 @@ export function openJournalStore(
         LEFT JOIN tasks
           ON review_status_commands.task_kind = 'review_fix'
           AND tasks.id = review_status_commands.task_id
-        JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id)
+        JOIN revisions AS status_revision ON status_revision.id = review_status_commands.revision_id
+        JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id,
+          CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.subject_id END)
         WHERE review_status_commands.state_tag = 'Pending'
           AND review_status_commands.phase = 'terminal'
           AND (
@@ -9940,13 +10051,17 @@ export function openJournalStore(
       LEFT JOIN tasks
         ON review_status_commands.task_kind = 'review_fix'
         AND tasks.id = review_status_commands.task_id
-      JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id)
+      JOIN revisions AS status_revision ON status_revision.id = review_status_commands.revision_id
+      JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id,
+        CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.subject_id END)
       JOIN repositories ON repositories.id = subjects.repository_id
       WHERE review_status_commands.state_tag = 'Pending'
         AND review_status_commands.phase = 'terminal'
         AND review_status_commands.revision_id = subjects.current_revision_id
-        AND COALESCE(worker_tasks.revision_id, tasks.revision_id) = subjects.current_revision_id
-        AND COALESCE(worker_tasks.state_tag, tasks.state_tag) != 'Running'
+        AND COALESCE(worker_tasks.revision_id, tasks.revision_id,
+          CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.id END) = subjects.current_revision_id
+        AND COALESCE(worker_tasks.state_tag, tasks.state_tag, 'Completed') != 'Running'
+        AND (review_status_commands.task_kind != 'existing_review' OR ${existingReviewLabelClaimSql})
         AND repositories.enabled = 1
         ${repositoryWriteAuthoritySql}
         AND json_extract(repositories.policy_json, '$.pullRequestReview') = 1
@@ -9970,7 +10085,10 @@ export function openJournalStore(
         -- and fence prove this is the authorized attempt.
         WHERE id = ? AND state_tag = 'Running' AND worker_id = ? AND fence = ?
           AND (
-            (
+            (review_status_commands.task_kind = 'existing_review' AND EXISTS (
+              SELECT 1 FROM subjects WHERE subjects.current_revision_id = review_status_commands.revision_id
+            ))
+            OR (
               review_status_commands.phase = 'terminal'
               AND (
                 EXISTS (

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4249,7 +4249,7 @@ function stageExistingReviewLabel(database: DatabaseSync, subject: GitHubPullReq
       desired_outcome, state_tag, github_comment_id, github_url, created_at, updated_at
     ) VALUES (?, 'existing_review', ?, 0, ?, ?, 'terminal', '', ?, 'EXISTING', 'Pending', ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET state_tag = 'Pending', updated_at = excluded.updated_at
-    WHERE review_status_commands.state_tag = 'Published'
+    WHERE review_status_commands.state_tag IN ('Published', 'Superseded')
   `).run(commandId, commandId, revisionId, subject.headSha, digest(''), commentId, prior.url, at, at)
   if (staged.changes === 1)
     recordReviewStatusEvent(database, { commandId, event: 'Staged', from: null, to: 'Pending', at })
@@ -10010,11 +10010,13 @@ export function openJournalStore(
         JOIN revisions AS status_revision ON status_revision.id = review_status_commands.revision_id
         JOIN subjects ON subjects.id = COALESCE(worker_tasks.subject_id, tasks.subject_id,
           CASE WHEN review_status_commands.task_kind = 'existing_review' THEN status_revision.subject_id END)
+        JOIN repositories ON repositories.id = subjects.repository_id
         WHERE review_status_commands.state_tag = 'Pending'
           AND review_status_commands.phase = 'terminal'
           AND (
             review_status_commands.revision_id != subjects.current_revision_id
             OR COALESCE(worker_tasks.revision_id, tasks.revision_id) != subjects.current_revision_id
+            OR (review_status_commands.task_kind = 'existing_review' AND NOT ${existingReviewLabelClaimSql})
           )
       `).all() as unknown as Array<{ id: string, fence: number }>
       const supersede = database.prepare(`

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -929,6 +929,7 @@ interface ReviewStatusCommandBase {
 export type ReviewStatusTaskPhase
   = | { taskKind: 'adversarial_review', phase: 'snapshot' | 'review' | 'terminal' }
     | { taskKind: 'review_fix', phase: 'repair' | 'terminal' }
+    | { taskKind: 'existing_review', phase: 'terminal' }
 
 export type ReviewStatusCommand = ReviewStatusCommandBase & ReviewStatusTaskPhase
 

--- a/packages/harlan-github-agent/test/existing-review-label-source.test.ts
+++ b/packages/harlan-github-agent/test/existing-review-label-source.test.ts
@@ -1,0 +1,75 @@
+import type { Octokit } from 'octokit'
+import { describe, expect, it } from 'vitest'
+import { createGitHubAgentSource } from '../src/github-agent-source.ts'
+import { ok } from '../src/result.ts'
+import { repositoryMapping } from './fixtures.ts'
+
+const headSha = 'a'.repeat(40)
+function harness(heading = '### 🤖 READY · 95/100') {
+  const comment = {
+    id: 42,
+    author_association: 'OWNER',
+    user: { login: 'harlan-zw' },
+    body: `<!-- harlan-agent-kit:pr-triage -->\n<!-- reviewed-sha: ${headSha} -->\n${heading}`,
+    html_url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+  }
+  const comments = [comment]
+  const pull = { state: 'open', head: { sha: headSha } }
+  const client = {
+    paginate: () => Promise.resolve(comments),
+    rest: {
+      issues: { listComments: () => undefined },
+      pulls: { get: () => Promise.resolve({ data: pull }) },
+    },
+  } as unknown as Octokit
+  const source = createGitHubAgentSource({
+    actorLogin: () => 'harlan-github-agent[bot]',
+    createClient: () => client,
+    tokens: {
+      getToken: () => Promise.resolve(ok({ token: 'token', expiresAt: '2026-08-14T00:00:00.000Z' })),
+      invalidate: () => undefined,
+    },
+  })
+  return { comment, comments, pull, read: () => source.readExistingReviewLabel(repositoryMapping(), 24, 42, headSha, AbortSignal.timeout(1000)) }
+}
+
+describe('reading an existing review label', () => {
+  it.each([
+    ['### 🤖 READY · 95/100', 'READY'],
+    ['### 🤖 BLOCKED', 'BLOCKED'],
+    ['### 🤖 REVIEW SKIPPED', 'ADVERSARIAL_REVIEW_SKIPPED'],
+    ['**PASS · 95/100 confidence**', 'READY'],
+    ['**PENDING**', 'PENDING'],
+    ['**BLOCKED**', 'BLOCKED'],
+  ])('reads the outcome from %s', async (heading, label) => {
+    const test = harness(heading)
+    expect(await test.read()).toEqual(ok({ commentId: 42, url: test.comment.html_url, label }))
+  })
+
+  it.each(['CONTRIBUTOR', 'NONE'])('rejects a marker from an untrusted %s', async (association) => {
+    const test = harness()
+    test.comment.author_association = association
+    expect(await test.read()).toEqual({ _tag: 'Err', error: 'The completed review changed before its label was restored.' })
+  })
+
+  it('rejects an unreviewed head', async () => {
+    const test = harness()
+    test.comment.body = test.comment.body.replace(headSha, 'b'.repeat(40))
+    expect((await test.read())._tag).toBe('Err')
+  })
+
+  it('yields to a later review on the same head', async () => {
+    const test = harness()
+    test.comments.push({ ...test.comment, id: 43, html_url: test.comment.html_url.replace('42', '43'), body: test.comment.body.replace('READY', 'REVIEWING') })
+    expect((await test.read())._tag).toBe('Err')
+  })
+
+  it.each(['closed', 'moved'])('rejects a pull request that %s after the comments were read', async (change) => {
+    const test = harness()
+    if (change === 'closed')
+      test.pull.state = 'closed'
+    else
+      test.pull.head.sha = 'b'.repeat(40)
+    expect(await test.read()).toEqual({ _tag: 'Err', error: 'The pull request changed before its review label was restored.' })
+  })
+})

--- a/packages/harlan-github-agent/test/existing-review-label-source.test.ts
+++ b/packages/harlan-github-agent/test/existing-review-label-source.test.ts
@@ -49,7 +49,10 @@ describe('reading an existing review label', () => {
   it.each(['CONTRIBUTOR', 'NONE'])('rejects a marker from an untrusted %s', async (association) => {
     const test = harness()
     test.comment.author_association = association
-    expect(await test.read()).toEqual({ _tag: 'Err', error: 'The completed review changed before its label was restored.' })
+    expect(await test.read()).toEqual({
+      _tag: 'Err',
+      error: { _tag: 'Permanent', message: 'The completed review changed before its label was restored.' },
+    })
   })
 
   it('rejects an unreviewed head', async () => {
@@ -70,6 +73,9 @@ describe('reading an existing review label', () => {
       test.pull.state = 'closed'
     else
       test.pull.head.sha = 'b'.repeat(40)
-    expect(await test.read()).toEqual({ _tag: 'Err', error: 'The pull request changed before its review label was restored.' })
+    expect(await test.read()).toEqual({
+      _tag: 'Err',
+      error: { _tag: 'Permanent', message: 'The pull request changed before its review label was restored.' },
+    })
   })
 })

--- a/packages/harlan-github-agent/test/existing-review-labels.test.ts
+++ b/packages/harlan-github-agent/test/existing-review-labels.test.ts
@@ -1,0 +1,159 @@
+import type { ExistingReviewLabel } from '../src/github-agent-source.ts'
+import type { GitHubPullRequestItem } from '../src/types.ts'
+import { afterEach, describe, expect, it } from 'vitest'
+import { err, ok } from '../src/result.ts'
+import { createReviewStatusScheduler } from '../src/review-status-scheduler.ts'
+import { openJournalStore } from '../src/store.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const stores: Array<ReturnType<typeof openJournalStore>> = []
+afterEach(() => stores.splice(0).forEach(store => store.close()))
+
+function harness() {
+  const store = openJournalStore(':memory:')
+  stores.push(store)
+  const repository = repositoryMapping()
+  let pullRequest = pullRequestItem({
+    mergeState: 'clean',
+    priorAutomatedReview: {
+      _tag: 'Found',
+      authorLogin: 'harlan-zw',
+      state: 'complete',
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    },
+  })
+  let now = new Date('2026-08-13T01:00:00.000Z')
+  store.syncRepositories([repository], now.toISOString())
+  const observe = (changes: Partial<GitHubPullRequestItem> = {}) => {
+    now = new Date(now.getTime() + 1000)
+    pullRequest = { ...pullRequest, ...changes, updatedAt: now.toISOString() }
+    store.recordObservation({ externalId: now.toISOString(), observedAt: now.toISOString(), source: 'poll', subject: pullRequest })
+  }
+  observe()
+  const labels: string[] = []
+  const failures: string[] = []
+  let failLabel = false
+  let outcome: ExistingReviewLabel['label'] = 'READY'
+  const scheduler = () => createReviewStatusScheduler({
+    github: {
+      getPullRequestReviewSnapshot: () => Promise.resolve(ok({
+        baseChecks: { _tag: 'Available', checks: [] },
+        body: '',
+        checks: { _tag: 'Available', checks: [] },
+        comments: [],
+        priorAutomatedReview: pullRequest.priorAutomatedReview,
+        pullRequest,
+        requiredChecks: { _tag: 'None' },
+        reviews: [],
+      })),
+      readExistingReviewLabel: (_repository, _number, commentId) => Promise.resolve(ok({ commentId, url: `${pullRequest.url}#issuecomment-${commentId}`, label: outcome })),
+      upsertReviewStatus: () => { throw new Error('The existing comment must stay unchanged.') },
+      stampAgentLabel: (_repository, _number, label) => {
+        if (failLabel)
+          return Promise.resolve(err('GitHub refused the label.'))
+        labels.push(label)
+        return Promise.resolve(ok(undefined))
+      },
+    },
+    intervalMilliseconds: 5_000,
+    leaseMilliseconds: 60_000,
+    now: () => now,
+    onError: (error) => { throw error },
+    onFailure: (_repository, _number, reason) => failures.push(reason),
+    onPublished: () => undefined,
+    store,
+    workerId: 'label-publisher',
+  })
+  return {
+    store,
+    labels,
+    failures,
+    observe,
+    scheduler,
+    failLabel: (value: boolean) => { failLabel = value },
+    outcome: (value: ExistingReviewLabel['label']) => { outcome = value },
+  }
+}
+
+describe('labels for an existing review', () => {
+  it('restores the label without starting an Agent or changing the comment', async () => {
+    const test = harness()
+    await test.scheduler().runNow()
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual(['READY'])
+    expect(test.store.claimNextAdversarialReviewTask('reviewer', '2026-08-13T01:02:00.000Z', 60_000)).toBeNull()
+    expect(test.store.listWorkflowEvents({ stream: 'review_status', limit: 20 }).map(event => event.event))
+      .toContain('OutcomeLabelConfirmed')
+  })
+
+  it('retries a failed label after the scheduler restarts', async () => {
+    const test = harness()
+    test.failLabel(true)
+    await test.scheduler().runNow()
+    test.failLabel(false)
+    await test.scheduler().runNow()
+
+    expect(test.failures).toEqual(['GitHub refused the label.'])
+    expect(test.labels).toEqual(['READY'])
+  })
+
+  it('checks the current comment again on later observations', async () => {
+    const test = harness()
+    await test.scheduler().runNow()
+    test.outcome('BLOCKED')
+    test.observe()
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual(['READY', 'BLOCKED'])
+  })
+
+  it('follows a replacement trusted comment on the same head', async () => {
+    const test = harness()
+    test.observe({ priorAutomatedReview: {
+      _tag: 'Found',
+      authorLogin: 'harlan-zw',
+      state: 'complete',
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-43',
+    } })
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual(['READY'])
+    expect(test.failures).toEqual([])
+  })
+
+  it.each([
+    { headSha: 'new-head', priorAutomatedReview: { _tag: 'None' as const } },
+    { state: 'closed' as const },
+  ])('does not restore a label after the pull request changes: %j', async (changes) => {
+    const test = harness()
+    test.observe(changes)
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual([])
+  })
+
+  it('honors Manual Selection mode when it changes before publication', async () => {
+    const test = harness()
+    test.store.setSelectionMode('manual')
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual([])
+  })
+
+  it('honors Dismissal before publication', async () => {
+    const test = harness()
+    test.store.dismissItem({ repository: 'harlan-zw/example', itemNumber: 24, at: '2026-08-13T01:00:02.000Z' })
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual([])
+  })
+
+  it('honors repository policy when it changes before publication', async () => {
+    const test = harness()
+    test.store.syncRepositories([repositoryMapping({ pullRequestReview: false })], '2026-08-13T01:00:02.000Z')
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual([])
+  })
+})

--- a/packages/harlan-github-agent/test/existing-review-labels.test.ts
+++ b/packages/harlan-github-agent/test/existing-review-labels.test.ts
@@ -27,7 +27,7 @@ function harness() {
   const observe = (changes: Partial<GitHubPullRequestItem> = {}) => {
     now = new Date(now.getTime() + 1000)
     pullRequest = { ...pullRequest, ...changes, updatedAt: now.toISOString() }
-    store.recordObservation({ externalId: now.toISOString(), observedAt: now.toISOString(), source: 'poll', subject: pullRequest })
+    return store.recordObservation({ externalId: now.toISOString(), observedAt: now.toISOString(), source: 'poll', subject: pullRequest })
   }
   observe()
   const labels: string[] = []
@@ -131,6 +131,27 @@ describe('labels for an existing review', () => {
     await test.scheduler().runNow()
 
     expect(test.labels).toEqual([])
+  })
+
+  it('retires the label publication when a fresh review is requested', async () => {
+    const test = harness()
+    const subject = test.observe()
+    if (subject._tag !== 'Inserted' && subject._tag !== 'Duplicate')
+      throw new Error('Expected the observed pull request.')
+    test.store.requestReviewRerun({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: subject.revisionId,
+      source: 'dashboard',
+      requestedBy: 'harlan-zw',
+      requestId: 'rerun',
+      at: '2026-08-13T01:00:02.000Z',
+    })
+    await test.scheduler().runNow()
+
+    expect(test.labels).toEqual([])
+    expect(test.store.listWorkflowEvents({ stream: 'review_status', limit: 20 }).map(event => event.event))
+      .toContain('Superseded')
   })
 
   it('honors Manual Selection mode when it changes before publication', async () => {

--- a/packages/harlan-github-agent/test/existing-review-labels.test.ts
+++ b/packages/harlan-github-agent/test/existing-review-labels.test.ts
@@ -33,6 +33,8 @@ function harness() {
   const labels: string[] = []
   const failures: string[] = []
   let failLabel = false
+  let reads = 0
+  let readFailure: string | null = null
   let outcome: ExistingReviewLabel['label'] = 'READY'
   const scheduler = () => createReviewStatusScheduler({
     github: {
@@ -46,7 +48,12 @@ function harness() {
         requiredChecks: { _tag: 'None' },
         reviews: [],
       })),
-      readExistingReviewLabel: (_repository, _number, commentId) => Promise.resolve(ok({ commentId, url: `${pullRequest.url}#issuecomment-${commentId}`, label: outcome })),
+      readExistingReviewLabel: (_repository, _number, commentId) => {
+        reads += 1
+        if (readFailure !== null)
+          return Promise.resolve(err({ _tag: 'Permanent', message: readFailure }))
+        return Promise.resolve(ok({ commentId, url: `${pullRequest.url}#issuecomment-${commentId}`, label: outcome }))
+      },
       upsertReviewStatus: () => { throw new Error('The existing comment must stay unchanged.') },
       stampAgentLabel: (_repository, _number, label) => {
         if (failLabel)
@@ -72,6 +79,8 @@ function harness() {
     scheduler,
     failLabel: (value: boolean) => { failLabel = value },
     outcome: (value: ExistingReviewLabel['label']) => { outcome = value },
+    readFailure: (value: string | null) => { readFailure = value },
+    reads: () => reads,
   }
 }
 
@@ -98,14 +107,27 @@ describe('labels for an existing review', () => {
     expect(test.labels).toEqual(['READY'])
   })
 
-  it('checks the current comment again on later observations', async () => {
+  it('does not republish a published label when the same observation repeats', async () => {
     const test = harness()
     await test.scheduler().runNow()
-    test.outcome('BLOCKED')
     test.observe()
     await test.scheduler().runNow()
 
-    expect(test.labels).toEqual(['READY', 'BLOCKED'])
+    expect(test.labels).toEqual(['READY'])
+    expect(test.reads()).toBe(1)
+  })
+
+  it('stops retrying when the trusted review changed before its label was restored', async () => {
+    const test = harness()
+    test.readFailure('The completed review changed before its label was restored.')
+    await test.scheduler().runNow()
+    await test.scheduler().runNow()
+
+    expect(test.failures).toEqual(['The completed review changed before its label was restored.'])
+    expect(test.reads()).toBe(1)
+    expect(test.store.claimNextTerminalReviewStatus('label-publisher-2', '2026-08-13T01:04:00.000Z', 60_000)).toBeNull()
+    expect(test.store.listWorkflowEvents({ stream: 'review_status', limit: 20 }).map(event => event.event))
+      .toContain('Superseded')
   })
 
   it('follows a replacement trusted comment on the same head', async () => {

--- a/packages/harlan-github-agent/test/review-status-controller.test.ts
+++ b/packages/harlan-github-agent/test/review-status-controller.test.ts
@@ -72,6 +72,7 @@ describe('review status controller', () => {
         completeReviewStatus: () => true,
         recordReviewStatusReceipt: () => true,
         deferReviewStatus: () => { throw new Error('Unexpected defer.') },
+        supersedeReviewStatus: () => { throw new Error('Unexpected supersede.') },
       },
       workerId: 'status-worker',
     })

--- a/packages/harlan-github-agent/test/review-status-controller.test.ts
+++ b/packages/harlan-github-agent/test/review-status-controller.test.ts
@@ -25,6 +25,7 @@ describe('review status controller', () => {
     let stagedBody = ''
     const controller = createReviewStatusController({
       github: {
+        readExistingReviewLabel: () => { throw new Error('Unexpected existing review.') },
         getPullRequestReviewSnapshot: () => Promise.resolve(ok({
           baseChecks: { _tag: 'Available', checks: [] },
           body: '',

--- a/packages/harlan-github-agent/test/review-status-scheduler.test.ts
+++ b/packages/harlan-github-agent/test/review-status-scheduler.test.ts
@@ -69,6 +69,7 @@ describe('review status scheduler', () => {
     const published: string[] = []
     const scheduler = createReviewStatusScheduler({
       github: {
+        readExistingReviewLabel: () => { throw new Error('Unexpected existing review.') },
         getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot(test.pullRequest))),
         upsertReviewStatus: (_repository, _number, _commentId, body) => {
           bodies.push(body)
@@ -102,6 +103,7 @@ describe('review status scheduler', () => {
     const published: string[] = []
     const scheduler = createReviewStatusScheduler({
       github: {
+        readExistingReviewLabel: () => { throw new Error('Unexpected existing review.') },
         getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot(test.pullRequest))),
         upsertReviewStatus: () => {
           writes += 1
@@ -134,6 +136,7 @@ describe('review status scheduler', () => {
     const commentIds: Array<number | null> = []
     const scheduler = createReviewStatusScheduler({
       github: {
+        readExistingReviewLabel: () => { throw new Error('Unexpected existing review.') },
         getPullRequestReviewSnapshot: () => Promise.resolve(ok(snapshot(test.pullRequest))),
         upsertReviewStatus: (_repository, _number, commentId) => {
           commentIds.push(commentId)

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { agentProfile, CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { MAXIMUM_RECOVERY_ATTEMPTS } from '../src/failure.ts'
 import { repositoryQuarantineReason } from '../src/github-write-gate.ts'
+import { ok } from '../src/result.ts'
+import { publishClaimedReviewStatus } from '../src/review-status-controller.ts'
+import { publishStoppedReviews } from '../src/review-stop-sweep.ts'
 import { routineReportCommand } from '../src/routine-report-controller.ts'
 import { openJournalStore } from '../src/store.ts'
 import { issueItem, pullRequestItem, repositoryMapping } from './fixtures.ts'
@@ -2419,6 +2422,166 @@ describe('journal store', () => {
       at: '2026-08-13T01:04:00.000Z',
     })).toBe(true)
     expect(store.listStoppedReviews()).toEqual([])
+  })
+
+  it('banners the agent comment, not a restored label, when GitHub closes the pull request', async () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const pullRequest = pullRequestItem({ mergeState: 'clean' })
+    store.recordObservation({
+      externalId: 'closure-with-restored-label',
+      observedAt: '2026-08-13T01:00:00.000Z',
+      source: 'poll',
+      subject: pullRequest,
+    })
+    const review = store.claimNextAdversarialReviewTask('review-agent', '2026-08-13T01:01:00.000Z', 600_000)
+    if (review === null)
+      throw new Error('Expected the Review Task.')
+    const agentBody = '### 🤖 PENDING\n\n- **CI gate:** PENDING. Base branch CI is still running.'
+    const staged = store.stageReviewStatus({
+      taskKind: 'adversarial_review',
+      phase: 'terminal',
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:00.000Z',
+      revisionId: review.revisionId,
+      expectedHeadSha: pullRequest.headSha,
+      body: agentBody,
+    })
+    if (staged._tag === 'Rejected')
+      throw new Error(staged.reason)
+    const command = store.claimReviewStatus(staged.commandId, 'status-worker', '2026-08-13T01:02:01.000Z', 60_000)
+    if (command === null)
+      throw new Error('Expected the review status command.')
+    store.completeReviewStatus({
+      commandId: command.id,
+      workerId: command.workerId,
+      fence: command.fence,
+      at: '2026-08-13T01:02:02.000Z',
+      commentId: 42,
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
+    })
+    expect(store.completeWorkerTask({
+      taskId: review.id,
+      workerId: review.state.workerId,
+      fence: review.state.fence,
+      at: '2026-08-13T01:02:03.000Z',
+      evidence: 'Waiting for Baseline repair baseline-task.',
+    })).toBe(true)
+
+    // A trusted actor reviewed the next head, so the service restores that
+    // actor's label on comment 77. That comment is never this service's own.
+    const headB = 'b'.repeat(40)
+    const trustedReview = {
+      _tag: 'Found',
+      authorLogin: 'harlan-zw',
+      state: 'complete',
+      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-77',
+    } as const
+    const pushed = store.recordObservation({
+      externalId: 'closure-with-restored-label-head-b',
+      observedAt: '2026-08-13T01:05:00.000Z',
+      source: 'poll',
+      subject: {
+        ...pullRequest,
+        headSha: headB,
+        updatedAt: '2026-08-13T01:05:00.000Z',
+        priorAutomatedReview: trustedReview,
+      },
+    })
+    if (pushed._tag !== 'Inserted')
+      throw new Error('Expected the pushed head Revision.')
+    const labelCommand = store.claimNextTerminalReviewStatus('label-publisher', '2026-08-13T01:06:00.000Z', 60_000)
+    if (labelCommand === null)
+      throw new Error('Expected the existing review label command.')
+    const labelPublished = await publishClaimedReviewStatus(
+      {
+        github: {
+          getPullRequestReviewSnapshot: () => { throw new Error('The existing comment needs no snapshot.') },
+          readExistingReviewLabel: (_repository, _number, commentId) => Promise.resolve(ok({
+            commentId,
+            url: `https://github.com/harlan-zw/example/pull/24#issuecomment-${commentId}`,
+            label: 'READY',
+          })),
+          upsertReviewStatus: () => { throw new Error('The existing comment must stay unchanged.') },
+          stampAgentLabel: () => Promise.resolve(ok(undefined)),
+        },
+        now: () => new Date('2026-08-13T01:06:00.000Z'),
+        store,
+      },
+      labelCommand,
+      false,
+      new AbortController().signal,
+    )
+    if (labelPublished._tag === 'Err')
+      throw new Error(labelPublished.error)
+
+    const closed = store.recordObservation({
+      externalId: 'closure-with-restored-label-closed',
+      observedAt: '2026-08-13T01:07:00.000Z',
+      source: 'poll',
+      subject: {
+        ...pullRequest,
+        headSha: headB,
+        state: 'closed',
+        mergedAt: '2026-08-13T01:07:00.000Z',
+        updatedAt: '2026-08-13T01:07:00.000Z',
+        priorAutomatedReview: trustedReview,
+      },
+    })
+    if (closed._tag !== 'Inserted')
+      throw new Error('Expected the closed pull request Revision.')
+    expect(store.recordVerifiedPullRequestClosure({
+      repository: 'harlan-zw/example',
+      pullRequestNumber: 24,
+      revisionId: closed.revisionId,
+      headSha: headB,
+      baseSha: pullRequest.baseSha,
+      disposition: { _tag: 'Merged' },
+      at: '2026-08-13T01:07:00.000Z',
+    })).toBe(true)
+
+    const stopped = store.listStoppedReviews()
+    expect(stopped).toEqual([expect.objectContaining({
+      taskId: review.id,
+      commentId: 42,
+      publishedBody: agentBody,
+    })])
+
+    const edits: Array<{ commentId: number, body: string }> = []
+    let closure: Parameters<ReturnType<typeof openJournalStore>['recordReviewClosure']>[0] | undefined
+    const { results } = await publishStoppedReviews({
+      github: {
+        clearAgentLabels: () => Promise.resolve(ok(undefined)),
+        getPullRequestReviewSnapshot: () => { throw new Error('A merged pull request needs no snapshot.') },
+        editReviewStatus: (_repository, _number, commentId, _expectedBody, body) => {
+          // Comment 77 belongs to the trusted actor, so GitHub refuses the edit.
+          if (commentId === 77)
+            return Promise.resolve(ok({ _tag: 'Foreign', reason: 'The stored automated review comment belongs to another GitHub actor.' }))
+          edits.push({ commentId, body })
+          return Promise.resolve(ok({ _tag: 'Edited', commentId, url: `https://github.com/harlan-zw/example/pull/24#issuecomment-${commentId}` }))
+        },
+      },
+      now: () => new Date('2026-08-13T01:08:00.000Z'),
+      repositories: [repositoryMapping()],
+      store: {
+        recordReviewClosure: (input) => {
+          closure = input
+          return true
+        },
+        recordDeletedReviewComment: () => true,
+        listStoppedReviews: () => store.listStoppedReviews(),
+        recordStoppedReviewStatus: () => true,
+      },
+    }, new AbortController().signal)
+
+    expect(results).toEqual([ok({ _tag: 'Published', repository: 'harlan-zw/example', pullRequestNumber: 24 })])
+    expect(edits).toEqual([{ commentId: 42, body: expect.stringContaining('### 🤖 MERGED') }])
+    expect(closure).toEqual(expect.objectContaining({
+      disposition: { _tag: 'Merged' },
+      result: expect.objectContaining({ _tag: 'Published', commentId: 42 }),
+    }))
   })
 
   it('closes the READY status that replaced a PENDING Review', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

[nuxtseo.com#864](https://github.com/harlan-zw/nuxtseo.com/pull/864) reached READY without a review label. The service recognized the existing comment and never added its label. Completed reviews from trusted actors now restore their matching labels without another Agent run.

![Existing reviews restore their labels through the publication queue after checking the current head](https://github.com/user-attachments/assets/82b811b1-b9db-4a4c-aae5-da4cf30c7dcb)

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
