### PR TITLE
fix(github-agent): settle checks from completed workflows

### DIFF
--- a/packages/harlan-github-agent/src/github-agent-source.ts
+++ b/packages/harlan-github-agent/src/github-agent-source.ts
@@ -841,16 +841,25 @@ export function createGitHubAgentSource(options: GitHubAgentSourceOptions): GitH
               checksClient.value.paginate(checksClient.value.rest.actions.listWorkflowRunsForRepo, { owner, repo, head_sha: ref, per_page: 100, request: { signal } }),
             ]).then(async ([allRuns, statuses, workflowRuns]): Promise<GitHubChecksSnapshot> => {
               const derivedSuites = derivedCheckSuiteIds(workflowRuns)
+              const completedWorkflows = new Map(workflowRuns.flatMap(run => run.status === 'completed' && run.conclusion && run.check_suite_id
+                ? [[run.check_suite_id, run.conclusion] as const]
+                : []))
               const runs = allRuns.filter(check => check.check_suite?.id === undefined || check.check_suite.id === null || !derivedSuites.has(check.check_suite.id))
               const current = currentGitHubChecks([
-                ...runs.map(check => ({
-                  id: check.id,
-                  failure: { _tag: 'NotAsked' as const },
-                  source: { _tag: 'CheckRun' as const, appId: check.app?.id ?? null },
-                  name: check.name,
-                  status: check.status,
-                  conclusion: check.conclusion,
-                })),
+                ...runs.map((check) => {
+                  // GitHub can leave jobs queued after their workflow has finished.
+                  const workflowConclusion = check.status !== 'completed' && check.check_suite?.id
+                    ? completedWorkflows.get(check.check_suite.id)
+                    : undefined
+                  return {
+                    id: check.id,
+                    failure: { _tag: 'NotAsked' as const },
+                    source: { _tag: 'CheckRun' as const, appId: check.app?.id ?? null },
+                    name: check.name,
+                    status: workflowConclusion ? 'completed' : check.status,
+                    conclusion: workflowConclusion || check.conclusion,
+                  }
+                }),
                 ...statuses.data.statuses.map(status => ({
                   id: status.id,
                   failure: { _tag: 'NotAsked' as const },

--- a/packages/harlan-github-agent/test/github-live-base.test.ts
+++ b/packages/harlan-github-agent/test/github-live-base.test.ts
@@ -127,6 +127,61 @@ describe('live pull request base', () => {
     expect(checkedRefs).not.toContain(historicBaseSha)
   })
 
+  it.each([
+    ['queued', null, 'completed', 'failure', 'completed', 'failure'],
+    ['in_progress', null, 'completed', 'cancelled', 'completed', 'cancelled'],
+    ['queued', null, 'completed', 'success', 'completed', 'success'],
+    ['completed', 'success', 'completed', 'failure', 'completed', 'success'],
+    ['queued', null, 'in_progress', null, 'queued', null],
+  ])('resolves check %s/%s against workflow %s/%s', async (status, conclusion, workflowStatus, workflowConclusion, expectedStatus, expectedConclusion) => {
+    const listForRef = () => undefined
+    const listWorkflowRunsForRepo = () => undefined
+    const client = {
+      paginate: (method: unknown, input: { ref?: string, head_sha?: string }) => {
+        if (method === listForRef && input.ref === liveBaseSha) {
+          return Promise.resolve([
+            { id: 1, name: 'build', status, conclusion, app: { id: 15368, slug: 'github-actions' }, check_suite: { id: 7 } },
+          ])
+        }
+        if (method === listWorkflowRunsForRepo && input.head_sha === liveBaseSha) {
+          return Promise.resolve([
+            { id: 70, event: 'push', status: workflowStatus, conclusion: workflowConclusion, check_suite_id: 7 },
+          ])
+        }
+        return Promise.resolve([])
+      },
+      rest: {
+        actions: { getJobForWorkflowRun: () => Promise.reject(new Error('Unexpected job lookup.')), listWorkflowRunsForRepo },
+        checks: { listForRef },
+        issues: { listComments: () => undefined },
+        pulls: {
+          get: () => Promise.resolve({ data: pullRequest() }),
+          listReviewComments: () => undefined,
+          listReviews: () => undefined,
+        },
+        repos: {
+          getBranch: () => Promise.resolve({ data: { commit: { sha: liveBaseSha } } }),
+          getBranchRules: () => Promise.resolve({ data: [] }),
+          getCombinedStatusForRef: () => Promise.resolve({ data: { statuses: [] } }),
+        },
+      },
+    } as unknown as Octokit
+    const source = createGitHubAgentSource({
+      actorLogin: () => 'harlan-github-agent[bot]',
+      createClient: () => client,
+      tokens: tokens(),
+    })
+
+    const result = await source.getPullRequestReviewSnapshot(repositoryMapping(), 24, new AbortController().signal)
+
+    expect(result).toEqual(ok(expect.objectContaining({
+      baseChecks: {
+        _tag: 'Available',
+        checks: [expect.objectContaining({ name: 'build', status: expectedStatus, conclusion: expectedConclusion })],
+      },
+    })))
+  })
+
   it('drops base check runs that a workflow_run event attached to the base commit', async () => {
     const listForRef = () => undefined
     const listWorkflowRunsForRepo = () => undefined


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/harlan-zw/.github/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Say **why** the change is needed. The diff shows how, so keep the fix itself to a sentence or two.
- Leave testing out of the description. CI reports that.
- Include a real before and after when the change is about performance. Never estimate one.
- Ideally, include relevant tests that fail without this PR but pass with it.
- If an agent drafted or edited the description, fill in the AI disclosure at the bottom. The agent names itself and links to itself, so a reader knows which one wrote this. Delete the line if you wrote the description yourself.

-->

### 🔗 Linked issue

Related to harlan-zw/nuxt-schema-org#153.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

<!-- Why this is needed, then 1 to 2 sentences on what changed. Add "### ⚠️ Breaking Changes" and "### 📝 Migration" sections only if the change actually breaks something or needs an operator step. -->

GitHub left a job queued after its workflow failed, so the review waited for a runner indefinitely.
Use the completed workflow result for unfinished jobs while preserving completed job results.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
