### PR TITLE
fix(github-agent): ignore cron and Dependabot suites in base CI

### DIFF
--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -213,7 +213,7 @@ If Review records `Repair` findings, queue all findings immediately under the ex
 
 Available empty base and head check sets with no declared required checks mean the repository has no CI. This passes the CI Review gate and permits Repair. An unavailable, running, or failed base check set does not permit Repair.
 
-Ignore a base check run that a `workflow_run`, `dynamic`, or an unfinished `schedule` event attached to the base commit. The first reports on another commit's workflow. The second is Dependabot's updater, which fails when an update is not possible. A queued or running cron run stalls the base gate on a timer, so drop it too. A concluded cron run executed on the base commit tip: keep it as base evidence, so a failed one holds the gate red and queues a Baseline repair.
+Ignore a base check run that a `workflow_run`, `dynamic`, or an unfinished `schedule` event attached to the base commit. The first reports on another commit's workflow. The second is Dependabot's updater, which fails when an update is not possible. A cron run GitHub has not reported `completed` stalls the base gate on a timer, in any of its unfinished statuses, so drop it too. A cron run reported `completed` executed on the base commit tip: keep it as base evidence, so a failed one holds the gate red and queues a Baseline repair.
 
 When the gate refresh of a settled review finds the default branch failed, queue one Baseline repair for that exact base commit. Report Existing on every later pass.
 

--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -213,7 +213,7 @@ If Review records `Repair` findings, queue all findings immediately under the ex
 
 Available empty base and head check sets with no declared required checks mean the repository has no CI. This passes the CI Review gate and permits Repair. An unavailable, running, or failed base check set does not permit Repair.
 
-Ignore a base check run that a `workflow_run` event attached to the base commit. It reports on another commit's workflow, not on the base commit.
+Ignore a base check run that a `workflow_run` or `schedule` event attached to the base commit. The first reports on another commit's workflow. The second runs housekeeping on a timer. Neither reports on the base commit.
 
 When the gate refresh of a settled review finds the default branch failed, queue one Baseline repair for that exact base commit. Report Existing on every later pass.
 

--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -213,7 +213,7 @@ If Review records `Repair` findings, queue all findings immediately under the ex
 
 Available empty base and head check sets with no declared required checks mean the repository has no CI. This passes the CI Review gate and permits Repair. An unavailable, running, or failed base check set does not permit Repair.
 
-Ignore a base check run that a `workflow_run` or `schedule` event attached to the base commit. The first reports on another commit's workflow. The second runs housekeeping on a timer. Neither reports on the base commit.
+Ignore a base check run that a `workflow_run`, `schedule`, or `dynamic` event attached to the base commit. The first reports on another commit's workflow. The second runs housekeeping on a timer. The third is Dependabot's updater, which fails when an update is not possible. None of them reports on the base commit.
 
 When the gate refresh of a settled review finds the default branch failed, queue one Baseline repair for that exact base commit. Report Existing on every later pass.
 

--- a/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
+++ b/harlan-agent-kit/skills/harlan-github-agent/SKILL.md
@@ -213,7 +213,7 @@ If Review records `Repair` findings, queue all findings immediately under the ex
 
 Available empty base and head check sets with no declared required checks mean the repository has no CI. This passes the CI Review gate and permits Repair. An unavailable, running, or failed base check set does not permit Repair.
 
-Ignore a base check run that a `workflow_run`, `schedule`, or `dynamic` event attached to the base commit. The first reports on another commit's workflow. The second runs housekeeping on a timer. The third is Dependabot's updater, which fails when an update is not possible. None of them reports on the base commit.
+Ignore a base check run that a `workflow_run`, `dynamic`, or an unfinished `schedule` event attached to the base commit. The first reports on another commit's workflow. The second is Dependabot's updater, which fails when an update is not possible. A queued or running cron run stalls the base gate on a timer, so drop it too. A concluded cron run executed on the base commit tip: keep it as base evidence, so a failed one holds the gate red and queues a Baseline repair.
 
 When the gate refresh of a settled review finds the default branch failed, queue one Baseline repair for that exact base commit. Report Existing on every later pass.
 

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -96,10 +96,13 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
  * ends, and the base gate read that as "the default branch has not passed"
  * while Repair waited.
  *
