### PR TITLE
fix(github-agent): close verified Sentry issues in routines

### DIFF
--- a/harlan-agent-kit/skills/sentry-checkin/SKILL.md
+++ b/harlan-agent-kit/skills/sentry-checkin/SKILL.md
@@ -7,6 +7,9 @@ description: "Triage and repair all open Sentry issues across Harlan's sites. Us
 
 Turn the complete open Sentry backlog into one verified PR per affected site. Account for every issue present at discovery time.
 
+For a controller-scheduled Routine, follow [the scheduled Routine contract](references/scheduled-routine.md) instead of the all-sites workflow below.
+The controller supplies one repository, its prepared worktree, the Routine run ID, and `report` or `propose` mode.
+
 ## Worktree isolation
 
 Before site edits, follow the [worktree isolation contract](../../references/worktree-isolation.md). It provides the atomic live-agent claim used below.

--- a/harlan-agent-kit/skills/sentry-checkin/references/scheduled-routine.md
+++ b/harlan-agent-kit/skills/sentry-checkin/references/scheduled-routine.md
@@ -1,0 +1,86 @@
+# Scheduled Routine
+
+Inspect the named repository's complete Sentry backlog from the controller's prepared worktree.
+The controller already owns the worktree and the Agent lease.
+Do not create, switch, remove, or delegate worktrees.
+Keep repository files unchanged. Do not commit, push, open pull requests, or deploy.
+
+## Scope and access
+
+Use the controller's repository mapping as the site inventory for this run.
+A separate `SITES.md` is unnecessary. Do not discover or act on other sites.
+Match every Sentry project through this repository's tracked configuration or DSN.
+Never match by name similarity alone.
+If the mapping is ambiguous, report the exact blocker before any Sentry write.
+
+Verify Sentry access with `sentry-cli info` and project discovery.
+If the CLI is missing, use `pnpm dlx @sentry/cli`.
+The bundled `scripts/sentry_api.py` uses the token from `~/.sentryclirc`.
+Missing tools, credentials, or deployment evidence are blockers, not zero-issue results.
+
+## Evidence and history
+
+Use the supplied Routine run ID as `SENTRY_CHECKIN_RUN_ID`.
+Keep artifacts outside repositories, under `${XDG_STATE_HOME:-$HOME/.local/state}/sentry-checkin`.
+Derive the run directory from the ID so retries retain the original snapshot:
+
+```bash
+SENTRY_CHECKIN_STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/sentry-checkin"
+SENTRY_CHECKIN_RUN_KEY=$(printf '%s' "$SENTRY_CHECKIN_RUN_ID" | sha256sum | cut -d ' ' -f1)
+SENTRY_CHECKIN_RUN_DIR="$SENTRY_CHECKIN_STATE_DIR/runs/$SENTRY_CHECKIN_RUN_KEY"
+mkdir -p "$SENTRY_CHECKIN_RUN_DIR"
+```
+
+Resolve `SKILL_DIR` to this Skill's absolute directory before running its scripts.
+Run `sentry_api.py snapshot` once per mapped project. Reuse existing snapshots after a retry.
+Run `ledger.py history` with every snapshot and `--exclude-run "$SENTRY_CHECKIN_RUN_ID"` before inspecting issues.
+Fetch `sentry_api.py bulk-bundles` for every snapshot, including small snapshots, to produce audit manifests.
+Read each event's stack, release, environment, request path, breadcrumbs, and source context.
+Run `ledger.py init` from all manifests. Reuse the existing ledger after a retry.
+Keep one evidence-backed row per frozen numeric issue ID.
+
+Use the Skill's dispositions and coverage rules.
+If code needs repair, return a Candidate and mark its issue `blocked`, pending that repair.
+Never call a proposed repair `fixed`. Include its Sentry IDs in the Candidate claim.
+Account for repairs beyond the Candidate file limit in the report and ledger.
+Do not propose unrelated repository cleanup.
+
+## Resolve verified fixes
+
+In `report` mode, keep Sentry read only and report eligible resolutions.
+In `propose` mode, resolve `already-fixed` rows after proving their fixes reached a deployed release.
+Resolve a `covered` row only after its owning `already-fixed` row resolves.
+Leave every other disposition open.
+
+Use the exact deployed release with `--in-release VERSION`.
+A release record, old event date, successful HTTP response, or commit ancestry alone does not prove deployment.
+Tie the deployed release to the fix through deployment records or live release metadata.
+If that evidence is unavailable, keep the issue open and name the missing evidence.
+Never use `--in-next-release` in a scheduled scan. Never mute issues.
+
+Run `ledger.py audit` against every manifest before resolving anything.
+Compare its numeric ID set and checksum with the frozen snapshots.
+Run `sentry_api.py resolve` without `--apply`, then apply that same plan in `propose` mode.
+Re-read each issue through the API and confirm its resolved status and release.
+Keep the plan, response, and verification in the run directory.
+If a resolution fails, record the failure and leave it explicit in the report.
+There is no Routine `apply` mode. `--apply` belongs to the Sentry helper.
+
+## Record and report
+
+After the complete ledger passes audit, record history in both modes, even when no code changes are proposed.
+Use the scheduled date for `RUN_DATE`. Serialize history writes across scheduled sites:
+
+```bash
+flock "$SENTRY_CHECKIN_STATE_DIR/history.lock" \
+  python3 "$SKILL_DIR/scripts/ledger.py" record \
+  --ledger "$SENTRY_CHECKIN_RUN_DIR/ledger.tsv" \
+  --run-id "$SENTRY_CHECKIN_RUN_ID" --run-date "$RUN_DATE"
+```
+
+Return the complete Markdown report in `report`.
+Include frozen issue count, ledger coverage, and `new`, `recurring`, and `unclosed` counts.
+List resolved IDs with their releases, unresolved IDs with reasons, and code repair Candidates.
+Include snapshot, ledger, audit, resolution evidence, and history paths.
+Report missing evidence and script failures explicitly. Never claim a failed step completed.
+For zero issues, still audit and record the empty ledger, and report the project query.

