### PR TITLE
fix(agent-context): run dev-browser headless without a display

### DIFF
--- a/agent-context/context.md
+++ b/agent-context/context.md
@@ -45,7 +45,7 @@ Never publish under my name without approval. Draft it, show the exact text, wai
 
 - Find and search files: ripgrep (`rg`).
 - Rename, move, or import update spanning 2+ files: `pnpm dlx @ripast/cli`. AST-aware across TS/JS/Vue SFCs; dry-run by default, `--apply` to write.
-- Browser testing and automation: `dev-browser` (`--help`).
+- Browser testing and automation: `dev-browser` (`--help`). If `$DISPLAY` is empty, pass `--headless`; a headed launch exits with "launched a headed browser without having a XServer".
 - Give each task its own `dev-browser` name. Close every named page when browser work ends. Never run `dev-browser stop`; it stops shared browsers.
 
 ## Worktrees


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

Agents on Hogwild have no `$DISPLAY`, and `dev-browser` launches Chromium headed by default. Every first screenshot attempt there died with:

```
Looks like you launched a headed browser without having a XServer running.
Set either 'headless: true' or use 'xvfb-run <your-playwright-app>' before running Playwright.
```

The opencode history on Hogwild shows it in 44 sessions since 5 Sep. Each one tried `xvfb-run` first, and 42 eventually found `--headless`, so the cost is a wasted turn or two per session rather than a lost task. This names the flag in the tools note so agents pass it when the display is empty.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012PsTeooG9PHkxZjBtKp33D