### PR TITLE
feat(hogwild): add hogwild skill and hw CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Opencode hooks
         run: pnpm test:opencode-hooks
 
+      - name: Hogwild CLI
+        run: pnpm test:hogwild
+
       # These three enforce the worktree and pull request rules. `pnpm test`
       # does not run them.
       - name: Plugin hooks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Hogwild CLI
         run: pnpm test:hogwild
 
+      - name: Skill doc paths
+        run: pnpm test:skill-doc-paths
+
       # These three enforce the worktree and pull request rules. `pnpm test`
       # does not run them.
       - name: Plugin hooks

--- a/harlan-agent-kit/skills/hogwild/SKILL.md
+++ b/harlan-agent-kit/skills/hogwild/SKILL.md
@@ -9,6 +9,23 @@ argument-hint: "[task on Hogwild]"
 
 Hogwild is one Ubuntu host on the LAN and the tailnet. It runs the Harlan GitHub Agent, the GitHub runner supervisor, three public sites behind one Cloudflare tunnel, AdGuard DNS, and Jellyfin.
 
+## The `hw` CLI
+
+`scripts/hw.ts` in this skill runs the routine tasks below and picks the right account each time. Run it with bun; it has no dependencies. The desktop alias `hw` points at it.
+
+```bash
+hw status                                  # host, services, containers, Agent unit
+hw logs agent -n 100                       # or runner, caddy, tunnel, adguard, jellyfin, docker, status, dragon
+hw install fd-find --link fd=fdfind        # apt as admin, link as the Agent
+hw caddy check                             # or reload: validate first, then reload
+hw runners                                 # live runners.conf against the repo copy, job containers
+hw pending                                 # open host items from hogwild/README.md
+hw run admin 'sudo iptables -S DOCKER-USER'
+hw run agent 'ls ~/.local/bin'
+```
+
+`hw --help` lists every command. Reach for `ssh` directly only when `hw run` does not fit.
+
 ## Pick the SSH host first
 
 | Command | Account | Use it for |

--- a/harlan-agent-kit/skills/hogwild/SKILL.md
+++ b/harlan-agent-kit/skills/hogwild/SKILL.md
@@ -68,7 +68,7 @@ Public routes go internet, Cloudflare tunnel, Caddy `:8080`, then the loopback p
 | Runner supervisor, runners.conf, Dockerfile, host hardening | `harlan-zw/hogwild-gh-runner` (private) `github-runner/` | `~/pkg/hogwild-gh-runner` | install steps in its README |
 | Host security layout, Docker rules, pending items | same repo, `hogwild/` | same | `hogwild/README.md` |
 | Status site | `harlan-zw/hogwild.harlanzw.com` | `~/pkg/hogwild.harlanzw.com` | GitHub Actions deploy job to `hogwild-deploy` |
-| Caddy routes | `harlan-agent-kit/scripts/30-agent.caddy` for the agent route; others live only on the host | | `sudo systemctl reload caddy` |
+| Caddy routes | `scripts/30-agent.caddy` for the agent route; others live only on the host | | `sudo systemctl reload caddy` |
 
 The live `runners.conf` is `/var/lib/github-runner/config/runners.conf`. Change it in the repo first, then install it.
 

