### PR TITLE
fix(github-agent): preserve concurrent issue delivery

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -33,6 +33,10 @@ Treat `harlan-agent-review` as a manual override that always requires adversaria
 
 Review every tracked pull request, whatever its labels. Merge one pull request automatically only when it carries `harlan-agent-auto-merge`, `auto_merge.enabled` is true, the repository is owned, the author is trusted, and review returned `READY` at or above `auto_merge.minimum_confidence`. A repository block with `auto_merge.pull_requests: every` drops the label condition and uses its own `minimum_confidence`. Recheck the head commit at merge time. Everything else waits for Harlan.
 
+Auto merge targets the default branch only. If a stack's exact parent merged there, retarget the child before the next observation.
+Keep independent Issue work on the default branch, even when another pull request changes the same file.
+If the default branch advances normally, publish the existing verified patch. Fresh Review and GitHub checks evaluate the current base.
+
 Start no new issue work above `max_open_pull_requests` open pull requests. Keep review, repair, and conflict fixes running.
 
 Plan Ready Routine-filed issues as one Batch per repository when two or more wait. The Batch reserves their Issue work Tasks, runs one Batch planning turn over every reserved issue, and stores units: the issues one pull request closes, and the unit each one stacks on. Units run as Issue work Agents under the Batch's one permit, three at a time, each in its own worktree. A unit publishes the moment its Agent finishes; a stacked unit waits only for its base pull request to open, then falls back to the default branch after ten minutes. A planning turn that fails or returns an invalid plan runs every issue alone. `issue_batches: false` turns planning off. Issue triage names fix-together partners as `Fix with #N`, and the planning turn reads them as hints.

--- a/packages/harlan-github-agent/src/auto-merge-controller.ts
+++ b/packages/harlan-github-agent/src/auto-merge-controller.ts
@@ -9,6 +9,7 @@ export type AutoMergeEvent
   = | { _tag: 'AutoMergeEnabled', repository: string, pullRequestNumber: number }
     /** GitHub had nothing left to wait for, so the merge happened immediately. */
     | { _tag: 'Merged', repository: string, pullRequestNumber: number, sha: string }
