### PR TITLE
chore(release): preview commits grouped by semantic type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
           sudo install "$RUNNER_TEMP/wt" /usr/local/bin/wt
           wt --version
 
+      - name: Release preview
+        run: pnpm test:release
+
       # `pnpm check:context` stays out of this workflow. It compares installed
       # files in a home directory against tracked sources. A runner installs
       # nothing, so it reports drift that does not exist. `pnpm test:context`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "pnpm --filter harlan-github-agent build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "pnpm test:context && pnpm test:commit-hook && pnpm test:himalaya && pnpm test:opencode-hooks && pnpm test:service && pnpm --filter harlan-github-agent test:run",
+    "test": "pnpm test:release && pnpm test:context && pnpm test:commit-hook && pnpm test:himalaya && pnpm test:opencode-hooks && pnpm test:service && pnpm --filter harlan-github-agent test:run",
     "typecheck": "pnpm --filter harlan-github-agent typecheck",
     "check:context": "scripts/check-agent-context.sh",
     "sync:context": "bash scripts/sync-agent-context.sh local",
@@ -30,6 +30,7 @@
     "test:pr-skill-only": "bash harlan-agent-kit/hooks/pr-skill-only.test.sh",
     "test:wt-only": "bash harlan-agent-kit/hooks/wt-only.test.sh",
     "test:sentry-checkin": "python3 -m unittest discover -s harlan-agent-kit/skills/sentry-checkin/scripts -p 'test_*.py'",
