### PR TITLE
feat(agent-context): sync the site inventory to Hogwild

### DIFF
--- a/agent-context/context.md
+++ b/agent-context/context.md
@@ -46,6 +46,7 @@ Never publish under my name without approval. Draft it, show the exact text, wai
 - Find and search files: ripgrep (`rg`).
 - Rename, move, or import update spanning 2+ files: `pnpm dlx @ripast/cli`. AST-aware across TS/JS/Vue SFCs; dry-run by default, `--apply` to write.
 - Browser testing and automation: `dev-browser` (`--help`). If `$DISPLAY` is empty, pass `--headless`; a headed launch exits with "launched a headed browser without having a XServer".
+- Wait for CI with `gh run watch <run-id>` or `gh pr checks <number> --watch`. Never poll with `sleep`; the shell tool times out first.
 - Give each task its own `dev-browser` name. Close every named page when browser work ends. Never run `dev-browser stop`; it stops shared browsers.
 
 ## Worktrees

--- a/scripts/sync-agent-context.sh
+++ b/scripts/sync-agent-context.sh
@@ -22,6 +22,10 @@ installed_hook_files=()
 hooks_install_suffix='.local/share/harlan-agent-kit/hooks'
 manifest_install_suffix='.local/share/harlan-agent-kit/.claude-plugin/plugin.json'
 plugin_install_suffix='.config/opencode/plugins/harlan-hooks.ts'
+# The site inventory the sentry-checkin skill reads first. The desktop owns it;
+# a worker on Hogwild starts without one and every routine run reports that.
+sites_inventory="${HARLAN_AGENT_CONTEXT_SITES_FILE:-$HOME/sites/SITES.md}"
+sites_install_suffix='sites/SITES.md'
 target_home="${HARLAN_AGENT_CONTEXT_HOME:-$HOME}"
 hogwild_host="${HARLAN_AGENT_CONTEXT_HOGWILD_HOST:-hogwild}"
 hogwild_home="${HARLAN_AGENT_CONTEXT_HOGWILD_HOME:-/home/harlan}"
@@ -114,6 +118,10 @@ sync_local() {
   done
   install -m 644 "$plugin_manifest" "$target_home/$manifest_install_suffix"
   install -m 644 "$opencode_plugin" "$target_home/$plugin_install_suffix"
+  if [ -f "$sites_inventory" ] && [ "$sites_inventory" != "$target_home/$sites_install_suffix" ]; then
+    mkdir -p "$target_home/$(dirname "$sites_install_suffix")"
+    install -m 644 "$sites_inventory" "$target_home/$sites_install_suffix"
+  fi
   printf '%s\n' 'Synced local Agent instructions.'
 }
 
@@ -212,6 +220,33 @@ sync_hogwild() {
   ssh -o BatchMode=yes "$hogwild_host" \
     "chmod 644 '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.codex/AGENTS.md.next' && mv '$hogwild_home/.claude/CLAUDE.md.next' '$hogwild_home/.claude/CLAUDE.md' && mv '$hogwild_home/.codex/AGENTS.md.next' '$hogwild_home/.codex/AGENTS.md' && chmod 755 '$hogwild_home/.config/git/hooks/commit-msg.next' && mv '$hogwild_home/.config/git/hooks/commit-msg.next' '$hogwild_home/.config/git/hooks/commit-msg'$activation && git config --global core.hooksPath '$hogwild_home/.config/git/hooks'"
   printf '%s\n' 'Synced Hogwild Agent instructions.'
+}
+
+# The site inventory goes the same way as the instructions: stage, verify the
+# digest, then one mv. A missing inventory is reported, never invented.
+sync_hogwild_sites() {
+  local local_hash remote_hash target
+  validate_hogwild
+  if [ ! -f "$sites_inventory" ]; then
+    printf 'No site inventory at %s. Hogwild keeps its current one.\n' "$sites_inventory"
+    return 0
+  fi
+  target="$hogwild_home/$sites_install_suffix"
+  local_hash=$(sha256sum "$sites_inventory" | cut -d' ' -f1)
+  ssh -n -o BatchMode=yes "$hogwild_host" "mkdir -p '$(dirname "$target")'" \
+    || fail 'Hogwild did not accept the site inventory directory.'
+  if ! scp "$sites_inventory" "$hogwild_host:$target.next"; then
+    ssh -n -o BatchMode=yes "$hogwild_host" "rm -f '$target.next'" >/dev/null 2>&1 || true
+    fail 'Hogwild did not receive the site inventory.'
+  fi
+  remote_hash=$(ssh -n -o BatchMode=yes "$hogwild_host" "sha256sum '$target.next'" | cut -d' ' -f1)
+  if [ "$local_hash" != "$remote_hash" ]; then
+    ssh -n -o BatchMode=yes "$hogwild_host" "rm -f '$target.next'" >/dev/null 2>&1 || true
+    fail 'Hogwild received a different site inventory.'
+  fi
+  ssh -n -o BatchMode=yes "$hogwild_host" "chmod 644 '$target.next' && mv '$target.next' '$target'" \
+    || fail 'Hogwild did not activate the site inventory.'
+  printf '%s\n' 'Synced Hogwild site inventory.'
 }
 
 # ---------------------------------------------------------------------------
@@ -336,12 +371,14 @@ case "${1:-local}" in
     ;;
   hogwild)
     sync_hogwild
+    sync_hogwild_sites
     sync_hogwild_memory
     ;;
   all)
     sync_local
     sync_local_memory
     sync_hogwild
+    sync_hogwild_sites
     sync_hogwild_memory
     ;;
   *)

