### PR TITLE
fix(github-agent): stop resolving a conflict that returns every turn

### DIFF
--- a/packages/harlan-github-agent/src/store.ts
+++ b/packages/harlan-github-agent/src/store.ts
@@ -3786,17 +3786,47 @@ function planConflictResolution(
     return
   resolveCleanMergeIncidents(database, subjectId, observedAt)
 
-  const state: TaskState = ready
-    ? { _tag: 'Queued' }
-    : { _tag: 'ActionRequired', reason: 'The controller cannot write this pull request branch.' }
+  // A pull request that conflicts again after every resolution is stale, not
+  // unlucky. Each published merge commit is a new head, so a new Revision and
+  // a fresh recovery budget: nuxtseo.com#725 took 148 turns in two days and
+  // melbjs-clone#98 sixteen in three hours that way. Count the day's finished
+  // turns across Revisions. A task superseded before it started never ran, so
+  // a person pushing five times in a day spends nothing here.
+  const finishedTurns = countFinishedConflictTurns(database, subjectId, revisionId, observedAt)
+  const stale = finishedTurns >= MAXIMUM_RECOVERY_ATTEMPTS
+  const state: TaskState = !ready
+    ? { _tag: 'ActionRequired', reason: 'The controller cannot write this pull request branch.' }
+    : stale
+      ? { _tag: 'ActionRequired', reason: `The controller resolved this conflict ${finishedTurns} times in one day and the pull request conflicts again. Rebase it by hand.` }
+      : { _tag: 'Queued' }
   const taskId = digest(`${mapping.github}:pull_request:${subject.number}:${revisionId}:resolve_conflict`)
   const reason = state._tag === 'ActionRequired' ? state.reason : null
+  // A stale task starts with its budget spent, so the approval path above
+  // never wakes it. Only a new head commit makes a new task.
+  const recoveryAttempts = stale ? MAXIMUM_RECOVERY_ATTEMPTS : 0
 
   database.prepare(`
-    INSERT INTO tasks (id, subject_id, revision_id, kind, state_tag, reason, updated_at)
-    VALUES (?, ?, ?, 'resolve_conflict', ?, ?, ?)
-  `).run(taskId, subjectId, revisionId, state._tag, reason, observedAt)
+    INSERT INTO tasks (id, subject_id, revision_id, kind, state_tag, reason, updated_at, recovery_attempts)
+    VALUES (?, ?, ?, 'resolve_conflict', ?, ?, ?, ?)
+  `).run(taskId, subjectId, revisionId, state._tag, reason, observedAt, recoveryAttempts)
   recordTransition(database, { taskId, from: null, to: state._tag, reason, fence: 0, at: observedAt })
+}
+
+const STALE_CONFLICT_WINDOW_MS = 24 * 60 * 60 * 1000
+
+/**
+ * How many conflict resolutions for this subject ran to an end in the last
+ * day, on other Revisions. Completed counts. Superseded counts only when the
+ * turn had started, because a task retired while still Queued cost nothing.
+ */
+function countFinishedConflictTurns(database: DatabaseSync, subjectId: number, revisionId: string, observedAt: string): number {
+  const windowStart = new Date(Date.parse(observedAt) - STALE_CONFLICT_WINDOW_MS).toISOString()
+  const rows = database.prepare(`
+    SELECT id, state_tag FROM tasks
+    WHERE subject_id = ? AND kind = 'resolve_conflict' AND revision_id != ?
+      AND state_tag IN ('Completed', 'Superseded') AND updated_at >= ?
+  `).all(subjectId, revisionId, windowStart) as Array<{ id: string, state_tag: 'Completed' | 'Superseded' }>
+  return rows.filter(row => row.state_tag === 'Completed' || supersededAfterStarting(database, row.id)).length
 }
 
 /**

--- a/packages/harlan-github-agent/test/store.test.ts
+++ b/packages/harlan-github-agent/test/store.test.ts
@@ -990,6 +990,41 @@ describe('journal store', () => {
     expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
   })
 
+  it('stops requeueing a pull request that conflicts again after every resolution', () => {
+    const store = createStore()
+    store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')
+    let elapsed = 0
+    const at = (): string => new Date(Date.parse('2026-08-13T01:00:00.000Z') + (elapsed += 1000)).toISOString()
+    // Every resolution publishes a merge commit, so the next poll sees a new
+    // head that GitHub still reports as conflicting. Each head is a new
+    // Revision with a fresh recovery budget, which is how one pull request
+    // took 148 turns in two days.
+    const observeConflict = (round: number): void => {
+      store.recordObservation({ externalId: `stale-${round}`, observedAt: at(), source: 'poll', subject: pullRequestItem({ mergeState: 'conflicting', headSha: `head-${round}` }) })
+    }
+    const resolveOnce = (): void => {
+      const task = store.claimNextConflictTask('worker-1', at(), 600_000)
+      if (task === null)
+        throw new Error('Expected a running conflict task.')
+      expect(store.completeTask({ taskId: task.id, workerId: 'worker-1', fence: task.state.fence, at: at(), evidence: 'merged' })).toBe(true)
+    }
+    for (let round = 0; round < MAXIMUM_RECOVERY_ATTEMPTS; round += 1) {
+      observeConflict(round)
+      resolveOnce()
+    }
+
+    observeConflict(MAXIMUM_RECOVERY_ATTEMPTS)
+
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
+    expect(store.getDashboardSnapshot(at()).queue[0]?.state).toEqual({
+      _tag: 'ActionRequired',
+      reason: 'The controller resolved this conflict 5 times in one day and the pull request conflicts again. Rebase it by hand.',
+    })
+    // The same head polled again must not wake it.
+    store.recordObservation({ externalId: `stale-${MAXIMUM_RECOVERY_ATTEMPTS}`, observedAt: at(), source: 'poll', subject: pullRequestItem({ mergeState: 'conflicting', headSha: `head-${MAXIMUM_RECOVERY_ATTEMPTS}` }) })
+    expect(store.claimNextConflictTask('worker-1', at(), 600_000)).toBeNull()
+  })
+
   it('does not requeue a conflict whose base merges cleanly until the head or the base changes', () => {
     const store = createStore()
     store.syncRepositories([repositoryMapping()], '2026-08-13T00:00:00.000Z')


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

The base-race cap from #158 stops a task that keeps losing publication. This is the other loop: the resolution publishes, the merge commit is a new head, GitHub reports the new head conflicting too, and the new Revision arrives with a fresh recovery budget. From the agent's own state on Hogwild:

```
nuxtseo.com#725   148 tasks, 148 revisions, 2 days
melbjs-clone#98    16 tasks,  16 revisions, 3 hours
melbjs-clone#99    15 tasks,  15 revisions
melbjs-clone#100   14 tasks,  14 revisions
```

Every one of them ended `Superseded: A newer pull request Revision replaced this conflict resolution.` and 82 opencode sessions burned 3.85M input tokens on 9 Sep alone.

A new conflict task now counts the finished turns on other Revisions of the same pull request in the last day. At the recovery cap it is created `ActionRequired` with its budget already spent, so only a new head commit after the window makes the controller try again. A task superseded before it started does not count, so a person pushing five times in a day costs nothing.

Not sure 24 hours is the right window. It fits both incidents; a busy repo with a genuinely re-conflicting PR would wait a day between attempts, which seems fine.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_012PsTeooG9PHkxZjBtKp33D