### PR TITLE
feat(dashboard): show repository avatars and run results

### DIFF
--- a/packages/harlan-github-agent/dashboard/app/components/EntityIdentity.vue
+++ b/packages/harlan-github-agent/dashboard/app/components/EntityIdentity.vue
@@ -53,7 +53,7 @@ const kindLabel = { issue: 'Issue', pull_request: 'Pull request' }
       <p class="flex items-center gap-1 text-sm text-muted">
         <UIcon :name="kindIcon[kind]" class="size-3.5 shrink-0 text-dimmed" aria-hidden="true" />
         <span class="sr-only">{{ kindLabel[kind] }}</span>
-        <a :href="url" target="_blank" rel="noreferrer" class="entity-link truncate">{{ repository }}<span class="text-dimmed"> #{{ number }}</span></a>
+        <a :href="url" target="_blank" rel="noreferrer" class="entity-link truncate"><RepositoryIdentity :repository="repository"><span class="text-dimmed"> #{{ number }}</span></RepositoryIdentity></a>
       </p>
       <!-- The clamp lives on the paragraph. A block anchor would override the clamp's display. -->
       <p class="mt-0.5 text-highlighted" :class="titleClass[size]">

--- a/packages/harlan-github-agent/dashboard/app/components/HistoryEvidenceSlideover.vue
+++ b/packages/harlan-github-agent/dashboard/app/components/HistoryEvidenceSlideover.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { AgentFeedbackInput } from '../../../src/types.ts'
-import type { DetailItem } from '../components/DetailList.vue'
+import type { AgentActivityItem, AgentFeedbackInput } from '../../../src/types.ts'
 import type { FeedbackVerdict, HistoryRow } from '../utils/history.ts'
+import type { DetailItem } from './DetailList.vue'
 import { useClipboard } from '@vueuse/core'
 import {
   gateTone,
@@ -146,7 +146,7 @@ const details = computed<DetailItem[]>(() => {
     { term: 'Scheduled', value: relativeTime(run.scheduledFor) },
     { term: 'Mode', value: run.mode },
     { term: 'Report', value: run.reportState ?? 'None' },
-    { term: 'Finished', value: relativeTime(run.updatedAt) },
+    { term: ['Queued', 'Running'].includes(run.state._tag) ? 'Updated' : 'Finished', value: relativeTime(run.updatedAt) },
     { term: 'Took', value: duration(run.createdAt, run.updatedAt), mono: true },
   ]
 })
