### PR TITLE
feat(github-agent): expose signed webhook updates

### DIFF
--- a/packages/harlan-github-agent/README.md
+++ b/packages/harlan-github-agent/README.md
@@ -159,15 +159,18 @@ const client = createControlClient({
 
 ## Webhooks
 
-Set `webhook.enabled` to start a second listener on its own port. It carries one route, `POST /webhook`, and nothing else. Keep the dashboard port on loopback: it can pause agents, approve pull requests, cancel tasks, and eject sessions, so it must never be exposed.
+Set `webhook.enabled` to start the separate listener on port 3211.
+The public route exposes only `POST /webhook` through Caddy.
+Dashboard routes retain their password and Origin checks.
+Follow the [public route setup](../../scripts/public-dashboard.md#github-webhooks) to configure the listener and GitHub App subscriptions.
 
-Point a tunnel at the webhook port alone, then set that URL and a shared secret on the GitHub App. Write the same secret to `webhook.secret_path` with mode `0600` and at least 32 characters.
+Deliveries request a fresh GitHub read. Their bodies never authorize actions or replace GitHub state.
+Signatures authenticate requests. Delivery identities suppress duplicates for one hour, up to 10,000 identities.
+The cache clears on restart. Polling recovers missed deliveries.
 
-A delivery is a hint, never a payload. It says "read this repository again", and the service answers by running the reconciliation pass it already runs on a timer. The delivery body is never stored and never trusted beyond the repository name, so a missed, duplicated, or forged delivery cannot move the journal anywhere a poll would not.
-
-Deliveries within three seconds of each other cost one pass, so a busy repository cannot spend the rate limit this feature exists to save.
-
-Keep polling on. It is the safety net for a delivery GitHub never sent.
+Deliveries within three seconds share one read.
+Deliveries during that read schedule at most one follow-up read.
+Keep polling enabled for recovery.
 
 GitHub is the durable Review workflow record. The newest confirmed canonical comment state wins across Review and gate updates. Before finalizing `CLOSED`, the service reads the exact pull request. It then publishes `MERGED` or `CLOSED`, clears Agent labels, and stores completion for restart Recovery.
 

--- a/packages/harlan-github-agent/src/webhook.ts
+++ b/packages/harlan-github-agent/src/webhook.ts
@@ -91,25 +91,40 @@ export interface ReconcileHintOptions {
  */
 export function createReconcileHint(options: ReconcileHintOptions): ReconcileHint {
   const delayMilliseconds = options.delayMilliseconds ?? 3_000
-  let timer: NodeJS.Timeout | undefined
+  let state:
+    | { _tag: 'Idle' }
+    | { _tag: 'Scheduled', timer: NodeJS.Timeout }
+    | { _tag: 'Running', pending: boolean }
+    | { _tag: 'Stopped' } = { _tag: 'Idle' }
   let active: Promise<void> = Promise.resolve()
-  let stopped = false
+
+  const schedule = (): void => {
+    const timer = setTimeout(() => {
+      state = { _tag: 'Running', pending: false }
+      active = Promise.resolve().then(options.run).catch(options.onError).finally(() => {
+        if (state._tag !== 'Running')
+          return
+        const pending = state.pending
+        state = { _tag: 'Idle' }
+        if (pending)
+          schedule()
+      })
+    }, delayMilliseconds)
+    timer.unref()
+    state = { _tag: 'Scheduled', timer }
+  }
 
   return {
     hint: () => {
-      if (stopped || timer !== undefined)
-        return
-      timer = setTimeout(() => {
-        timer = undefined
-        active = active.then(options.run).catch(options.onError)
-      }, delayMilliseconds)
-      timer.unref()
+      if (state._tag === 'Idle')
+        schedule()
+      else if (state._tag === 'Running')
+        state.pending = true
     },
     stop: async () => {
-      stopped = true
-      if (timer !== undefined)
-        clearTimeout(timer)
-      timer = undefined
+      if (state._tag === 'Scheduled')
+        clearTimeout(state.timer)
+      state = { _tag: 'Stopped' }
       await active
     },
   }
@@ -120,6 +135,7 @@ export interface WebhookAppOptions {
   logger: { info: (message: string) => void }
   onHint: (repository: string) => void
   secret: string
+  now?: () => number
 }
 
 /**
@@ -131,6 +147,10 @@ export interface WebhookAppOptions {
  */
 export function createWebhookApp(options: WebhookAppOptions): H3 {
   const app = new H3()
+  const deliveries = new Map<string, number>()
+  const now = options.now ?? Date.now
+  const retentionMilliseconds = 60 * 60_000
+  const maximumDeliveries = 10_000
 
   app.get('/health', () => Response.json({ status: 'ok' }))
 
@@ -140,6 +160,19 @@ export function createWebhookApp(options: WebhookAppOptions): H3 {
       // Never say which part failed. A precise answer is a probing oracle.
       return new Response('Signature mismatch.', { status: 401 })
     }
+
+    const delivery = event.req.headers.get('x-github-delivery')
+    if (delivery === null || delivery.trim() === '' || delivery.length > 128)
+      return new Response('Delivery identity is missing or invalid.', { status: 400 })
+
+    const at = now()
+    for (const [id, expiresAt] of deliveries) {
+      if (expiresAt > at)
+        break
+      deliveries.delete(id)
+    }
+    if (deliveries.has(delivery))
+      return new Response(null, { status: 204 })
 
     const name = event.req.headers.get('x-github-event') ?? ''
     let payload: unknown
@@ -155,8 +188,14 @@ export function createWebhookApp(options: WebhookAppOptions): H3 {
       options.logger.info(`Webhook: ${name} on ${hint.repository}.`)
       options.onHint(hint.repository)
     }
-    // Always 204. GitHub retries a failure, and a delivery this service chose
-    // to ignore is not a failure it should send again.
+    // Record only accepted deliveries. Polling recovers work after a restart.
+    if (deliveries.size >= maximumDeliveries) {
+      const oldest = deliveries.keys().next().value
+      if (oldest !== undefined)
+        deliveries.delete(oldest)
+    }
+    deliveries.set(delivery, at + retentionMilliseconds)
+    // Acknowledge ignored events as well as scheduled reads.
     return new Response(null, { status: 204 })
   })
 

--- a/packages/harlan-github-agent/test/webhook.test.ts
+++ b/packages/harlan-github-agent/test/webhook.test.ts
@@ -1,6 +1,6 @@
 import { createHmac } from 'node:crypto'
 import { describe, expect, it, vi } from 'vitest'
-import { createReconcileHint, createWebhookApp, verifyWebhookSignature, webhookHint } from '../src/webhook.ts'
+import { createReconcileHint, createWebhookApp, verifyWebhookSignature, webhookHint } from '../src/index.ts'
 
 const secret = 'a'.repeat(40)
 
@@ -10,10 +10,11 @@ function sign(body: string, key = secret): string {
 
 function deliver(app: ReturnType<typeof createWebhookApp>, input: {
   body: string
+  delivery?: string
   event?: string
   signature?: string | null
 }): Promise<Response> {
-  const headers = new Headers({ 'content-type': 'application/json' })
+  const headers = new Headers({ 'content-type': 'application/json', 'x-github-delivery': input.delivery ?? 'delivery-1' })
   if (input.event !== undefined)
     headers.set('x-github-event', input.event)
   if (input.signature !== null && input.signature !== undefined)
@@ -218,6 +219,86 @@ describe('coalescing a burst of deliveries', () => {
       await vi.advanceTimersByTimeAsync(5_000)
 
       expect(runs).toBe(0)
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('delivery recovery', () => {
+  it('acknowledges a repeated delivery without requesting another read', async () => {
+    const hints: string[] = []
+    const app = createWebhookApp({ allowedOwners: ['harlan-zw'], logger: { info: () => undefined }, onHint: repository => hints.push(repository), secret })
+    const body = JSON.stringify({ repository: { full_name: 'harlan-zw/example' } })
+    const input = { body, event: 'check_run', signature: sign(body) }
+
+    expect((await deliver(app, input)).status).toBe(204)
+    expect((await deliver(app, input)).status).toBe(204)
+    expect(hints).toEqual(['harlan-zw/example'])
+  })
+
+  it('accepts another delivery and permits redelivery after retention expires', async () => {
+    const hints: string[] = []
+    let now = 0
+    const app = createWebhookApp({ allowedOwners: ['harlan-zw'], logger: { info: () => undefined }, onHint: repository => hints.push(repository), secret, now: () => now })
+    const body = JSON.stringify({ repository: { full_name: 'harlan-zw/example' } })
+    const input = { body, event: 'check_suite', signature: sign(body) }
+
+    await deliver(app, input)
+    await deliver(app, { ...input, delivery: 'delivery-2' })
+    now = 60 * 60_000
+    await deliver(app, input)
+    expect(hints).toEqual(['harlan-zw/example', 'harlan-zw/example', 'harlan-zw/example'])
+  })
+
+  it('does not let a rejected signature consume a delivery', async () => {
+    const hints: string[] = []
+    const app = createWebhookApp({ allowedOwners: ['harlan-zw'], logger: { info: () => undefined }, onHint: repository => hints.push(repository), secret })
+    const body = JSON.stringify({ repository: { full_name: 'harlan-zw/example' } })
+
+    expect((await deliver(app, { body, event: 'status', signature: sign(body, 'wrong') })).status).toBe(401)
+    expect((await deliver(app, { body, event: 'status', signature: sign(body) })).status).toBe(204)
+    expect(hints).toEqual(['harlan-zw/example'])
+  })
+
+  it('rejects a signed delivery without an identity', async () => {
+    const hints: string[] = []
+    const app = createWebhookApp({ allowedOwners: ['harlan-zw'], logger: { info: () => undefined }, onHint: repository => hints.push(repository), secret })
+    const body = JSON.stringify({ repository: { full_name: 'harlan-zw/example' } })
+
+    expect((await deliver(app, { body, event: 'status', delivery: '', signature: sign(body) })).status).toBe(400)
+    expect(hints).toEqual([])
+  })
+
+  it('coalesces all hints during an active read into one later read', async () => {
+    vi.useFakeTimers()
+    try {
+      let finish = () => {}
+      const blocked = new Promise<void>((resolve) => {
+        finish = resolve
+      })
+      let runs = 0
+      const coalescer = createReconcileHint({
+        delayMilliseconds: 100,
+        onError: (error) => { throw error },
+        run: async () => {
+          runs += 1
+          if (runs === 1)
+            await blocked
+        },
+      })
+      coalescer.hint()
+      await vi.advanceTimersByTimeAsync(100)
+      for (let n = 0; n < 10; n += 1) {
+        coalescer.hint()
+        await vi.advanceTimersByTimeAsync(100)
+      }
+      expect(runs).toBe(1)
+      finish()
+      await vi.advanceTimersByTimeAsync(100)
+      await coalescer.stop()
+      expect(runs).toBe(2)
     }
     finally {
       vi.useRealTimers()

--- a/scripts/30-agent.caddy
+++ b/scripts/30-agent.caddy
@@ -4,15 +4,24 @@ handle @agent {
 	@agentHttp header X-Forwarded-Proto http
 	redir @agentHttp https://agent.harlanzw.com{uri} 308
 
-	@agentForeignOrigin {
-		not method GET HEAD
-		not header Origin https://agent.harlanzw.com
+	handle /webhook {
+		request_body {
+			max_size 25MB
+		}
+		reverse_proxy 127.0.0.1:3211
 	}
-	respond @agentForeignOrigin "Request origin is not allowed." 403
 
-	reverse_proxy 127.0.0.1:3210 {
-		header_up Host hogwild.tailcad325.ts.net
-		# Translate only the exact public origin. Preserve every other value.
-		header_up Origin "^https://agent[.]harlanzw[.]com$" "https://hogwild.tailcad325.ts.net"
+	handle {
+		@agentForeignOrigin {
+			not method GET HEAD
+			not header Origin https://agent.harlanzw.com
+		}
+		respond @agentForeignOrigin "Request origin is not allowed." 403
+
+		reverse_proxy 127.0.0.1:3210 {
+			header_up Host hogwild.tailcad325.ts.net
+			# Translate only the exact public origin. Preserve every other value.
+			header_up Origin "^https://agent[.]harlanzw[.]com$" "https://hogwild.tailcad325.ts.net"
+		}
 	}
 }

--- a/scripts/public-dashboard.md
+++ b/scripts/public-dashboard.md
@@ -76,3 +76,69 @@ The Dashboard's live Hogwild metrics remain available through Tailscale only.
 Remove the `agent.harlanzw.com` DNS record.
 Remove `/etc/caddy/routes/30-agent.caddy`, validate Caddy, then reload it.
 If replacing a previous route, restore that route instead.
+
+## GitHub webhooks
+
+The same hostname accepts GitHub deliveries at `https://agent.harlanzw.com/webhook`.
+Caddy sends only that exact path to the separate listener on `127.0.0.1:3211`.
+GitHub signatures authenticate deliveries. They do not use the Dashboard password or browser Origin.
+Every other path keeps the existing Dashboard authentication and Origin checks.
+The request body limit is 25 MB.
+
+```mermaid
+flowchart LR
+    GitHub -->|Signed POST /webhook| Caddy
+    Caddy --> Listener[Signature and delivery identity checks]
+    Listener --> Queue[Coalesce deliveries]
+    Queue --> Reconcile[Read current GitHub state]
+    Poll[Recovery polling] --> Reconcile
+    Browser -->|All other paths| Dashboard[Dashboard authentication and Origin checks]
+```
+
+After this change merges, update the Service and install the Caddy route using the commands above.
+Create a secret on Hogwild without printing it:
+
+```sh
+umask 077
+if [ ! -e ~/.config/harlan-github-agent/webhook-secret ]; then
+  openssl rand -hex 32 > ~/.config/harlan-github-agent/webhook-secret
+fi
+```
+
+Generate it once. If a secret already exists, keep it.
+Add this block to `~/.config/harlan-github-agent/config.yml`:
+
+```yaml
+webhook:
+  enabled: true
+  port: 3211
+  secret_path: /home/harlan/.config/harlan-github-agent/webhook-secret
+```
+
+Use `pnpm service:hogwild:restart` to let active Agents finish before the Service restarts.
+Keep `poll_interval_seconds` unchanged until real deliveries succeed.
+
+In [GitHub App settings](https://github.com/settings/apps/harlan-github-agent), enable Active under Webhook.
+Set the URL above and the same secret. Keep SSL verification enabled.
+Under Permissions and events, subscribe to:
+
+- Check run and Check suite
+- Commit status
+- Issue comment and Issues
+- Pull request and Pull request review
+- Push
+
+Use Recent deliveries to redeliver an event. Require a 204 response and a matching `Webhook:` Service log.
+Unsigned requests to `/webhook` must return 401.
+Requests to `/webhook/` and `/api/state` must still use Dashboard protection.
+Repeat the Origin checks above after installing the route.
+
+The listener remembers up to 10,000 delivery identities for one hour.
+A restart clears that cache. Repeated reads remain safe because GitHub supplies the current state.
+Deliveries during a read schedule at most one follow-up read.
+Polling recovers deliveries missed during shutdown or connection failures.
+GitHub does not automatically redeliver failed deliveries.
+See [GitHub delivery recovery](https://docs.github.com/en/webhooks/using-webhooks/handling-failed-webhook-deliveries).
+
+To disable deliveries, clear Active in GitHub App settings and set `webhook.enabled: false`.
+Restart through the same Service command. Keep polling enabled.


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

Agent status can lag behind CI because the public hostname has no webhook route.
Expose signed deliveries on `/webhook`, suppress duplicates, and limit busy periods to one follow-up read.

![Public deliveries reach the webhook listener while Dashboard authentication stays separate](https://github.com/user-attachments/assets/d8cd41b0-866e-4a86-9124-5171bb73810f)

### 📝 Migration

Follow [the activation steps](https://github.com/harlan-zw/harlan-agent-kit/blob/main/scripts/public-dashboard.md#github-webhooks) after merge.
Install the Caddy route, enable the listener, and subscribe the GitHub App. Keep recovery polling enabled.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