--- a/harlan-agent-kit/skills/hogwild/SKILL.md
+++ b/harlan-agent-kit/skills/hogwild/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: hogwild
+description: "Operate the Hogwild home server: which SSH host to use, which account holds sudo, what runs there, where each repo, service, route, and config lives, and how to install tools for the Agent. Use for any task that touches Hogwild over SSH."
+user_invocable: true
+argument-hint: "[task on Hogwild]"
+---
+
+# Hogwild
+
+Hogwild is one Ubuntu host on the LAN and the tailnet. It runs the Harlan GitHub Agent, the GitHub runner supervisor, three public sites behind one Cloudflare tunnel, AdGuard DNS, and Jellyfin.
+
+## Pick the SSH host first
+
+| Command | Account | Use it for |
+| --- | --- | --- |
+| `ssh hogwild` | `harlan` | Agent state, config, checkouts under `~/pkg` and `~/sites`, `systemctl --user`, tool links in `~/.local/bin`. No sudo, no docker. |
+| `ssh hogwild-admin` | `harlan-admin` | `sudo`, `apt`, `docker`, system `systemctl`, `/etc`, `/opt`, `/var/lib`. Cannot read `/home/harlan`. |
+
+If the task needs both, run two commands. Never grant `harlan` sudo or docker. Never SSH as root. The Agent runs public issue text under `harlan`; root there is the attack path the split closed on 2026-09-11.
+
+The desktop zsh aliases `hogwild`, `hogwild-lan`, `hogwild-admin`, `hogwild-admin-lan` use the same key `~/.ssh/id_ed25519_hogwild`.
+
+## What runs there
+
+| Service | Unit | Account | Listens | Source |
+| --- | --- | --- | --- | --- |
+| Harlan GitHub Agent | `harlan-github-agent.service` (user unit, linger) | `harlan` | `127.0.0.1:3210` dashboard, `:3211` webhook | `~/.local/share/harlan-github-agent/service` |
+| GitHub runner supervisor | `hogwild-github-runner.service` | `github-runner` | none; one Docker container per job | `/var/lib/github-runner` |
+| Status site | `hogwild-status.service` | `hogwild-status` | `127.0.0.1:9100` | `/opt/hogwild-status/current` |
+| Dragon deck | `chasing-the-ai-dragon.service` | `dragon-deck` | `127.0.0.1:3031` | `/opt/chasing-the-ai-dragon/current` |
+| Caddy | `caddy.service` | `caddy` | `127.0.0.1:8080` | `/etc/caddy/Caddyfile`, routes in `/etc/caddy/routes/*.caddy` |
+| Cloudflare tunnel | `cloudflared.service` | root | outbound only | `/etc/cloudflared/config.yml` |
+| AdGuard Home | `adguardhome.service` | root | DNS `:53`, admin `:5380` | `/opt/AdGuardHome` |
+| Jellyfin | `jellyfin.service` | `jellyfin` | `:8096` tailnet | `/srv/jellyfin` |
+| Docker | `docker.service` | root | published ports bind loopback | `/etc/docker/daemon.json`, `DOCKER-USER` rules from `hogwild-docker-user.service` |
+
+Public routes go internet, Cloudflare tunnel, Caddy `:8080`, then the loopback port above:
+
+- `hogwild.harlanzw.com`, the status site
+- `dragon.harlanzw.com`, the deck
+- `agent.harlanzw.com`, the Agent dashboard behind Basic auth; `/webhook` reaches the signed webhook listener
+
+## Repos and config that own each part
+
+| Part | Repo | Local checkout | Deploy |
+| --- | --- | --- | --- |
+| Agent service code | `harlan-zw/harlan-agent-kit` `packages/harlan-github-agent` | `~/pkg/harlan-agent-kit` | `pnpm service:hogwild:update` from the repo root |
+| Agent context, worktrunk, env files | same repo, `scripts/` | same | `pnpm sync:context:hogwild`, `pnpm service:hogwild:sync-env`, `pnpm service:hogwild:sync-worktrunk` |
+| Agent config | not in git | `hogwild:~/.config/harlan-github-agent/config.yml` | edit, then restart the user unit |
+| Agent state | not in git | `hogwild:~/.local/share/harlan-github-agent/state.sqlite`, `journal.sqlite`, `worktrees/` | back up before a migration |
+| Runner supervisor, runners.conf, Dockerfile, host hardening | `harlan-zw/hogwild-gh-runner` (private) `github-runner/` | `~/pkg/hogwild-gh-runner` | install steps in its README |
+| Host security layout, Docker rules, pending items | same repo, `hogwild/` | same | `hogwild/README.md` |
+| Status site | `harlan-zw/hogwild.harlanzw.com` | `~/pkg/hogwild.harlanzw.com` | GitHub Actions deploy job to `hogwild-deploy` |
+| Caddy routes | `harlan-agent-kit/scripts/30-agent.caddy` for the agent route; others live only on the host | | `sudo systemctl reload caddy` |
+
+The live `runners.conf` is `/var/lib/github-runner/config/runners.conf`. Change it in the repo first, then install it.
+
+## Agent checkouts on the host
+
+`harlan` holds a primary checkout for every repository the Agent works on. They live under `/home/harlan/pkg` and `/home/harlan/sites` and must stay clean on `main`. The Agent creates its worktrees under `~/.local/share/harlan-github-agent/worktrees/`.
+
+Mapped in `config.yml` today: `nuxt-modules/robots`, `nuxt-modules/og-image`, `nuxt-modules/sitemap`, `nuxt/scripts`, `harlan-zw/nuxt-seo-utils`, `harlan-zw/nuxt-site-config`, `harlan-zw/nuxt-seo`, and the sites under `~/sites`. Read the file for the current list; do not trust this paragraph.
+
+If a new repository joins, clone it as `harlan` into the matching directory, then add a `repositories` entry and restart the Agent.
+
+## Install a tool for the Agent
+
+1. Install as admin: `ssh hogwild-admin 'sudo apt-get install -y <package>'`.
+2. If the Agent needs it under a different name, link it as harlan: `ssh hogwild 'ln -sf "$(command -v fdfind)" ~/.local/bin/fd'`.
+3. Record it in the tools table in `hogwild-gh-runner/hogwild/README.md`.
+
+Tools in `hogwild:~/.local/bin` today: `node`, `pnpm`, `bun`, `uv`, `gh`, `wt`, `rg`, `fd`, `ripast`, `opencode`, `codex`, `wrangler`, `sentry-cli`, `nuxtseo`, `himalaya`, `dev-browser`. No `claude`; the Agent uses `opencode`.
+
+## Control the Agent
+
+Prefer the control CLI from the desktop over raw `systemctl`:
+
+```bash
+harlan-github-agent control status
+harlan-github-agent control pause
+harlan-github-agent control restart --source helper
+```
+
+If a change needs the process to pick up new groups or a new Node, restart the user manager as admin. That kills in-flight Agent work, so pause first and get Harlan's say so:
+
+```bash
+ssh hogwild-admin 'sudo systemctl restart user@1000.service'
+```
+
+Logs: `ssh hogwild 'journalctl --user -u harlan-github-agent -n 200'`.
+
+## Docker and firewall
+
+`ufw` allows SSH, DNS, and the tailnet. Docker bypasses ufw, so `hogwild-docker-user.service` fills `DOCKER-USER`: containers cannot reach the LAN, the tailnet, or link-local; the LAN cannot open published ports. `daemon.json` binds published ports to loopback. After `ufw reload`, restart Docker. Verify with `sudo iptables -S DOCKER-USER`.
+
+## Do not
+
+- Do not start `harlan-desktop-github-runner.service` on the desktop. Hogwild is the only runner host.
+- Do not add `harlan` to `sudo` or `docker`.
+- Do not edit a primary checkout under `~/pkg` or `~/sites` on the host. The Agent owns them.
+- Do not reboot without draining the runner: `sudo systemctl stop hogwild-github-runner.service`, then `sudo reboot`.