+    "test:release": "vitest run scripts/release.test.ts",
     "release": "node --experimental-strip-types scripts/release.ts",
     "test:opencode-hooks": "vitest run harlan-agent-kit/plugins/opencode"
   },

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -1,0 +1,123 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import { afterEach, expect, it, vi } from 'vitest'
+
+// Git subprocesses need the same timeout as the Service integration tests.
+vi.setConfig({ testTimeout: 30_000 })
+
+const script = resolve('scripts/release.ts')
+const fixtures: string[] = []
+
+function fixture() {
+  const cwd = mkdtempSync(join(tmpdir(), 'release-preview-'))
+  fixtures.push(cwd)
+  const git = (...args: string[]) => execFileSync('git', ['-c', 'core.hooksPath=/dev/null', ...args], { cwd, encoding: 'utf8' }).trim()
+  git('init', '--quiet')
+  git('config', 'user.name', 'Release test')
+  git('config', 'user.email', 'release@example.com')
+  for (const dir of ['harlan-agent-kit/.claude-plugin', 'harlan-agent-kit/.codex-plugin', '.claude-plugin'])
+    mkdirSync(join(cwd, dir), { recursive: true })
+  for (const dir of ['.claude-plugin', '.codex-plugin'])
+    writeFileSync(join(cwd, 'harlan-agent-kit', dir, 'plugin.json'), JSON.stringify({ version: '1.0.0' }))
+  writeFileSync(join(cwd, '.claude-plugin/marketplace.json'), JSON.stringify({ plugins: [{ version: '1.0.0' }] }))
+  git('add', '.')
+  git('commit', '--quiet', '-m', 'chore: initial release')
+  const commit = (message: string) => git('commit', '--quiet', '--allow-empty', '-m', message)
+  const preview = (...args: string[]) => spawnSync(process.execPath, ['--experimental-strip-types', script, ...args], { cwd, encoding: 'utf8' })
+  return { cwd, git, commit, preview }
+}
+
+afterEach(() => {
+  for (const path of fixtures.splice(0))
+    rmSync(path, { recursive: true, force: true })
+})
+
+it('groups only unreleased commits and leaves the repository unchanged', () => {
+  const { git, commit, preview } = fixture()
+  git('tag', 'v1.0.0')
+  commit('feat(cli): add preview')
+  commit('fix: repair output')
+  commit('chore: update tools')
+  commit('docs: explain usage')
+  commit('Refresh examples')
+  const head = git('rev-parse', 'HEAD')
+  const result = preview('minor', '--dry-run')
+  expect(result.status).toBe(0)
+  expect(result.stdout).toContain('v1.0.0 → v1.1.0')
+  expect(result.stdout).toMatch(/feat \(1\)[\s\S]*feat\(cli\): add preview/)
+  expect(result.stdout).toMatch(/fix \(1\)[\s\S]*fix: repair output/)
+  expect(result.stdout).toMatch(/chore \(1\)[\s\S]*chore: update tools/)
+  expect(result.stdout).toMatch(/docs \(1\)[\s\S]*docs: explain usage/)
+  expect(result.stdout).toMatch(/other \(1\)[\s\S]*Refresh examples/)
+  expect(result.stdout).not.toContain('initial release')
+  expect(git('rev-parse', 'HEAD')).toBe(head)
+  expect(git('status', '--porcelain')).toBe('')
+  expect(git('tag', '--list')).toBe('v1.0.0')
+})
+
+it('puts breaking markers and footers first without duplicating commits', () => {
+  const { git, commit, preview } = fixture()
+  git('tag', 'v1.0.0')
+  commit('feat(api)!: remove old API')
+  commit('fix: change defaults\n\nBREAKING CHANGE: configure the new default')
+  commit('chore: remove option\n\nBREAKING-CHANGE: use the replacement')
+  const result = preview('major', '--dry-run')
+  expect(result.status).toBe(0)
+  expect(result.stdout).toContain('breaking change (3)')
+  expect(result.stdout).toContain('configure the new default')
+  expect(result.stdout).toContain('use the replacement')
+  expect(result.stdout.match(/remove old API/g)).toHaveLength(1)
+  expect(result.stdout).not.toContain('\nfeat (')
+  expect(result.stdout).not.toContain('\nfix (')
+})
+
+it('uses the nearest reachable release tag, ignoring unrelated tags', () => {
+  const { git, commit, preview } = fixture()
+  git('tag', 'v0.9.0')
+  commit('feat: released already')
+  git('tag', 'v1.0.0')
+  commit('fix: pending change')
+  git('tag', 'deployment')
+  const result = preview('patch', '--dry-run')
+  expect(result.stdout).toContain('Commits: v1.0.0..HEAD')
+  expect(result.stdout).toContain('pending change')
+  expect(result.stdout).not.toContain('released already')
+})
+
+it('shows initial history when no release tag exists and explains empty releases', () => {
+  const { git, preview } = fixture()
+  expect(preview('patch', '--dry-run').stdout).toContain('chore: initial release')
+  git('tag', 'v1.0.0')
+  expect(preview('patch', '--dry-run').stdout).toContain('No commits since v1.0.0.')
+})
+
+it('shows uncommitted paths without changing them during a dry run', () => {
+  const { cwd, git, preview } = fixture()
+  writeFileSync(join(cwd, 'pending.txt'), 'pending')
+  const before = git('status', '--porcelain')
+  expect(preview('patch', '--dry-run').stdout).toContain('?? pending.txt')
+  expect(git('status', '--porcelain')).toBe(before)
+})
+
+it('prints the preview before releasing and pushes the new version to a local remote', () => {
+  const { git, commit, preview } = fixture()
+  const remote = mkdtempSync(join(tmpdir(), 'release-remote-'))
+  fixtures.push(remote)
+  execFileSync('git', ['init', '--quiet', '--bare', remote])
+  git('config', 'core.hooksPath', '/dev/null')
+  git('remote', 'add', 'origin', remote)
+  git('push', '--quiet', '-u', 'origin', 'HEAD')
+  git('tag', 'v1.0.0')
+  commit('feat: add release preview')
+  const result = preview('minor')
+  expect(result.status, result.stderr).toBe(0)
+  expect(result.stdout).toContain('feat (1)')
+  expect(result.stdout.indexOf('feat (1)')).toBeLessThan(result.stdout.indexOf('Bumping'))
+  expect(result.stdout).toContain('Released v1.1.0')
+  const manifest = execFileSync('git', ['--git-dir', remote, 'show', 'v1.1.0:harlan-agent-kit/.claude-plugin/plugin.json'], { encoding: 'utf8' })
+  expect(JSON.parse(manifest).version).toBe('1.1.0')
+  expect(git('status', '--porcelain')).toBe('')
+})

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,12 +1,13 @@
-import { execSync } from 'node:child_process'
+import { execFileSync, execSync } from 'node:child_process'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { glob } from 'node:fs/promises'
 import process from 'node:process'
 