--- a/packages/harlan-github-agent/src/routine-worker.ts
+++ b/packages/harlan-github-agent/src/routine-worker.ts
@@ -96,6 +96,20 @@ Follow its workflow completely, including running its data script and writing it
 
 Return each proposed action as one Candidate. Use the ledger fingerprint as the Candidate fingerprint when the action has one. Put a short issue title in \`title\`, the action in \`claim\`, the file or system it changes in \`target\`, and the check that proves it in \`verification\`.`
 
+function sentryCheckinTurn(mode: ClaimedRoutineRun['mode']): string {
+  return `Apply the harlan-agent-kit:sentry-checkin skill and its references/scheduled-routine.md contract. Read both before you start.
+
+This is a scheduled Routine for the named repository and the controller's prepared worktree only.
+Do not edit repository files, commit, push, open pull requests, deploy, or delegate another site Agent.
+Persist the audited ledger and record the run history, even with zero code proposals.
+Return the complete issue report in \`report\`, including issue counts, resolution results, and artifact paths.
+Return only code repairs as Candidates. Sentry resolutions do not require code proposals.
+
+${mode === 'propose'
+  ? 'Resolve eligible issues in their verified deployed release during this run. Run the resolution plan before --apply, then verify each issue status.'
+  : 'Keep Sentry read only. Do not resolve issues or run resolve with --apply. Report eligible resolutions for a propose run.'}`
+}
+
 const agentFeedbackSkillTarget = /^harlan-agent-kit\/skills\/[^/]+\/SKILL\.md$/
 
 /** Applies the controller-owned publication scope after the Agent answers. */