- * `schedule`: a cron run also lands on the default branch tip, and it runs
- * housekeeping on a timer, not the commit's tests. A queued cleanup sweep on
- * nuxtseo.com `main` held the base gate at PENDING for a day while its runner
- * fleet was down, and Repair for the reviewed pull request never started.
+ * `schedule`: an unfinished cron run also lands on the default branch tip, and
+ * a stalled one holds the base gate at PENDING while Repair waits. A queued
+ * cleanup sweep on nuxtseo.com `main` held the gate for a day while its runner
+ * fleet was down. A concluded cron run is different: it executed on the base
+ * commit tip and its result is real evidence, so a failed one must keep the
+ * base red and queue a Baseline repair. Only an unfinished scheduled run is
+ * derived here.
  *
  * `dynamic`: Dependabot's updater workflow runs with this event on the branch
  * tip. Its `Dependabot` check fails when an update was not possible, such as a
@@ -112,9 +115,15 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
  */
 const DERIVED_RUN_EVENTS = new Set(['workflow_run', 'schedule', 'dynamic'])
 
+const UNFINISHED_RUN_STATUSES = new Set(['queued', 'in_progress'])
+
 /** The check suites of workflow runs that answer for a timer or another commit. */
-export function derivedCheckSuiteIds(runs: ReadonlyArray<{ event: string, check_suite_id?: number | null }>): Set<number> {
-  return new Set(runs.flatMap(run => DERIVED_RUN_EVENTS.has(run.event) && typeof run.check_suite_id === 'number' ? [run.check_suite_id] : []))
+export function derivedCheckSuiteIds(runs: ReadonlyArray<{ event: string, status?: string | null, check_suite_id?: number | null }>): Set<number> {
+  return new Set(runs.flatMap(run => DERIVED_RUN_EVENTS.has(run.event)
+    && typeof run.check_suite_id === 'number'
+    && !(run.event === 'schedule' && !UNFINISHED_RUN_STATUSES.has(run.status ?? ''))
+    ? [run.check_suite_id]
+    : []))
 }
 
 export function chronologicalPullRequestComments(entries: Array<{ body: string, createdAt: string }>): string[] {

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -101,10 +101,16 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
  * nuxtseo.com `main` held the base gate at PENDING for a day while its runner
  * fleet was down, and Repair for the reviewed pull request never started.
  *
+ * `dynamic`: Dependabot's updater workflow runs with this event on the branch
+ * tip. Its `Dependabot` check fails when an update was not possible, such as a
+ * security update with no compatible version. That is a fact about the
+ * dependency, not the commit, and a failed base would queue a pointless
+ * Baseline repair.
+ *
  * `workflow_dispatch` stays. A person starts it on purpose, often to rerun the
  * real checks, so its result is evidence about the commit.
  */
-const DERIVED_RUN_EVENTS = new Set(['workflow_run', 'schedule'])
+const DERIVED_RUN_EVENTS = new Set(['workflow_run', 'schedule', 'dynamic'])
 
 /** The check suites of workflow runs that answer for a timer or another commit. */
 export function derivedCheckSuiteIds(runs: ReadonlyArray<{ event: string, check_suite_id?: number | null }>): Set<number> {

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -96,13 +96,14 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
  * ends, and the base gate read that as "the default branch has not passed"
  * while Repair waited.
  *
- * `schedule`: an unfinished cron run also lands on the default branch tip, and
- * a stalled one holds the base gate at PENDING while Repair waits. A queued
- * cleanup sweep on nuxtseo.com `main` held the gate for a day while its runner
- * fleet was down. A concluded cron run is different: it executed on the base
- * commit tip and its result is real evidence, so a failed one must keep the
- * base red and queue a Baseline repair. Only an unfinished scheduled run is
- * derived here.
+ * `schedule`: a cron run also lands on the default branch tip, and a stalled
+ * one holds the base gate at PENDING while Repair waits: a queued cleanup
+ * sweep on nuxtseo.com `main` held the gate for a day while its runner fleet
+ * was down. GitHub reports an unfinished run with more statuses than the two
+ * everyone remembers, and one more added later must not reopen the stall, so
+ * only a run already reported `completed` counts as concluded. A concluded
+ * cron run executed on the base commit tip and its result is real evidence, so
+ * a failed one must keep the base red and queue a Baseline repair.
  *
  * `dynamic`: Dependabot's updater workflow runs with this event on the branch
  * tip. Its `Dependabot` check fails when an update was not possible, such as a
@@ -115,13 +116,11 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
  */
 const DERIVED_RUN_EVENTS = new Set(['workflow_run', 'schedule', 'dynamic'])
 
-const UNFINISHED_RUN_STATUSES = new Set(['queued', 'in_progress'])
-
 /** The check suites of workflow runs that answer for a timer or another commit. */
 export function derivedCheckSuiteIds(runs: ReadonlyArray<{ event: string, status?: string | null, check_suite_id?: number | null }>): Set<number> {
   return new Set(runs.flatMap(run => DERIVED_RUN_EVENTS.has(run.event)
     && typeof run.check_suite_id === 'number'
-    && !(run.event === 'schedule' && !UNFINISHED_RUN_STATUSES.has(run.status ?? ''))
+    && !(run.event === 'schedule' && run.status === 'completed')
     ? [run.check_suite_id]
     : []))
 }

--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -88,16 +88,27 @@ export function currentGitHubChecks(checks: GitHubCheck[]): GitHubCheck[] {
 }
 
 /**
- * The check suites of workflow runs a `workflow_run` event started.
+ * Workflow run events whose check suites say nothing about the commit.
  *
- * GitHub attaches such a run to the default branch tip, not to the commit
- * whose workflow finished. A bundle-size comment job on `main` therefore
- * appears as a running base check every time any pull request's CI ends, and
- * the base gate read that as "the default branch has not passed" while Repair
- * waited. Those suites answer for another commit, so they are dropped.
+ * `workflow_run`: GitHub attaches such a run to the default branch tip, not to
+ * the commit whose workflow finished. A bundle-size comment job on `main`
+ * therefore appears as a running base check every time any pull request's CI
+ * ends, and the base gate read that as "the default branch has not passed"
+ * while Repair waited.
+ *
+ * `schedule`: a cron run also lands on the default branch tip, and it runs
+ * housekeeping on a timer, not the commit's tests. A queued cleanup sweep on
+ * nuxtseo.com `main` held the base gate at PENDING for a day while its runner
+ * fleet was down, and Repair for the reviewed pull request never started.
+ *
+ * `workflow_dispatch` stays. A person starts it on purpose, often to rerun the
+ * real checks, so its result is evidence about the commit.
  */
+const DERIVED_RUN_EVENTS = new Set(['workflow_run', 'schedule'])
+
+/** The check suites of workflow runs that answer for a timer or another commit. */
 export function derivedCheckSuiteIds(runs: ReadonlyArray<{ event: string, check_suite_id?: number | null }>): Set<number> {
-  return new Set(runs.flatMap(run => run.event === 'workflow_run' && typeof run.check_suite_id === 'number' ? [run.check_suite_id] : []))
+  return new Set(runs.flatMap(run => DERIVED_RUN_EVENTS.has(run.event) && typeof run.check_suite_id === 'number' ? [run.check_suite_id] : []))
 }
 
 export function chronologicalPullRequestComments(entries: Array<{ body: string, createdAt: string }>): string[] {

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -190,8 +190,8 @@ describe('live pull request base', () => {
         }
         if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
           return Promise.resolve([
-            { id: 70, event: 'schedule', check_suite_id: 7 },
-            { id: 80, event: 'push', check_suite_id: 8 },
+            { id: 70, event: 'schedule', status: 'queued', check_suite_id: 7 },
+            { id: 80, event: 'push', status: 'completed', check_suite_id: 8 },
           ])
         }
         return Promise.resolve([])
@@ -224,6 +224,59 @@ describe('live pull request base', () => {
       baseChecks: {
         _tag: 'Available',
         checks: [expect.objectContaining({ name: 'test', status: 'completed', conclusion: 'success' })],
+      },
+    })))
+  })
+
+  it('keeps a concluded failed scheduled run as base evidence', async () => {
+    const listForRef = () => undefined
+    const listWorkflowRunsForRepo = () => undefined
+    const client = {
+      paginate: (method: unknown, input: { ref?: string, head_sha?: string }) => {
+        if (method === listForRef && input.ref === liveBaseSha) {
+          return Promise.resolve([
+            { id: 1, name: 'Fuzz', status: 'completed', conclusion: 'failure', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 7 } },
+            { id: 2, name: 'test', status: 'completed', conclusion: 'success', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } },
+          ])
+        }
+        if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
+          return Promise.resolve([
+            { id: 70, event: 'schedule', status: 'completed', check_suite_id: 7 },
+            { id: 80, event: 'push', status: 'completed', check_suite_id: 8 },
+          ])
+        }
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: expect.arrayContaining([
+          expect.objectContaining({ name: 'Fuzz', status: 'completed', conclusion: 'failure' }),
+        ]),
       },
     })))
   })

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -281,6 +281,57 @@ describe('live pull request base', () => {
     })))
   })
 
