### PR TITLE
fix(github-agent): review retargeted pull requests

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -243,7 +243,7 @@ If GitHub closes a pull request, publish `MERGED` or `CLOSED`. Clear every Agent
 
 Before trusting a locally inferred close, read that exact pull request from GitHub. Store comment and label cleanup separately from the Task that last owned the comment. Resume incomplete cleanup after restart.
 
-Before dispatch, detect trusted marked comments for the current head commit. A terminal comment completes the queued review unless Harlan explicitly requests a rerun. An active comment is status only. Use local Task ownership to decide whether an Agent still runs.
+Treat trusted marked comments as status only. Complete queued Review only when stored Review evidence matches the current head commit, target branch, and repository policy. If Harlan requests a rerun, dispatch fresh Review. Use local Task ownership to decide whether an Agent still runs.
 
 Allow Harlan to rerun the current head commit from the dashboard or with the exact pull request comment `/harlan-agent rerun`. GitHub does not autocomplete regular GitHub Apps as native agents. Reject GitHub rerun commands from every other author. Store the command identity before queueing work. Repeated polls must not queue it twice.
 

--- a/packages/harlan-github-agent/src/auto-merge.ts
+++ b/packages/harlan-github-agent/src/auto-merge.ts
@@ -40,9 +40,9 @@ export interface AutoMergeInput {
   repository: RepositoryMapping
 }
 
-function readyAttemptForHead(attempts: ReviewRun[], headSha: string): ReviewRun | undefined {
+function readyAttemptForHead(attempts: ReviewRun[], headSha: string, baseRef: string): ReviewRun | undefined {
   return attempts
-    .filter(attempt => attempt.headSha === headSha && attempt.outcome._tag === 'Ready')
+    .filter(attempt => attempt.headSha === headSha && attempt.baseRef === baseRef && attempt.outcome._tag === 'Ready')
     .sort((left, right) => right.completedAt.localeCompare(left.completedAt))[0]
 }
 
@@ -68,7 +68,7 @@ export function autoMergeDecision(input: AutoMergeInput): AutoMergeDecision {
   if (pullRequest.mergeState !== 'clean')
     return { _tag: 'Hold', reason: 'GitHub does not report the pull request as mergeable.' }
 
-  const attempt = readyAttemptForHead(attempts, pullRequest.headSha)
+  const attempt = readyAttemptForHead(attempts, pullRequest.headSha, pullRequest.baseRef)
   if (attempt === undefined || attempt.outcome._tag !== 'Ready')
     return { _tag: 'Hold', reason: 'The current head commit has no READY review.' }
   if (!attempt.publications.some(publication => publication.result._tag === 'Published'))

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1180,16 +1180,6 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
         )
       }
 