@@ -134,7 +148,9 @@ export function routineScanPrompt(input: {
 
   const turn = input.name === 'daily-checkin'
     ? DAILY_CHECKIN_TURN
-    : `Apply the ${ROUTINE_SKILLS[input.name]} skill. Read it before you start.
+    : input.name === 'sentry-checkin'
+      ? sentryCheckinTurn(input.mode)
+      : `Apply the ${ROUTINE_SKILLS[input.name]} skill. Read it before you start.
 
 This turn is read only. The worktree is the default branch. Do not edit, commit,
 or push anything. Report what you find and stop.`
@@ -261,13 +277,13 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
           // A Routine answers a clock, so it belongs to no issue or pull
           // request. Nothing reads this number, because no session is saved.
           number: 0,
-          prompt: routineScanPrompt({
+          prompt: `${routineScanPrompt({
             mode: task.mode,
             name: task.name,
             rejected: options.store.listCandidates(task.routineId),
             repository: task.repository,
             feedback,
-          }),
+          })}\n\nRoutine run ID: ${JSON.stringify(task.id)}\nScheduled for: ${task.scheduledFor}`,
           repository: task.repository,
           role: 'routine_scan',
           schema: CANDIDATE_SCHEMA,
@@ -292,6 +308,8 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
       // The run log is the only place a check-in report lives once the
       // worktree is gone, so the whole report travels with the evidence line.
       const detail = typeof response.report === 'string' ? response.report.trim() : ''
+      if (task.name === 'sentry-checkin' && detail === '')
+        return err('The Sentry Routine answered without its issue report.')
 
       // Oversized proposals are dropped here rather than recorded and skipped
       // later, so the ledger never holds a Candidate nothing will ever open.
@@ -330,7 +348,7 @@ export function createRoutineScanWorker(options: RoutineScanWorkerOptions): Rout
 
       const evidence = [
         `${task.name} on ${task.repository}`,
-        `${response.candidates.length} found`,
+        `${response.candidates.length} ${task.name === 'sentry-checkin' ? 'code proposals' : 'found'}`,
         `${fresh.length} new`,
         `${withinSize.length - fresh.length} already known`,
         `${outsideScope} outside allowed scope`,

--- a/packages/harlan-github-agent/src/service.ts
+++ b/packages/harlan-github-agent/src/service.ts
@@ -637,7 +637,7 @@ export async function startAgentService(options: StartAgentServiceOptions): Prom
         onTaskStarted: stampRunningLabel,
         onTaskSettled: settleTask,
         permits,
-        // A scan is read only, so it needs no write access to start.
+        // GitHub writes remain controller-owned. Sentry propose runs may resolve verified fixes.
         worker: createRoutineScanWorker({
           activityLog,
           logger: {

--- a/packages/harlan-github-agent/src/types.ts
+++ b/packages/harlan-github-agent/src/types.ts
@@ -644,8 +644,8 @@ export type RoutineName = 'sentry-checkin' | 'pr-triage' | 'agent-feedback' | 'd
  * What a Routine run does with what it finds.
  *
  * `report` writes to the tracking issue and opens nothing. `propose` opens one
- * pull request per Candidate. An unproven Routine earns `propose` by holding
- * its Candidate precision in `report` first.
+ * pull request per Candidate. Sentry `propose` runs may also resolve verified
+ * deployed fixes. An unproven Routine earns `propose` through Candidate precision.
  */
 export type RoutineMode = 'report' | 'propose'
 

--- a/packages/harlan-github-agent/test/routine-worker.test.ts
+++ b/packages/harlan-github-agent/test/routine-worker.test.ts
@@ -48,16 +48,16 @@ function workerFor(
   })
 }
 
-function seed(store: ReturnType<typeof openJournalStore>): void {
+function seed(store: ReturnType<typeof openJournalStore>, name: ClaimedRoutineRun['name'] = 'pr-triage'): void {
   store.syncRepositories([repositoryMapping()], '2026-08-27T00:00:00.000Z')
   store.syncRoutines({
     repository: 'harlan-zw/example',
     specSha: 'abc123',
-    entries: [{ name: 'pr-triage', crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
+    entries: [{ name, crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'propose', enabled: true }],
     at: '2026-08-27T00:00:00.000Z',
   })
   store.openRoutineRun({
-    routineId: 'harlan-zw/example:pr-triage',
+    routineId: `harlan-zw/example:${name}`,
     scheduledFor: '2026-08-27T07:00:00.000Z',
     specSha: 'abc123',
     at: '2026-08-27T07:00:05.000Z',
@@ -108,10 +108,22 @@ describe('building the scan prompt', () => {
     expect(prompt).toContain('controller defect')
   })
 
-  it('names the skill that answers the routine', () => {
+  it('lets a proposing Sentry Routine close verified fixes and persist its ledger', () => {
     const prompt = routineScanPrompt({ mode: 'propose', name: 'sentry-checkin', rejected: [], repository: 'harlan-zw/example' })
 
     expect(prompt).toContain('harlan-agent-kit:sentry-checkin')
+    expect(prompt).toContain('references/scheduled-routine.md')
+    expect(prompt).toContain('Resolve eligible issues in their verified deployed release during this run.')
+    expect(prompt).toContain('Persist the audited ledger and record the run history, even with zero code proposals.')
+    expect(prompt).not.toContain('This turn is read only')
+  })
+
+  it('keeps Sentry report mode read only while allowing local evidence files', () => {
+    const prompt = routineScanPrompt({ mode: 'report', name: 'sentry-checkin', rejected: [], repository: 'harlan-zw/example' })
+
+    expect(prompt).toContain('Keep Sentry read only. Do not resolve issues or run resolve with --apply.')
+    expect(prompt).toContain('Persist the audited ledger and record the run history, even with zero code proposals.')
+    expect(prompt).not.toContain('Resolve eligible issues in their verified deployed release during this run.')
   })
 
   it('points a check-in at the repository skill and lets it write its report files', () => {
@@ -184,6 +196,45 @@ describe('building the scan prompt', () => {
 })
 
 describe('running one scan', () => {
+  it('reports zero code proposals without hiding the Sentry issue ledger', async () => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store, 'sentry-checkin')
+      store.setRepositoryWritesEnabled('harlan-zw/example', true)
+      const detail = '12 Sentry issues. 12 ledger rows. 12 resolved in release abc123. History recorded.'
+
+      const result = await workerFor(store, scanning({ report: detail, candidates: [] }))
+        .run(claimStoredRun(store), new AbortController().signal)
+
+      expect(result).toMatchObject({ _tag: 'Ok', value: { evidence: expect.stringContaining('0 code proposals') } })
+      const report = store.claimNextRoutineReport('controller-1', now().toISOString(), 60_000)
+      expect(report?.body).toContain('0 code proposals')
+      expect(report?.body).toContain(detail)
+      expect(store.claimNextCandidateIssue('controller-1', now().toISOString(), 60_000)).toBeNull()
+    }
+    finally {
+      store.close()
+    }
+  })
+
+  it.each([undefined, '', '  '])('refuses a Sentry result without a report: %s', async (report) => {
+    const store = openJournalStore(':memory:')
+    try {
+      seed(store, 'sentry-checkin')
+      store.setRepositoryWritesEnabled('harlan-zw/example', true)
+
+      const result = await workerFor(store, scanning({ report, candidates: [candidate] }))
+        .run(claimStoredRun(store), new AbortController().signal)
+
+      expect(result).toEqual({ _tag: 'Err', error: 'The Sentry Routine answered without its issue report.' })
+      expect(store.claimNextRoutineReport('controller-1', now().toISOString(), 60_000)).toBeNull()
+      expect(store.claimNextCandidateIssue('controller-1', now().toISOString(), 60_000)).toBeNull()
+    }
+    finally {
+      store.close()
+    }
+  })
+
   it('refuses the global Agent feedback Routine in another repository', async () => {
     const store = openJournalStore(':memory:')
     try {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Scheduled Sentry check-ins kept reporting deployed fixes without resolving the issues.
`propose` runs now resolve verified fixes and record their ledgers; `report` keeps Sentry read only.
The summary labels code proposals, and a missing issue report fails the run.

![Scheduled Sentry resolution: verified fixes close in propose mode, with persistent history and controller-owned GitHub reports](https://github.com/user-attachments/assets/6aaa923f-8c08-4dea-8e68-5981237ce2f2)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