@@ -165,6 +165,15 @@ function save(verdict: FeedbackVerdict): void {
 function rerun(): void {
   if (review.value !== undefined)
     void rerunReview(review.value.repository, review.value.pullRequestNumber, review.value.revisionId)
+}
+
+function activityLine(item: AgentActivityItem): string {
+  switch (item._tag) {
+    case 'Command': return `$ ${item.command}${item.exitCode !== null && item.exitCode !== 0 ? ` (exit ${item.exitCode})` : ''}${item.output.length > 0 ? `\n${item.output}` : ''}`
+    case 'FileChange': return `edited ${item.changes.map(change => change.path).join(', ')}`
+    case 'Progress': return item.text
+    case 'Reasoning': return item.text
+  }
 }
 
 function candidateTone(result: { _tag: string }): 'success' | 'warning' | 'error' | 'neutral' {
@@ -302,10 +311,32 @@ function candidateTone(result: { _tag: string }): 'success' | 'warning' | 'error
               <p class="text-sm">
                 {{ candidate.claim }}
               </p>
+              <p v-if="candidate.result._tag === 'Rejected' || candidate.result._tag === 'Superseded'" class="text-sm text-muted">
+                {{ candidate.result.reason }}
+              </p>
+              <a
+                v-if="(candidate.result._tag === 'Proposed' || candidate.result._tag === 'Merged') && candidate.result.pullRequest !== null"
+                :href="`https://github.com/${row.run.repository}/pull/${candidate.result.pullRequest}`"
+                target="_blank"
+                rel="noreferrer"
+                class="entity-link text-sm"
+              >Pull request #{{ candidate.result.pullRequest }}</a>
             </li>
           </ul>
           <p v-else class="text-sm text-muted">
             No candidates.
+          </p>
+        </section>
+
+        <section v-if="row._tag === 'Routine'">
+          <details v-if="row.run.activity.length > 0" class="text-sm">
+            <summary class="cursor-pointer text-muted">
+              Terminal
+            </summary>
+            <pre class="terminal mt-2">{{ row.run.activity.map(activityLine).join('\n') }}</pre>
+          </details>
+          <p v-else class="text-sm text-muted">
+            No activity recorded.
           </p>
         </section>
 

--- a/packages/harlan-github-agent/dashboard/app/components/RepositoryIdentity.vue
+++ b/packages/harlan-github-agent/dashboard/app/components/RepositoryIdentity.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { avatarUrl } from '../utils/dashboard.ts'
+
+const { repository } = defineProps<{ repository: string }>()
+const owner = computed(() => repository.split('/')[0]!)
+</script>
+
+<template>
+  <span class="inline-flex min-w-0 max-w-full items-center gap-1.5 align-middle">
+    <span class="shrink-0" aria-hidden="true">
+      <UAvatar :src="avatarUrl(owner)" :alt="owner" size="3xs" />
+    </span>
+    <span class="min-w-0 truncate">{{ repository }}<slot /></span>
+  </span>
+</template>

--- a/packages/harlan-github-agent/dashboard/app/components/SystemSlideover.vue
+++ b/packages/harlan-github-agent/dashboard/app/components/SystemSlideover.vue
@@ -181,7 +181,7 @@ function activityLine(item: AgentActivityItem): string {
         <ul class="mt-1 divide-y divide-default">
           <li v-for="batch in batches" :key="batch.id" class="space-y-1 py-3">
             <div class="flex flex-wrap items-center gap-2">
-              <span class="font-mono text-sm text-highlighted">{{ batch.repository }}</span>
+              <RepositoryIdentity :repository="batch.repository" class="font-mono text-sm text-highlighted" />
               <span class="font-mono text-sm text-muted">{{ batch.issues }}</span>
               <StateBadge :tone="batch.tone" :label="batch.label" class="ms-auto" />
             </div>
@@ -229,8 +229,8 @@ function activityLine(item: AgentActivityItem): string {
                 target="_blank"
                 rel="noreferrer"
                 class="entity-link font-mono text-sm text-muted"
-              >{{ record.routine.repository }}#{{ record.routine.trackingIssueNumber }}</a>
-              <span v-else class="font-mono text-sm text-muted">{{ record.routine.repository }}</span>
+              ><RepositoryIdentity :repository="record.routine.repository"> #{{ record.routine.trackingIssueNumber }}</RepositoryIdentity></a>
+              <RepositoryIdentity v-else :repository="record.routine.repository" class="font-mono text-sm text-muted" />
               <StateBadge :tone="record.tone" :label="record.label" class="ms-auto" />
             </div>
             <p class="text-sm text-muted">

--- a/packages/harlan-github-agent/dashboard/app/pages/_BoardCard.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/_BoardCard.vue
@@ -293,7 +293,7 @@ defineExpose({
         <a :href="identity.url" target="_blank" rel="noreferrer" class="entity-link truncate">{{ identity.title }}<span class="sr-only"> on GitHub</span></a>
       </p>
       <p class="min-w-0 truncate text-sm text-muted [grid-area:repository]">
-        <a :href="identity.url" target="_blank" rel="noreferrer" class="entity-link">{{ identity.repository }}<span class="text-dimmed"> #{{ identity.number }}</span></a>
+        <a :href="identity.url" target="_blank" rel="noreferrer" class="entity-link"><RepositoryIdentity :repository="identity.repository"><span class="text-dimmed"> #{{ identity.number }}</span></RepositoryIdentity></a>
       </p>
       <div class="min-w-0 text-sm [grid-area:meta]">
         <p v-if="recommendation" class="whitespace-nowrap text-sm font-medium lg:text-xs" :class="recommendation.owner === 'You' ? 'text-warning' : 'text-muted'">
@@ -371,7 +371,7 @@ defineExpose({
         <p v-if="identity" class="flex min-w-0 flex-1 items-center gap-1 text-sm text-muted">
           <UIcon :name="kindIcon[identity.kind]" class="size-3.5 shrink-0 text-dimmed" aria-hidden="true" />
           <span class="sr-only">{{ identity.kind === 'issue' ? 'Issue' : 'Pull request' }}</span>
-          <a :href="identity.url" target="_blank" rel="noreferrer" class="entity-link truncate">{{ identity.repository }}<span class="text-dimmed"> #{{ identity.number }}</span></a>
+          <a :href="identity.url" target="_blank" rel="noreferrer" class="entity-link truncate"><RepositoryIdentity :repository="identity.repository"><span class="text-dimmed"> #{{ identity.number }}</span></RepositoryIdentity></a>
         </p>
         <span v-if="card._tag === 'Queued'" class="shrink-0 font-mono text-sm text-dimmed">{{ String(entry?.position).padStart(2, '0') }}</span>
         <a

--- a/packages/harlan-github-agent/dashboard/app/pages/_StatsDailyChart.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/_StatsDailyChart.vue
@@ -34,8 +34,9 @@ const summary = computed(() => days.map(dayTitle).join('. '))
       </div>
       <div class="relative mt-1.5 h-5 font-mono text-sm text-dimmed" aria-hidden="true">
         <span
-          v-for="tick in ticks"
+          v-for="(tick, index) in ticks"
           :key="tick.index"
+          :class="index % 2 === 1 ? 'hidden sm:block' : undefined"
           class="absolute top-0 whitespace-nowrap"
           :style="{ left: `${tick.left}%`, transform: tick.left === 0 ? 'none' : tick.left >= 99 ? 'translateX(-100%)' : 'translateX(-50%)' }"
         >{{ tick.label }}</span>

--- a/packages/harlan-github-agent/dashboard/app/pages/_StatsRepositoryTable.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/_StatsRepositoryTable.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { RepositoryStats } from '../../../src/stats.ts'
+
+defineProps<{ repositories: RepositoryStats[] }>()
+</script>
+
+<template>
+  <section class="min-w-0" aria-labelledby="stats-repositories-heading">
+    <UiSectionHeader id="stats-repositories-heading" title="Repositories" />
+    <UiTableShell label="Runs and results per repository" size="sm" row-hover>
+      <template #head>
+        <UiTableTh>Repository</UiTableTh>
+        <UiTableTh numeric>
+          Runs
+        </UiTableTh>
+        <UiTableTh numeric>
+          Pull requests changed
+        </UiTableTh>
+        <UiTableTh numeric>
+          Repair commits
+        </UiTableTh>
+        <UiTableTh numeric>
+          Conflicts resolved
+        </UiTableTh>
+        <UiTableTh numeric>
+          Pull requests opened
+        </UiTableTh>
+        <UiTableTh numeric>
+          Review issues found
+        </UiTableTh>
+      </template>
+      <tr v-for="entry in repositories" :key="entry.repository">
+        <UiTableTd row-header size="sm">
+          <a :href="`https://github.com/${entry.repository}`" target="_blank" rel="noreferrer" class="entity-link text-sm">
+            <RepositoryIdentity :repository="entry.repository" />
+          </a>
+        </UiTableTd>
+        <UiTableTd v-for="(metric, index) in [entry.runs, entry.changedPullRequests, entry.fixCommits, entry.conflictResolutions, entry.openedPullRequests, entry.reviewFindings]" :key="index" numeric size="sm">
+          <UiTableMetricCell :value="metric" />
+        </UiTableTd>
+      </tr>
+    </UiTableShell>
+  </section>
+</template>

--- a/packages/harlan-github-agent/dashboard/app/pages/_StatsWorkTable.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/_StatsWorkTable.vue
@@ -15,7 +15,7 @@ const maximumRuns = computed(() => Math.max(...work.map(entry => entry.runs), 0)
 <template>
   <section class="min-w-0" aria-labelledby="stats-work-heading">
     <UiSectionHeader id="stats-work-heading" title="Work" />
-    <UiTableShell label="Runs and results per kind of work" size="sm" row-hover>
+    <UiTableShell label="Runs and results per kind of work" size="sm" row-hover table-class="min-w-3xl">
       <template #head>
         <UiTableTh>Work</UiTableTh>
         <UiTableTh numeric>

--- a/packages/harlan-github-agent/dashboard/app/pages/history.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/history.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { DropdownMenuItem } from '@nuxt/ui'
 import type { HistoryRow, OutcomeFilter } from '../utils/history.ts'
+import HistoryEvidenceSlideover from '../components/HistoryEvidenceSlideover.vue'
 import { routineRunPresentation, taskNumber, taskRowSummary, taskSubjectUrl } from '../utils/dashboard.ts'
 import {
   canRerunReview,
@@ -11,7 +12,6 @@ import {
   historyRowWork,
   outcomeFilters,
 } from '../utils/history.ts'
-import HistoryEvidenceSlideover from './_HistoryEvidenceSlideover.vue'
 
 /**
  * What already happened, on what evidence. GitHub style list rows; every row
@@ -178,12 +178,12 @@ useHead({
               size="sm"
             />
             <p v-else-if="row._tag === 'Task'" class="flex min-w-0 flex-wrap items-baseline gap-x-2">
-              <a :href="taskSubjectUrl(row.task)" target="_blank" rel="noreferrer" class="entity-link shrink-0 font-mono text-sm">{{ row.task.repository }}#{{ taskNumber(row.task) }}</a>
+              <a :href="taskSubjectUrl(row.task)" target="_blank" rel="noreferrer" class="entity-link shrink-0 font-mono text-sm"><RepositoryIdentity :repository="row.task.repository"> #{{ taskNumber(row.task) }}</RepositoryIdentity></a>
               <span v-if="taskRowSummary(row.task)" class="min-w-0 flex-1 truncate text-sm text-muted">{{ taskRowSummary(row.task) }}</span>
             </p>
             <p v-else class="flex min-w-0 flex-wrap items-baseline gap-x-2">
               <span class="text-sm font-medium text-highlighted">{{ row.run.name }}</span>
-              <span class="font-mono text-sm text-dimmed">{{ row.run.repository }}</span>
+              <RepositoryIdentity :repository="row.run.repository" class="font-mono text-sm text-dimmed" />
               <span v-if="routineRunPresentation(row.run).detail" class="min-w-0 flex-1 truncate text-sm text-muted">{{ routineRunPresentation(row.run).detail }}</span>
             </p>
           </div>

--- a/packages/harlan-github-agent/dashboard/app/pages/routines.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/routines.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { HistoryRow } from '../utils/history.ts'
 import { routineRunPresentation } from '../utils/dashboard.ts'
 import { recentRoutineRuns, routineRows, routineRunDetail } from '../utils/routines.ts'
 
@@ -11,6 +12,17 @@ const { snapshot, loading, now, relativeTime } = useDashboard()
 const minute = computed(() => Math.floor(now.value.getTime() / 60_000))
 const rows = computed(() => routineRows(snapshot.value.routines, snapshot.value.routineRuns, new Date(minute.value * 60_000)))
 const runs = computed(() => recentRoutineRuns(snapshot.value.routineRuns))
+const selectedRunId = ref<string>()
+const evidenceOpen = ref(false)
+const selectedRun = computed<HistoryRow | undefined>(() => {
+  const run = snapshot.value.routineRuns.find(run => run.id === selectedRunId.value)
+  return run === undefined ? undefined : { _tag: 'Routine', key: run.id, at: run.updatedAt, run }
+})
+
+function showRun(id: string): void {
+  selectedRunId.value = id
+  evidenceOpen.value = true
+}
 
 const absolute = new Intl.DateTimeFormat('en', { weekday: 'short', hour: '2-digit', minute: '2-digit', hourCycle: 'h23' })
 function at(iso: string): string {
@@ -56,8 +68,8 @@ useHead({
             <span v-if="!row.routine.enabled" class="ms-2 text-sm text-dimmed">Disabled</span>
           </UiTableTd>
           <UiTableTd size="sm">
-            <a v-if="row.trackingUrl" :href="row.trackingUrl" target="_blank" rel="noreferrer" class="entity-link text-sm text-muted">{{ row.routine.repository }}<span class="text-dimmed"> #{{ row.routine.trackingIssueNumber }}</span></a>
-            <a v-else :href="`https://github.com/${row.routine.repository}`" target="_blank" rel="noreferrer" class="entity-link text-sm text-muted">{{ row.routine.repository }}</a>
+            <a v-if="row.trackingUrl" :href="row.trackingUrl" target="_blank" rel="noreferrer" class="entity-link text-sm text-muted"><RepositoryIdentity :repository="row.routine.repository"><span class="text-dimmed"> #{{ row.routine.trackingIssueNumber }}</span></RepositoryIdentity></a>
+            <a v-else :href="`https://github.com/${row.routine.repository}`" target="_blank" rel="noreferrer" class="entity-link text-sm text-muted"><RepositoryIdentity :repository="row.routine.repository" /></a>
           </UiTableTd>
           <UiTableTd size="sm" visible-from="md">
             <span class="text-sm text-muted">{{ row.schedule }}</span>
@@ -88,16 +100,26 @@ useHead({
         </template>
       </UiSectionHeader>
       <ul class="divide-y divide-default border-y border-default" role="list">
-        <li v-for="run in runs" :key="run.id" class="flex min-h-11 flex-wrap items-center gap-x-3 gap-y-1 px-2 py-2 transition-colors hover:bg-muted">
-          <span class="w-32 shrink-0">
-            <StateBadge :tone="routineRunPresentation(run).tone === 'primary' ? 'neutral' : routineRunPresentation(run).tone" :label="routineRunPresentation(run).label" />
-          </span>
-          <span class="font-medium text-highlighted">{{ run.name }}</span>
-          <span class="text-sm text-muted">{{ run.repository }}</span>
-          <span v-if="routineRunDetail(run)" class="min-w-0 flex-1 truncate text-sm text-muted">{{ routineRunDetail(run) }}</span>
-          <span class="ms-auto shrink-0 font-mono text-sm text-dimmed"><time :datetime="run.scheduledFor">{{ relativeTime(run.scheduledFor) }}</time></span>
+        <li v-for="run in runs" :key="run.id">
+          <button
+            type="button"
+            class="flex min-h-11 w-full flex-wrap items-center gap-x-3 gap-y-1 px-2 py-2 text-start transition-colors hover:bg-muted"
+            :aria-label="`Open ${run.name} on ${run.repository}, ${at(run.scheduledFor)}`"
+            aria-haspopup="dialog"
+            @click="showRun(run.id)"
+          >
+            <span class="w-32 shrink-0">
+              <StateBadge :tone="routineRunPresentation(run).tone === 'primary' ? 'neutral' : routineRunPresentation(run).tone" :label="routineRunPresentation(run).label" />
+            </span>
+            <span class="font-medium text-highlighted">{{ run.name }}</span>
+            <RepositoryIdentity :repository="run.repository" class="text-sm text-muted" />
+            <span v-if="routineRunDetail(run)" class="min-w-0 flex-1 truncate text-sm text-muted">{{ routineRunDetail(run) }}</span>
+            <span class="ms-auto shrink-0 font-mono text-sm text-dimmed"><time :datetime="run.scheduledFor">{{ relativeTime(run.scheduledFor) }}</time></span>
+            <UIcon name="i-octicon-chevron-right-16" class="size-4 shrink-0 text-dimmed" aria-hidden="true" />
+          </button>
         </li>
       </ul>
     </section>
+    <HistoryEvidenceSlideover v-model:open="evidenceOpen" :row="selectedRun" />
   </div>
 </template>

--- a/packages/harlan-github-agent/dashboard/app/pages/stats.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/stats.vue
@@ -2,6 +2,7 @@
 import type { StatsSnapshot } from '../../../src/stats.ts'
 import { activeStatsPreset, coverageText, hasStatsResults, outcomeStats, statsDateRange, statsPresets, statsRequestRange } from '../utils/stats.ts'
 import StatsDailyChart from './_StatsDailyChart.vue'
+import StatsRepositoryTable from './_StatsRepositoryTable.vue'
 import StatsWorkTable from './_StatsWorkTable.vue'
 
 /**
@@ -183,8 +184,9 @@ useHead({
 
     <template v-else-if="snapshot">
       <div v-if="hasResults" class="grid min-w-0 gap-10">
-        <UiStats :data="strip" variant="card" />
+        <UiStats :data="strip" variant="card" wrap class="gap-y-4" />
         <StatsDailyChart :days="snapshot.days" />
+        <StatsRepositoryTable :repositories="snapshot.repositories" />
         <StatsWorkTable :work="snapshot.work" :from="from" :to="to" />
       </div>
 

--- a/packages/harlan-github-agent/dashboard/app/pages/watching.vue
+++ b/packages/harlan-github-agent/dashboard/app/pages/watching.vue
@@ -156,7 +156,7 @@ useHead({
         <tr v-for="repository in repositories" :key="repository.github">
           <UiTableTd row-header size="sm">
             <span class="flex flex-wrap items-center gap-2">
-              <a :href="`https://github.com/${repository.github}`" target="_blank" rel="noreferrer" class="entity-link whitespace-nowrap font-mono text-sm">{{ repository.github }}</a>
+              <a :href="`https://github.com/${repository.github}`" target="_blank" rel="noreferrer" class="entity-link whitespace-nowrap font-mono text-sm"><RepositoryIdentity :repository="repository.github" /></a>
               <UiStatusBadge v-for="flag in repositoryFlags(repository)" :key="flag.label" :status="flag.tone" :label="flag.label" size="sm" />
             </span>
             <p v-if="repository.lastError !== null" class="status-error mt-1 whitespace-normal text-sm">

--- a/packages/harlan-github-agent/dashboard/server/api/stats.get.ts
+++ b/packages/harlan-github-agent/dashboard/server/api/stats.get.ts
@@ -104,5 +104,19 @@ export default defineEventHandler((event): StatsSnapshot => {
     },
     days,
     work: work(days),
+    repositories: days.some(entry => entry.fixCommits + entry.reviewFindings > 0)
+      ? ['harlan-zw/nuxt-seo', 'nuxt-modules/sitemap', 'nuxt-modules/robots'].map((repository, index) => {
+          const share = (value: number) => Math.floor(value / 3) + (index < value % 3 ? 1 : 0)
+          return {
+            repository,
+            runs: share(work(days).reduce((total, entry) => total + entry.runs, 0)),
+            changedPullRequests: share(changed(days)),
+            fixCommits: share(sum(days, 'fixCommits')),
+            conflictResolutions: share(sum(days, 'conflictResolutions')),
+            openedPullRequests: share(sum(days, 'openedPullRequests')),
+            reviewFindings: share(sum(days, 'reviewFindings')),
+          }
+        })
+      : [],
   }
 })

--- a/packages/harlan-github-agent/src/stats.ts
+++ b/packages/harlan-github-agent/src/stats.ts
@@ -39,8 +39,8 @@ export type RecordPullRequestTriageRunResult
 
 export type StatsTaskKind = 'review_fix' | 'conflict_resolution' | 'baseline_repair' | 'issue_triage' | 'issue_work'
 
-export type StatsFact
-  = | {
+export type StatsFact = { repository: string } & (
+  | {
     _tag: 'PullRequestTriage'
     at: string
     startedAt: string
@@ -63,7 +63,6 @@ export type StatsFact
   | {
     _tag: 'Publication'
     at: string
-    repository: string
     itemNumber: number
     work: 'review_fix' | 'conflict_resolution' | 'baseline_repair' | 'issue_work'
     changedFiles: number
@@ -75,6 +74,7 @@ export type StatsFact
     outcome: 'Completed' | 'ActionRequired' | 'Failed' | 'Skipped' | 'Superseded'
     candidates: number
   }
+)
 
 export interface StatsComparison {
   value: number
@@ -137,6 +137,16 @@ export type StatsWork = PullRequestTriageWorkStats | ReviewWorkStats | TaskWorkS
 
 export type StatsCoverage = { _tag: 'Complete' } | { _tag: 'Partial', startedAt: string }
 
+export interface RepositoryStats {
+  repository: string
+  runs: number
+  changedPullRequests: number
+  conflictResolutions: number
+  fixCommits: number
+  openedPullRequests: number
+  reviewFindings: number
+}
+
 export interface StatsSnapshot {
   generatedAt: string
   range: StatsRange
@@ -151,6 +161,7 @@ export interface StatsSnapshot {
   }
   days: StatsDay[]
   work: StatsWork[]
+  repositories: RepositoryStats[]
 }
 
 export function parseStatsRange(input: {
@@ -320,6 +331,13 @@ export function buildStats(input: {
       reviewFindings: comparison(currentSummary.reviewFindings, previousSummary.reviewFindings),
     },
     days: [...daysByDate.values()],
+    repositories: [...Map.groupBy(currentFacts, fact => fact.repository)]
+      .map(([repository, facts]) => ({
+        repository,
+        runs: facts.filter(fact => fact._tag !== 'Publication').length,
+        ...summary(facts),
+      }))
+      .sort((left, right) => right.runs - left.runs || left.repository.localeCompare(right.repository)),
     work: [
       {
         _tag: 'PullRequestTriage',

--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -11625,16 +11625,20 @@ export function openJournalStore(
     const facts: StatsFact[] = []
 
     const triageRows = database.prepare(`
-      SELECT started_at, completed_at, outcome_tag
+      SELECT started_at, completed_at, outcome_tag, repositories.github AS repository
       FROM pull_request_triage_runs
+      JOIN subjects ON subjects.id = pull_request_triage_runs.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
       WHERE completed_at >= ? AND completed_at < ?
     `).all(queryFrom, range.to) as unknown as Array<{
+      repository: string
       started_at: string
       completed_at: string
       outcome_tag: 'ReviewRequired' | 'ReviewSkipped' | 'ReviewRequiredAfterFailure'
     }>
     facts.push(...triageRows.map(row => ({
       _tag: 'PullRequestTriage' as const,
+      repository: row.repository,
       at: row.completed_at,
       startedAt: row.started_at,
       outcome: row.outcome_tag,
@@ -11643,8 +11647,10 @@ export function openJournalStore(
     const reviewRows = database.prepare(`
       SELECT review_runs.started_at, review_runs.completed_at,
         COALESCE(review_gate_projections.outcome_tag, review_runs.outcome_tag) AS outcome_tag,
-        review_runs.findings
+        review_runs.findings, repositories.github AS repository
       FROM review_runs
+      JOIN subjects ON subjects.id = review_runs.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
       LEFT JOIN review_gate_projections ON review_gate_projections.review_run_id = review_runs.id
       WHERE completed_at >= ? AND completed_at < ?
         AND NOT EXISTS (
@@ -11652,6 +11658,7 @@ export function openJournalStore(
           WHERE settlement.supersedes_review_run_id = review_runs.id
         )
     `).all(queryFrom, range.to) as unknown as Array<{
+      repository: string
       started_at: string
       completed_at: string
       outcome_tag: 'Ready' | 'Pending' | 'Blocked'
@@ -11661,6 +11668,7 @@ export function openJournalStore(
       const findings = JSON.parse(row.findings) as ReviewFinding[]
       return {
         _tag: 'Review' as const,
+        repository: row.repository,
         at: row.completed_at,
         startedAt: row.started_at,
         outcome: row.outcome_tag,
@@ -11671,6 +11679,7 @@ export function openJournalStore(
     const taskRows = database.prepare(`
       SELECT
         tasks.kind,
+        repositories.github AS repository,
         terminal.to_tag,
         terminal.created_at,
         (
@@ -11680,11 +11689,14 @@ export function openJournalStore(
         ) AS started_at
       FROM task_transitions AS terminal
       JOIN tasks ON tasks.id = terminal.task_id
+      JOIN subjects ON subjects.id = tasks.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
       WHERE terminal.to_tag IN ('Completed', 'ActionRequired', 'Failed', 'Superseded')
         AND terminal.created_at >= ? AND terminal.created_at < ?
       UNION ALL
       SELECT
         worker_tasks.kind,
+        repositories.github AS repository,
         terminal.to_tag,
         terminal.created_at,
         (
@@ -11694,10 +11706,13 @@ export function openJournalStore(
         ) AS started_at
       FROM worker_task_transitions AS terminal
       JOIN worker_tasks ON worker_tasks.id = terminal.task_id
+      JOIN subjects ON subjects.id = worker_tasks.subject_id
+      JOIN repositories ON repositories.id = subjects.repository_id
       WHERE worker_tasks.kind = 'issue_triage'
         AND terminal.to_tag IN ('Completed', 'ActionRequired', 'Failed', 'Superseded')
         AND terminal.created_at >= ? AND terminal.created_at < ?
     `).all(queryFrom, range.to, queryFrom, range.to) as unknown as Array<{
+      repository: string
       kind: 'resolve_conflict' | 'review_fix' | 'baseline_repair' | 'issue_triage' | 'issue_work'
       to_tag: 'Completed' | 'ActionRequired' | 'Failed' | 'Superseded'
       created_at: string
@@ -11706,6 +11721,7 @@ export function openJournalStore(
     const taskWork = (kind: typeof taskRows[number]['kind']): StatsTaskKind => kind === 'resolve_conflict' ? 'conflict_resolution' : kind
     facts.push(...taskRows.map(row => ({
       _tag: 'Task' as const,
+      repository: row.repository,
       at: row.created_at,
       startedAt: row.started_at,
       work: taskWork(row.kind),
@@ -11743,21 +11759,25 @@ export function openJournalStore(
 
     const routineRows = database.prepare(`
       SELECT
+        routines.repository,
         routine_runs.state_tag,
         routine_runs.updated_at,
         COUNT(candidates.id) AS candidates
       FROM routine_runs
+      JOIN routines ON routines.id = routine_runs.routine_id
       LEFT JOIN candidates ON candidates.run_id = routine_runs.id
       WHERE routine_runs.state_tag IN ('Completed', 'ActionRequired', 'Failed', 'Skipped', 'Superseded')
         AND routine_runs.updated_at >= ? AND routine_runs.updated_at < ?
       GROUP BY routine_runs.id
     `).all(queryFrom, range.to) as unknown as Array<{
+      repository: string
       state_tag: 'Completed' | 'ActionRequired' | 'Failed' | 'Skipped' | 'Superseded'
       updated_at: string
       candidates: number
     }>
     facts.push(...routineRows.map(row => ({
       _tag: 'Routine' as const,
+      repository: row.repository,
       at: row.updated_at,
       startedAt: null,
       outcome: row.state_tag,

--- a/packages/harlan-github-agent/test/app.test.ts
+++ b/packages/harlan-github-agent/test/app.test.ts
@@ -30,6 +30,7 @@ function statsSnapshot(range: StatsRange, generatedAt: string): StatsSnapshot {
     },
     days: [],
     work: [],
+    repositories: [],
   }
 }
 const agentControls = {

--- a/packages/harlan-github-agent/test/stats-view.test.ts
+++ b/packages/harlan-github-agent/test/stats-view.test.ts
@@ -124,6 +124,7 @@ describe('stats work rows', () => {
       },
       days: [],
       work: [],
+      repositories: [],
     }
     expect(hasStatsResults(empty)).toBe(false)
     expect(hasStatsResults({ ...empty, work: [task] })).toBe(true)

--- a/packages/harlan-github-agent/test/stats.test.ts
+++ b/packages/harlan-github-agent/test/stats.test.ts
@@ -47,6 +47,34 @@ describe('stats range', () => {
 })
 
 describe('stats aggregation', () => {
+  it('groups current work and delivered outcomes by repository without counting publications as runs', () => {
+    const repository = 'harlan-zw/example'
+    const other = 'skilld-dev/skilld'
+    const at = '2026-08-02T00:00:00.000Z'
+    const stats = buildStats({
+      generatedAt: at,
+      range: { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z', timeZone: 'UTC' },
+      triageCoverageStartedAt: '2026-08-01T00:00:00.000Z',
+      facts: [
+        { _tag: 'Publication', repository, at, itemNumber: 1, work: 'review_fix', changedFiles: 1 },
+        { _tag: 'Publication', repository, at, itemNumber: 1, work: 'review_fix', changedFiles: 2 },
+        { _tag: 'Publication', repository: other, at, itemNumber: 1, work: 'conflict_resolution', changedFiles: 1 },
+        { _tag: 'Review', repository, at, startedAt: at, outcome: 'Ready', findings: 3 },
+        { _tag: 'Task', repository, at, startedAt: at, work: 'review_fix', outcome: 'Completed' },
+        { _tag: 'PullRequestTriage', repository, at, startedAt: at, outcome: 'ReviewRequired' },
+        { _tag: 'Routine', repository: other, at, startedAt: null, outcome: 'Completed', candidates: 2 },
+        { _tag: 'Publication', repository: other, at, itemNumber: 2, work: 'issue_work', changedFiles: 1 },
+        { _tag: 'Review', repository: 'harlan-zw/previous', at: '2026-07-31T00:00:00.000Z', startedAt: at, outcome: 'Ready', findings: 9 },
+        { _tag: 'Review', repository, at: '2026-08-08T00:00:00.000Z', startedAt: at, outcome: 'Ready', findings: 9 },
+      ],
+    })
+
+    expect(stats.repositories).toEqual([
+      { repository, runs: 3, changedPullRequests: 1, fixCommits: 2, conflictResolutions: 0, openedPullRequests: 0, reviewFindings: 3 },
+      { repository: other, runs: 1, changedPullRequests: 1, fixCommits: 0, conflictResolutions: 1, openedPullRequests: 1, reviewFindings: 0 },
+    ])
+  })
+
   it('counts delivered outcomes without treating commits as unique pull requests', () => {
     const range = {
       from: '2026-08-01T00:00:00.000Z',
@@ -63,10 +91,10 @@ describe('stats aggregation', () => {
         { _tag: 'Publication', at: '2026-08-02T15:00:00.000Z', repository: 'harlan-zw/example', itemNumber: 24, work: 'review_fix', changedFiles: 1 },
         { _tag: 'Publication', at: '2026-08-03T15:00:00.000Z', repository: 'harlan-zw/example', itemNumber: 24, work: 'conflict_resolution', changedFiles: 3 },
         { _tag: 'Publication', at: '2026-08-04T15:00:00.000Z', repository: 'harlan-zw/example', itemNumber: 24, work: 'baseline_repair', changedFiles: 1 },
-        { _tag: 'Review', at: '2026-08-02T16:00:00.000Z', startedAt: '2026-08-02T15:50:00.000Z', outcome: 'Blocked', findings: 2 },
-        { _tag: 'Task', at: '2026-08-02T15:10:00.000Z', startedAt: '2026-08-02T15:00:00.000Z', work: 'review_fix', outcome: 'Completed' },
-        { _tag: 'Task', at: '2026-08-03T15:10:00.000Z', startedAt: null, work: 'conflict_resolution', outcome: 'ActionRequired' },
-        { _tag: 'PullRequestTriage', at: '2026-08-02T12:00:00.000Z', startedAt: '2026-08-02T11:59:55.000Z', outcome: 'ReviewSkipped' },
+        { _tag: 'Review', repository: 'harlan-zw/example', at: '2026-08-02T16:00:00.000Z', startedAt: '2026-08-02T15:50:00.000Z', outcome: 'Blocked', findings: 2 },
+        { _tag: 'Task', repository: 'harlan-zw/example', at: '2026-08-02T15:10:00.000Z', startedAt: '2026-08-02T15:00:00.000Z', work: 'review_fix', outcome: 'Completed' },
+        { _tag: 'Task', repository: 'harlan-zw/example', at: '2026-08-03T15:10:00.000Z', startedAt: null, work: 'conflict_resolution', outcome: 'ActionRequired' },
+        { _tag: 'PullRequestTriage', repository: 'harlan-zw/example', at: '2026-08-02T12:00:00.000Z', startedAt: '2026-08-02T11:59:55.000Z', outcome: 'ReviewSkipped' },
       ],
     })
 
@@ -154,6 +182,7 @@ describe('pull request triage Stats', () => {
       timeZone: 'UTC',
     }, '2026-08-08T00:00:00.000Z')
 
+    expect(stats.repositories).toEqual([expect.objectContaining({ repository: task.repository, runs: 1 })])
     expect(stats.work.find(work => work._tag === 'PullRequestTriage')).toEqual(expect.objectContaining({
       runs: 1,
       reviewSkipped: 1,
@@ -162,6 +191,36 @@ describe('pull request triage Stats', () => {
 })
 
 describe('journal Stats evidence', () => {
+  it('keeps skipped Routine runs in their repository and excludes them outside the range', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    store.syncRoutines({
+      repository: 'harlan-zw/example',
+      specSha: 'abc123',
+      entries: [{ name: 'pr-triage', crons: ['0 7 * * *'], timeZone: 'UTC', mode: 'report', enabled: true }],
+      at: '2026-08-13T00:00:00.000Z',
+    })
+    store.skipRoutineRun({
+      routineId: 'harlan-zw/example:pr-triage',
+      scheduledFor: '2026-08-13T07:00:00.000Z',
+      specSha: 'abc123',
+      reason: 'Outside the catch-up window.',
+      at: '2026-08-13T08:00:00.000Z',
+    })
+    const range = { from: '2026-08-13T00:00:00.000Z', to: '2026-08-14T00:00:00.000Z', timeZone: 'UTC' }
+
+    expect(store.getStats(range, range.to).repositories).toEqual([{
+      repository: 'harlan-zw/example',
+      runs: 1,
+      changedPullRequests: 0,
+      fixCommits: 0,
+      conflictResolutions: 0,
+      openedPullRequests: 0,
+      reviewFindings: 0,
+    }])
+    expect(store.getStats({ ...range, from: range.to, to: '2026-08-15T00:00:00.000Z' }, range.to).repositories).toEqual([])
+  })
+
   it('counts a Publication only after it publishes', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
@@ -209,6 +268,7 @@ describe('journal Stats evidence', () => {
       at: '2026-08-13T01:04:00.000Z',
       evidence: 'Updated pull request #24.',
     })).toBe(true)
+    expect(store.getStats(range, range.to).repositories).toEqual([expect.objectContaining({ repository: task.repository, conflictResolutions: 1 })])
     expect(store.getStats(range, range.to).summary).toEqual(expect.objectContaining({
       changedPullRequests: { value: 1, previous: 0 },
       conflictResolutions: { value: 1, previous: 0 },
@@ -267,6 +327,7 @@ describe('journal Stats evidence', () => {
       to: '2026-08-14T00:00:00.000Z',
       timeZone: 'UTC',
     }, '2026-08-14T00:00:00.000Z')
+    expect(stats.repositories).toEqual([expect.objectContaining({ repository: task.repository, runs: 1 })])
     expect(stats.work.find(work => work._tag === 'Review')).toEqual(expect.objectContaining({ runs: 1 }))
   })
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Repository names need a visual cue, and Recent runs offered no way to inspect their results.
Owner avatars now accompany full repository paths, and runs open their evidence, candidates, and recorded activity.
Stats also shows runs and outcomes per repository for the selected dates.

![Repository identity and results](https://github.com/user-attachments/assets/228bc3d1-96f8-413c-b65e-37b81da3b9b8)

<!-- Agents: replace NAME and URL with your own. Humans: delete this line. -->

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
