### PR TITLE
fix(github-agent): name unstarted jobs in CI gate incident

### DIFF
--- a/packages/harlan-github-agent/src/ci-gate-pending.ts
+++ b/packages/harlan-github-agent/src/ci-gate-pending.ts
@@ -28,8 +28,10 @@ export type CiGateCause
     | { _tag: 'BaseBranchFailed', check: string }
     /** GitHub owes a check run it has never reported. */
     | { _tag: 'NoCheckRun', detail: string }
-    /** A check run exists and has not reported a conclusion. */
+    /** A check run started and has not reported a conclusion. */
     | { _tag: 'CheckRunning', check: string }
+    /** A check run is queued, so no runner has accepted its job. */
+    | { _tag: 'CheckQueued', check: string }
     /** The controller could not read the check runs at all. */
     | { _tag: 'ChecksUnreadable', reason: string }
     /** A runner stopped mid job. `runner_lost` already names this one. */
@@ -42,6 +44,10 @@ export type CiGateCause
  * has killed the job, so a check run that still reports no conclusion will
  * never report one. The bound is GitHub's own, not a number picked to feel
  * right, and it never fires while a job could still finish.
+ *
+ * A queued job shares the bound for a different reason. The runner supervisor
+ * on Hogwild drops a queued run older than six hours, so past that no runner
+ * will ever take the job, and a re-run keeps the run's creation time.
  */
 export const RUNNING_CHECK_BOUND_MILLISECONDS = 6 * 60 * 60_000
 
@@ -78,7 +84,7 @@ export interface CiGateReadingInput {
 }
 
 function boundMilliseconds(cause: CiGateCause): number {
-  return cause._tag === 'CheckRunning' ? RUNNING_CHECK_BOUND_MILLISECONDS : IDLE_GATE_BOUND_MILLISECONDS
+  return cause._tag === 'CheckRunning' || cause._tag === 'CheckQueued' ? RUNNING_CHECK_BOUND_MILLISECONDS : IDLE_GATE_BOUND_MILLISECONDS
 }
 
 /**
@@ -115,6 +121,8 @@ function causeSentence(cause: CiGateCause): string {
       return cause.detail
     case 'CheckRunning':
       return `Check run "${cause.check}" has not reported a conclusion.`
+    case 'CheckQueued':
+      return `Check run "${cause.check}" is queued, and no runner has accepted the job.`
     case 'ChecksUnreadable':
       return `The controller cannot read the check runs. GitHub said: ${cause.reason}`
     default:
@@ -130,6 +138,8 @@ function actionSentence(cause: CiGateCause): string {
       return 'If CI never started, read the workflow triggers and the runner.'
     case 'CheckRunning':
       return 'GitHub stops a job after six hours, so re-run the check run.'
+    case 'CheckQueued':
+      return 'If the job stays queued, read the runner supervisor on Hogwild.'
     case 'ChecksUnreadable':
       return 'If the read keeps failing, read the GitHub App installation permissions.'
     default:

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -440,10 +440,24 @@ function checkUndecided(check: GitHubCheck): boolean {
   return checkRunning(check) || checkRunnerLost(check)
 }
 
+/**
+ * True when GitHub holds the job and no runner has accepted it.
+ *
+ * On 2026-09-09 gscdump#49 read "has not reported a conclusion" for ten hours
+ * while its job had never started: the self-hosted runners could not resolve
+ * GitHub. The advice to re-run was wrong, because the runner supervisor drops
+ * a queued run older than six hours and a re-run keeps its creation time.
+ */
+function checkQueued(check: GitHubCheck): boolean {
+  return check.status === 'queued'
+}
+
 function undecidedReason(check: GitHubCheck): string {
-  return checkRunnerLost(check)
-    ? `${cleanLine(check.name)} lost its runner, so it has not reported.`
-    : `${cleanLine(check.name)} is still running.`
+  if (checkRunnerLost(check))
+    return `${cleanLine(check.name)} lost its runner, so it has not reported.`
+  if (checkQueued(check))
+    return `${cleanLine(check.name)} is queued, and no runner has accepted the job.`
+  return `${cleanLine(check.name)} is still running.`
 }
 
 /** True when any check run in one snapshot lost its runner. */