+const dryRun = process.argv.includes('--dry-run')
 const bumpType = process.argv[2] as 'patch' | 'minor' | 'major' | undefined
 
 if (!bumpType || !['patch', 'minor', 'major'].includes(bumpType)) {
-  console.error('Usage: pnpm release <patch|minor|major>')
+  console.error('Usage: pnpm release <patch|minor|major> [--dry-run]')
   process.exit(1)
 }
 
@@ -29,7 +30,48 @@ const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf-8'))
 const oldVersion = plugin.version
 const newVersion = bumpVersion(oldVersion, bumpType)
 
-console.log(`Bumping ${oldVersion} → ${newVersion}`)
+// Read the same reachable history that the new tag will contain.
+const git = (...args: string[]) => execFileSync('git', args, { encoding: 'utf8' }).trimEnd()
+const releaseTags = git('tag', '--merged', 'HEAD', '--list', 'v[0-9]*')
+const previousTag = releaseTags ? git('describe', '--tags', '--match', 'v[0-9]*', '--abbrev=0', 'HEAD') : undefined
+const range = previousTag ? `${previousTag}..HEAD` : 'HEAD'
+const fields = git('log', '--reverse', '-z', '--format=%h%x00%s%x00%b', range, '--').split('\0')
+const groups = new Map<string, string[]>([
+  ['breaking change', []],
+  ['feat', []],
+  ['fix', []],
+  ['chore', []],
+])
+
+for (let i = 0; i + 2 < fields.length; i += 3) {
+  const [hash, subject, body] = fields.slice(i, i + 3)
+  const conventional = subject.match(/^([a-z]+)(?:\([^()]+\))?(!)?: .+/i)
+  const breaking = body.match(/^BREAKING[ -]CHANGE: .*/m)
+  const type = conventional?.[2] || breaking ? 'breaking change' : conventional?.[1].toLowerCase() ?? 'other'
+  const entries = groups.get(type) ?? []
+  entries.push(`  • ${subject} (${hash})${breaking ? `\n    ${breaking[0]}` : ''}`)
+  groups.set(type, entries)
+}
+
+console.log(`\nRelease ${previousTag ?? '(no previous tag)'} → v${newVersion}`)
+console.log(`Commits: ${range}`)
+for (const [type, entries] of groups) {
+  if (entries.length)
+    console.log(`\n${type} (${entries.length})\n${entries.join('\n')}`)
+}
+if (!fields[0])
+  console.log(previousTag ? `\nNo commits since ${previousTag}.` : '\nNo commits.')
+
+const uncommitted = git('status', '--short')
+if (uncommitted)
+  console.log(`\nUncommitted files included by the release:\n${uncommitted}`)
+
+if (dryRun) {
+  console.log('\nDry run complete. No files, commits, or tags changed.')
+  process.exit(0)
+}
+
+console.log(`\nBumping ${oldVersion} → ${newVersion}`)
 
 // Update plugin.json
 plugin.version = newVersion


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### 🔗 Linked issue

<!-- e.g. "Resolves #123", or delete this section if there is no issue -->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

`pnpm release` currently bumps and pushes without showing which commits the tag will include.
It now prints commits since the previous release tag, grouped by type, with breaking changes first.
Use `pnpm release patch --dry-run` to inspect the preview without changing files or pushing.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description.