--- a/scripts/sync-agent-context.test.sh
+++ b/scripts/sync-agent-context.test.sh
@@ -26,11 +26,18 @@ printf '%s\n' '- [Worktree](worktree.md)' > "$memory_root/$worktree_slug/memory/
 printf '%s\n' '- [Unrelated](unrelated.md)' > "$memory_root/-unrelated/memory/MEMORY.md"
 export HARLAN_AGENT_CONTEXT_MEMORY_ROOT="$memory_root"
 export HARLAN_AGENT_CONTEXT_CHECKOUT_ROOTS="$checkout_root"
+# The site inventory fixture stands in for ~/sites/SITES.md on the desktop.
+sites_fixture="$test_root/desktop-sites/SITES.md"
+mkdir -p "$(dirname "$sites_fixture")"
+printf '%s\n' '# Sites' '- example.com' > "$sites_fixture"
+export HARLAN_AGENT_CONTEXT_SITES_FILE="$sites_fixture"
 
 HARLAN_AGENT_CONTEXT_HOME="$test_home" bash "$script_dir/sync-agent-context.sh" local >/dev/null
 
 cmp "$memory_root/$primary_slug/memory/MEMORY.md" "$test_home/.claude/projects/$primary_slug/memory/MEMORY.md"
 cmp "$memory_root/$primary_slug/memory/deployment.md" "$test_home/.claude/projects/$primary_slug/memory/deployment.md"
+cmp "$sites_fixture" "$test_home/sites/SITES.md"
+test "$(stat -c %a "$test_home/sites/SITES.md")" = 644
 if [ -e "$test_home/.claude/projects/$worktree_slug" ]; then
   printf '%s\n' 'The sync copied memory for a wt worktree sibling.' >&2
   exit 1
@@ -95,6 +102,7 @@ export HARLAN_AGENT_CONTEXT_TEST_CALLS="$calls"
 export HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH="$claude_hash"
 export HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH="$codex_hash"
 export HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH="$hook_hash"
+export HARLAN_AGENT_CONTEXT_TEST_SITES_HASH="$(/usr/bin/sha256sum "$sites_fixture" | cut -d' ' -f1)"
 
 cat > "$test_root/bin/ssh" <<'FAKE_SSH'
 #!/usr/bin/env bash
@@ -107,6 +115,7 @@ if [[ "$1" != '-n' && ( "$*" == *"tar -C"* || "$*" == *"/memory'"* ) ]]; then ca
 if [[ "$*" == *CLAUDE.md.next*sha256sum* || "$*" == *sha256sum*CLAUDE.md.next* ]]; then printf '%s  CLAUDE.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CLAUDE_HASH"; fi
 if [[ "$*" == *AGENTS.md.next*sha256sum* || "$*" == *sha256sum*AGENTS.md.next* ]]; then printf '%s  AGENTS.md.next\n' "$HARLAN_AGENT_CONTEXT_TEST_CODEX_HASH"; fi
 if [[ "$*" == *commit-msg.next*sha256sum* || "$*" == *sha256sum*commit-msg.next* ]]; then printf '%s  commit-msg.next\n' "$HARLAN_AGENT_CONTEXT_TEST_HOOK_HASH"; fi
+if [[ "$*" == *sha256sum*SITES.md.next* ]]; then printf '%s  SITES.md.next\n' "${HARLAN_AGENT_CONTEXT_TEST_SITES_HASH:-different}"; fi
 # The opencode files are verified in one batched sha256sum, so answer per path.
 if [[ "$*" == *"sha256sum "* && "$*" == *harlan-hooks.ts.next* ]]; then
   for token in $*; do
@@ -141,6 +150,8 @@ grep -F 'hogwild:/home/harlan/.codex/AGENTS.md.next' "$calls" >/dev/null
 grep -F "mv '/home/harlan/.claude/CLAUDE.md.next' '/home/harlan/.claude/CLAUDE.md'" "$calls" >/dev/null
 grep -F "mv '/home/harlan/.codex/AGENTS.md.next' '/home/harlan/.codex/AGENTS.md'" "$calls" >/dev/null
 grep -F 'hogwild:/home/harlan/.config/git/hooks/commit-msg.next' "$calls" >/dev/null
+grep -F 'hogwild:/home/harlan/sites/SITES.md.next' "$calls" >/dev/null
+grep -F "mv '/home/harlan/sites/SITES.md.next' '/home/harlan/sites/SITES.md'" "$calls" >/dev/null
 grep -F "mv '/home/harlan/.config/git/hooks/commit-msg.next' '/home/harlan/.config/git/hooks/commit-msg'" "$calls" >/dev/null
 grep -F "core.hooksPath '/home/harlan/.config/git/hooks'" "$calls" >/dev/null
 for hook_file in "${opencode_hooks[@]}"; do


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement

### 📚 Description

Every sentry-checkin run on Hogwild starts with the same dead end, 22 sessions in three weeks:

```
SITES_FILE=unset
ls: cannot access '/home/harlan/SITES.md': No such file or directory
ls: cannot access '/home/harlan/sites/SITES.md': No such file or directory
```

The desktop owns `~/sites/SITES.md`, so it now travels with the instructions and project memory: stage, verify the digest, one `mv`, same as `CLAUDE.md`. A missing inventory is reported and skipped, never invented. `HARLAN_AGENT_CONTEXT_SITES_FILE` overrides the source for tests.

Also adds one line to the tools note: wait for CI with `gh run watch` or `gh pr checks --watch`, never `sleep`. 57 sessions blew the shell tool timeout on `sleep N; gh run list`, rising every day this week.

Not sure whether `scheduled-routine.md` in the sentry skill still wants its "a separate SITES.md is unnecessary" line. Left it alone.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012PsTeooG9PHkxZjBtKp33D