--- a/harlan-agent-kit/skills/hogwild/SKILL.md
+++ b/harlan-agent-kit/skills/hogwild/SKILL.md
@@ -29,9 +29,9 @@ The desktop zsh aliases `hogwild`, `hogwild-lan`, `hogwild-admin`, `hogwild-admi
 | Status site | `hogwild-status.service` | `hogwild-status` | `127.0.0.1:9100` | `/opt/hogwild-status/current` |
 | Dragon deck | `chasing-the-ai-dragon.service` | `dragon-deck` | `127.0.0.1:3031` | `/opt/chasing-the-ai-dragon/current` |
 | Caddy | `caddy.service` | `caddy` | `127.0.0.1:8080` | `/etc/caddy/Caddyfile`, routes in `/etc/caddy/routes/*.caddy` |
-| Cloudflare tunnel | `cloudflared.service` | root | outbound only | `/etc/cloudflared/config.yml` |
-| AdGuard Home | `adguardhome.service` | root | DNS `:53`, admin `:5380` | `/opt/AdGuardHome` |
-| Jellyfin | `jellyfin.service` | `jellyfin` | `:8096` tailnet | `/srv/jellyfin` |
+| Cloudflare tunnel | `cloudflared.service` | `cloudflared` | outbound only | `/etc/cloudflared/config.yml` |
+| AdGuard Home | `adguardhome.service` | `adguardhome` | DNS `:53` on the LAN and tailnet addresses, admin `:5380` on every interface, ufw blocks it from the LAN | `/opt/AdGuardHome`, config in `/var/lib/adguardhome` |
+| Jellyfin | `jellyfin.service` | `jellyfin` | `:8096`, ufw allows the LAN and the tailnet | `/srv/jellyfin` |
 | Docker | `docker.service` | root | published ports bind loopback | `/etc/docker/daemon.json`, `DOCKER-USER` rules from `hogwild-docker-user.service` |
 
 Public routes go internet, Cloudflare tunnel, Caddy `:8080`, then the loopback port above:
@@ -59,7 +59,7 @@ The live `runners.conf` is `/var/lib/github-runner/config/runners.conf`. Change 
 
 `harlan` holds a primary checkout for every repository the Agent works on. They live under `/home/harlan/pkg` and `/home/harlan/sites` and must stay clean on `main`. The Agent creates its worktrees under `~/.local/share/harlan-github-agent/worktrees/`.
 
-Mapped in `config.yml` today: `nuxt-modules/robots`, `nuxt-modules/og-image`, `nuxt-modules/sitemap`, `nuxt/scripts`, `harlan-zw/nuxt-seo-utils`, `harlan-zw/nuxt-site-config`, `harlan-zw/nuxt-seo`, and the sites under `~/sites`. Read the file for the current list; do not trust this paragraph.
+Not every checkout is mapped. `config.yml` lists the active `repositories` and the observe-only `external_repositories`. Read the file for the current list: `ssh hogwild 'rg -n "^  - github:" ~/.config/harlan-github-agent/config.yml'`.
 
 If a new repository joins, clone it as `harlan` into the matching directory, then add a `repositories` entry and restart the Agent.
 
@@ -78,7 +78,7 @@ Prefer the control CLI from the desktop over raw `systemctl`:
 ```bash
 harlan-github-agent control status
 harlan-github-agent control pause
-harlan-github-agent control restart --source helper
+harlan-github-agent control restart
 ```
 
 If a change needs the process to pick up new groups or a new Node, restart the user manager as admin. That kills in-flight Agent work, so pause first and get Harlan's say so:
@@ -91,7 +91,7 @@ Logs: `ssh hogwild 'journalctl --user -u harlan-github-agent -n 200'`.
 
 ## Docker and firewall
 
-`ufw` allows SSH, DNS, and the tailnet. Docker bypasses ufw, so `hogwild-docker-user.service` fills `DOCKER-USER`: containers cannot reach the LAN, the tailnet, or link-local; the LAN cannot open published ports. `daemon.json` binds published ports to loopback. After `ufw reload`, restart Docker. Verify with `sudo iptables -S DOCKER-USER`.
+`ufw` allows SSH, DNS, and Jellyfin from the LAN, and everything on `tailscale0`. Docker bypasses ufw, so `hogwild-docker-user.service` fills `DOCKER-USER`: containers cannot reach the LAN, the tailnet, or link-local; the LAN cannot open published ports. `daemon.json` binds published ports to loopback. After `ufw reload`, restart Docker. Verify with `sudo iptables -S DOCKER-USER`.
 
 ## Do not
 

--- a/harlan-agent-kit/skills/hogwild/scripts/hw.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/hw.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env bun
+// Effectful shell for the `hw` CLI. Runs the plan from `plan.ts` step by step
+// and stops at the first failure. Run it with bun; it needs no dependencies.
+
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+import { plan, stepArgv } from './plan.ts'
+
+const result = plan(process.argv.slice(2))
+if (result._tag === 'Err') {
+  console.error(result.message)
+  process.exit(2)
+}
+
+for (const step of result.steps) {
+  if (step.title)
+    console.log(`\x1B[1m# ${step.title} (${step.host})\x1B[0m`)
+  const [file, ...args] = stepArgv(step)
+  const { status } = spawnSync(file as string, args, { stdio: 'inherit' })
+  if (status !== 0) {
+    console.error(`Step failed with exit ${status} on ${step.host}: ${step.command}`)
+    process.exit(status ?? 1)
+  }
+}

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
@@ -109,7 +109,8 @@ describe('hw plan', () => {
   it('diffs the live runners conf against the repo copy read on the agent account', () => {
     const [diff] = steps(['runners'])
     expect(diff?.host).toBe('local')
-    expect(diff?.command).toContain(`ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}'`)
+    expect(diff?.command).toContain(`ssh ${SSH_HOST.agent} cat ${RUNNER_REPO_CONF}`)
+    expect(diff?.command).toContain('|| exit 1')
     expect(diff?.command).not.toContain('|| true')
   })
 
@@ -129,21 +130,28 @@ describe('hw plan', () => {
     expect(status).not.toBe(0)
     expect(output).not.toBe('')
   })
+
+  it('runners diff exits non-zero when both conf reads fail', () => {
+    const { status } = runnersDiff(false, false)
+    expect(status).not.toBe(0)
+  })
 })
 
-/** Runs the runners diff step with its two ssh reads swapped for local files. */
-function runnersDiff(live: string, repo: string | undefined) {
+/** Runs the runners diff step with each ssh read swapped for a local read or a failing read. */
+function runnersDiff(live: string | false, repo: string | false | undefined) {
   const dir = mkdtempSync(join(tmpdir(), 'hw-runners-'))
   try {
     const liveFile = join(dir, 'live.conf')
-    writeFileSync(liveFile, live)
+    if (live !== false && live !== undefined)
+      writeFileSync(liveFile, live)
     const repoFile = join(dir, 'repo.conf')
-    if (repo !== undefined)
+    if (repo !== false && repo !== undefined)
       writeFileSync(repoFile, repo)
     const [step] = steps(['runners'])
     const command = step!.command
-      .replaceAll(`ssh ${SSH_HOST.admin} sudo cat /var/lib/github-runner/config/runners.conf`, `cat ${liveFile}`)
-      .replaceAll(`ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}'`, `cat ${repoFile}`)
+      .replaceAll(`ssh ${SSH_HOST.admin} sudo cat /var/lib/github-runner/config/runners.conf`, live === false ? 'false' : `cat ${liveFile}`)
+      .replaceAll(`ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}'`, repo === false ? 'false' : `cat ${repoFile}`)
+      .replaceAll(`ssh ${SSH_HOST.agent} cat ${RUNNER_REPO_CONF}`, repo === false ? 'false' : `cat ${repoFile}`)
     const { status, stdout, stderr } = spawnSync('bash', ['-o', 'pipefail', '-c', command], { encoding: 'utf8' })
     return { status: status ?? 1, output: `${stdout}${stderr}` }
   }

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
@@ -48,6 +48,13 @@ describe('hw plan', () => {
       expect(step.command).not.toContain('sudo')
   })
 
+  it('refuses sudo in run agent and keeps it for run admin', () => {
+    expect(plan(['run', 'agent', 'sudo', 'ls'])).toMatchObject({ _tag: 'Err' })
+    expect(plan(['run', 'agent', 'ls', '&&', 'sudo', 'ls'])).toMatchObject({ _tag: 'Err' })
+    expect(steps(['run', 'admin', 'sudo', 'ls'])).toEqual([{ host: 'admin', command: 'sudo ls' }])
+    expect(steps(['run', 'agent', 'echo', 'pseudo'])).toEqual([{ host: 'agent', command: 'echo pseudo' }])
+  })
+
   it('passes the remote command to ssh as one unquoted argument', () => {
     const argv = stepArgv({ host: 'admin', command: 'echo "here" | cat' })
     expect(argv).toEqual(['ssh', '-o', 'BatchMode=yes', 'hogwild-admin', 'echo "here" | cat'])

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
@@ -1,9 +1,9 @@
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { HOST_README, plan, stepArgv } from './plan.ts'
+import { HOST_README, plan, RUNNER_REPO_CONF, SSH_HOST, stepArgv } from './plan.ts'
 
 function steps(argv: string[]) {
   const result = plan(argv)
@@ -19,7 +19,9 @@ function pendingOutput(body: string) {
     writeFileSync(file, `# Host\n\n${body}`)
     const [step] = steps(['pending'])
     const command = step!.command.replace(HOST_README, file)
-    const argv = stepArgv({ ...step!, command })
+    // The plan sends this awk to the agent account; the helper runs the same
+    // command through the local executor so the test needs no host.
+    const argv = stepArgv({ ...step!, host: 'local', command })
     return execFileSync(argv[0]!, argv.slice(1), { encoding: 'utf8' })
   }
   finally {
@@ -91,4 +93,61 @@ describe('hw plan', () => {
     expect(output).toContain('item two')
     expect(output).not.toContain('##')
   })
+
+  it('reads the pending list on the agent account over ssh', () => {
+    const [step] = steps(['pending'])
+    expect(step?.host).toBe('agent')
+    expect(stepArgv(step!)).toEqual([
+      'ssh',
+      '-o',
+      'BatchMode=yes',
+      SSH_HOST.agent,
+      `awk '/^## Pending/{f=1;next} f && /^## /{f=0} f' ${HOST_README}`,
+    ])
+  })
+
+  it('diffs the live runners conf against the repo copy read on the agent account', () => {
+    const [diff] = steps(['runners'])
+    expect(diff?.host).toBe('local')
+    expect(diff?.command).toContain(`ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}'`)
+    expect(diff?.command).not.toContain('|| true')
+  })
+
+  it('runners diff exits 0 with empty output only when the confs are equal', () => {
+    expect(runnersDiff('same\n', 'same\n')).toEqual({ status: 0, output: '' })
+  })
+
+  it('runners diff prints a difference and exits non-zero', () => {
+    const { status, output } = runnersDiff('live\n', 'repo\n')
+    expect(status).not.toBe(0)
+    expect(output).toContain('live')
+    expect(output).toContain('repo')
+  })
+
+  it('runners diff exits non-zero when the repo copy cannot be read', () => {
+    const { status, output } = runnersDiff('live\n', undefined)
+    expect(status).not.toBe(0)
+    expect(output).not.toBe('')
+  })
 })
+
+/** Runs the runners diff step with its two ssh reads swapped for local files. */
+function runnersDiff(live: string, repo: string | undefined) {
+  const dir = mkdtempSync(join(tmpdir(), 'hw-runners-'))
+  try {
+    const liveFile = join(dir, 'live.conf')
+    writeFileSync(liveFile, live)
+    const repoFile = join(dir, 'repo.conf')
+    if (repo !== undefined)
+      writeFileSync(repoFile, repo)
+    const [step] = steps(['runners'])
+    const command = step!.command
+      .replaceAll(`ssh ${SSH_HOST.admin} sudo cat /var/lib/github-runner/config/runners.conf`, `cat ${liveFile}`)
+      .replaceAll(`ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}'`, `cat ${repoFile}`)
+    const { status, stdout, stderr } = spawnSync('bash', ['-o', 'pipefail', '-c', command], { encoding: 'utf8' })
+    return { status: status ?? 1, output: `${stdout}${stderr}` }
+  }
+  finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { plan, stepArgv } from './plan.ts'
+
+function steps(argv: string[]) {
+  const result = plan(argv)
+  if (result._tag === 'Err')
+    throw new Error(result.message)
+  return result.steps
+}
+
+describe('hw plan', () => {
+  it('sends the agent journal to the agent account and system units to admin', () => {
+    expect(steps(['logs', 'agent'])).toEqual([
+      { host: 'agent', command: 'journalctl --user -u harlan-github-agent -n 200 --no-pager' },
+    ])
+    expect(steps(['logs', 'runner', '-n', '50'])).toEqual([
+      { host: 'admin', command: 'sudo journalctl -u hogwild-github-runner -n 50 --no-pager' },
+    ])
+  })
+
+  it('refuses an unknown unit and a non numeric line count', () => {
+    expect(plan(['logs', 'sudo'])).toMatchObject({ _tag: 'Err' })
+    expect(plan(['logs', 'caddy', '-n', 'many'])).toMatchObject({ _tag: 'Err' })
+  })
+
+  it('installs as admin and links as the agent, never the other way', () => {
+    const result = steps(['install', 'fd-find', '--link', 'fd=fdfind'])
+    expect(result.map(step => step.host)).toEqual(['admin', 'agent', 'local'])
+    expect(result[0]?.command).toBe('sudo apt-get install -y fd-find')
+    expect(result[1]?.command).toContain('ln -sf "$(command -v fdfind)" ~/.local/bin/fd')
+  })
+
+  it('rejects package and link names that could carry shell text', () => {
+    expect(plan(['install', 'fd; rm -rf /'])).toMatchObject({ _tag: 'Err' })
+    expect(plan(['install', 'fd-find', '--link', 'fd=$(id)'])).toMatchObject({ _tag: 'Err' })
+  })
+
+  it('validates before a caddy reload', () => {
+    const [step] = steps(['caddy', 'reload'])
+    expect(step?.host).toBe('admin')
+    expect(step?.command.indexOf('caddy validate')).toBeLessThan(step?.command.indexOf('reload caddy') ?? -1)
+  })
+
+  it('never runs a sudo command on the agent account', () => {
+    const every = ['status', 'runners', 'pending', 'caddy check', 'logs jellyfin', 'install unzip']
+      .flatMap(argv => steps(argv.split(' ')))
+    for (const step of every.filter(step => step.host === 'agent'))
+      expect(step.command).not.toContain('sudo')
+  })
+
+  it('passes the remote command to ssh as one unquoted argument', () => {
+    const argv = stepArgv({ host: 'admin', command: 'echo "here" | cat' })
+    expect(argv).toEqual(['ssh', '-o', 'BatchMode=yes', 'hogwild-admin', 'echo "here" | cat'])
+  })
+})

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.test.ts
@@ -1,11 +1,30 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { plan, stepArgv } from './plan.ts'
+import { HOST_README, plan, stepArgv } from './plan.ts'
 
 function steps(argv: string[]) {
   const result = plan(argv)
   if (result._tag === 'Err')
     throw new Error(result.message)
   return result.steps
+}
+
+function pendingOutput(body: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'hw-pending-'))
+  try {
+    const file = join(dir, 'README.md')
+    writeFileSync(file, `# Host\n\n${body}`)
+    const [step] = steps(['pending'])
+    const command = step!.command.replace(HOST_README, file)
+    const argv = stepArgv({ ...step!, command })
+    return execFileSync(argv[0]!, argv.slice(1), { encoding: 'utf8' })
+  }
+  finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 }
 
 describe('hw plan', () => {
@@ -58,5 +77,18 @@ describe('hw plan', () => {
   it('passes the remote command to ssh as one unquoted argument', () => {
     const argv = stepArgv({ host: 'admin', command: 'echo "here" | cat' })
     expect(argv).toEqual(['ssh', '-o', 'BatchMode=yes', 'hogwild-admin', 'echo "here" | cat'])
+  })
+
+  it('prints every pending item when the Pending section ends the README', () => {
+    const output = pendingOutput('## Done\n\n- closed item\n\n## Pending\n\n- item one\n- item two\n')
+    expect(output).toContain('item one')
+    expect(output).toContain('item two')
+  })
+
+  it('prints every pending item and no heading when a section follows Pending', () => {
+    const output = pendingOutput('## Pending\n\n- item one\n- item two\n\n## Done\n\n- closed item\n')
+    expect(output).toContain('item one')
+    expect(output).toContain('item two')
+    expect(output).not.toContain('##')
   })
 })

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.ts
@@ -152,7 +152,7 @@ export function plan(argv: string[]): Plan {
           {
             host: 'local',
             title: 'runners.conf: live against repo (empty means equal)',
-            command: `diff <(ssh ${SSH_HOST.admin} sudo cat ${LIVE_RUNNER_CONF}) ${RUNNER_REPO_CONF} || true`,
+            command: `diff <(ssh ${SSH_HOST.admin} sudo cat ${LIVE_RUNNER_CONF}) <(ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}')`,
           },
           {
             host: 'admin',
@@ -164,7 +164,7 @@ export function plan(argv: string[]): Plan {
     case 'pending':
       return {
         _tag: 'Ok',
-        steps: [{ host: 'local', command: `awk '/^## Pending/{f=1;next} f && /^## /{f=0} f' ${HOST_README}` }],
+        steps: [{ host: 'agent', command: `awk '/^## Pending/{f=1;next} f && /^## /{f=0} f' ${HOST_README}` }],
       }
     case 'run': {
       const [host, ...shell] = rest

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.ts
@@ -152,7 +152,11 @@ export function plan(argv: string[]): Plan {
           {
             host: 'local',
             title: 'runners.conf: live against repo (empty means equal)',
-            command: `diff <(ssh ${SSH_HOST.admin} sudo cat ${LIVE_RUNNER_CONF}) <(ssh ${SSH_HOST.agent} cat '${RUNNER_REPO_CONF}')`,
+            command: [
+              `live=$(ssh ${SSH_HOST.admin} sudo cat ${LIVE_RUNNER_CONF}) || exit 1`,
+              `repo=$(ssh ${SSH_HOST.agent} cat ${RUNNER_REPO_CONF}) || exit 1`,
+              `diff <(printf '%s' "$live") <(printf '%s' "$repo")`,
+            ].join('\n'),
           },
           {
             host: 'admin',

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.ts
@@ -65,6 +65,7 @@ export const USAGE = `hw <command>
 
 const APT_PACKAGE = /^[a-z0-9][a-z0-9+.-]*$/
 const LINK_NAME = /^[a-z0-9][\w.-]*$/i
+const SUDO_WORD = /(?:^|[\s;&|(`$])sudo(?:\s|$)/
 
 function flag(argv: string[], name: string): { value: string | undefined, rest: string[] } {
   const index = argv.indexOf(name)
@@ -171,7 +172,10 @@ export function plan(argv: string[]): Plan {
         return { _tag: 'Err', message: 'run takes agent or admin, then the command.' }
       if (shell.length === 0)
         return { _tag: 'Err', message: 'Give run a command.' }
-      return { _tag: 'Ok', steps: [{ host, command: shell.join(' ') }] }
+      const command = shell.join(' ')
+      if (host === 'agent' && SUDO_WORD.test(command))
+        return { _tag: 'Err', message: 'sudo does not run on the Agent account. Use hw run admin.' }
+      return { _tag: 'Ok', steps: [{ host, command }] }
     }
     case 'ssh': {
       const host = rest[0]

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.ts
@@ -164,7 +164,7 @@ export function plan(argv: string[]): Plan {
     case 'pending':
       return {
         _tag: 'Ok',
-        steps: [{ host: 'local', command: `sed -n '/^## Pending/,/^## /p' ${HOST_README} | sed '1d;$d'` }],
+        steps: [{ host: 'local', command: `awk '/^## Pending/{f=1;next} f && /^## /{f=0} f' ${HOST_README}` }],
       }
     case 'run': {
       const [host, ...shell] = rest

--- a/harlan-agent-kit/skills/hogwild/scripts/plan.ts
+++ b/harlan-agent-kit/skills/hogwild/scripts/plan.ts
@@ -1,0 +1,201 @@
+// Pure planner for the `hw` CLI. It turns argv into the commands to run and
+// where to run them. No I/O here; `hw.ts` executes the plan.
+
+export type Host = 'agent' | 'admin' | 'local'
+
+export interface Step {
+  host: Host
+  /** Shell text. On `agent` and `admin` it runs through `ssh`. */
+  command: string
+  /** Printed before the step. */
+  title?: string
+}
+
+export type Plan
+  = | { _tag: 'Ok', steps: Step[] }
+    | { _tag: 'Err', message: string }
+
+export const SSH_HOST: Record<Exclude<Host, 'local'>, string> = {
+  agent: 'hogwild',
+  admin: 'hogwild-admin',
+}
+
+export const RUNNER_REPO_CONF = '~/pkg/hogwild-gh-runner/github-runner/hogwild-runners.conf'
+export const HOST_README = '~/pkg/hogwild-gh-runner/hogwild/README.md'
+const LIVE_RUNNER_CONF = '/var/lib/github-runner/config/runners.conf'
+
+/** System units the admin account reads with `sudo journalctl`. */
+const SYSTEM_UNITS = [
+  'hogwild-github-runner',
+  'caddy',
+  'cloudflared',
+  'adguardhome',
+  'jellyfin',
+  'docker',
+  'hogwild-status',
+  'chasing-the-ai-dragon',
+  'hogwild-docker-user',
+  'tailscaled',
+  'ssh',
+] as const
+
+const UNIT_ALIASES: Record<string, string> = {
+  agent: 'harlan-github-agent',
+  runner: 'hogwild-github-runner',
+  runners: 'hogwild-github-runner',
+  status: 'hogwild-status',
+  dragon: 'chasing-the-ai-dragon',
+  adguard: 'adguardhome',
+  tunnel: 'cloudflared',
+}
+
+export const USAGE = `hw <command>
+
+  status                    Host, services, containers, Agent unit, on one screen.
+  logs <unit> [-n LINES]    Journal for one unit. Units: agent, runner, caddy, tunnel,
+                            adguard, jellyfin, docker, status, dragon, tailscaled, ssh.
+  install <apt-package> [--link NAME=SOURCE]
+                            apt as admin, then link SOURCE into the Agent's ~/.local/bin.
+  caddy check|reload        Validate the Caddyfile, or validate then reload.
+  runners                   Live runners.conf against the repo copy, plus job containers.
+  pending                   Open host items from hogwild/README.md.
+  run agent|admin <shell>   Run one shell command on that account.
+  ssh agent|admin           Print the ssh host name.
+`
+
+const APT_PACKAGE = /^[a-z0-9][a-z0-9+.-]*$/
+const LINK_NAME = /^[a-z0-9][\w.-]*$/i
+
+function flag(argv: string[], name: string): { value: string | undefined, rest: string[] } {
+  const index = argv.indexOf(name)
+  if (index === -1)
+    return { value: undefined, rest: argv }
+  const value = argv[index + 1]
+  return { value, rest: [...argv.slice(0, index), ...argv.slice(index + 2)] }
+}
+
+export function plan(argv: string[]): Plan {
+  const [command, ...rest] = argv
+  switch (command) {
+    case 'status':
+      return {
+        _tag: 'Ok',
+        steps: [
+          {
+            host: 'admin',
+            title: 'host',
+            command: [
+              'uptime',
+              'df -h / | tail -n +2',
+              'free -h | sed -n 2p',
+              `systemctl is-active ${SYSTEM_UNITS.join(' ')} | paste -d" " - - - - - - - - - - -`,
+              'docker ps --format "{{.Names}}  {{.Status}}"',
+            ].join('; '),
+          },
+          {
+            host: 'agent',
+            title: 'agent',
+            command: 'systemctl --user is-active harlan-github-agent; systemctl --user show harlan-github-agent -p ActiveEnterTimestamp --value',
+          },
+        ],
+      }
+    case 'logs': {
+      const { value: linesRaw, rest: positional } = flag(rest, '-n')
+      const lines = linesRaw ?? '200'
+      if (!/^\d+$/.test(lines))
+        return { _tag: 'Err', message: `Lines must be a number, got ${lines}.` }
+      const requested = positional[0]
+      if (!requested)
+        return { _tag: 'Err', message: 'Name a unit. See hw --help.' }
+      const unit = UNIT_ALIASES[requested] ?? requested
+      if (unit === 'harlan-github-agent')
+        return { _tag: 'Ok', steps: [{ host: 'agent', command: `journalctl --user -u harlan-github-agent -n ${lines} --no-pager` }] }
+      if (!(SYSTEM_UNITS as readonly string[]).includes(unit))
+        return { _tag: 'Err', message: `Unknown unit ${requested}. See hw --help.` }
+      return { _tag: 'Ok', steps: [{ host: 'admin', command: `sudo journalctl -u ${unit} -n ${lines} --no-pager` }] }
+    }
+    case 'install': {
+      const { value: link, rest: positional } = flag(rest, '--link')
+      const pkg = positional[0]
+      if (!pkg || !APT_PACKAGE.test(pkg))
+        return { _tag: 'Err', message: 'Name one apt package, lowercase letters, digits, "+", ".", "-".' }
+      const steps: Step[] = [
+        { host: 'admin', title: `apt install ${pkg}`, command: `sudo apt-get install -y ${pkg}` },
+      ]
+      if (link !== undefined) {
+        const [name, source] = link.split('=')
+        if (!name || !source || !LINK_NAME.test(name) || !LINK_NAME.test(source))
+          return { _tag: 'Err', message: '--link takes NAME=SOURCE, for example --link fd=fdfind.' }
+        steps.push({
+          host: 'agent',
+          title: `link ${name} -> ${source}`,
+          command: `mkdir -p ~/.local/bin && ln -sf "$(command -v ${source})" ~/.local/bin/${name} && ~/.local/bin/${name} --version`,
+        })
+      }
+      steps.push({ host: 'local', title: 'next', command: `echo "Record ${pkg} in ${HOST_README}."` })
+      return { _tag: 'Ok', steps }
+    }
+    case 'caddy': {
+      const action = rest[0]
+      const validate = 'sudo caddy validate --config /etc/caddy/Caddyfile'
+      if (action === 'check')
+        return { _tag: 'Ok', steps: [{ host: 'admin', command: validate }] }
+      if (action === 'reload')
+        return { _tag: 'Ok', steps: [{ host: 'admin', command: `${validate} && sudo systemctl reload caddy && systemctl is-active caddy` }] }
+      return { _tag: 'Err', message: 'caddy takes check or reload.' }
+    }
+    case 'runners':
+      return {
+        _tag: 'Ok',
+        steps: [
+          {
+            host: 'local',
+            title: 'runners.conf: live against repo (empty means equal)',
+            command: `diff <(ssh ${SSH_HOST.admin} sudo cat ${LIVE_RUNNER_CONF}) ${RUNNER_REPO_CONF} || true`,
+          },
+          {
+            host: 'admin',
+            title: 'job containers',
+            command: 'systemctl is-active hogwild-github-runner; docker ps --format "{{.Names}}  {{.Status}}"',
+          },
+        ],
+      }
+    case 'pending':
+      return {
+        _tag: 'Ok',
+        steps: [{ host: 'local', command: `sed -n '/^## Pending/,/^## /p' ${HOST_README} | sed '1d;$d'` }],
+      }
+    case 'run': {
+      const [host, ...shell] = rest
+      if (host !== 'agent' && host !== 'admin')
+        return { _tag: 'Err', message: 'run takes agent or admin, then the command.' }
+      if (shell.length === 0)
+        return { _tag: 'Err', message: 'Give run a command.' }
+      return { _tag: 'Ok', steps: [{ host, command: shell.join(' ') }] }
+    }
+    case 'ssh': {
+      const host = rest[0]
+      if (host !== 'agent' && host !== 'admin')
+        return { _tag: 'Err', message: 'ssh takes agent or admin.' }
+      return { _tag: 'Ok', steps: [{ host: 'local', command: `echo ${SSH_HOST[host]}` }] }
+    }
+    case undefined:
+    case '-h':
+    case '--help':
+    case 'help':
+      return { _tag: 'Ok', steps: [{ host: 'local', command: `cat <<'HW_USAGE'\n${USAGE}HW_USAGE` }] }
+    default:
+      return { _tag: 'Err', message: `Unknown command ${command}. See hw --help.` }
+  }
+}
+
+/**
+ * The argv `hw.ts` spawns for one step. ssh joins its trailing arguments with
+ * spaces and the remote login shell parses the result, so the command travels
+ * as one argument with no extra quoting.
+ */
+export function stepArgv(step: Step): string[] {
+  if (step.host === 'local')
+    return ['bash', '-o', 'pipefail', '-c', step.command]
+  return ['ssh', '-o', 'BatchMode=yes', SSH_HOST[step.host], step.command]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "pnpm --filter harlan-github-agent build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "pnpm test:context && pnpm test:commit-hook && pnpm test:himalaya && pnpm test:opencode-hooks && pnpm test:service && pnpm --filter harlan-github-agent test:run",
+    "test": "pnpm test:context && pnpm test:commit-hook && pnpm test:himalaya && pnpm test:opencode-hooks && pnpm test:hogwild && pnpm test:service && pnpm --filter harlan-github-agent test:run",
     "typecheck": "pnpm --filter harlan-github-agent typecheck",
     "check:context": "scripts/check-agent-context.sh",
     "sync:context": "bash scripts/sync-agent-context.sh local",
@@ -31,7 +31,8 @@
     "test:wt-only": "bash harlan-agent-kit/hooks/wt-only.test.sh",
     "test:sentry-checkin": "python3 -m unittest discover -s harlan-agent-kit/skills/sentry-checkin/scripts -p 'test_*.py'",
     "release": "node --experimental-strip-types scripts/release.ts",
-    "test:opencode-hooks": "vitest run harlan-agent-kit/plugins/opencode"
+    "test:opencode-hooks": "vitest run harlan-agent-kit/plugins/opencode",
+    "test:hogwild": "vitest run harlan-agent-kit/skills/hogwild/scripts"
   },
   "dependencies": {
     "@antfu/eslint-config": "catalog:",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "pnpm --filter harlan-github-agent build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "pnpm test:release && pnpm test:context && pnpm test:commit-hook && pnpm test:himalaya && pnpm test:opencode-hooks && pnpm test:hogwild && pnpm test:service && pnpm --filter harlan-github-agent test:run",
+    "test": "pnpm test:release && pnpm test:context && pnpm test:commit-hook && pnpm test:himalaya && pnpm test:opencode-hooks && pnpm test:hogwild && pnpm test:skill-doc-paths && pnpm test:service && pnpm --filter harlan-github-agent test:run",
     "typecheck": "pnpm --filter harlan-github-agent typecheck",
     "check:context": "scripts/check-agent-context.sh",
     "sync:context": "bash scripts/sync-agent-context.sh local",
@@ -33,7 +33,8 @@
     "test:release": "vitest run scripts/release.test.ts",
     "release": "node --experimental-strip-types scripts/release.ts",
     "test:opencode-hooks": "vitest run harlan-agent-kit/plugins/opencode",
-    "test:hogwild": "vitest run harlan-agent-kit/skills/hogwild/scripts"
+    "test:hogwild": "vitest run harlan-agent-kit/skills/hogwild/scripts",
+    "test:skill-doc-paths": "vitest run scripts/skill-doc-paths.test.ts"
   },
   "dependencies": {
     "@antfu/eslint-config": "catalog:",

--- a/scripts/skill-doc-paths.test.ts
+++ b/scripts/skill-doc-paths.test.ts
@@ -1,0 +1,25 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { expect, it } from 'vitest'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+const skillsDir = join(repoRoot, 'harlan-agent-kit', 'skills')
+
+it('resolves every repository path quoted in a skill to a file in this repository', () => {
+  const missing: string[] = []
+  for (const skill of readdirSync(skillsDir)) {
+    const file = join(skillsDir, skill, 'SKILL.md')
+    if (!existsSync(file))
+      continue
+    const quoted = readFileSync(file, 'utf8').match(/`[^`\n]+`/g) ?? []
+    for (const tick of quoted) {
+      const quotedPath = tick.slice(1, -1)
+      if (!quotedPath.startsWith('harlan-agent-kit/') || quotedPath.includes('<'))
+        continue
+      if (!existsSync(join(repoRoot, quotedPath)))
+        missing.push(`${quotedPath} in ${skill}/SKILL.md`)
+    }
+  }
+  expect(missing).toEqual([])
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Since the 2026-09-11 account split, `ssh hogwild` lands on the Agent account with no sudo. A desktop agent asked to "grant harlan sudo" instead of using `ssh hogwild-admin`, and nothing in the kit told it otherwise.

Adds a `hogwild` skill: the two SSH hosts and what each may do, every service on the host with its unit, account, port, and source path, and the repo that owns each part (agent kit, `hogwild-gh-runner`, status site). Also covers installing tools for the Agent, controlling the Agent, and the Docker firewall.

Adds `scripts/hw.ts`, a bun CLI with a pure, tested planner: status, logs, install with link, caddy check and reload, runners diff, pending items, and a run passthrough. Each step names the account it runs on, and the planner never puts `sudo` on the Agent account. The `hw` zsh alias on the desktop points at it. CI runs `pnpm test:hogwild`.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).

https://claude.ai/code/session_01GCA5wzqrPbCj6LL4BK7NHu