+  it('drops base check runs of a scheduled run that has not completed', async () => {
+    const listForRef = () => undefined
+    const listWorkflowRunsForRepo = () => undefined
+    const client = {
+      paginate: (method: unknown, input: { ref?: string, head_sha?: string }) => {
+        if (method === listForRef && input.ref === liveBaseSha) {
+          return Promise.resolve([
+            { id: 1, name: 'cancel', status: 'queued', conclusion: null, app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 7 } },
+            { id: 2, name: 'test', status: 'completed', conclusion: 'success', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } },
+          ])
+        }
+        if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
+          return Promise.resolve([
+            { id: 70, event: 'schedule', status: 'requested', check_suite_id: 7 },
+            { id: 80, event: 'push', status: 'completed', check_suite_id: 8 },
+          ])
+        }
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'test', status: 'completed', conclusion: 'success' })],
+      },
+    })))
+  })
+
   it('drops base check runs that a dynamic Dependabot run attached to the base commit', async () => {
     const listForRef = () => undefined
     const listWorkflowRunsForRepo = () => undefined

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -176,4 +176,55 @@ describe('live pull request base', () => {
       },
     })))
   })
+
+  it('drops base check runs that a schedule event attached to the base commit', async () => {
+    const listForRef = () => undefined
+    const listWorkflowRunsForRepo = () => undefined
+    const client = {
+      paginate: (method: unknown, input: { ref?: string, head_sha?: string }) => {
+        if (method === listForRef && input.ref === liveBaseSha) {
+          return Promise.resolve([
+            { id: 1, name: 'cancel', status: 'queued', conclusion: null, app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 7 } },
+            { id: 2, name: 'test', status: 'completed', conclusion: 'success', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } },
+          ])
+        }
+        if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
+          return Promise.resolve([
+            { id: 70, event: 'schedule', check_suite_id: 7 },
+            { id: 80, event: 'push', check_suite_id: 8 },
+          ])
+        }
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'test', status: 'completed', conclusion: 'success' })],
+      },
+    })))
+  })
 })

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -227,4 +227,55 @@ describe('live pull request base', () => {
       },
     })))
   })