@@ -452,9 +466,11 @@ function checksLostRunner(checks: GitHubChecksSnapshot): boolean {
 }
 
 function undecidedCause(check: GitHubCheck): CiGateCause {
-  return checkRunnerLost(check)
-    ? { _tag: 'RunnerLost', check: cleanLine(check.name) }
-    : { _tag: 'CheckRunning', check: cleanLine(check.name) }
+  if (checkRunnerLost(check))
+    return { _tag: 'RunnerLost', check: cleanLine(check.name) }
+  if (checkQueued(check))
+    return { _tag: 'CheckQueued', check: cleanLine(check.name) }
+  return { _tag: 'CheckRunning', check: cleanLine(check.name) }
 }
 
 function checksGate(

--- a/packages/harlan-github-agent/test/ci-gate-pending.test.ts
+++ b/packages/harlan-github-agent/test/ci-gate-pending.test.ts
@@ -29,6 +29,7 @@ function gates(overrides: Partial<ReviewGates> = {}): ReviewGates {
 
 const baseFailed: CiGateCause = { _tag: 'BaseBranchFailed', check: 'build' }
 const running: CiGateCause = { _tag: 'CheckRunning', check: 'ci / test' }
+const queued: CiGateCause = { _tag: 'CheckQueued', check: 'test' }
 
 describe('readCiGate', () => {
   it('reports a base branch failure the pull request cannot resolve as overdue', () => {
@@ -130,5 +131,23 @@ describe('ciGatePendingMessage', () => {
 
     expect(ciGatePendingMessage('harlan-zw/example', 24, early)).toBe(ciGatePendingMessage('harlan-zw/example', 24, late))
     expect(ciGatePendingMessage('harlan-zw/example', 24, early)).toContain('Check run "ci / test" has not reported a conclusion.')
+  })
+
+  it('names a queued job no runner accepted, and does not tell Harlan to re-run it', () => {
+    const reading = readCiGate({ gates: gates(), cause: queued, pendingSince, now: at(RUNNING_CHECK_BOUND_MILLISECONDS + 60_000) })
+    if (reading._tag !== 'Overdue')
+      throw new Error('Expected an overdue CI Review gate.')
+
+    expect(ciGatePendingMessage('harlan-zw/gscdump', 49, reading)).toBe([
+      'harlan-zw/gscdump#49: the CI Review gate reads PENDING for more than 6 hours.',
+      'The gate last moved at 2026-09-05 00:00 UTC.',
+      'Check run "test" is queued, and no runner has accepted the job.',
+      'If the job stays queued, read the runner supervisor on Hogwild.',
+    ].join(' '))
+  })
+
+  it('gives a queued job the six hour bound, because the runner supervisor drops older runs', () => {
+    expect(readCiGate({ gates: gates(), cause: queued, pendingSince, now: at(RUNNING_CHECK_BOUND_MILLISECONDS - 60_000) })._tag).toBe('Within')
+    expect(readCiGate({ gates: gates(), cause: queued, pendingSince, now: at(RUNNING_CHECK_BOUND_MILLISECONDS + 60_000) })._tag).toBe('Overdue')
   })
 })

--- a/packages/harlan-github-agent/test/review-gate-sweep.test.ts
+++ b/packages/harlan-github-agent/test/review-gate-sweep.test.ts
@@ -148,6 +148,23 @@ function harness(options: {
   return { recorded, run }
 }
 
+describe('refreshControllerGates', () => {
+  it('names a queued check run no runner accepted, apart from one that runs', () => {
+    const queued = snapshot([check({ name: 'test', status: 'queued', conclusion: null })])
+    const running = snapshot([check({ name: 'test', status: 'in_progress', conclusion: null })])
+    if (queued._tag !== 'Ok' || running._tag !== 'Ok')
+      throw new Error('Expected Review snapshots.')
+
+    const queuedGates = refreshControllerGates(pendingControllerGates(), queued.value, repositoryMapping())
+    const runningGates = refreshControllerGates(pendingControllerGates(), running.value, repositoryMapping())
+
+    expect(queuedGates.ciCause).toEqual({ _tag: 'CheckQueued', check: 'test' })
+    expect(queuedGates.gates.ci).toMatchObject({ _tag: 'Pending', reason: 'Base branch CI: test is queued, and no runner has accepted the job.' })
+    expect(runningGates.ciCause).toEqual({ _tag: 'CheckRunning', check: 'test' })
+    expect(runningGates.gates.ci).toMatchObject({ _tag: 'Pending', reason: 'Base branch CI: test is still running.' })
+  })
+})
+
 describe('refreshReviewGates', () => {
   it('queues a Baseline repair once the default branch fails under a settled review', async () => {
     const live = snapshot([check({ name: 'Fuzz fuzz_options', conclusion: 'failure' })])


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

gscdump#49 read this for ten hours today:

```
Check run "test" has not reported a conclusion. GitHub stops a job after six hours, so re-run the check run.
```

The job had never started. Its status was `queued` with no runner, because the self-hosted runners could not resolve GitHub. The advice was wrong twice over: the six hour limit only kills a job that started, and a re-run keeps the run's creation time, so the runner supervisor drops it as aged all the same.

A queued check run now gets its own cause, and the Incident says no runner accepted the job and points at the runner supervisor on Hogwild. An in-progress job keeps the six hour wording. The queued case shares the six hour bound, since that is when the supervisor stops serving the run.

Not covered here: the supervisor itself still drops aged `push` runs even when an open pull request holds that commit. That is a harlan-nuxt change.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01M7niME5WXD6s62J8L9BF6i