### PR TITLE
fix(github-agent): read base CI from the last commit that ran it

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -9,7 +9,7 @@ import { approvalLabels } from './approval-labels.ts'
 import { hasAutoMergeLabel } from './auto-merge.ts'
 import { isControllerOwned, pullRequestPurpose } from './baseline-repair-state.ts'
 import { createAuthenticatedClient } from './github-auth.ts'
-import { currentBaseSha } from './github-base.ts'
+import { currentBaseChecks, currentBaseSha } from './github-base.ts'
 import { AUTOMATED_ISSUE_TRIAGE_MARKER } from './issue-triage-comment.ts'
 import { err, ok } from './result.ts'
 import { AUTOMATED_REVIEW_MARKER, automatedReviewHead, priorAutomatedReviewForHead } from './review-comment.ts'
@@ -886,9 +886,12 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
           })
           .catch((error: unknown): RequiredChecks => ({ _tag: 'Unavailable', reason: message(error) }))
         const liveBaseSha = await currentBaseSha(octokit.value, owner, repo, pull.data.base.ref, signal)
+        const baseCommits = (sha: string, count: number): Promise<string[]> => octokit.value.rest.repos
+          .listCommits({ owner, repo, sha, per_page: count, request: { signal } })
+          .then(response => response.data.map(commit => commit.sha))
         const [checks, baseChecks, requiredChecks] = await Promise.all([
           checksFor(pull.data.head.sha),
-          checksFor(liveBaseSha),
+          currentBaseChecks(liveBaseSha, checksFor, baseCommits),
           requiredChecksFor(pull.data.base.ref),
         ])
         return ok({

--- a/packages/harlan-github-agent/src/github-base.ts
+++ b/packages/harlan-github-agent/src/github-base.ts
@@ -21,7 +21,9 @@ export async function currentBaseSha(
  * How many base branch commits the CI read walks back from the branch head.
  *
  * A run of docs-only merges is a few commits long. Ten covers that, and it
- * bounds the API cost on a repository that runs no CI at all.
+ * bounds the API cost on a repository that runs no CI at all. The commit
+ * listing includes the base head itself, so the read requests one extra
+ * commit to examine ten ancestors.
  */
 export const BASE_CHECKS_HISTORY = 10
 
@@ -46,7 +48,7 @@ export async function currentBaseChecks<Checks extends { _tag: 'Available', chec
   const head = await checksFor(headSha)
   if (head._tag !== 'Available' || head.checks.length > 0)
     return head
-  const earlier = (await commits(headSha, BASE_CHECKS_HISTORY)).filter(sha => sha !== headSha)
+  const earlier = (await commits(headSha, BASE_CHECKS_HISTORY + 1)).filter(sha => sha !== headSha)
   for (const sha of earlier) {
     const checks = await checksFor(sha)
     if (checks._tag !== 'Available' || checks.checks.length > 0)

--- a/packages/harlan-github-agent/src/github-base.ts
+++ b/packages/harlan-github-agent/src/github-base.ts
@@ -16,3 +16,41 @@ export async function currentBaseSha(
   })
   return response.data.commit.sha
 }
+
+/**
+ * How many base branch commits the CI read walks back from the branch head.
+ *
+ * A run of docs-only merges is a few commits long. Ten covers that, and it
+ * bounds the API cost on a repository that runs no CI at all.
+ */
+export const BASE_CHECKS_HISTORY = 10
+
+/**
+ * Reads base branch CI from the newest commit that has a check run.
+ *
+ * A workflow with `paths-ignore` runs nothing for a docs-only commit, so a
+ * docs-only merge leaves the base head with no check run. On 2026-09-10
+ * gscdump#55 read "Base branch CI is unavailable" for that reason, with no
+ * future CI result able to resolve it. A commit that ran no CI changed no
+ * tested file, so the last CI verdict on the branch still describes it.
+ *
+ * `commits` lists the branch from its head, newest first. The read stops at
+ * the first commit with a check run, and returns the head snapshot unchanged
+ * when it is unreadable or when nothing in the window ran CI.
+ */
+export async function currentBaseChecks<Checks extends { _tag: 'Available', checks: unknown[] } | { _tag: 'Unavailable' }>(
+  headSha: string,
+  checksFor: (sha: string) => Promise<Checks>,
+  commits: (headSha: string, count: number) => Promise<string[]>,
+): Promise<Checks> {
+  const head = await checksFor(headSha)
+  if (head._tag !== 'Available' || head.checks.length > 0)
+    return head
+  const earlier = (await commits(headSha, BASE_CHECKS_HISTORY)).filter(sha => sha !== headSha)
+  for (const sha of earlier) {
+    const checks = await checksFor(sha)
+    if (checks._tag !== 'Available' || checks.checks.length > 0)
+      return checks
+  }
+  return head
+}

--- a/packages/harlan-github-agent/src/item-agent.ts
+++ b/packages/harlan-github-agent/src/item-agent.ts
@@ -502,7 +502,7 @@ function checksGate(
     return {
       state: { _tag: 'Pending', reason: base ? 'Base branch CI is unavailable.' : 'Required CI is unavailable.', evidence: checkEvidence },
       reported: [],
-      cause: { _tag: 'NoCheckRun', detail: base ? 'GitHub reported no check run for the base commit.' : 'GitHub reported no check run for the head commit.' },
+      cause: { _tag: 'NoCheckRun', detail: base ? 'GitHub reported no check run for the base commit or the ten commits before it.' : 'GitHub reported no check run for the head commit.' },
     }
   }
   const failed = checks.checks.find(checkFailed)

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -108,6 +108,7 @@ describe('live pull request base', () => {
             checkedRefs.push(input.ref)
             return Promise.resolve({ data: { statuses: [] } })
           },
+          listCommits: () => Promise.resolve({ data: [{ sha: liveBaseSha }] }),
         },
       },
     } as unknown as Octokit
@@ -381,5 +382,108 @@ describe('live pull request base', () => {
         checks: [expect.objectContaining({ name: 'test', status: 'completed', conclusion: 'success' })],
       },
     })))