+
+  it('drops base check runs that a dynamic Dependabot run attached to the base commit', async () => {
+    const listForRef = () => undefined
+    const listWorkflowRunsForRepo = () => undefined
+    const client = {
+      paginate: (method: unknown, input: { ref?: string, head_sha?: string }) => {
+        if (method === listForRef && input.ref === liveBaseSha) {
+          return Promise.resolve([
+            { id: 1, name: 'Dependabot', status: 'completed', conclusion: 'failure', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 7 } },
+            { id: 2, name: 'test', status: 'completed', conclusion: 'success', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } },
+          ])
+        }
+        if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
+          return Promise.resolve([
+            { id: 70, event: 'dynamic', check_suite_id: 7 },
+            { id: 80, event: 'push', check_suite_id: 8 },
+          ])
+        }
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'test', status: 'completed', conclusion: 'success' })],
+      },
+    })))
+  })
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

nuxtseo.com#879 sat BLOCKED with a Repair finding for a day while its base gate read:

```
CI gate: PENDING. Base branch CI: cancel is still running.
```

The `cancel` check came from the cron workflow `cancel-pr-runs.yml`. It queued on `main` while the Hogwild runner fleet had no DNS, aged past the supervisor's six-hour bound, and was never going to run. Its result says nothing about the commit anyway: a scheduled run lands on the branch tip and does housekeeping on a timer.

Same commit, an hour later: Dependabot's updater run (event `dynamic`) failed its `Dependabot` check because a security update for maplibre-gl was not possible. That would have read as a red `main` and queued a Baseline repair for a dependency Dependabot itself cannot bump.

PR #210 already drops `workflow_run` suites for the same reason, so `schedule` and `dynamic` join that set. `workflow_dispatch` stays. A person starts it, often to rerun the real checks.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01M7niME5WXD6s62J8L9BF6i