+    | { _tag: 'Retargeted', repository: string, pullRequestNumber: number }
     | { _tag: 'Refused', repository: string, pullRequestNumber: number, reason: string }
 
 export interface AutoMergeController {
@@ -28,6 +29,21 @@ export function createAutoMergeController(options: AutoMergeControllerOptions): 
     async reconcile(repository, subject, signal) {
       if (options.policy._tag === 'Disabled' || subject.kind !== 'pull_request' || !autoMergeCandidate(repository, subject))
         return
+      if (subject.baseRef === undefined)
+        return
+      if (subject.baseRef !== repository.defaultBranch) {
+        const retargeted = await options.merger.retargetMergedParent({
+          repository,
+          number: subject.number,
+          expectedHeadSha: subject.headSha,
+          expectedBaseRef: subject.baseRef,
+        }, signal)
+        if (retargeted._tag === 'Err')
+          options.report({ _tag: 'Refused', repository: repository.github, pullRequestNumber: subject.number, reason: retargeted.error.message })
+        else if (retargeted.value)
+          options.report({ _tag: 'Retargeted', repository: repository.github, pullRequestNumber: subject.number })
+        return
+      }
       const decision = autoMergeDecision({
         attempts: options.store.listReviewRuns(repository.github, subject.number),
         policy: options.policy,

--- a/packages/harlan-github-agent/src/auto-merge.ts
+++ b/packages/harlan-github-agent/src/auto-merge.ts
@@ -63,6 +63,8 @@ export function autoMergeDecision(input: AutoMergeInput): AutoMergeDecision {
     return { _tag: 'Hold', reason: 'The pull request is not open.' }
   if (pullRequest.draft)
     return { _tag: 'Hold', reason: 'The pull request is a draft.' }
+  if (pullRequest.baseRef !== repository.defaultBranch)
+    return { _tag: 'Hold', reason: 'The pull request must target the default branch before Auto merge.' }
   if (pullRequest.mergeState !== 'clean')
     return { _tag: 'Hold', reason: 'GitHub does not report the pull request as mergeable.' }
 

--- a/packages/harlan-github-agent/src/batch-store.ts
+++ b/packages/harlan-github-agent/src/batch-store.ts
@@ -439,6 +439,8 @@ export function createBatchStore(database: DatabaseSync, dependencies: BatchStor
       return { _tag: 'Unavailable', reason: row.publication_reason ?? 'The unit publication failed.' }
     if (row.task_state === 'Failed' || row.task_state === 'ActionRequired' || row.task_state === 'Superseded')
       return { _tag: 'Unavailable', reason: row.task_reason ?? `The unit Task is ${row.task_state}.` }
+    if (row.state_tag === 'Running' && row.task_state === 'Queued')
+      return { _tag: 'Unavailable', reason: 'The unit task was requeued before publication.' }
     return { _tag: 'Pending' }
   }
 

--- a/packages/harlan-github-agent/src/batch-worker.ts
+++ b/packages/harlan-github-agent/src/batch-worker.ts
@@ -100,6 +100,7 @@ Decide units. One unit is one pull request. Rules:
 - Combine issues into one unit only when one change fixes them all, or when fixing them apart would conflict in the same lines.
 - Keep issues apart when a reviewer would want to read them apart. Small pull requests merge sooner.
 - A unit that must build on another unit's change names that unit in dependsOn, as the zero-based index of an earlier unit. Its pull request then stacks on that pull request's head branch. Use null when the unit stands on the default branch.
+- Shared files alone do not create a dependency. Keep independent changes on the default branch, even in the same file.
 - Order units so that shared groundwork comes first.
 - An issue whose triage difficulty is 4 or 5 stays in its own unit and comes after the easier units, unless another issue shares its exact cause. One long fix must never hold the quick ones.
 - Every issue appears in exactly one unit. Do not invent issue numbers.
@@ -394,7 +395,7 @@ export function createBatchWorker(options: BatchWorkerOptions): BatchWorker {
       }
       if (signal.aborted)
         return err('The Batch was stopped before every unit finished.')
-      await settlePublished(settled.filter(unit => options.store.getBatchDependency(unit.id)._tag !== 'Unavailable'), signal)
+      await settlePublished(settled, signal)
       // A blocked unit stays Waiting. The scheduler releases the permit and
       // keeps the plan queued, so reviews can clear the pull request limit.
       if (queue.length > 0 || suspended)

--- a/packages/harlan-github-agent/src/github.ts
+++ b/packages/harlan-github-agent/src/github.ts
@@ -864,6 +864,13 @@ export type MergeHandoff
     | { _tag: 'Merged', sha: string }
 
 export interface GitHubPullRequestMerger {
+  /** Moves a stack to the default branch only after its exact parent merged there. */
+  retargetMergedParent: (input: {
+    repository: RepositoryMapping
+    number: number
+    expectedHeadSha: string
+    expectedBaseRef: string
+  }, signal?: AbortSignal) => Promise<Result<boolean, GitHubReadError>>
   merge: (input: {
     repository: RepositoryMapping
     number: number
@@ -901,6 +908,57 @@ const enableAutoMergeMutation = `
 
 export function createGitHubPullRequestMerger(options: GitHubPullRequestPublisherOptions): GitHubPullRequestMerger {
   return {
+    async retargetMergedParent(input, signal) {
+      const mapping = input.repository
+      if (!mapping.enabled || mapping.ownership !== 'owned' || input.expectedBaseRef === mapping.defaultBranch)
+        return ok(false)
+      const credential = await options.tokens.getToken(mapping.github, 'pull_request_merge', signal)
+      if (credential._tag === 'Err')
+        return credential
+      const octokit = options.createClient?.(credential.value.token) ?? createAuthenticatedClient({
+        access: 'pull_request_merge',
+        repository: mapping.github,
+        signal,
+        token: credential.value.token,
+        tokens: options.tokens,
+        userAgent: options.userAgent ?? 'harlan-github-agent/0.0.0',
+      })
+      const { owner, repo } = repositoryParts(mapping.github)
+      const request = signal === undefined ? {} : { request: { signal } }
+      const failure = (error: unknown): Result<never, GitHubReadError> => err({
+        repository: mapping.github,
+        message: error instanceof Error ? error.message : 'GitHub could not retarget the stack.',
+      })
+      const current = await octokit.rest.pulls.get({ owner, repo, pull_number: input.number, ...request })
+        .then(response => ok(response.data))
+        .catch(failure)
+      if (current._tag === 'Err')
+        return current
+      const pullRequest = current.value
+      if (pullRequest.state !== 'open' || pullRequest.draft || pullRequest.merged_at !== null
+        || pullRequest.head.sha !== input.expectedHeadSha || pullRequest.base.ref !== input.expectedBaseRef
+        || pullRequest.head.repo?.full_name.toLowerCase() !== mapping.github.toLowerCase()
+        || pullRequest.base.repo.full_name.toLowerCase() !== mapping.github.toLowerCase()
+        || !mapping.writablePullRequestAuthors.some(author => author.toLowerCase() === pullRequest.user?.login.toLowerCase())) {
+        return ok(false)
+      }
+      const parents = await octokit.rest.pulls.list({ owner, repo, head: `${owner}:${input.expectedBaseRef}`, state: 'all', per_page: 100, ...request })
+        .then(response => ok(response.data))
+        .catch(failure)
+      if (parents._tag === 'Err')
+        return parents
+      const integrated = parents.value.some(parent => parent.merged_at !== null
+        && parent.base.ref === mapping.defaultBranch && parent.head.sha === pullRequest.base.sha
+        && parent.head.repo?.full_name.toLowerCase() === mapping.github.toLowerCase())
+      if (!integrated)
+        return ok(false)
+      // GitHub stores this idempotent change. A restart resumes from the live base ref.
+      return octokit.rest.pulls.update({ owner, repo, pull_number: input.number, base: mapping.defaultBranch, ...request })
+        .then(response => response.data.base.ref === mapping.defaultBranch
+          ? ok(true)
+          : err({ repository: mapping.github, message: 'GitHub did not confirm the new stack base.' }))
+        .catch(failure)
+    },
     async merge(input, signal) {
       const { owner, repo } = repositoryParts(input.repository.github)
       const credential = await options.tokens.getToken(input.repository.github, 'pull_request_merge', signal)
@@ -955,6 +1013,12 @@ export function createGitHubPullRequestMerger(options: GitHubPullRequestPublishe
         return err({
           repository: input.repository.github,
           message: 'The head commit moved before the merge was handed to GitHub.',
+        })
+      }
+      if (pullRequest.value.base.ref !== input.repository.defaultBranch) {
+        return err({
+          repository: input.repository.github,
+          message: 'The pull request no longer targets the default branch.',
         })
       }
 

--- a/packages/harlan-github-agent/src/issue-work-worker.ts
+++ b/packages/harlan-github-agent/src/issue-work-worker.ts
@@ -6,8 +6,8 @@ import type { IssueTriageResult } from './issue-triage.ts'
 import type { PullRequestDiagramReference } from './pull-request-diagram.ts'
 import type { Result } from './result.ts'
 import type { JournalStore } from './store.ts'
-import type { AgentProgress, ClaimedIssueWorkTask, MutationWorkerOutcome, OpenAgentPullRequest, PullRequestBase, RepositoryMapping, RoutineIssueSource } from './types.ts'
-import type { IssueWorktreeManager, PreparedWorkerWorkspace, VerifiedIssuePatch } from './worktree.ts'
+import type { AgentProgress, ClaimedIssueWorkTask, MutationWorkerOutcome, PullRequestBase, RepositoryMapping, RoutineIssueSource } from './types.ts'
+import type { IssueWorktreeManager } from './worktree.ts'
 import { redactSecrets, truncateOutput } from './agent-activity.ts'
 import { CHECK_SCOPES, checkBudgetLines, findRepositoryMemory, instructionFilesLine, listInstructionFiles, PULL_REQUEST_BODY_LINES, repositoryMemoryLine, TOOLCHAIN_LINES, UNIT_TEST_LINES } from './agent-context.ts'
 import { runRepairedAgentTurn, unwrapJsonResponse } from './agent-turn.ts'
@@ -16,7 +16,7 @@ import { issueSnapshotDigest } from './item-agent.ts'
 import { PULL_REQUEST_DIAGRAM_PATH, readPullRequestDiagram } from './pull-request-diagram.ts'
 import { canWorkIssues } from './repository-policy.ts'
 import { err, ok } from './result.ts'
-import { chooseOverlappingStackBase, chooseStackBase } from './stack.ts'
+import { chooseStackBase } from './stack.ts'
 import { cleanLine } from './text.ts'
 
 interface ImplementedAgentResponse {
@@ -356,51 +356,6 @@ Untrusted issue data follows as JSON:
 ${JSON.stringify({ title: task.issue.title, body: input.body.slice(0, 12_000), comments: input.comments.slice(0, 30).map(value => value.slice(0, 4_000)) })}`
 }
 
-interface StackedWork {
-  base: PullRequestBase
-  patch: VerifiedIssuePatch
-  workspace: PreparedWorkerWorkspace
-}
-
-/**
- * Moves finished work onto an open pull request that changes the same files.
- *
- * The overlap is only knowable after the agent works, so the worktree starts on
- * the chosen base and moves afterwards. A conflict keeps the prepared base, so
- * the pull request always has somewhere to go.
- *
- * A candidate whose files GitHub will not report has unknown overlap, and
- * unknown overlap never stacks.
- */
-async function stackOnOverlap(
-  options: IssueWorkWorkerOptions,
-  task: ClaimedIssueWorkTask,
-  mapping: RepositoryMapping,
-  current: StackedWork,
-  candidates: readonly OpenAgentPullRequest[],
-  signal: AbortSignal,
-): Promise<Result<StackedWork, string>> {
-  if (current.base._tag === 'Stacked' || candidates.length === 0)
-    return ok(current)
-  const withFiles = await Promise.all(candidates.map(async (candidate) => {
-    const files = await options.github.listPullRequestFiles(mapping, candidate.pullRequestNumber, signal)
-    return files._tag === 'Err' ? [] : [{ ...candidate, changedFiles: files.value }]
-  }))
-  const chosen = chooseOverlappingStackBase({
-    chosen: current.base,
-    changedFiles: current.patch.changedPaths,
-    candidates: withFiles.flat(),
-  })
-  if (chosen._tag !== 'Stacked')
-    return ok(current)
-  const restacked = await options.worktrees.restack(task, current.workspace, { headRef: chosen.ref, headSha: chosen.headSha }, signal)
-  if (restacked._tag === 'Err')
-    return restacked
-  return ok(restacked.value._tag === 'Unstacked'
-    ? current
-    : { base: chosen, patch: restacked.value.patch, workspace: restacked.value.workspace })
-}
-
 export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWorkWorker {
   return {
     async run(task, signal, unit) {
@@ -536,16 +491,6 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
         && (verified.value.changedPaths.length !== 1 || verified.value.changedPaths[0] !== routineSource.target)) {
         return err('Agent feedback issue work changed files outside its skill target.')
       }
-      const stacked = await stackOnOverlap(
-        options,
-        task,
-        validated.value,
-        { base: preparedBase, patch: verified.value, workspace: prepared.value },
-        candidates,
-        signal,
-      )
-      if (stacked._tag === 'Err')
-        return stacked
       const checked = reportProgress({ percent: 90, label: 'Issue work checked' })
       if (checked._tag === 'Err')
         return checked
@@ -555,12 +500,12 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
       if (issueSnapshotDigest(frozen.value) !== scopeDigest)
         return err('The issue changed before the controller committed the fix.')
 
-      const committed = await options.worktrees.commit(task, stacked.value.workspace, stacked.value.patch, response.commitMessage, signal)
+      const committed = await options.worktrees.commit(task, prepared.value, verified.value, response.commitMessage, signal)
       if (committed._tag === 'Err')
         return committed
       // The picture is optional. A document that does not validate is the
       // Agent's mistake to read about, never a reason to hold a finished change.
-      const drawn = await readPullRequestDiagram(stacked.value.workspace.path, {
+      const drawn = await readPullRequestDiagram(prepared.value.path, {
         repository: task.repository,
         baseSha: committed.value.baseSha,
         headSha: committed.value.commitSha,
@@ -585,7 +530,7 @@ export function createIssueWorkWorker(options: IssueWorkWorkerOptions): IssueWor
           diagram: drawn._tag === 'Drawn' ? drawn.diagram : null,
           commitSha: committed.value.commitSha,
           baseSha: committed.value.baseSha,
-          baseRef: stacked.value.base.ref,
+          baseRef: preparedBase.ref,
           expectedHeadSha: committed.value.baseSha,
           headRef: `${prefix}issue-${task.issueNumber}`,
           artifactRef: committed.value.artifactRef,

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -576,6 +576,10 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         merger: createGitHubPullRequestMerger({ tokens }),
         policy: config.autoMerge,
         report: (event) => {
+          if (event._tag === 'Retargeted') {
+            options.logger.info(`${event.repository}#${event.pullRequestNumber}: the parent merged. The stack now targets the default branch.`)
+            return
+          }
           if (event._tag === 'AutoMergeEnabled') {
             options.logger.info(`${event.repository}#${event.pullRequestNumber}: GitHub auto-merge is enabled. GitHub merges it when its checks pass.`)
             store.resolveIncidents({ _tag: 'Repository', repository: event.repository }, now().toISOString(), 'auto_merge')

--- a/packages/harlan-github-agent/src/stack.ts
+++ b/packages/harlan-github-agent/src/stack.ts
@@ -1,10 +1,5 @@
 import type { OpenAgentPullRequest, PullRequestBase } from './types.ts'
 
-/** One stack candidate with the files its pull request changes. */
-export interface StackCandidateFiles extends OpenAgentPullRequest {
-  changedFiles: readonly string[]
-}
-
 function stacked(candidate: OpenAgentPullRequest): PullRequestBase {
   return {
     _tag: 'Stacked',
@@ -32,29 +27,4 @@ export function chooseStackBase(input: {
     .filter(candidate => candidate.taskKind === 'baseline_repair' && candidate.baseRef === input.defaultBranch)
     .sort((left, right) => right.pullRequestNumber - left.pullRequestNumber)[0]
   return repair === undefined ? { _tag: 'DefaultBranch', ref: input.defaultBranch } : stacked(repair)
-}
-
-/**
- * Chooses the base branch again once the changed files are known.
- *
- * Overlapping files mean the new work builds on work that is still in review, so
- * the new pull request stacks on it and reviewers read one diff each.
- *
- * A base chosen before the agent ran already has a stronger reason, so it wins.
- */
-export function chooseOverlappingStackBase(input: {
-  chosen: PullRequestBase
-  changedFiles: readonly string[]
-  candidates: readonly StackCandidateFiles[]
-}): PullRequestBase {
-  const chosen = input.chosen
-  if (chosen._tag === 'Stacked')
-    return chosen
-  const changed = new Set(input.changedFiles)
-  const best = input.candidates
-    .filter(candidate => candidate.baseRef === chosen.ref)
-    .map(candidate => ({ candidate, overlap: candidate.changedFiles.filter(file => changed.has(file)).length }))
-    .filter(entry => entry.overlap > 0)
-    .sort((left, right) => right.overlap - left.overlap || right.candidate.pullRequestNumber - left.candidate.pullRequestNumber)[0]
-  return best === undefined ? chosen : stacked(best.candidate)
 }

--- a/packages/harlan-github-agent/src/worktree.ts
+++ b/packages/harlan-github-agent/src/worktree.ts
@@ -1343,6 +1343,17 @@ export function createGitPublicationRemote(options: GitPublicationRemoteOptions)
       if (base.exitCode !== 0)
         return err(`Could not read the remote base branch: ${base.stderr}`)
       const baseSha = base.stdout.split(/\s+/)[0]
+      // Independent Issue work keeps its verified patch when a sibling merges.
+      // Fresh Review and GitHub checks evaluate it against the current default branch.
+      if (baseSha && command._tag === 'OpenPullRequest' && command.taskKind === 'issue_work'
+        && command.baseRef === command.repositoryMapping.defaultBranch && baseSha !== command.baseSha) {
+        const repository = repositoryGitDirectory(options.root, command.repository)
+        const fetched = await runGit(repository, ['fetch', '--no-tags', remoteUrl(command.repository), baseSha], signal, credential.value, options.remoteUrl !== undefined)
+        if (fetched.exitCode !== 0)
+          return err(`Could not read the current default branch commit: ${fetched.stderr}`)
+        const ancestor = await runGit(repository, ['merge-base', '--is-ancestor', command.baseSha, baseSha], signal)
+        return ancestor.exitCode === 0 ? ok(undefined) : err('The default branch no longer contains the issue work base commit.')
+      }
       return baseSha === command.baseSha
         ? ok(undefined)
         : err('The base branch changed before publication.')

--- a/packages/harlan-github-agent/test/auto-merge.test.ts
+++ b/packages/harlan-github-agent/test/auto-merge.test.ts
@@ -69,6 +69,13 @@ describe('auto merge label', () => {
 })
 
 describe('auto merge decision', () => {
+  it('holds a reviewed stack until it targets the default branch', () => {
+    expect(decide({ pullRequest: { baseRef: 'fix/parent' } })).toEqual({
+      _tag: 'Hold',
+      reason: 'The pull request must target the default branch before Auto merge.',
+    })
+  })
+
   it('merges a labelled pull request with a READY review at full confidence', () => {
     expect(decide()).toEqual({ _tag: 'Merge', headSha: 'abc123', method: 'squash', reviewRunId: 'attempt-1' })
   })

--- a/packages/harlan-github-agent/test/batch-store.test.ts
+++ b/packages/harlan-github-agent/test/batch-store.test.ts
@@ -120,6 +120,64 @@ describe('normalizeBatchPlan', () => {
 })
 
 describe('batches in the journal', () => {
+  it('releases a requeued publication instead of waiting for a pull request that cannot open', () => {
+    const store = openJournalStore(':memory:', true)
+    try {
+      seedReadyHumanIssues(store, [101, 102])
+      store.planBatches(at(6))
+      const batch = store.claimNextBatch('batch-worker', at(7), 600_000)!
+      const plan = store.recordBatchPlan({
+        batchId: batch.id,
+        workerId: 'batch-worker',
+        fence: batch.state.fence,
+        at: at(8),
+        units: [{ issueNumbers: [101], dependsOn: null, rationale: 'Independent.' }, { issueNumbers: [102], dependsOn: null, rationale: 'Independent.' }],
+      })
+      if (plan._tag === 'Err')
+        throw new Error(plan.error)
+      const unit = plan.value[0]!
+      const task = store.claimBatchUnitTask({ unitId: unit.id, workerId: 'batch-worker', now: at(9), leaseMilliseconds: 600_000 })!
+      store.stagePublication({
+        taskId: task.id,
+        workerId: 'batch-worker',
+        fence: task.state.fence,
+        at: at(10),
+        publication: {
+          _tag: 'OpenPullRequest',
+          taskKind: 'issue_work',
+          issueNumber: 101,
+          pullRequestTitle: 'fix: handle the request',
+          pullRequestBody: 'Closes #101.',
+          diagram: null,
+          commitSha: 'commit-1',
+          baseSha: 'base-1',
+          baseRef: 'main',
+          expectedHeadSha: 'base-1',
+          headRef: 'fix/issue-101',
+          artifactRef: 'refs/artifact-1',
+          patchDigest: 'digest-1',
+          changedFiles: 1,
+        },
+      })
+      const command = store.claimNextPublication('publisher', at(11), 600_000)!
+      store.supersedePublication({ commandId: command.id, workerId: 'publisher', fence: command.fence, at: at(12), reason: 'The base branch changed before publication.' })
+      store.recordObservation({
+        externalId: 'issue-101',
+        observedAt: at(13),
+        source: 'poll',
+        subject: issueItem({ number: 101, author: 'harlan-zw', title: 'Reported bug 101', url: 'https://github.com/harlan-zw/example/issues/101' }),
+      })
+
+      expect(store.getBatchDependency(unit.id)).toEqual({ _tag: 'Unavailable', reason: 'The unit task was requeued before publication.' })
+      store.completeBatch({ batchId: batch.id, workerId: 'batch-worker', fence: batch.state.fence, at: at(14) })
+      const ready = [store.claimNextIssueWorkTask('retry', at(15), 600_000), store.claimNextIssueWorkTask('retry', at(15), 600_000)]
+      expect(ready).toEqual(expect.arrayContaining([expect.objectContaining({ id: task.id, issueNumber: 101 })]))
+    }
+    finally {
+      store.close()
+    }
+  })
+
   it('reserves Ready Routine-filed issues, keeps plain Issue work off them, and runs units under one Batch lease', async () => {
     const store = openJournalStore(':memory:', true)
     try {

--- a/packages/harlan-github-agent/test/github-auto-merge.test.ts
+++ b/packages/harlan-github-agent/test/github-auto-merge.test.ts
@@ -8,6 +8,7 @@ import { repositoryMapping } from './fixtures.ts'
 
 interface FakeGitHub {
   headSha?: string
+  baseRef?: string
   /** Thrown by the auto-merge mutation, if anything. */
   autoMergeError?: Error
   mergeResponse?: { merged: boolean, sha?: string, message?: string }
@@ -30,7 +31,7 @@ function merger(github: FakeGitHub, recorded: Recorded) {
       rest: {
         pulls: {
           get: () => Promise.resolve({
-            data: { node_id: 'PR_node_1', head: { sha: github.headSha ?? 'abc123' } },
+            data: { node_id: 'PR_node_1', head: { sha: github.headSha ?? 'abc123' }, base: { ref: github.baseRef ?? 'main' } },
           }),
           merge: (input: Record<string, unknown>) => {
             recorded.merges.push(input)
@@ -56,6 +57,49 @@ const input = {
 
 describe('gitHub auto-merge handoff', () => {
   afterEach(() => vi.restoreAllMocks())
+
+  it.each(['merged', 'open', 'other-base', 'changed-parent', 'outside-author'])('retargets only an integrated parent: %s', async (scenario) => {
+    const updates: unknown[] = []
+    const current = {
+      state: 'open',
+      draft: false,
+      merged_at: null,
+      user: { login: scenario === 'outside-author' ? 'outside' : 'harlan-zw' },
+      head: { sha: 'abc123', repo: { full_name: input.repository.github } },
+      base: { ref: 'fix/parent', sha: 'parent-sha', repo: { full_name: input.repository.github } },
+    }
+    const parent = {
+      merged_at: scenario === 'open' ? null : '2026-09-08T01:00:00Z',
+      head: { sha: scenario === 'changed-parent' ? 'old-parent' : 'parent-sha', repo: { full_name: input.repository.github } },
+      base: { ref: scenario === 'other-base' ? 'fix/grandparent' : 'main' },
+    }
+    const service = createGitHubPullRequestMerger({
+      tokens: { getToken: async () => ok({ token: 'token', expiresAt: '2126-01-01T00:00:00Z' }), invalidate: () => undefined },
+      createClient: () => ({ rest: { pulls: {
+        get: async () => ({ data: current }),
+        list: async () => ({ data: [parent] }),
+        update: async (request: unknown) => {
+          updates.push(request)
+          return { data: { ...current, base: { ...current.base, ref: 'main' } } }
+        },
+      } } }) as unknown as Octokit,
+    })
+
+    expect(await service.retargetMergedParent({ ...input, expectedBaseRef: 'fix/parent' })).toEqual(ok(scenario === 'merged'))
+    expect(updates).toEqual(scenario === 'merged' ? [{ owner: 'harlan-zw', repo: 'example', pull_number: 24, base: 'main' }] : [])
+  })
+
+  it('refuses when the target changed to another branch after the review', async () => {
+    const recorded: Recorded = { graphql: [], merges: [] }
+    const result = await merger({ baseRef: 'fix/merged-parent' }, recorded).merge(input)
+
+    expect(result).toEqual({ _tag: 'Err', error: {
+      repository: input.repository.github,
+      message: 'The pull request no longer targets the default branch.',
+    } })
+    expect(recorded.graphql).toEqual([])
+    expect(recorded.merges).toEqual([])
+  })
 
   it.each([false, true])('mints merge access for a direct merge, authentication retry: %s', async (retry) => {
     const minted: Array<Record<string, string>> = []
@@ -85,7 +129,7 @@ describe('gitHub auto-merge handoff', () => {
         merged.push(JSON.parse(String(init?.body)))
         return json({ merged: true, sha: 'merge-sha' })
       }
-      return json({ node_id: 'PR_node_1', head: { sha: 'abc123' } })
+      return json({ node_id: 'PR_node_1', head: { sha: 'abc123' }, base: { ref: 'main' } })
     })
 
     const result = await createGitHubPullRequestMerger({ tokens }).merge(input)

--- a/packages/harlan-github-agent/test/issue-work-worker.test.ts
+++ b/packages/harlan-github-agent/test/issue-work-worker.test.ts
@@ -517,7 +517,7 @@ Closes #12.`,
     }))
   })
 
-  it('stacks on an open pull request that changes the same file', async () => {
+  it('publishes independent work against main when another pull request changes the same file', async () => {
     const overlapping: OpenAgentPullRequest = {
       pullRequestNumber: 55,
       headRef: 'fix/issue-9',
@@ -542,9 +542,9 @@ Closes #12.`,
       _tag: 'Publish',
       usage: { _tag: 'Unavailable' },
       publication: expect.objectContaining({
-        baseRef: 'fix/issue-9',
-        baseSha: 'issue-head',
-        patchDigest: 'restacked-digest',
+        baseRef: 'main',
+        baseSha: 'base-sha',
+        patchDigest: 'patch-digest',
       }),
     }))
   })

--- a/packages/harlan-github-agent/test/issue-worktree.test.ts
+++ b/packages/harlan-github-agent/test/issue-worktree.test.ts
@@ -1,10 +1,11 @@
-import type { ClaimedIssueWorkTask, PullRequestBase } from '../src/types.ts'
+import type { ClaimedIssueWorkTask, ClaimedPublicationCommand, PullRequestBase } from '../src/types.ts'
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { createIssueWorktreeManager } from '../src/worktree.ts'
+import { ok } from '../src/result.ts'
+import { createGitPublicationRemote, createIssueWorktreeManager } from '../src/worktree.ts'
 import { issueItem, repositoryMapping } from './fixtures.ts'
 
 const temporaryDirectories: string[] = []
@@ -85,6 +86,76 @@ function pushStackBase(checkout: string, ref: string, contents: string): string 
 const defaultBranch: PullRequestBase = { _tag: 'DefaultBranch', ref: 'main' }
 
 describe('issue worktree', () => {
+  it('publishes ten finished changes as main advances between each publication', async () => {
+    const { checkout, manager, remote, root, task } = fixture()
+    const signal = new AbortController().signal
+    const commands: ClaimedPublicationCommand[] = []
+    const targets: string[] = []
+    const publisher = createGitPublicationRemote({
+      root,
+      remoteUrl: () => remote,
+      tokens: { getToken: async () => ok({ token: 'unused', expiresAt: '2126-01-01T00:00:00Z' }), invalidate: () => undefined },
+      github: {
+        getPullRequest: async () => { throw new Error('This burst opens new pull requests.') },
+        hasOpenPullRequestForBranch: async () => ok(false),
+        isBranchProtected: async () => ok(false),
+      },
+      pullRequests: { ensurePullRequest: async (input) => {
+        targets.push(input.baseRef)
+        return ok({ number: targets.length, url: `https://github.com/harlan-zw/example/pull/${targets.length}`, diagram: { _tag: 'None' } })
+      } },
+    })
+    for (let index = 0; index < 10; index++) {
+      const issue = { ...task, id: `burst-${index}`, issueNumber: index + 100 }
+      const prepared = await manager.prepare(issue, defaultBranch, signal)
+      if (prepared._tag === 'Err')
+        throw new Error(prepared.error)
+      writeFileSync(join(prepared.value.path, `change-${index}.ts`), `export const value = ${index}\n`)
+      const verified = await manager.verify(issue, prepared.value, signal)
+      if (verified._tag === 'Err')
+        throw new Error(verified.error)
+      const committed = await manager.commit(issue, prepared.value, verified.value, `feat: add change ${index}`, signal)
+      if (committed._tag === 'Err')
+        throw new Error(committed.error)
+      commands.push({
+        _tag: 'OpenPullRequest',
+        taskKind: 'issue_work',
+        id: `publication-${index}`,
+        taskId: issue.id,
+        repository: task.repository,
+        repositoryMapping: task.repositoryMapping,
+        issueNumber: issue.issueNumber,
+        baseRef: 'main',
+        baseSha: committed.value.baseSha,
+        expectedHeadSha: committed.value.baseSha,
+        headRef: `fix/issue-${issue.issueNumber}`,
+        commitSha: committed.value.commitSha,
+        artifactRef: committed.value.artifactRef,
+        patchDigest: committed.value.digest,
+        changedFiles: committed.value.changedFiles,
+        pullRequestTitle: `feat: add change ${index}`,
+        pullRequestBody: `Closes #${issue.issueNumber}.`,
+        diagram: null,
+        outcomeUnknown: false,
+        workerId: 'publisher',
+        fence: 1,
+        leaseExpiresAt: '2126-01-01T00:00:00Z',
+      })
+    }
+    for (const command of commands) {
+      expect(await publisher.validateAuthority(command, signal)).toEqual(ok(undefined))
+      expect(await publisher.push(command, signal)).toEqual(ok(undefined))
+      expect(await publisher.getHeadSha(command, signal)).toEqual(ok(command.commitSha))
+      expect((await publisher.finalize(command, signal))._tag).toBe('Ok')
+      git(checkout, 'fetch', 'origin', command.headRef)
+      git(checkout, 'merge', '--no-ff', `origin/${command.headRef}`, '-m', 'feat: merge a reviewed change')
+      git(checkout, 'push', 'origin', 'main')
+    }
+    expect(targets).toEqual(Array.from({ length: 10 }).fill('main'))
+    for (const command of commands)
+      expect(git(checkout, 'merge-base', '--is-ancestor', command.commitSha, 'main')).toBe('')
+  }, 30_000)
+
   it('pins a controller commit based on the approved default branch', async () => {
     const { baseSha, manager, root, task } = fixture()
     const prepared = await manager.prepare(task, defaultBranch, new AbortController().signal)

--- a/packages/harlan-github-agent/test/publication-remote.test.ts
+++ b/packages/harlan-github-agent/test/publication-remote.test.ts
@@ -188,7 +188,7 @@ describe('git publication remote', () => {
     expect(requested).toEqual([expectedAccess])
   })
 
-  it('pins the stack base branch, not the default branch', async () => {
+  it('allows issue publication after the default branch advances', async () => {
     const { bare, command, expectedHeadSha, root } = fixture()
     const stacked: Extract<ClaimedPublicationCommand, { _tag: 'OpenPullRequest' }> = {
       ...command,
@@ -215,9 +215,9 @@ describe('git publication remote', () => {
     })
 
     expect(await remote.validateAuthority(stacked, new AbortController().signal)).toEqual(ok(undefined))
-    // The same commit is not the default branch tip, so the default branch cannot stand in for it.
+    // A reviewed sibling may merge while this issue is being implemented.
     expect(await remote.validateAuthority({ ...stacked, baseRef: 'main' }, new AbortController().signal))
-      .toEqual({ _tag: 'Err', error: 'The base branch changed before publication.' })
+      .toEqual(ok(undefined))
   })
 
   it('refuses to rewrite a branch that already has an open pull request', async () => {

--- a/packages/harlan-github-agent/test/stack.test.ts
+++ b/packages/harlan-github-agent/test/stack.test.ts
@@ -1,6 +1,6 @@
 import type { OpenAgentPullRequest } from '../src/types.ts'
 import { describe, expect, it } from 'vitest'
-import { chooseOverlappingStackBase, chooseStackBase } from '../src/stack.ts'
+import { chooseStackBase } from '../src/stack.ts'
 
 function candidate(overrides: Partial<OpenAgentPullRequest> = {}): OpenAgentPullRequest {
   return {
@@ -48,47 +48,5 @@ describe('stack base before the agent runs', () => {
       candidates: [candidate({ pullRequestNumber: 101 }), candidate({ pullRequestNumber: 140, headRef: 'fix/baseline-ci-later', headSha: 'later-head' })],
     })
     expect(chosen).toEqual({ _tag: 'Stacked', ref: 'fix/baseline-ci-later', pullRequestNumber: 140, headSha: 'later-head' })
-  })
-})
-
-describe('stack base after the changed files are known', () => {
-  const overlapping = { ...candidate({ pullRequestNumber: 55, headRef: 'fix/issue-9', headSha: 'issue-head', taskKind: 'issue_work' }), changedFiles: ['src/parser.ts', 'test/parser.test.ts'] }
-
-  it('keeps the default branch when no open pull request touches the same file', () => {
-    expect(chooseOverlappingStackBase({
-      chosen: { _tag: 'DefaultBranch', ref: 'main' },
-      changedFiles: ['src/router.ts'],
-      candidates: [overlapping],
-    })).toEqual({ _tag: 'DefaultBranch', ref: 'main' })
-  })
-
-  it('stacks on the open pull request that changes the same file', () => {
-    expect(chooseOverlappingStackBase({
-      chosen: { _tag: 'DefaultBranch', ref: 'main' },
-      changedFiles: ['src/parser.ts'],
-      candidates: [overlapping],
-    })).toEqual({ _tag: 'Stacked', ref: 'fix/issue-9', pullRequestNumber: 55, headSha: 'issue-head' })
-  })
-
-  it('keeps a base that was already chosen for a broken default branch', () => {
-    const chosen = { _tag: 'Stacked', ref: 'fix/baseline-ci-70a5f7bd49f2', pullRequestNumber: 101, headSha: 'repair-head' } as const
-    expect(chooseOverlappingStackBase({ chosen, changedFiles: ['src/parser.ts'], candidates: [overlapping] })).toEqual(chosen)
-  })
-
-  it('prefers the pull request with the most overlap', () => {
-    const wider = { ...candidate({ pullRequestNumber: 60, headRef: 'fix/issue-11', headSha: 'wider-head', taskKind: 'issue_work' }), changedFiles: ['src/parser.ts', 'src/router.ts'] }
-    expect(chooseOverlappingStackBase({
-      chosen: { _tag: 'DefaultBranch', ref: 'main' },
-      changedFiles: ['src/parser.ts', 'src/router.ts'],
-      candidates: [overlapping, wider],
-    })).toEqual({ _tag: 'Stacked', ref: 'fix/issue-11', pullRequestNumber: 60, headSha: 'wider-head' })
-  })
-
-  it('never stacks on a pull request that is itself stacked', () => {
-    expect(chooseOverlappingStackBase({
-      chosen: { _tag: 'DefaultBranch', ref: 'main' },
-      changedFiles: ['src/parser.ts'],
-      candidates: [{ ...overlapping, baseRef: 'fix/other' }],
-    })).toEqual({ _tag: 'DefaultBranch', ref: 'main' })
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Concurrent MelbJS changes lost completed work when main advanced. Stacked pull requests also merged into branches that never deployed.

Keep independent changes on main and release requeued Batch work. Retarget stacks only after their exact parent merges.

![Issue work preserves completed patches, and Auto merge targets the default branch](https://github.com/user-attachments/assets/823cf10f-8cce-400c-8af9-02e49a1b536e)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