-      // A complete comment stands in for a Review only when this service never
-      // reviewed the head. Its own comment under an older policy is what the
-      // planner queued this fresh Review to replace.
-      if (stored._tag === 'None' && snapshot.value.priorAutomatedReview._tag === 'Found' && snapshot.value.priorAutomatedReview.state === 'complete' && task.rerun._tag === 'NotRequested' && !manualReview) {
-        return ok({
-          evidence: `Existing automated review by @${snapshot.value.priorAutomatedReview.authorLogin}: ${snapshot.value.priorAutomatedReview.url}`,
-          resolution: { _tag: 'ExistingReview', url: snapshot.value.priorAutomatedReview.url },
-        })
-      }
-
       let freshReviewSession = false
       if (manualReview) {
         const routed = await options.github.stampAgentLabel(task.repositoryMapping, task.pullRequestNumber, 'ADVERSARIAL_REVIEW_REQUIRED', signal)

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -1368,6 +1368,7 @@ export function createReviewWorker(options: ReviewWorkerOptions): ReviewWorker {
           : { _tag: 'Blocked' as const, confidence: response.confidence }
       return projectReviewRun(options, task, frozen.value, {
         id: reviewRunId,
+        baseRef: task.pullRequest.baseRef ?? null,
         repository: task.repository,
         pullRequestNumber: task.pullRequestNumber,
         revisionId: task.revisionId,

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -4241,35 +4241,6 @@ const existingReviewLabelClaimSql = `(review_status_commands.task_kind = 'existi
             WHERE lower(value) = lower(json_extract(status_revision.payload, '$.author'))))
       ))`
 
-/** Restores the label omitted by a completed review from another trusted actor. */
-function stageExistingReviewLabel(database: DatabaseSync, subject: GitHubPullRequestItem, revisionId: string, at: string): void {
-  const prior = subject.priorAutomatedReview
-  if (prior._tag !== 'Found' || prior.state !== 'complete')
-    return
-  const prefix = `${subject.url}#issuecomment-`
-  if (!prior.url.startsWith(prefix))
-    return
-  const commentId = Number(prior.url.slice(prefix.length))
-  if (!Number.isSafeInteger(commentId) || commentId <= 0)
-    return
-  const commandId = digest(`existing-review-label:${revisionId}:${commentId}`)
-  const staged = database.prepare(`
-    INSERT INTO review_status_commands (
-      id, task_kind, task_id, task_fence, revision_id, expected_head_sha, phase, body, body_sha256,
-      desired_outcome, state_tag, github_comment_id, github_url, created_at, updated_at
-    ) VALUES (?, 'existing_review', ?, 0, ?, ?, 'terminal', '', ?, 'EXISTING', 'Pending', ?, ?, ?, ?)
-    -- The id pins one revision to one comment, so an unchanged observation names
-    -- a Published command whose label is already on the pull request. Restaging
-    -- it would republish through GitHub on every poll and never converge. Only a
-    -- Superseded command yields again, so retired work can return when the
-    -- observation that retired it goes away.
-    ON CONFLICT(id) DO UPDATE SET state_tag = 'Pending', updated_at = excluded.updated_at
-    WHERE review_status_commands.state_tag = 'Superseded'
-  `).run(commandId, commandId, revisionId, subject.headSha, digest(''), commentId, prior.url, at, at)
-  if (staged.changes === 1)
-    recordReviewStatusEvent(database, { commandId, event: 'Staged', from: null, to: 'Pending', at })
-}
-
 function planAdversarialReview(
   database: DatabaseSync,
   subject: GitHubItem,
@@ -4290,18 +4261,18 @@ function planAdversarialReview(
   `).get(subjectId, revisionId) !== undefined
   const localAttempt = database.prepare(`
     SELECT
-      EXISTS (SELECT 1 FROM review_runs WHERE subject_id = ?) AS any_attempt,
       EXISTS (SELECT 1 FROM review_runs WHERE subject_id = ? AND revision_id = ?) AS revision_attempt,
+      EXISTS (SELECT 1 FROM review_resolutions WHERE subject_id = ? AND revision_id = ? AND resolution_tag = 'ExistingReview') AS unscoped_comment,
       (SELECT review_runs.id FROM review_runs
         JOIN review_evidence_scopes ON review_evidence_scopes.review_run_id = review_runs.id
-        JOIN revisions AS reviewed ON reviewed.id = review_runs.revision_id
         WHERE review_runs.subject_id = ? AND review_runs.head_sha = ?
           AND review_runs.kind = 'adversarial_review'
           AND review_evidence_scopes.policy_digest = ?
-          AND json_extract(reviewed.payload, '$.baseRef') IS ?
+          AND review_runs.base_ref = ?
         ORDER BY review_runs.completed_at DESC, review_runs.id DESC LIMIT 1) AS head_review_run_id
   `).get(
     subjectId,
+    revisionId,
     subjectId,
     revisionId,
     subjectId,
@@ -4309,15 +4280,12 @@ function planAdversarialReview(
     reviewPolicyDigest(mapping),
     subject.kind === 'pull_request' ? subject.baseRef ?? null : null,
   ) as {
-    any_attempt: number
     revision_attempt: number
+    unscoped_comment: number
     head_review_run_id: string | null
   }
-  const priorComplete = subject.kind === 'pull_request'
-    && subject.priorAutomatedReview._tag === 'Found'
-    && subject.priorAutomatedReview.state === 'complete'
   const alreadyReviewed = subject.kind === 'pull_request'
-    && (localAttempt.head_review_run_id !== null || (priorComplete && localAttempt.any_attempt === 0))
+    && localAttempt.head_review_run_id !== null
     && !rerunRequested
     && !(manualReviewRequested && localAttempt.revision_attempt === 0)
   const reviewable = subject.kind === 'pull_request'
@@ -4368,32 +4336,6 @@ function planAdversarialReview(
       })
     }
   }
-  else if (alreadyReviewed && subject.kind === 'pull_request' && subject.priorAutomatedReview._tag === 'Found') {
-    const stored = database.prepare(`
-      INSERT INTO review_resolutions (
-        subject_id, revision_id, task_id, task_fence, resolution_tag,
-        review_run_id, baseline_task_id, github_url, reason, created_at
-      ) VALUES (?, ?, NULL, 0, 'ExistingReview', NULL, NULL, ?, NULL, ?)
-      ON CONFLICT(subject_id, revision_id) DO UPDATE SET
-        task_id = NULL, task_fence = 0, resolution_tag = 'ExistingReview',
-        review_run_id = NULL, baseline_task_id = NULL, github_url = excluded.github_url,
-        reason = NULL, created_at = excluded.created_at
-      WHERE review_resolutions.resolution_tag IN ('UnknownNeedsReconciliation', 'ExistingReview')
-    `).run(subjectId, revisionId, subject.priorAutomatedReview.url, observedAt)
-    if (stored.changes === 1) {
-      recordWorkflowEvent(database, {
-        stream: 'review_resolution',
-        event: 'Recorded',
-        entityId: `${subjectId}:${revisionId}`,
-        repository: mapping.github,
-        itemNumber: subject.number,
-        revisionId,
-        from: null,
-        to: 'ExistingReview',
-        at: observedAt,
-      })
-    }
-  }
 
   if (!eligible) {
     // A worker records its run, then publishes the comment. A poll between
@@ -4412,11 +4354,6 @@ function planAdversarialReview(
       undefined,
       ownRunLanded ? revisionId : undefined,
     )
-    if (alreadyReviewed && localAttempt.head_review_run_id === null && subject.kind === 'pull_request'
-      && subject.state === 'open' && mapping.enabled && mapping.pullRequestReview
-      && (!approvalRequired || reviewApproved) && !manualReviewRequested) {
-      stageExistingReviewLabel(database, subject, revisionId, observedAt)
-    }
     return
   }
 
@@ -4469,7 +4406,7 @@ function planAdversarialReview(
     })
     return
   }
-  if (existing?.state_tag === 'Completed' && localAttempt.revision_attempt === 1 && localAttempt.head_review_run_id === null) {
+  if (existing?.state_tag === 'Completed' && (localAttempt.revision_attempt === 1 || localAttempt.unscoped_comment === 1) && localAttempt.head_review_run_id === null) {
     database.prepare(`
       UPDATE worker_tasks
       SET state_tag = 'Queued', reason = NULL, evidence = NULL, attempts = 0,
@@ -4483,7 +4420,7 @@ function planAdversarialReview(
       taskId: existing.id,
       from: 'Completed',
       to: 'Queued',
-      reason: 'Trusted Review policy changed.',
+      reason: 'Current Review evidence is missing.',
       fence: existing.fence,
       at: observedAt,
     })
@@ -6236,7 +6173,17 @@ function installSchema(database: DatabaseSync): void {
     applyMigration(database, existingReviewLabelMigration)
     version = 68
   }
-  if (version === 68)
+  if (version === 68) {
+    // Old Revisions could move across target branches. They cannot prove a Review target.
+    // Replayed journals may already contain the column. Legacy values stay unknown.
+    const columns = (database.prepare('PRAGMA table_info(review_runs)').all() as unknown as Array<{ name: string }>)
+      .map(column => column.name)
+    applyMigration(database, columns.includes('base_ref')
+      ? 'PRAGMA user_version = 69;'
+      : 'ALTER TABLE review_runs ADD COLUMN base_ref TEXT; PRAGMA user_version = 69;')
+    version = 69
+  }
+  if (version === 69)
     return
   throw new Error(`Unsupported database schema version: ${version}.`)
 }
@@ -6416,7 +6363,7 @@ function dashboardReviewAgents(database: DatabaseSync): Array<Extract<DashboardA
       subjects.github_number,
       review_runs.revision_id,
       review_runs.head_sha,
-      json_extract(revisions.payload, '$.baseRef') AS base_ref,
+      review_runs.base_ref,
       review_runs.provider,
       review_runs.session_id,
       review_runs.model,
@@ -7611,8 +7558,8 @@ export function openJournalStore(
         INSERT INTO review_runs (
           id, subject_id, revision_id, kind, provider, session_id, model, agent_version,
           skill_digest, head_sha, started_at, completed_at, gates, outcome_tag,
-          confidence, findings, content_digest, usage
-        ) VALUES (?, ?, ?, 'adversarial_review', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          confidence, findings, content_digest, usage, base_ref
+        ) VALUES (?, ?, ?, 'adversarial_review', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         input.id,
         revision.subject_id,
@@ -7631,6 +7578,7 @@ export function openJournalStore(
         findings,
         contentDigest,
         usage,
+        pullRequest.baseRef ?? null,
       )
       database.prepare(`
         INSERT INTO review_evidence_scopes (review_run_id, policy_digest, created_at)
@@ -7747,6 +7695,7 @@ export function openJournalStore(
       const parent = database.prepare(`
         SELECT 1 FROM review_runs
         WHERE id = ? AND subject_id = ? AND revision_id = ? AND head_sha = ?
+          AND base_ref = ?
           AND NOT EXISTS (
             SELECT 1 FROM review_runs AS settled
             WHERE settled.supersedes_review_run_id = review_runs.id
@@ -7756,6 +7705,7 @@ export function openJournalStore(
         revision.subject_id,
         revisionId,
         input.headSha,
+        pullRequest.baseRef ?? null,
       )
       if (parent === undefined) {
         const orphaned = database.prepare('SELECT 1 FROM review_runs WHERE id = ?').get(input.supersedesReviewRunId)
@@ -7768,8 +7718,8 @@ export function openJournalStore(
         INSERT INTO review_runs (
           id, subject_id, revision_id, kind, provider, session_id, model, agent_version,
           skill_digest, head_sha, started_at, completed_at, gates, outcome_tag,
-          confidence, findings, content_digest, usage, supersedes_review_run_id
-        ) VALUES (?, ?, ?, 'adversarial_review', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          confidence, findings, content_digest, usage, supersedes_review_run_id, base_ref
+        ) VALUES (?, ?, ?, 'adversarial_review', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
         input.id,
         revision.subject_id,
@@ -7789,6 +7739,7 @@ export function openJournalStore(
         contentDigest,
         usage,
         input.supersedesReviewRunId,
+        pullRequest.baseRef ?? null,
       )
       database.prepare(`
         INSERT INTO review_evidence_scopes (review_run_id, policy_digest, created_at)
@@ -7987,8 +7938,7 @@ export function openJournalStore(
   // repository's current policy digest. A worker that then resumed the old
   // run, or accepted its comment on GitHub as an existing review, completed
   // with no new scope, and the planner requeued it on every poll. Only a run
-  // recorded under the current policy is worth resuming, and only a head this
-  // service never reviewed may lean on another actor's comment.
+  // recorded under the current policy and target branch is worth resuming.
   const storedReviewForHead: JournalStore['storedReviewForHead'] = (repository, pullRequestNumber, headSha) => {
     const row = database.prepare(`
       SELECT
@@ -7997,11 +7947,10 @@ export function openJournalStore(
           SELECT 1 FROM review_evidence_scopes
           WHERE review_evidence_scopes.review_run_id = review_runs.id
             AND review_evidence_scopes.policy_digest = repositories.policy_digest
-            AND json_extract(reviewed.payload, '$.baseRef') IS json_extract(current.payload, '$.baseRef')
+            AND review_runs.base_ref = json_extract(current.payload, '$.baseRef')
         ) AS current
       FROM review_runs
       JOIN subjects ON subjects.id = review_runs.subject_id
-      JOIN revisions AS reviewed ON reviewed.id = review_runs.revision_id
       JOIN revisions AS current ON current.id = subjects.current_revision_id
       JOIN repositories ON repositories.id = subjects.repository_id
       WHERE repositories.github = ? AND subjects.github_number = ?
@@ -8024,7 +7973,7 @@ export function openJournalStore(
         subjects.github_number,
         review_runs.revision_id,
         review_runs.head_sha,
-        json_extract(revisions.payload, '$.baseRef') AS base_ref,
+        review_runs.base_ref,
         review_runs.provider,
         review_runs.session_id,
         review_runs.model,
@@ -9783,6 +9732,7 @@ export function openJournalStore(
           AND subjects.kind = 'pull_request'
           AND review_runs.revision_id = ? AND subjects.current_revision_id = ?
           AND review_runs.head_sha = ?
+          AND review_runs.base_ref = json_extract(revisions.payload, '$.baseRef')
           AND json_extract(revisions.payload, '$.state') = 'open'
           AND json_extract(revisions.payload, '$.headSha') = ?
           AND repositories.enabled = 1
@@ -12431,6 +12381,7 @@ export function openJournalStore(
       AND ranked.revision_id = subjects.current_revision_id
       AND json_extract(current_revisions.payload, '$.state') = 'open'
       AND json_extract(current_revisions.payload, '$.headSha') = ranked.head_sha
+      AND ranked.base_ref = json_extract(current_revisions.payload, '$.baseRef')
       AND NOT EXISTS (SELECT 1 FROM item_dismissals WHERE subject_id = ranked.subject_id)
       AND NOT EXISTS (
         SELECT 1 FROM task_cancellations

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -1202,6 +1202,7 @@ interface ClaimRow extends TaskRow {
 }
 
 interface ReviewRunRow {
+  base_ref: string | null
   id: string
   repository: string
   github_number: number
@@ -2587,6 +2588,7 @@ function reviewRunFromRow(row: ReviewRunRow, publications: ReviewPublication[]):
     pullRequestNumber: row.github_number,
     revisionId: row.revision_id,
     headSha: row.head_sha,
+    baseRef: row.base_ref,
     provider: row.provider,
     sessionId: row.session_id,
     model: row.model,
@@ -3962,7 +3964,8 @@ function planReviewFix(
  * while it works, when the base branch moves or GitHub recomputes mergeability,
  * and the Review rows follow the subject's current Revision. A write that names
  * the claimed Revision lands on the current one while both share the head
- * commit. A different head commit keeps the claimed id, and the caller's own
+ * commit and target branch. A changed target keeps the claimed id, so the write fails.
+ * A different head commit keeps the claimed id, and the caller's own
  * checks refuse it.
  */
 function currentSameHeadRevision(database: DatabaseSync, revisionId: string): string {
@@ -3974,6 +3977,7 @@ function currentSameHeadRevision(database: DatabaseSync, revisionId: string): st
     WHERE claimed.id = ? AND subjects.kind = 'pull_request'
       AND json_extract(current.payload, '$.state') = 'open'
       AND json_extract(current.payload, '$.headSha') = json_extract(claimed.payload, '$.headSha')
+      AND json_extract(current.payload, '$.baseRef') IS json_extract(claimed.payload, '$.baseRef')
   `).get(revisionId) as { current_id: string } | undefined
   return row?.current_id ?? revisionId
 }
@@ -3987,18 +3991,20 @@ function currentSameHeadRevision(database: DatabaseSync, revisionId: string): st
  * superseded, a READY verdict stopped refreshing, and a Repair lost its
  * findings. 208 Reviews died that way in one fortnight. Rows follow the head.
  *
+ * A different target branch changes the reviewed diff. Those rows stay on their original Revision.
  * Conflict resolution and Baseline repair answer a base commit, so they stay.
  */
 function followHeadCommit(database: DatabaseSync, subjectId: number, revisionId: string, headSha: string): void {
   const sameHead = `
     SELECT id FROM revisions
     WHERE subject_id = ? AND id != ? AND json_extract(payload, '$.headSha') = ?
+      AND json_extract(payload, '$.baseRef') IS (SELECT json_extract(payload, '$.baseRef') FROM revisions WHERE id = ?)
   `
-  const sameHeadArgs = [subjectId, revisionId, headSha]
+  const sameHeadArgs = [subjectId, revisionId, headSha, revisionId]
   database.prepare(`
     UPDATE review_runs SET revision_id = ?
-    WHERE subject_id = ? AND head_sha = ? AND revision_id != ?
-  `).run(revisionId, subjectId, headSha, revisionId)
+    WHERE subject_id = ? AND revision_id IN (${sameHead})
+  `).run(revisionId, subjectId, ...sameHeadArgs)
   // A Review that queued a Baseline repair answers that base commit. It stays,
   // and the moved base gets a fresh Review that can read the repaired base.
   const waitsOnBaseline = `
@@ -4071,7 +4077,7 @@ function followHeadCommit(database: DatabaseSync, subjectId: number, revisionId:
     UPDATE approval_prompt_comments SET revision_id = ?
     WHERE subject_id = ? AND revision_id IN (${sameHead})
   `).run(revisionId, subjectId, ...sameHeadArgs)
-  // A person approved this head commit, whatever the base was at the time.
+  // An Approval follows the head only while its target branch stays unchanged.
   database.prepare(`
     INSERT OR IGNORE INTO pull_request_approvals (subject_id, revision_id, kind, approved_at)
     SELECT subject_id, ?, kind, MIN(approved_at)
@@ -4288,9 +4294,11 @@ function planAdversarialReview(
       EXISTS (SELECT 1 FROM review_runs WHERE subject_id = ? AND revision_id = ?) AS revision_attempt,
       (SELECT review_runs.id FROM review_runs
         JOIN review_evidence_scopes ON review_evidence_scopes.review_run_id = review_runs.id
+        JOIN revisions AS reviewed ON reviewed.id = review_runs.revision_id
         WHERE review_runs.subject_id = ? AND review_runs.head_sha = ?
           AND review_runs.kind = 'adversarial_review'
           AND review_evidence_scopes.policy_digest = ?
+          AND json_extract(reviewed.payload, '$.baseRef') IS ?
         ORDER BY review_runs.completed_at DESC, review_runs.id DESC LIMIT 1) AS head_review_run_id
   `).get(
     subjectId,
@@ -4299,6 +4307,7 @@ function planAdversarialReview(
     subjectId,
     subject.kind === 'pull_request' ? subject.headSha : '',
     reviewPolicyDigest(mapping),
+    subject.kind === 'pull_request' ? subject.baseRef ?? null : null,
   ) as {
     any_attempt: number
     revision_attempt: number
@@ -6407,6 +6416,7 @@ function dashboardReviewAgents(database: DatabaseSync): Array<Extract<DashboardA
       subjects.github_number,
       review_runs.revision_id,
       review_runs.head_sha,
+      json_extract(revisions.payload, '$.baseRef') AS base_ref,
       review_runs.provider,
       review_runs.session_id,
       review_runs.model,
@@ -7987,9 +7997,12 @@ export function openJournalStore(
           SELECT 1 FROM review_evidence_scopes
           WHERE review_evidence_scopes.review_run_id = review_runs.id
             AND review_evidence_scopes.policy_digest = repositories.policy_digest
+            AND json_extract(reviewed.payload, '$.baseRef') IS json_extract(current.payload, '$.baseRef')
         ) AS current
       FROM review_runs
       JOIN subjects ON subjects.id = review_runs.subject_id
+      JOIN revisions AS reviewed ON reviewed.id = review_runs.revision_id
+      JOIN revisions AS current ON current.id = subjects.current_revision_id
       JOIN repositories ON repositories.id = subjects.repository_id
       WHERE repositories.github = ? AND subjects.github_number = ?
         AND subjects.kind = 'pull_request' AND review_runs.kind = 'adversarial_review'
@@ -8011,6 +8024,7 @@ export function openJournalStore(
         subjects.github_number,
         review_runs.revision_id,
         review_runs.head_sha,
+        json_extract(revisions.payload, '$.baseRef') AS base_ref,
         review_runs.provider,
         review_runs.session_id,
         review_runs.model,
@@ -8028,6 +8042,7 @@ export function openJournalStore(
         agent_feedback.updated_at AS feedback_updated_at
       FROM review_runs
       JOIN subjects ON subjects.id = review_runs.subject_id
+      JOIN revisions ON revisions.id = review_runs.revision_id
       JOIN repositories ON repositories.id = subjects.repository_id
       LEFT JOIN review_gate_projections ON review_gate_projections.review_run_id = review_runs.id
       LEFT JOIN agent_feedback ON agent_feedback.review_run_id = review_runs.id

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -378,6 +378,8 @@ export type RecordAgentFeedbackResult
     | { _tag: 'Rejected', reason: { _tag: 'ReviewRunNotFound' } }
 
 export interface ReviewRun {
+  /** The target branch whose diff this Review covered. */
+  baseRef: string | null
   id: string
   repository: string
   pullRequestNumber: number
@@ -403,7 +405,7 @@ export interface ReviewRun {
  * What this service already holds for one head commit, from a worker's view.
  *
  * `Current` was recorded under the repository's current policy and may be
- * resumed. `Stale` predates that policy: the planner queued a fresh Review to
+ * resumed. `Stale` covers an old policy or target branch: the planner queued a fresh Review to
  * replace it, so neither it nor its comment on GitHub may stand in. `None`
  * means this service never reviewed the head, so a complete comment from
  * another actor may.

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -424,7 +424,7 @@ export type ReviewResolution
 
 export type ReviewDesiredOutcome = 'READY' | 'PENDING' | 'BLOCKED' | 'WAITING' | 'EXISTING' | 'SKIPPED'
 
-export interface RecordReviewRunInput extends Omit<ReviewRun, 'feedback' | 'outcome' | 'publications' | 'usage'> {
+export interface RecordReviewRunInput extends Omit<ReviewRun, 'baseRef' | 'feedback' | 'outcome' | 'publications' | 'usage'> {
   confidence?: number
   /** Trusted repository policy used by this Review. */
   policyDigest?: string

--- a/packages/harlan-github-agent/test/auto-merge.test.ts
+++ b/packages/harlan-github-agent/test/auto-merge.test.ts
@@ -28,6 +28,7 @@ function attempt(overrides: { headSha?: string, outcome?: ReviewOutcome, finding
     pullRequestNumber: 24,
     revisionId: 'revision-1',
     headSha: overrides.headSha ?? 'abc123',
+    baseRef: 'main',
     provider: 'codex',
     sessionId: 'session-1',
     model: 'gpt-5.6-sol',
@@ -107,6 +108,10 @@ describe('auto merge decision', () => {
     expect(decide({ pullRequest: { mergeState: 'conflicting' } })._tag).toBe('Hold')
     expect(decide({ pullRequest: { mergeState: 'unknown' } })._tag).toBe('Hold')
     expect(decide({ pullRequest: { state: 'closed' } })._tag).toBe('Hold')
+  })
+
+  it('holds when the same head was reviewed against a different target branch', () => {
+    expect(decide({ attempts: [{ ...attempt(), baseRef: 'fix/parent' }] })._tag).toBe('Hold')
   })
 
   it('holds when the READY review covers an older head commit', () => {

--- a/packages/harlan-github-agent/test/dashboard-view.test.ts
+++ b/packages/harlan-github-agent/test/dashboard-view.test.ts
@@ -143,6 +143,7 @@ function queueEntry(overrides: Partial<QueueEntry> = {}): QueueEntry {
 function reviewAgent(overrides: Partial<ReviewAgent> = {}): ReviewAgent {
   return {
     _tag: 'ReviewAgent',
+    baseRef: 'main',
     role: 'adversarial_review',
     id: 'attempt-1',
     repository: 'harlan-zw/nuxt-seo',

--- a/packages/harlan-github-agent/test/existing-review-labels.test.ts
+++ b/packages/harlan-github-agent/test/existing-review-labels.test.ts
@@ -1,7 +1,5 @@
-import type { ExistingReviewLabel } from '../src/github-agent-source.ts'
-import type { GitHubPullRequestItem } from '../src/types.ts'
-import { afterEach, describe, expect, it } from 'vitest'
-import { err, ok } from '../src/result.ts'
+import { afterEach, expect, it } from 'vitest'
+import { ok } from '../src/result.ts'
 import { createReviewStatusScheduler } from '../src/review-status-scheduler.ts'
 import { openJournalStore } from '../src/store.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
@@ -9,11 +7,10 @@ import { pullRequestItem, repositoryMapping } from './fixtures.ts'
 const stores: Array<ReturnType<typeof openJournalStore>> = []
 afterEach(() => stores.splice(0).forEach(store => store.close()))
 
-function harness() {
+it('requires fresh Review before publishing a READY label for an unscoped comment', async () => {
   const store = openJournalStore(':memory:')
   stores.push(store)
-  const repository = repositoryMapping()
-  let pullRequest = pullRequestItem({
+  const pullRequest = pullRequestItem({
     mergeState: 'clean',
     priorAutomatedReview: {
       _tag: 'Found',
@@ -22,21 +19,9 @@ function harness() {
       url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
     },
   })
-  let now = new Date('2026-08-13T01:00:00.000Z')
-  store.syncRepositories([repository], now.toISOString())
-  const observe = (changes: Partial<GitHubPullRequestItem> = {}) => {
-    now = new Date(now.getTime() + 1000)
-    pullRequest = { ...pullRequest, ...changes, updatedAt: now.toISOString() }
-    return store.recordObservation({ externalId: now.toISOString(), observedAt: now.toISOString(), source: 'poll', subject: pullRequest })
-  }
-  observe()
+  store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
   const labels: string[] = []
-  const failures: string[] = []
-  let failLabel = false
-  let reads = 0
-  let readFailure: string | null = null
-  let outcome: ExistingReviewLabel['label'] = 'READY'
-  const scheduler = () => createReviewStatusScheduler({
+  const scheduler = createReviewStatusScheduler({
     github: {
       getPullRequestReviewSnapshot: () => Promise.resolve(ok({
         baseChecks: { _tag: 'Available', checks: [] },
@@ -48,155 +33,27 @@ function harness() {
         requiredChecks: { _tag: 'None' },
         reviews: [],
       })),
-      readExistingReviewLabel: (_repository, _number, commentId) => {
-        reads += 1
-        if (readFailure !== null)
-          return Promise.resolve(err({ _tag: 'Permanent', message: readFailure }))
-        return Promise.resolve(ok({ commentId, url: `${pullRequest.url}#issuecomment-${commentId}`, label: outcome }))
-      },
+      readExistingReviewLabel: () => Promise.resolve(ok({ commentId: 42, url: pullRequest.url, label: 'READY' })),
       upsertReviewStatus: () => { throw new Error('The existing comment must stay unchanged.') },
       stampAgentLabel: (_repository, _number, label) => {
-        if (failLabel)
-          return Promise.resolve(err('GitHub refused the label.'))
         labels.push(label)
         return Promise.resolve(ok(undefined))
       },
     },
     intervalMilliseconds: 5_000,
     leaseMilliseconds: 60_000,
-    now: () => now,
+    now: () => new Date('2026-08-13T01:01:00.000Z'),
     onError: (error) => { throw error },
-    onFailure: (_repository, _number, reason) => failures.push(reason),
+    onFailure: (_repository, _number, reason) => { throw new Error(reason) },
     onPublished: () => undefined,
     store,
     workerId: 'label-publisher',
   })
-  return {
-    store,
-    labels,
-    failures,
-    observe,
-    scheduler,
-    failLabel: (value: boolean) => { failLabel = value },
-    outcome: (value: ExistingReviewLabel['label']) => { outcome = value },
-    readFailure: (value: string | null) => { readFailure = value },
-    reads: () => reads,
+  for (const externalId of ['first', 'repeat']) {
+    store.recordObservation({ externalId, observedAt: '2026-08-13T01:00:00.000Z', source: 'poll', subject: pullRequest })
+    await scheduler.runNow()
   }
-}
 
-describe('labels for an existing review', () => {
-  it('restores the label without starting an Agent or changing the comment', async () => {
-    const test = harness()
-    await test.scheduler().runNow()
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual(['READY'])
-    expect(test.store.claimNextAdversarialReviewTask('reviewer', '2026-08-13T01:02:00.000Z', 60_000)).toBeNull()
-    expect(test.store.listWorkflowEvents({ stream: 'review_status', limit: 20 }).map(event => event.event))
-      .toContain('OutcomeLabelConfirmed')
-  })
-
-  it('retries a failed label after the scheduler restarts', async () => {
-    const test = harness()
-    test.failLabel(true)
-    await test.scheduler().runNow()
-    test.failLabel(false)
-    await test.scheduler().runNow()
-
-    expect(test.failures).toEqual(['GitHub refused the label.'])
-    expect(test.labels).toEqual(['READY'])
-  })
-
-  it('does not republish a published label when the same observation repeats', async () => {
-    const test = harness()
-    await test.scheduler().runNow()
-    test.observe()
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual(['READY'])
-    expect(test.reads()).toBe(1)
-  })
-
-  it('stops retrying when the trusted review changed before its label was restored', async () => {
-    const test = harness()
-    test.readFailure('The completed review changed before its label was restored.')
-    await test.scheduler().runNow()
-    await test.scheduler().runNow()
-
-    expect(test.failures).toEqual(['The completed review changed before its label was restored.'])
-    expect(test.reads()).toBe(1)
-    expect(test.store.claimNextTerminalReviewStatus('label-publisher-2', '2026-08-13T01:04:00.000Z', 60_000)).toBeNull()
-    expect(test.store.listWorkflowEvents({ stream: 'review_status', limit: 20 }).map(event => event.event))
-      .toContain('Superseded')
-  })
-
-  it('follows a replacement trusted comment on the same head', async () => {
-    const test = harness()
-    test.observe({ priorAutomatedReview: {
-      _tag: 'Found',
-      authorLogin: 'harlan-zw',
-      state: 'complete',
-      url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-43',
-    } })
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual(['READY'])
-    expect(test.failures).toEqual([])
-  })
-
-  it.each([
-    { headSha: 'new-head', priorAutomatedReview: { _tag: 'None' as const } },
-    { state: 'closed' as const },
-  ])('does not restore a label after the pull request changes: %j', async (changes) => {
-    const test = harness()
-    test.observe(changes)
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual([])
-  })
-
-  it('retires the label publication when a fresh review is requested', async () => {
-    const test = harness()
-    const subject = test.observe()
-    if (subject._tag !== 'Inserted' && subject._tag !== 'Duplicate')
-      throw new Error('Expected the observed pull request.')
-    test.store.requestReviewRerun({
-      repository: 'harlan-zw/example',
-      pullRequestNumber: 24,
-      revisionId: subject.revisionId,
-      source: 'dashboard',
-      requestedBy: 'harlan-zw',
-      requestId: 'rerun',
-      at: '2026-08-13T01:00:02.000Z',
-    })
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual([])
-    expect(test.store.listWorkflowEvents({ stream: 'review_status', limit: 20 }).map(event => event.event))
-      .toContain('Superseded')
-  })
-
-  it('honors Manual Selection mode when it changes before publication', async () => {
-    const test = harness()
-    test.store.setSelectionMode('manual')
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual([])
-  })
-
-  it('honors Dismissal before publication', async () => {
-    const test = harness()
-    test.store.dismissItem({ repository: 'harlan-zw/example', itemNumber: 24, at: '2026-08-13T01:00:02.000Z' })
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual([])
-  })
-
-  it('honors repository policy when it changes before publication', async () => {
-    const test = harness()
-    test.store.syncRepositories([repositoryMapping({ pullRequestReview: false })], '2026-08-13T01:00:02.000Z')
-    await test.scheduler().runNow()
-
-    expect(test.labels).toEqual([])
-  })
+  expect(labels).toEqual([])
+  expect(store.claimNextAdversarialReviewTask('reviewer', '2026-08-13T01:02:00.000Z', 60_000)?.pullRequest.baseRef).toBe('main')
 })

--- a/packages/harlan-github-agent/test/history-view.test.ts
+++ b/packages/harlan-github-agent/test/history-view.test.ts
@@ -15,6 +15,7 @@ import { dashboardSnapshot, pullRequestItem } from './fixtures.ts'
 function reviewAgent(overrides: Partial<ReviewAgent> = {}): ReviewAgent {
   return {
     _tag: 'ReviewAgent',
+    baseRef: 'main',
     role: 'adversarial_review',
     id: 'review-1',
     repository: 'harlan-zw/nuxt-seo',

--- a/packages/harlan-github-agent/test/item-agent.test.ts
+++ b/packages/harlan-github-agent/test/item-agent.test.ts
@@ -418,7 +418,7 @@ describe('subject Workers', () => {
     })])
   })
 
-  it('does not start a second review for the same head commit', async () => {
+  it.each(['None', 'Stale'] as const)('reviews afresh when a complete comment has %s local target evidence', async (storedTag) => {
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
     let workspaceCreated = false
     const capture: ProviderCapture = { requests: [] }
@@ -461,99 +461,7 @@ describe('subject Workers', () => {
         queueReviewFixTaskForReview: () => { throw new Error('A second review must not queue Repair work.') },
         getRepairedHeadFindings: () => [],
         getWorkerSession: () => null,
-        storedReviewForHead: () => ({ _tag: 'None' }),
-        supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
-        recordIncident: () => { throw new Error('Unexpected Incident.') },
-        recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },
-        queueBaselineRepairForReview: () => { throw new Error('A second review must not queue Baseline repair.') },
-        retireBaselineRepairForReview: () => 0,
-        saveWorkerSession: () => undefined,
-        updateAgentProgress: () => true,
-        recordReviewRun: () => { throw new Error('A second review must not be recorded.') },
-        recordReviewPublication: () => { throw new Error('A second comment must not be recorded.') },
-      },
-      status: {
-        publish: () => Promise.reject(new Error('A second comment must not be posted.')),
-      },
-      triageStatus: { publish: () => Promise.reject(new Error('Review must not publish issue triage.')) },
-      workspaces: {
-        prepareIssue: () => Promise.reject(new Error('Unexpected issue workspace.')),
-        prepareReview: () => {
-          workspaceCreated = true
-          return Promise.reject(new Error('A second Git worktree must not be created.'))
-        },
-        verifyReview: () => Promise.reject(new Error('A second Review must not verify a worktree.')),
-      },
-    })
-
-    const result = await worker.run({
-      id: 'review-task',
-      kind: 'adversarial_review',
-      repository: 'harlan-zw/example',
-      pullRequestNumber: 24,
-      revisionId: 'revision-1',
-      state: { _tag: 'Running', workerId: 'worker-1', fence: 1, leaseExpiresAt: '2026-08-13T02:00:00.000Z' },
-      updatedAt: '2026-08-13T01:00:00.000Z',
-      repositoryMapping: repositoryMapping(),
-      pullRequest,
-      rerun: { _tag: 'NotRequested' },
-    }, new AbortController().signal)
-
-    expect(result).toEqual({
-      _tag: 'Ok',
-      value: {
-        evidence: 'Existing automated review by @harlan-zw: https://github.com/harlan-zw/example/pull/24#issuecomment-42',
-        resolution: { _tag: 'ExistingReview', url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' },
-      },
-    })
-    expect(capture.requests).toEqual([])
-    expect(workspaceCreated).toBe(false)
-  })
-
-  it('reviews afresh when its own comment predates the current policy', async () => {
-    const pullRequest = pullRequestItem({ mergeState: 'clean' })
-    let workspaceCreated = false
-    const capture: ProviderCapture = { requests: [] }
-    const worker = createReviewWorker({
-      runtime: agentRuntime(CODEX_AGENT_PROFILE, stubProvider([], capture)),
-      github: {
-        consumeApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
-        editReviewStatus: () => Promise.reject(new Error('Unexpected comment edit.')),
-        ensureApprovalLabel: () => Promise.reject(new Error('Unexpected label mutation.')),
-        clearAgentLabels: () => Promise.reject(new Error('Unexpected label clear.')),
-        clearRunningLabel: () => Promise.reject(new Error('Unexpected Running label clear.')),
-        listRunningLabelledItems: () => Promise.reject(new Error('Unexpected Running label read.')),
-        stampAgentLabel: () => Promise.resolve(ok(undefined)),
-        findOpenPullRequestForBranch: () => Promise.reject(new Error('Unexpected pull request lookup.')),
-        getFailedJobContext: () => Promise.reject(new Error('Unexpected job log read.')),
-        getIssueTriageSnapshot: () => Promise.reject(new Error('Unexpected issue request.')),
-        getPullRequestTemplate: () => Promise.resolve(ok({ _tag: 'Missing' })),
-        listPullRequestFiles: () => Promise.resolve(ok([])),
-        getPullRequestReviewSnapshot: () => Promise.resolve(ok({
-          baseChecks: { _tag: 'Available', checks: [{ id: 1, failure: { _tag: 'NotAsked' as const }, source: { _tag: 'CheckRun', appId: 15368 }, name: 'test', status: 'completed', conclusion: 'success' }] },
-          body: 'Fixes the bug.',
-          checks: { _tag: 'Available', checks: [] },
-          comments: [],
-          priorAutomatedReview: {
-            _tag: 'Found',
-            authorLogin: 'harlan-zw',
-            state: 'complete',
-            url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42',
-          },
-          pullRequest,
-          requiredChecks: { _tag: 'None' as const },
-          reviews: [],
-        })),
-        upsertIssueTriageComment: () => Promise.reject(new Error('Review must not post issue triage.')),
-        upsertReviewStatus: () => Promise.reject(new Error('A second comment must not be posted.')),
-      },
-      now: () => new Date('2026-08-13T01:00:00.000Z'),
-      preflightRepair: () => Promise.resolve(ok(undefined)),
-      store: {
-        queueReviewFixTaskForReview: () => { throw new Error('A second review must not queue Repair work.') },
-        getRepairedHeadFindings: () => [],
-        getWorkerSession: () => null,
-        storedReviewForHead: () => ({ _tag: 'Stale' }),
+        storedReviewForHead: () => ({ _tag: storedTag }),
         supersedeReviewRun: input => ({ _tag: 'Inserted', reviewRunId: input.id }),
         recordIncident: () => { throw new Error('Unexpected Incident.') },
         recordPullRequestTriageRun: () => { throw new Error('Unexpected pull request triage record.') },

--- a/packages/harlan-github-agent/test/pull-request-status.test.ts
+++ b/packages/harlan-github-agent/test/pull-request-status.test.ts
@@ -16,6 +16,7 @@ describe('pull request status controller', () => {
     })
     const review = {
       _tag: 'ReviewAgent' as const,
+      baseRef: 'main',
       role: 'adversarial_review' as const,
       id: 'attempt-1',
       repository: 'harlan-zw/example',

--- a/packages/harlan-github-agent/test/review-resilience.test.ts
+++ b/packages/harlan-github-agent/test/review-resilience.test.ts
@@ -179,6 +179,7 @@ describe('review resilience', () => {
       response: {},
       reviewRuns: [{
         id: 'stored-review',
+        baseRef: 'main',
         repository: 'harlan-zw/example',
         pullRequestNumber: 24,
         revisionId: 'revision-1',
@@ -242,6 +243,7 @@ describe('review resilience', () => {
     const { confidence, ...stored } = attempt
     reviewRuns.push({
       ...stored,
+      baseRef: pullRequest.baseRef ?? null,
       usage: attempt.usage ?? { _tag: 'Unavailable' },
       outcome: { _tag: 'Ready', confidence },
       feedback: null,

--- a/packages/harlan-github-agent/test/review-target.test.ts
+++ b/packages/harlan-github-agent/test/review-target.test.ts
@@ -1,0 +1,121 @@
+import type { ReviewGates } from '../src/types.ts'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createAutoMergeController, openJournalStore } from '../src/index.ts'
+import { pullRequestItem, repositoryMapping } from './fixtures.ts'
+
+const cleanups: Array<() => void> = []
+afterEach(() => cleanups.splice(0).reverse().forEach(cleanup => cleanup()))
+
+const gates: ReviewGates = {
+  merge: { _tag: 'Passed', evidence: [{ label: 'merge', sha256: 'a'.repeat(64) }] },
+  review: { _tag: 'Passed', evidence: [{ label: 'review', sha256: 'b'.repeat(64) }] },
+  ci: { _tag: 'Passed', evidence: [{ label: 'ci', sha256: 'c'.repeat(64) }] },
+}
+const ready = {
+  repository: 'harlan-zw/example',
+  pullRequestNumber: 24,
+  headSha: 'abc123',
+  provider: 'codex' as const,
+  sessionId: 'session',
+  model: 'gpt-5.6',
+  agentVersion: '1.2.3',
+  skillDigest: 'd'.repeat(64),
+  startedAt: '2026-08-13T01:01:00.000Z',
+  completedAt: '2026-08-13T01:02:00.000Z',
+  gates,
+  confidence: 100,
+  findings: [],
+}
+
+describe('review target branch authority', () => {
+  it('requires a new Review after retargeting, including after restart', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'harlan-review-target-'))
+    cleanups.push(() => rmSync(directory, { recursive: true, force: true }))
+    const path = join(directory, 'journal.sqlite')
+    const repository = repositoryMapping()
+    const child = pullRequestItem({ mergeState: 'clean', autoMerge: true, baseRef: 'fix/parent', baseSha: 'parent-v1' })
+    const before = openJournalStore(path, true)
+    before.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    before.setRepositoryWritesEnabled(repository.github, true)
+    before.recordObservation({ externalId: 'before', observedAt: '2026-08-13T01:00:00.000Z', source: 'poll', subject: child })
+    const task = before.claimNextAdversarialReviewTask('reviewer', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (task === null)
+      throw new Error('Expected the first Review.')
+    before.recordReviewRun({ ...ready, id: 'parent-review', revisionId: task.revisionId })
+    before.completeReviewTask({
+      taskId: task.id,
+      workerId: task.state.workerId,
+      fence: task.state.fence,
+      at: '2026-08-13T01:02:30.000Z',
+      evidence: 'parent-review',
+      resolution: { _tag: 'Reviewed', reviewRunId: 'parent-review' },
+    })
+    before.recordReviewPublication({
+      id: 'parent-publication',
+      reviewRunId: 'parent-review',
+      body: '### READY',
+      at: '2026-08-13T01:03:00.000Z',
+      result: { _tag: 'Published', githubCommentId: 42, url: `${child.url}#issuecomment-42` },
+    })
+    before.close()
+
+    // Parent v2 removed a file after the child forked. The same child head now
+    // restores that file in its diff against main. Its old Review cannot cover it.
+    const retargeted = { ...child, baseRef: 'main', baseSha: 'squashed-parent-v2' }
+    const observed = openJournalStore(path, true)
+    observed.recordObservation({ externalId: 'retargeted', observedAt: '2026-08-13T02:00:00.000Z', source: 'poll', subject: retargeted })
+    observed.close()
+    const restarted = openJournalStore(path, true)
+    cleanups.push(() => restarted.close())
+    const merges: string[] = []
+    const controller = createAutoMergeController({
+      policy: { _tag: 'Enabled', minimumConfidence: 100, method: 'squash' },
+      store: restarted,
+      report: () => {},
+      merger: {
+        retargetMergedParent: async () => ({ _tag: 'Ok', value: false }),
+        merge: async (input) => {
+          merges.push(input.expectedHeadSha)
+          return { _tag: 'Ok', value: { _tag: 'Merged', sha: 'merged-child' } }
+        },
+      },
+    })
+    await controller.reconcile(repository, retargeted, new AbortController().signal)
+    expect(merges).toEqual([])
+    expect(restarted.storedReviewForHead(repository.github, child.number, child.headSha)).toEqual({ _tag: 'Stale' })
+    expect(restarted.listReviewGateRefreshes()).toEqual([])
+    const fresh = restarted.claimNextAdversarialReviewTask('reviewer-2', '2026-08-13T02:00:30.000Z', 60 * 60_000)
+    expect(fresh?.pullRequest.baseRef).toBe('main')
+    if (fresh === null)
+      throw new Error('Expected a new Review of the target branch.')
+    expect(restarted.recordReviewRun({ ...ready, id: 'main-review', revisionId: fresh.revisionId, completedAt: '2026-08-13T02:02:00.000Z' })._tag).toBe('Inserted')
+    restarted.recordReviewPublication({
+      id: 'main-publication',
+      reviewRunId: 'main-review',
+      body: '### READY',
+      at: '2026-08-13T02:03:00.000Z',
+      result: { _tag: 'Published', githubCommentId: 43, url: `${child.url}#issuecomment-43` },
+    })
+    await controller.reconcile(repository, retargeted, new AbortController().signal)
+    expect(merges).toEqual([child.headSha])
+  })
+
+  it('rejects a running Review result when its target branch changed', () => {
+    const store = openJournalStore(':memory:')
+    cleanups.push(() => store.close())
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    const child = pullRequestItem({ mergeState: 'clean', baseRef: 'fix/parent' })
+    store.recordObservation({ externalId: 'running', observedAt: '2026-08-13T01:00:00.000Z', source: 'poll', subject: child })
+    const task = store.claimNextAdversarialReviewTask('reviewer', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (task === null)
+      throw new Error('Expected the running Review.')
+    store.recordObservation({ externalId: 'changed', observedAt: '2026-08-13T01:01:00.000Z', source: 'poll', subject: { ...child, baseRef: 'main' } })
+    expect(store.recordReviewRun({ ...ready, id: 'late-review', revisionId: task.revisionId })).toEqual({
+      _tag: 'Rejected',
+      reason: { _tag: 'RevisionMismatch' },
+    })
+  })
+})

--- a/packages/harlan-github-agent/test/review-target.test.ts
+++ b/packages/harlan-github-agent/test/review-target.test.ts
@@ -2,6 +2,7 @@ import type { ReviewGates } from '../src/types.ts'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
 import { afterEach, describe, expect, it } from 'vitest'
 import { createAutoMergeController, openJournalStore } from '../src/index.ts'
 import { pullRequestItem, repositoryMapping } from './fixtures.ts'
@@ -101,6 +102,90 @@ describe('review target branch authority', () => {
     })
     await controller.reconcile(repository, retargeted, new AbortController().signal)
     expect(merges).toEqual([child.headSha])
+  })
+
+  it('requires fresh Review when an upgraded journal already moved legacy evidence to the new target', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'harlan-review-upgrade-'))
+    cleanups.push(() => rmSync(directory, { recursive: true, force: true }))
+    const path = join(directory, 'journal.sqlite')
+    const repository = repositoryMapping()
+    const child = pullRequestItem({ mergeState: 'clean', autoMerge: true, baseRef: 'fix/parent' })
+    const before = openJournalStore(path)
+    before.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    before.recordObservation({ externalId: 'legacy-parent', observedAt: '2026-08-13T01:00:00.000Z', source: 'poll', subject: child })
+    const task = before.claimNextAdversarialReviewTask('reviewer', '2026-08-13T01:00:30.000Z', 60 * 60_000)
+    if (task === null)
+      throw new Error('Expected the parent Review.')
+    before.recordReviewRun({ ...ready, id: 'legacy-review', revisionId: task.revisionId })
+    before.completeReviewTask({ taskId: task.id, workerId: task.state.workerId, fence: task.state.fence, at: ready.completedAt, evidence: 'legacy-review', resolution: { _tag: 'Reviewed', reviewRunId: 'legacy-review' } })
+    before.recordReviewPublication({ id: 'legacy-publication', reviewRunId: 'legacy-review', body: '### READY', at: ready.completedAt, result: { _tag: 'Published', githubCommentId: 42, url: `${child.url}#issuecomment-42` } })
+    const main = { ...child, baseRef: 'main' }
+    const retargeted = before.recordObservation({ externalId: 'legacy-main', observedAt: '2026-08-13T02:00:00.000Z', source: 'poll', subject: main })
+    if (retargeted._tag !== 'Inserted')
+      throw new Error('Expected the new target Revision.')
+    before.close()
+
+    // Version 68 followed the head across target changes and overwrote provenance.
+    const legacy = new DatabaseSync(path)
+    legacy.prepare('DELETE FROM worker_task_transitions WHERE task_id != ?').run(task.id)
+    legacy.prepare('DELETE FROM worker_tasks WHERE id != ?').run(task.id)
+    legacy.prepare('UPDATE worker_tasks SET revision_id = ?').run(retargeted.revisionId)
+    legacy.prepare('UPDATE review_runs SET revision_id = ?').run(retargeted.revisionId)
+    legacy.prepare('UPDATE review_resolutions SET revision_id = ?').run(retargeted.revisionId)
+    if ((legacy.prepare('PRAGMA table_info(review_runs)').all() as Array<{ name: string }>).some(column => column.name === 'base_ref'))
+      legacy.exec('ALTER TABLE review_runs DROP COLUMN base_ref')
+    legacy.exec('PRAGMA user_version = 68')
+    legacy.close()
+
+    const upgraded = openJournalStore(path)
+    cleanups.push(() => upgraded.close())
+    const merges: string[] = []
+    const controller = createAutoMergeController({
+      policy: { _tag: 'Enabled', minimumConfidence: 100, method: 'squash' },
+      store: upgraded,
+      report: () => {},
+      merger: {
+        retargetMergedParent: async () => ({ _tag: 'Ok', value: false }),
+        merge: async (input) => {
+          merges.push(input.expectedHeadSha)
+          return { _tag: 'Ok', value: { _tag: 'Merged', sha: 'merged-child' } }
+        },
+      },
+    })
+    expect(upgraded.listReviewRuns(repository.github, child.number)[0]?.baseRef).toBeNull()
+    expect(upgraded.storedReviewForHead(repository.github, child.number, child.headSha)).toEqual({ _tag: 'Stale' })
+    expect(upgraded.listReviewGateRefreshes()).toEqual([])
+    await controller.reconcile(repository, main, new AbortController().signal)
+    expect(merges).toEqual([])
+    upgraded.recordObservation({ externalId: 'upgraded-main', observedAt: '2026-08-13T03:00:00.000Z', source: 'poll', subject: main })
+    expect(upgraded.claimNextAdversarialReviewTask('fresh-reviewer', '2026-08-13T03:00:30.000Z', 60_000)?.pullRequest.baseRef).toBe('main')
+  })
+
+  it.each([false, true])('dispatches fresh Review after a trusted comment without journal evidence, legacy completion: %s', (legacyCompletion) => {
+    const directory = mkdtempSync(join(tmpdir(), 'harlan-review-comment-'))
+    cleanups.push(() => rmSync(directory, { recursive: true, force: true }))
+    const path = join(directory, 'journal.sqlite')
+    const repository = repositoryMapping()
+    const child = pullRequestItem({
+      mergeState: 'clean',
+      baseRef: 'fix/parent',
+      priorAutomatedReview: { _tag: 'Found', authorLogin: 'harlan-zw', state: 'complete', url: 'https://github.com/harlan-zw/example/pull/24#issuecomment-42' },
+    })
+    const before = openJournalStore(path)
+    before.syncRepositories([repository], '2026-08-13T00:00:00.000Z')
+    before.recordObservation({ externalId: 'comment-parent', observedAt: '2026-08-13T01:00:00.000Z', source: 'poll', subject: child })
+    before.recordObservation({ externalId: 'comment-main', observedAt: '2026-08-13T02:00:00.000Z', source: 'poll', subject: { ...child, baseRef: 'main' } })
+    if (legacyCompletion) {
+      const task = before.claimNextAdversarialReviewTask('legacy-reviewer', '2026-08-13T02:00:01.000Z', 60_000)
+      if (task === null)
+        throw new Error('Expected the Review Task.')
+      before.completeReviewTask({ taskId: task.id, workerId: task.state.workerId, fence: task.state.fence, at: '2026-08-13T02:00:02.000Z', evidence: 'Trusted comment', resolution: { _tag: 'ExistingReview', url: child.url } })
+    }
+    before.close()
+    const restarted = openJournalStore(path)
+    cleanups.push(() => restarted.close())
+    restarted.recordObservation({ externalId: 'comment-restart', observedAt: '2026-08-13T02:00:03.000Z', source: 'poll', subject: { ...child, baseRef: 'main' } })
+    expect(restarted.claimNextAdversarialReviewTask('fresh-reviewer', '2026-08-13T02:00:30.000Z', 60_000)?.pullRequest.baseRef).toBe('main')
   })
 
   it('rejects a running Review result when its target branch changed', () => {

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -7,7 +7,6 @@ import { agentProfile, CODEX_AGENT_PROFILE } from '../src/agent-profile.ts'
 import { MAXIMUM_RECOVERY_ATTEMPTS } from '../src/failure.ts'
 import { repositoryQuarantineReason } from '../src/github-write-gate.ts'
 import { ok } from '../src/result.ts'
-import { publishClaimedReviewStatus } from '../src/review-status-controller.ts'
 import { publishStoppedReviews } from '../src/review-stop-sweep.ts'
 import { routineReportCommand } from '../src/routine-report-controller.ts'
 import { openJournalStore } from '../src/store.ts'
@@ -2424,7 +2423,7 @@ describe('journal store', () => {
     expect(store.listStoppedReviews()).toEqual([])
   })
 
-  it('banners the agent comment, not a restored label, when GitHub closes the pull request', async () => {
+  it('banners its own comment when GitHub closes a pull request with another trusted comment', async () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
@@ -2470,8 +2469,7 @@ describe('journal store', () => {
       evidence: 'Waiting for Baseline repair baseline-task.',
     })).toBe(true)
 
-    // A trusted actor reviewed the next head, so the service restores that
-    // actor's label on comment 77. That comment is never this service's own.
+    // An external comment carries no target evidence and remains context only.
     const headB = 'b'.repeat(40)
     const trustedReview = {
       _tag: 'Found',
@@ -2492,30 +2490,7 @@ describe('journal store', () => {
     })
     if (pushed._tag !== 'Inserted')
       throw new Error('Expected the pushed head Revision.')
-    const labelCommand = store.claimNextTerminalReviewStatus('label-publisher', '2026-08-13T01:06:00.000Z', 60_000)
-    if (labelCommand === null)
-      throw new Error('Expected the existing review label command.')
-    const labelPublished = await publishClaimedReviewStatus(
-      {
-        github: {
-          getPullRequestReviewSnapshot: () => { throw new Error('The existing comment needs no snapshot.') },
-          readExistingReviewLabel: (_repository, _number, commentId) => Promise.resolve(ok({
-            commentId,
-            url: `https://github.com/harlan-zw/example/pull/24#issuecomment-${commentId}`,
-            label: 'READY',
-          })),
-          upsertReviewStatus: () => { throw new Error('The existing comment must stay unchanged.') },
-          stampAgentLabel: () => Promise.resolve(ok(undefined)),
-        },
-        now: () => new Date('2026-08-13T01:06:00.000Z'),
-        store,
-      },
-      labelCommand,
-      false,
-      new AbortController().signal,
-    )
-    if (labelPublished._tag === 'Err')
-      throw new Error(labelPublished.error)
+    expect(store.claimNextTerminalReviewStatus('label-publisher', '2026-08-13T01:06:00.000Z', 60_000)).toBeNull()
 
     const closed = store.recordObservation({
       externalId: 'closure-with-restored-label-closed',
@@ -2544,7 +2519,6 @@ describe('journal store', () => {
 
     const stopped = store.listStoppedReviews()
     expect(stopped).toEqual([expect.objectContaining({
-      taskId: review.id,
       commentId: 42,
       publishedBody: agentBody,
     })])
@@ -3915,7 +3889,7 @@ describe('journal store', () => {
     expect(store.getDashboardSnapshot('2026-08-13T01:02:00.000Z').queue).toEqual([])
   })
 
-  it('revokes a running review when a trusted review covers the current head commit', () => {
+  it('keeps a running Review when a trusted comment has no target evidence', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
     const pullRequest = pullRequestItem({ mergeState: 'clean' })
@@ -3950,11 +3924,8 @@ describe('journal store', () => {
       fence: task.state.fence,
       at: '2026-08-13T01:02:01.000Z',
       leaseMilliseconds: 45 * 60_000,
-    })).toBe(false)
-    expect(store.getDashboardSnapshot('2026-08-13T01:02:01.000Z').tasks.find(item => item.id === task.id)?.state).toEqual({
-      _tag: 'Superseded',
-      reason: 'The current head commit already has an automated review.',
-    })
+    })).toBe(true)
+    expect(store.getDashboardSnapshot('2026-08-13T01:02:01.000Z').tasks.find(item => item.id === task.id)?.state._tag).toBe('Running')
   })
 
   it('keeps Review work when the prior automated comment is still active', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Follow-up to #233. Retargeting a stack can expand its diff while leaving its head unchanged, so its old Review could authorize unreviewed code.

Save each Review’s original target branch and require it to match before Auto merge. Existing Reviews without recorded targets run again after upgrade.

![A changed target requires a new Review before Auto merge](https://github.com/user-attachments/assets/82a14dcb-e00e-4801-ae26-fe8db91b8360)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