+  })
+})
+
+describe('base checks behind a commit that ran no CI', () => {
+  const docsOnlyBaseSha = 'd'.repeat(40)
+  const lastCodeBaseSha = 'e'.repeat(40)
+
+  function clientReadingHistory(checksBySha: Record<string, unknown[]>, checkedRefs: string[]) {
+    const listForRef = () => undefined
+    const listCommits = () => undefined
+    return {
+      paginate: (method: unknown, input: { ref?: string, sha?: string }) => {
+        if (method === listForRef && input.ref !== undefined) {
+          checkedRefs.push(input.ref)
+          return Promise.resolve(checksBySha[input.ref] ?? [])
+        }
+        if (method === listCommits)
+          return Promise.reject(new Error('Unexpected paginated commit listing.'))
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo: () => undefined },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: docsOnlyBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+          listCommits: (input: { sha: string, per_page: number }) => {
+            expect(input.sha).toBe(docsOnlyBaseSha)
+            return Promise.resolve({ data: [{ sha: docsOnlyBaseSha }, { sha: lastCodeBaseSha }, { sha: historicBaseSha }] })
+          },
+        },
+      },
+    } as unknown as Octokit
+  }
+
+  it('reads the newest base commit that has a check run when the head ran none', async () => {
+    // gscdump#55 on 2026-09-10: a docs-only merge became the main head, the
+    // test workflow ignores Markdown, and the CI gate reported "Base branch CI
+    // is unavailable" with nothing left to wait for.
+    const checkedRefs: string[] = []
+    const client = clientReadingHistory({
+      [lastCodeBaseSha]: [{ id: 2, name: 'test', status: 'completed', conclusion: 'success', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } }],
+    }, checkedRefs)
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'test', conclusion: 'success' })],
+      },
+      pullRequest: expect.objectContaining({ baseSha: docsOnlyBaseSha }),
+    })))
+    expect(checkedRefs).toEqual([headSha, docsOnlyBaseSha, lastCodeBaseSha])
+  })
+
+  it('keeps a red earlier base commit red', async () => {
+    const client = clientReadingHistory({
+      [lastCodeBaseSha]: [{ id: 2, name: 'test', status: 'completed', conclusion: 'failure', app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 8 } }],
+    }, [])
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'test', conclusion: 'failure' })],
+      },
+    })))
+  })
+
+  it('reports no base check run when no listed commit has one', async () => {
+    const checkedRefs: string[] = []
+    const client = clientReadingHistory({}, checkedRefs)
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: { _tag: 'Available', checks: [] },
+    })))
+    expect(checkedRefs).toEqual([headSha, docsOnlyBaseSha, lastCodeBaseSha, historicBaseSha])
   })
 })

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -389,7 +389,7 @@ describe('base checks behind a commit that ran no CI', () => {
   const docsOnlyBaseSha = 'd'.repeat(40)
   const lastCodeBaseSha = 'e'.repeat(40)
 
-  function clientReadingHistory(checksBySha: Record<string, unknown[]>, checkedRefs: string[]) {
+  function clientReadingHistory(checksBySha: Record<string, unknown[]>, checkedRefs: string[], history: string[] = [docsOnlyBaseSha, lastCodeBaseSha, historicBaseSha]) {
     const listForRef = () => undefined
     const listCommits = () => undefined
     return {
@@ -417,7 +417,7 @@ describe('base checks behind a commit that ran no CI', () => {
           getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
           listCommits: (input: { sha: string, per_page: number }) => {
             expect(input.sha).toBe(docsOnlyBaseSha)
-            return Promise.resolve({ data: [{ sha: docsOnlyBaseSha }, { sha: lastCodeBaseSha }, { sha: historicBaseSha }] })
+            return Promise.resolve({ data: history.slice(0, input.per_page).map(sha => ({ sha })) })
           },
         },
       },
@@ -472,7 +472,8 @@ describe('base checks behind a commit that ran no CI', () => {
 
   it('reports no base check run when no listed commit has one', async () => {
     const checkedRefs: string[] = []
-    const client = clientReadingHistory({}, checkedRefs)
+    const ancestors = Array.from({ length: 10 }, (_, index) => String(index + 1).padStart(2, '0').repeat(20))
+    const client = clientReadingHistory({}, checkedRefs, [docsOnlyBaseSha, ...ancestors])
     const source = createGitHubAgentSource({
       actorLogin: () => 'harlan-github-agent[bot]',
       createClient: () => client,
@@ -484,6 +485,7 @@ describe('base checks behind a commit that ran no CI', () => {
     expect(result).toEqual(ok(expect.objectContaining({
       baseChecks: { _tag: 'Available', checks: [] },
     })))
-    expect(checkedRefs).toEqual([headSha, docsOnlyBaseSha, lastCodeBaseSha, historicBaseSha])
+    expect(checkedRefs).toEqual([headSha, docsOnlyBaseSha, ...ancestors])
+    expect(checkedRefs).toContain(ancestors[9])
   })
 })

--- a/packages/harlan-github-agent/test/review-snapshot-approval-labels.test.ts
+++ b/packages/harlan-github-agent/test/review-snapshot-approval-labels.test.ts
@@ -40,6 +40,7 @@ function client(labels: string[]): Octokit {
         getBranch: () => Promise.resolve({ data: { commit: { sha: baseSha } } }),
         getBranchRules: () => Promise.resolve({ data: [] }),
         getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        listCommits: () => Promise.resolve({ data: [{ sha: baseSha }] }),
       },
     },
   } as unknown as Octokit


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

harlan-zw/gscdump#55 sat at PENDING for hours today with this line:

```
CI gate: PENDING. Base branch CI is unavailable.
```

The PR's own CI was green. The main head was a docs-only merge, and the gscdump test workflow uses `paths-ignore` for Markdown, so that commit never ran CI. The gate read check runs for the live base SHA alone, found none, and had no future CI result to wait for. Every docs-only merge does this to every open PR in the repo until a code commit lands.

The base read now walks back up to ten commits on the base branch and uses the newest one that has a check run. A commit that ran no CI changed no tested file, so the last verdict still describes it. A red earlier commit stays red, and a running one stays pending.

Ten is a guess. A repository with no CI at all now pays ten extra check reads per snapshot, which I think is fine, but say if you want the window smaller.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01RbiqeDw6Ygebx5ohYgJmFS